### PR TITLE
North Star 3/4: add agentfs knowledge backing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,12 +67,7 @@ name = "alan-agent-engine"
 version = "0.1.0"
 dependencies = [
  "alan-agent-protocol",
- "alan-agentfs",
- "alan-ap",
- "alan-kernel",
  "alan-llm",
- "alan-llmfs",
- "alan-shell",
  "anyhow",
  "async-trait",
  "chrono",
@@ -123,6 +118,7 @@ dependencies = [
  "alan-ap",
  "alan-kernel",
  "alan-knowledge",
+ "alan-memfs",
  "alan-shell",
  "async-trait",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,12 @@ name = "alan-agent-engine"
 version = "0.1.0"
 dependencies = [
  "alan-agent-protocol",
+ "alan-agentfs",
+ "alan-ap",
+ "alan-kernel",
  "alan-llm",
+ "alan-llmfs",
+ "alan-shell",
  "anyhow",
  "async-trait",
  "chrono",
@@ -116,6 +121,9 @@ name = "alan-agentfs"
 version = "0.1.0"
 dependencies = [
  "alan-ap",
+ "alan-kernel",
+ "alan-knowledge",
+ "alan-shell",
  "async-trait",
  "tokio",
 ]
@@ -164,6 +172,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "alan-knowledge"
+version = "0.1.0"
+dependencies = [
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "alan-llm"
 version = "0.1.0"
 dependencies = [
@@ -196,6 +215,16 @@ dependencies = [
  "async-trait",
  "serde",
  "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "alan-memfs"
+version = "0.1.0"
+dependencies = [
+ "alan-ap",
+ "alan-knowledge",
+ "async-trait",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ members = [
     "crates/agentfs",
     "crates/auth",
     "crates/kernel",
+    "crates/knowledge",
+    "crates/memfs",
     "crates/agent-protocol",
     "crates/llm",
     "crates/llmfs",
@@ -116,6 +118,8 @@ alan-auth = { path = "crates/auth" }
 alan-agent-protocol = { path = "crates/agent-protocol" }
 alan-llm = { path = "crates/llm" }
 alan-agent-engine = { path = "crates/agent-engine" }
+alan-knowledge = { path = "crates/knowledge" }
+alan-memfs = { path = "crates/memfs" }
 alan-swebench-tooling = { path = "crates/agent-engine/skills/swebench/tooling" }
 alan-shell-core = { path = "crates/shell-core" }
 alan-shell-core-ffi = { path = "crates/shell-core-ffi" }

--- a/crates/agent-engine/src/rollout.rs
+++ b/crates/agent-engine/src/rollout.rs
@@ -378,6 +378,8 @@ pub struct CheckpointRecord {
     pub checkpoint_type: String,
     pub summary: String,
     pub choice: Option<String>, // approved, modified, rejected
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub knowledge_root: Option<String>,
     pub timestamp: String,
 }
 
@@ -386,6 +388,23 @@ pub struct EventRecord {
     pub event_type: String,
     pub payload: serde_json::Value,
     pub timestamp: String,
+}
+
+fn checkpoint_record(
+    checkpoint_id: &str,
+    checkpoint_type: &str,
+    summary: &str,
+    choice: Option<&str>,
+    knowledge_root: Option<&str>,
+) -> CheckpointRecord {
+    CheckpointRecord {
+        checkpoint_id: checkpoint_id.to_string(),
+        checkpoint_type: checkpoint_type.to_string(),
+        summary: summary.to_string(),
+        choice: choice.map(str::to_string),
+        knowledge_root: knowledge_root.map(str::to_string),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+    }
 }
 
 /// Commands for the background writer task
@@ -912,13 +931,34 @@ impl RolloutRecorder {
         summary: &str,
         choice: Option<&str>,
     ) -> Result<()> {
-        let item = RolloutItem::Checkpoint(CheckpointRecord {
-            checkpoint_id: checkpoint_id.to_string(),
-            checkpoint_type: checkpoint_type.to_string(),
-            summary: summary.to_string(),
-            choice: choice.map(|s| s.to_string()),
-            timestamp: chrono::Utc::now().to_rfc3339(),
-        });
+        let item = RolloutItem::Checkpoint(checkpoint_record(
+            checkpoint_id,
+            checkpoint_type,
+            summary,
+            choice,
+            None,
+        ));
+        self.record(item).await?;
+        self.flush().await?; // Important events are flushed immediately
+        Ok(())
+    }
+
+    /// Record a checkpoint with the content-addressed knowledge root it names.
+    pub async fn record_checkpoint_with_knowledge_root(
+        &self,
+        checkpoint_id: &str,
+        checkpoint_type: &str,
+        summary: &str,
+        choice: Option<&str>,
+        knowledge_root: &str,
+    ) -> Result<()> {
+        let item = RolloutItem::Checkpoint(checkpoint_record(
+            checkpoint_id,
+            checkpoint_type,
+            summary,
+            choice,
+            Some(knowledge_root),
+        ));
         self.record(item).await?;
         self.flush().await?; // Important events are flushed immediately
         Ok(())
@@ -932,13 +972,35 @@ impl RolloutRecorder {
         summary: &str,
         choice: Option<&str>,
     ) -> Result<()> {
-        let item = RolloutItem::Checkpoint(CheckpointRecord {
-            checkpoint_id: checkpoint_id.to_string(),
-            checkpoint_type: checkpoint_type.to_string(),
-            summary: summary.to_string(),
-            choice: choice.map(|s| s.to_string()),
-            timestamp: chrono::Utc::now().to_rfc3339(),
-        });
+        let item = RolloutItem::Checkpoint(checkpoint_record(
+            checkpoint_id,
+            checkpoint_type,
+            summary,
+            choice,
+            None,
+        ));
+        self.record_nowait(item)?;
+        self.flush_nowait()?;
+        Ok(())
+    }
+
+    /// Record a checkpoint with a content-addressed knowledge root without
+    /// waiting on IO completion.
+    pub fn record_checkpoint_with_knowledge_root_nowait(
+        &self,
+        checkpoint_id: &str,
+        checkpoint_type: &str,
+        summary: &str,
+        choice: Option<&str>,
+        knowledge_root: &str,
+    ) -> Result<()> {
+        let item = RolloutItem::Checkpoint(checkpoint_record(
+            checkpoint_id,
+            checkpoint_type,
+            summary,
+            choice,
+            Some(knowledge_root),
+        ));
         self.record_nowait(item)?;
         self.flush_nowait()?;
         Ok(())
@@ -1245,6 +1307,41 @@ mod tests {
             restored.thinking_content().as_deref(),
             Some("internal reasoning")
         );
+    }
+
+    #[tokio::test]
+    async fn test_record_checkpoint_persists_knowledge_root() {
+        let temp_dir = TempDir::new().unwrap();
+        let recorder = RolloutRecorder::new_in_dir(
+            "test-root-checkpoint",
+            "gemini-2.0-flash",
+            temp_dir.path(),
+        )
+        .await
+        .unwrap();
+
+        recorder
+            .record_checkpoint_with_knowledge_root(
+                "turn-1",
+                "turn_completed",
+                "turn completed",
+                None,
+                "sha256:abc123",
+            )
+            .await
+            .unwrap();
+
+        let items = RolloutRecorder::load_history(recorder.path())
+            .await
+            .unwrap();
+        let checkpoint = items.into_iter().find_map(|item| match item {
+            RolloutItem::Checkpoint(checkpoint) => Some(checkpoint),
+            _ => None,
+        });
+
+        let checkpoint = checkpoint.expect("checkpoint should be persisted");
+        assert_eq!(checkpoint.checkpoint_id, "turn-1");
+        assert_eq!(checkpoint.knowledge_root.as_deref(), Some("sha256:abc123"));
     }
 
     #[tokio::test]
@@ -1882,16 +1979,22 @@ this is not valid json
             checkpoint_type: "supplier_list".to_string(),
             summary: "Found 5 suppliers".to_string(),
             choice: Some("approved".to_string()),
+            knowledge_root: Some("sha256:abc123".to_string()),
             timestamp: "2026-01-29T14:35:00Z".to_string(),
         };
 
         let json = serde_json::to_string(&cp).unwrap();
         assert!(json.contains("cp-123"));
         assert!(json.contains("approved"));
+        assert!(json.contains("sha256:abc123"));
 
         let deserialized: CheckpointRecord = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.checkpoint_id, "cp-123");
         assert_eq!(deserialized.choice, Some("approved".to_string()));
+        assert_eq!(
+            deserialized.knowledge_root.as_deref(),
+            Some("sha256:abc123")
+        );
     }
 
     #[test]
@@ -1901,15 +2004,21 @@ this is not valid json
             checkpoint_type: "requirements".to_string(),
             summary: "Requirements gathered".to_string(),
             choice: None,
+            knowledge_root: None,
             timestamp: "2026-01-29T14:36:00Z".to_string(),
         };
 
         let json = serde_json::to_string(&cp).unwrap();
         assert!(json.contains("cp-456"));
         assert!(json.contains("null"));
+        assert!(
+            !json.contains("knowledge_root"),
+            "missing root stays omitted for legacy-compatible checkpoints: {json}"
+        );
 
         let deserialized: CheckpointRecord = serde_json::from_str(&json).unwrap();
         assert!(deserialized.choice.is_none());
+        assert!(deserialized.knowledge_root.is_none());
     }
 
     #[test]

--- a/crates/agent-engine/src/session.rs
+++ b/crates/agent-engine/src/session.rs
@@ -2327,6 +2327,7 @@ mod tests {
                     checkpoint_type: "tool_escalation".to_string(),
                     summary: "approve side effect".to_string(),
                     choice: Some("approved".to_string()),
+                    knowledge_root: None,
                     timestamp: "2026-01-29T14:30:54Z".to_string(),
                 }),
                 RolloutItem::Message(MessageRecord {
@@ -2351,6 +2352,7 @@ mod tests {
                     checkpoint_type: "effect_replay_confirmation".to_string(),
                     summary: "reject side effect".to_string(),
                     choice: Some("rejected".to_string()),
+                    knowledge_root: None,
                     timestamp: "2026-01-29T14:30:56Z".to_string(),
                 }),
             ];

--- a/crates/agentfs/Cargo.toml
+++ b/crates/agentfs/Cargo.toml
@@ -8,5 +8,10 @@ license.workspace = true
 
 [dependencies]
 alan-ap = { path = "../ap" }
+alan-knowledge.workspace = true
 async-trait.workspace = true
 tokio = { workspace = true }
+
+[dev-dependencies]
+alan-kernel = { path = "../kernel" }
+alan-shell = { path = "../shell" }

--- a/crates/agentfs/Cargo.toml
+++ b/crates/agentfs/Cargo.toml
@@ -14,4 +14,5 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 alan-kernel = { path = "../kernel" }
+alan-memfs = { path = "../memfs" }
 alan-shell = { path = "../shell" }

--- a/crates/agentfs/src/conformance.rs
+++ b/crates/agentfs/src/conformance.rs
@@ -75,8 +75,6 @@ impl AgentConformanceChecker {
         let mut report = ConformanceReport::new(path);
         self.check_generic_process_into(path, &mut report).await;
         for (rel, kind) in [
-            ("io/input", FileKind::Stream),
-            ("io/events", FileKind::Stream),
             ("events", FileKind::Stream),
             ("machine", FileKind::Dir),
             ("machine/tape", FileKind::Stream),
@@ -152,7 +150,9 @@ impl AgentConformanceChecker {
     async fn check_generic_process_into(&self, path: &str, report: &mut ConformanceReport) {
         for (rel, kind) in [
             ("io", FileKind::Dir),
+            ("io/input", FileKind::Stream),
             ("io/output", FileKind::Stream),
+            ("io/events", FileKind::Stream),
             ("status", FileKind::File),
             ("ctl", FileKind::File),
         ] {

--- a/crates/agentfs/src/conformance.rs
+++ b/crates/agentfs/src/conformance.rs
@@ -1,0 +1,346 @@
+//! Agent file-layout conformance checker.
+//!
+//! The checker speaks only aP against a supplied root file server. That keeps
+//! conformance as a filesystem property: any runtime that exports a compatible
+//! tree can be tested without a kernel flag or an Alan-internal type check.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+use std::time::Duration;
+
+use alan_ap::{ErrorCode, Fid, FileKind, InProcessTransport, OpenMode, Request, Response};
+
+/// One conformance failure found while inspecting a process tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConformanceIssue {
+    pub path: String,
+    pub message: String,
+}
+
+/// The accumulated result of a conformance check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConformanceReport {
+    pub target: String,
+    pub issues: Vec<ConformanceIssue>,
+}
+
+impl ConformanceReport {
+    fn new(target: impl Into<String>) -> Self {
+        Self {
+            target: target.into(),
+            issues: Vec::new(),
+        }
+    }
+
+    pub fn is_ok(&self) -> bool {
+        self.issues.is_empty()
+    }
+
+    pub fn push(&mut self, path: impl Into<String>, message: impl Into<String>) {
+        self.issues.push(ConformanceIssue {
+            path: path.into(),
+            message: message.into(),
+        });
+    }
+
+    pub fn assert_ok(&self) {
+        assert!(
+            self.is_ok(),
+            "agent file-layout conformance failed for {}: {:?}",
+            self.target,
+            self.issues
+        );
+    }
+}
+
+/// aP-only checker for the agent file-layout contract.
+#[derive(Clone)]
+pub struct AgentConformanceChecker {
+    root: InProcessTransport,
+    next_fid: Arc<AtomicU64>,
+}
+
+impl AgentConformanceChecker {
+    pub fn new(root: InProcessTransport) -> Self {
+        Self {
+            root,
+            next_fid: Arc::new(AtomicU64::new(9_000_000)),
+        }
+    }
+
+    /// Verify the generic process layout plus the agent superset at `path`.
+    pub async fn check_agent_process(&self, path: &str) -> ConformanceReport {
+        let mut report = ConformanceReport::new(path);
+        self.check_generic_process_into(path, &mut report).await;
+        for (rel, kind) in [
+            ("events", FileKind::Stream),
+            ("machine", FileKind::Dir),
+            ("machine/tape", FileKind::Stream),
+            ("machine/status", FileKind::File),
+            ("machine/ctl", FileKind::File),
+            ("requests", FileKind::Dir),
+            ("requests/clone", FileKind::Clone),
+            ("requests/events", FileKind::Stream),
+            ("actions", FileKind::Dir),
+            ("actions/clone", FileKind::Clone),
+            ("actions/events", FileKind::Stream),
+            ("context", FileKind::Dir),
+            ("children", FileKind::Dir),
+        ] {
+            self.expect_kind(&mut report, &join_path(path, rel), kind)
+                .await;
+        }
+        report
+    }
+
+    /// Verify only the generic process layout at `path`.
+    pub async fn check_generic_process(&self, path: &str) -> ConformanceReport {
+        let mut report = ConformanceReport::new(path);
+        self.check_generic_process_into(path, &mut report).await;
+        report
+    }
+
+    /// Verify that dynamic agent containers announce clone-created children on
+    /// their observable `events` stream.
+    pub async fn check_dynamic_container_events(&self, agent_path: &str) -> ConformanceReport {
+        let mut report = ConformanceReport::new(agent_path);
+        for container in ["requests", "actions"] {
+            self.check_container_events(agent_path, container, &mut report)
+                .await;
+        }
+        report
+    }
+
+    /// Verify that `/agent/root` resolves to the same conforming surface as the
+    /// supplied current root pid.
+    pub async fn check_root_alias(
+        &self,
+        agent_root_path: &str,
+        current_root_pid: &str,
+    ) -> ConformanceReport {
+        let root_alias = join_path(agent_root_path, "root");
+        let pid_path = join_path(agent_root_path, current_root_pid);
+        let mut report = ConformanceReport::new(root_alias.clone());
+
+        let alias_report = self.check_agent_process(&root_alias).await;
+        report.issues.extend(alias_report.issues);
+
+        let pid_report = self.check_agent_process(&pid_path).await;
+        report.issues.extend(pid_report.issues);
+
+        match (
+            self.read_dir_entries(&root_alias).await,
+            self.read_dir_entries(&pid_path).await,
+        ) {
+            (Ok(alias_entries), Ok(pid_entries)) if alias_entries == pid_entries => {}
+            (Ok(alias_entries), Ok(pid_entries)) => report.push(
+                root_alias,
+                format!(
+                    "root alias listing differs from pid listing: {alias_entries:?} != {pid_entries:?}"
+                ),
+            ),
+            (Err(error), _) => report.push(root_alias, format!("cannot read root alias: {error:?}")),
+            (_, Err(error)) => report.push(pid_path, format!("cannot read root pid: {error:?}")),
+        }
+        report
+    }
+
+    async fn check_generic_process_into(&self, path: &str, report: &mut ConformanceReport) {
+        for (rel, kind) in [
+            ("io", FileKind::Dir),
+            ("io/input", FileKind::Stream),
+            ("io/output", FileKind::Stream),
+            ("io/events", FileKind::Stream),
+            ("status", FileKind::File),
+            ("ctl", FileKind::File),
+        ] {
+            self.expect_kind(report, &join_path(path, rel), kind).await;
+        }
+    }
+
+    async fn check_container_events(
+        &self,
+        agent_path: &str,
+        container: &str,
+        report: &mut ConformanceReport,
+    ) {
+        let events_path = join_path(agent_path, &format!("{container}/events"));
+        let clone_path = join_path(agent_path, &format!("{container}/clone"));
+        let event_fid = match self.walk_open(&events_path, OpenMode::Read).await {
+            Ok((fid, _)) => fid,
+            Err(error) => {
+                report.push(events_path, format!("cannot open events stream: {error:?}"));
+                return;
+            }
+        };
+        let offset = match self.stat(event_fid).await {
+            Ok(stat) => stat.length,
+            Err(error) => {
+                report.push(
+                    events_path.clone(),
+                    format!("cannot stat events stream: {error:?}"),
+                );
+                let _ = self.clunk(event_fid).await;
+                return;
+            }
+        };
+
+        let reader = {
+            let checker = self.clone();
+            tokio::spawn(async move { checker.read(event_fid, offset, 4096).await })
+        };
+
+        match self.walk_open(&clone_path, OpenMode::ReadWrite).await {
+            Ok((clone_fid, _)) => {
+                let _ = self.read(clone_fid, 0, 64).await;
+                let _ = self.clunk(clone_fid).await;
+            }
+            Err(error) => {
+                report.push(
+                    clone_path,
+                    format!("cannot clone container child: {error:?}"),
+                );
+                let _ = self.clunk(event_fid).await;
+                return;
+            }
+        }
+
+        match tokio::time::timeout(Duration::from_millis(250), reader).await {
+            Ok(Ok(Ok(bytes))) if !bytes.is_empty() => {}
+            Ok(Ok(Ok(_))) => report.push(events_path, "events stream returned no bytes"),
+            Ok(Ok(Err(error))) => {
+                report.push(events_path, format!("events stream read failed: {error:?}"))
+            }
+            Ok(Err(error)) => report.push(events_path, format!("events read task failed: {error}")),
+            Err(_) => report.push(
+                events_path,
+                "events stream did not unblock after clone allocation",
+            ),
+        }
+        let _ = self.clunk(event_fid).await;
+    }
+
+    async fn expect_kind(&self, report: &mut ConformanceReport, path: &str, expected: FileKind) {
+        match self.walk_stat(path).await {
+            Ok((fid, stat)) => {
+                if stat.qid.kind != expected {
+                    report.push(
+                        path,
+                        format!("expected {expected:?}, got {:?}", stat.qid.kind),
+                    );
+                }
+                let _ = self.clunk(fid).await;
+            }
+            Err(error) => report.push(path, format!("missing or unreadable: {error:?}")),
+        }
+    }
+
+    async fn read_dir_entries(&self, path: &str) -> Result<Vec<String>, ErrorCode> {
+        let (fid, _) = self.walk_open(path, OpenMode::Read).await?;
+        let bytes = self.read(fid, 0, 64 * 1024).await;
+        let clunk = self.clunk(fid).await;
+        let bytes = bytes?;
+        clunk?;
+        let text = String::from_utf8(bytes).map_err(|_| ErrorCode::Io)?;
+        let mut entries = text
+            .lines()
+            .filter(|line| !line.is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        entries.sort();
+        Ok(entries)
+    }
+
+    async fn walk_stat(&self, path: &str) -> Result<(Fid, alan_ap::Stat), ErrorCode> {
+        let fid = self.walk(path).await?;
+        let stat = self.stat(fid).await?;
+        Ok((fid, stat))
+    }
+
+    async fn walk_open(
+        &self,
+        path: &str,
+        mode: OpenMode,
+    ) -> Result<(Fid, alan_ap::Qid), ErrorCode> {
+        let fid = self.walk(path).await?;
+        match self.open(fid, mode).await {
+            Ok(qid) => Ok((fid, qid)),
+            Err(error) => {
+                let _ = self.clunk(fid).await;
+                Err(error)
+            }
+        }
+    }
+
+    async fn walk(&self, path: &str) -> Result<Fid, ErrorCode> {
+        let fid = Fid(self.next_fid.fetch_add(1, Ordering::Relaxed));
+        self.call(Request::Walk {
+            fid: Fid::ROOT,
+            newfid: fid,
+            names: split_path(path),
+        })
+        .await
+        .and_then(|response| match response {
+            Response::Walk { .. } => Ok(fid),
+            _ => Err(ErrorCode::Io),
+        })
+    }
+
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<alan_ap::Qid, ErrorCode> {
+        self.call(Request::Open { fid, mode })
+            .await
+            .and_then(|response| match response {
+                Response::Open { qid } => Ok(qid),
+                _ => Err(ErrorCode::Io),
+            })
+    }
+
+    async fn read(&self, fid: Fid, offset: u64, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        self.call(Request::Read { fid, offset, count })
+            .await
+            .and_then(|response| match response {
+                Response::Read { data } => Ok(data),
+                _ => Err(ErrorCode::Io),
+            })
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<alan_ap::Stat, ErrorCode> {
+        self.call(Request::Stat { fid })
+            .await
+            .and_then(|response| match response {
+                Response::Stat { stat } => Ok(stat),
+                _ => Err(ErrorCode::Io),
+            })
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.call(Request::Clunk { fid })
+            .await
+            .and_then(|response| match response {
+                Response::Clunk => Ok(()),
+                _ => Err(ErrorCode::Io),
+            })
+    }
+
+    async fn call(&self, request: Request) -> Result<Response, ErrorCode> {
+        self.root.call(request).await
+    }
+}
+
+fn split_path(path: &str) -> Vec<String> {
+    path.split('/')
+        .filter(|component| !component.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn join_path(base: &str, rel: &str) -> String {
+    let base = base.trim_end_matches('/');
+    if base.is_empty() {
+        format!("/{rel}")
+    } else {
+        format!("{base}/{rel}")
+    }
+}

--- a/crates/agentfs/src/conformance.rs
+++ b/crates/agentfs/src/conformance.rs
@@ -78,6 +78,8 @@ impl AgentConformanceChecker {
             ("events", FileKind::Stream),
             ("machine", FileKind::Dir),
             ("machine/tape", FileKind::Stream),
+            ("machine/checkpoints", FileKind::Dir),
+            ("machine/checkpoints/current", FileKind::File),
             ("machine/status", FileKind::File),
             ("machine/ctl", FileKind::File),
             ("requests", FileKind::Dir),

--- a/crates/agentfs/src/conformance.rs
+++ b/crates/agentfs/src/conformance.rs
@@ -75,6 +75,8 @@ impl AgentConformanceChecker {
         let mut report = ConformanceReport::new(path);
         self.check_generic_process_into(path, &mut report).await;
         for (rel, kind) in [
+            ("io/input", FileKind::Stream),
+            ("io/events", FileKind::Stream),
             ("events", FileKind::Stream),
             ("machine", FileKind::Dir),
             ("machine/tape", FileKind::Stream),
@@ -150,9 +152,7 @@ impl AgentConformanceChecker {
     async fn check_generic_process_into(&self, path: &str, report: &mut ConformanceReport) {
         for (rel, kind) in [
             ("io", FileKind::Dir),
-            ("io/input", FileKind::Stream),
             ("io/output", FileKind::Stream),
-            ("io/events", FileKind::Stream),
             ("status", FileKind::File),
             ("ctl", FileKind::File),
         ] {
@@ -191,6 +191,7 @@ impl AgentConformanceChecker {
             let checker = self.clone();
             tokio::spawn(async move { checker.read(event_fid, offset, 4096).await })
         };
+        let mut reader = reader;
 
         match self.walk_open(&clone_path, OpenMode::ReadWrite).await {
             Ok((clone_fid, _)) => {
@@ -198,6 +199,8 @@ impl AgentConformanceChecker {
                 let _ = self.clunk(clone_fid).await;
             }
             Err(error) => {
+                reader.abort();
+                let _ = reader.await;
                 report.push(
                     clone_path,
                     format!("cannot clone container child: {error:?}"),
@@ -207,17 +210,21 @@ impl AgentConformanceChecker {
             }
         }
 
-        match tokio::time::timeout(Duration::from_millis(250), reader).await {
+        match tokio::time::timeout(Duration::from_millis(250), &mut reader).await {
             Ok(Ok(Ok(bytes))) if !bytes.is_empty() => {}
             Ok(Ok(Ok(_))) => report.push(events_path, "events stream returned no bytes"),
             Ok(Ok(Err(error))) => {
                 report.push(events_path, format!("events stream read failed: {error:?}"))
             }
             Ok(Err(error)) => report.push(events_path, format!("events read task failed: {error}")),
-            Err(_) => report.push(
-                events_path,
-                "events stream did not unblock after clone allocation",
-            ),
+            Err(_) => {
+                reader.abort();
+                let _ = reader.await;
+                report.push(
+                    events_path,
+                    "events stream did not unblock after clone allocation",
+                );
+            }
         }
         let _ = self.clunk(event_fid).await;
     }

--- a/crates/agentfs/src/lib.rs
+++ b/crates/agentfs/src/lib.rs
@@ -247,6 +247,14 @@ impl AgentFs {
         state.io_events.append(record.as_bytes()).await;
         state.events.append(record.as_bytes()).await;
     }
+
+    pub(crate) async fn append_status_event(&self, status: &str) {
+        let state = self.state.lock().await;
+        state
+            .events
+            .append(format!("status:{status}\n").as_bytes())
+            .await;
+    }
 }
 
 impl State {

--- a/crates/agentfs/src/lib.rs
+++ b/crates/agentfs/src/lib.rs
@@ -95,7 +95,6 @@ struct State {
     action_events: Stream,
     tape: Stream,
     knowledge: KnowledgeStore,
-    tape_blocks: Vec<ContentHash>,
     tape_root: ContentHash,
     requests: BTreeMap<String, Request>,
     actions: BTreeMap<String, Action>,
@@ -195,7 +194,6 @@ impl AgentFs {
                 action_events: Stream::new(),
                 tape: Stream::new(),
                 knowledge,
-                tape_blocks: Vec::new(),
                 tape_root,
                 requests: BTreeMap::new(),
                 actions: BTreeMap::new(),
@@ -408,11 +406,9 @@ impl State {
     }
 
     fn append_tape_block(&mut self, data: &[u8]) -> Result<(), ErrorCode> {
-        let block = self.knowledge.put_block(data);
-        self.tape_blocks.push(block);
         let root = self
             .knowledge
-            .checkpoint_from_blocks(self.tape_blocks.clone())
+            .fork_append_bytes(&self.tape_root, [data])
             .map_err(map_knowledge_error)?;
         self.knowledge
             .bind_root(TAPE_ROOT_NAME, root.clone(), RootAccess::ReadWrite)
@@ -900,4 +896,25 @@ fn slice(bytes: Vec<u8>, offset: Offset, count: u32) -> Vec<u8> {
     let start = (offset as usize).min(bytes.len());
     let end = bytes.len().min(start + count as usize);
     bytes[start..end].to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn tape_checkpoint_appends_one_delta_node_per_write() {
+        let fs = AgentFs::new();
+        let mut state = fs.state.lock().await;
+        let initial_nodes = state.knowledge.node_count();
+
+        state.append_tape_block(b"turn-1\n").unwrap();
+        let after_first = state.knowledge.node_count();
+        state.append_tape_block(b"turn-2\n").unwrap();
+        let after_second = state.knowledge.node_count();
+
+        assert_eq!(after_first, initial_nodes + 1);
+        assert_eq!(after_second, after_first + 1);
+        assert_eq!(state.materialized_tape().unwrap(), b"turn-1\nturn-2\n");
+    }
 }

--- a/crates/agentfs/src/lib.rs
+++ b/crates/agentfs/src/lib.rs
@@ -26,16 +26,24 @@
 //!
 //! It depends on `alan-ap` only — no `alan-agent-protocol`/`EventEnvelope` on the
 //! live path (that alphabet remains only as legacy compatibility transport, ADR-
-//! 0025 D4). The engine wiring that drives these writes from a running session is
-//! a follow-on slice; here the surfaces are exercised directly over aP.
+//! 0025 D4). [`AgentRootFs`] is the thin `/agent` view over these per-agent file
+//! servers: it derives visible pids from `/proc` and forwards `/agent/<pid>` or
+//! `/agent/root` to the corresponding [`AgentFs`] backing tree.
+
+mod conformance;
+mod root;
 
 use std::collections::{BTreeMap, HashMap};
 
 use alan_ap::{
     ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat, Stream, VersionTable,
 };
+use alan_knowledge::{ContentHash, KnowledgeError, KnowledgeStore, RootAccess};
 use async_trait::async_trait;
 use tokio::sync::Mutex;
+
+pub use conformance::{AgentConformanceChecker, ConformanceIssue, ConformanceReport};
+pub use root::AgentRootFs;
 
 /// Cap on a buffered document write (request/action field), so a hostile offset
 /// cannot allocate unbounded memory.
@@ -50,6 +58,8 @@ const MACHINE_CTL_HELP: &str = "\
 compact   compact the tape into a checkpoint
 rollback  roll back to the previous checkpoint
 ";
+
+const TAPE_ROOT_NAME: &str = "machine/tape";
 
 #[derive(Default)]
 struct Request {
@@ -84,6 +94,9 @@ struct State {
     request_events: Stream,
     action_events: Stream,
     tape: Stream,
+    knowledge: KnowledgeStore,
+    tape_blocks: Vec<ContentHash>,
+    tape_root: ContentHash,
     requests: BTreeMap<String, Request>,
     actions: BTreeMap<String, Action>,
     /// Agent run-state (machine/status): read-only over aP, transitioned only by
@@ -141,6 +154,8 @@ enum Node {
     /// (agent-file-layout-contract). Generic process control (interrupt/cancel)
     /// is the kernel's `/proc/<pid>/ctl`, not here.
     MachineCtl,
+    CheckpointsDir,
+    CurrentCheckpoint,
     Events,
     RequestsDir,
     RequestsClone,
@@ -169,6 +184,7 @@ impl Default for AgentFs {
 
 impl AgentFs {
     pub fn new() -> Self {
+        let (knowledge, tape_root) = initial_tape_knowledge();
         Self {
             state: Mutex::new(State {
                 input: Stream::new(),
@@ -178,6 +194,9 @@ impl AgentFs {
                 request_events: Stream::new(),
                 action_events: Stream::new(),
                 tape: Stream::new(),
+                knowledge,
+                tape_blocks: Vec::new(),
+                tape_root,
                 requests: BTreeMap::new(),
                 actions: BTreeMap::new(),
                 status: "running".to_string(),
@@ -188,6 +207,25 @@ impl AgentFs {
                 fids: HashMap::new(),
             }),
         }
+    }
+
+    /// Current content-addressed checkpoint root for `machine/tape`.
+    pub async fn current_tape_checkpoint(&self) -> ContentHash {
+        self.state.lock().await.tape_root.clone()
+    }
+
+    /// Verify and materialize the current `machine/tape` checkpoint root.
+    pub async fn materialize_tape_checkpoint(&self) -> Result<Vec<u8>, ErrorCode> {
+        self.state.lock().await.materialized_tape()
+    }
+
+    /// Verify the current `machine/tape` root without materializing bytes.
+    pub async fn verify_tape_checkpoint(&self) -> Result<(), ErrorCode> {
+        let state = self.state.lock().await;
+        state
+            .knowledge
+            .verify_root_hash(&state.tape_root)
+            .map_err(map_knowledge_error)
     }
 }
 
@@ -240,6 +278,11 @@ impl State {
                 "tape" => Ok(Node::Tape),
                 "status" => Ok(Node::Status),
                 "ctl" => Ok(Node::MachineCtl),
+                "checkpoints" => Ok(Node::CheckpointsDir),
+                _ => Err(ErrorCode::NotFound),
+            },
+            Node::CheckpointsDir => match name {
+                "current" => Ok(Node::CurrentCheckpoint),
                 _ => Err(ErrorCode::NotFound),
             },
             Node::RequestsDir => match name {
@@ -283,7 +326,9 @@ impl State {
             Node::Root => b"io\nmachine\nevents\nrequests\nactions\ncontext\nchildren".to_vec(),
             Node::ContextDir | Node::ChildrenDir => Vec::new(),
             Node::IoDir => b"input\noutput\nevents".to_vec(),
-            Node::MachineDir => b"tape\nstatus\nctl".to_vec(),
+            Node::MachineDir => b"tape\nstatus\nctl\ncheckpoints".to_vec(),
+            Node::CheckpointsDir => b"current".to_vec(),
+            Node::CurrentCheckpoint => format!("{}\n", self.tape_root).into_bytes(),
             Node::Status => self.status.clone().into_bytes(),
             // machine/ctl exposes its accepted commands in-band, so a
             // namespace-native client discovers them by reading the file rather
@@ -345,6 +390,31 @@ impl State {
             Node::ActionsEvents => Some(self.action_events.clone()),
             _ => None,
         }
+    }
+
+    fn append_tape_block(&mut self, data: &[u8]) -> Result<(), ErrorCode> {
+        let block = self.knowledge.put_block(data);
+        self.tape_blocks.push(block);
+        let root = self
+            .knowledge
+            .checkpoint_from_blocks(self.tape_blocks.clone())
+            .map_err(map_knowledge_error)?;
+        self.knowledge
+            .bind_root(TAPE_ROOT_NAME, root.clone(), RootAccess::ReadWrite)
+            .map_err(map_knowledge_error)?;
+        self.tape_root = root;
+        self.bump(&Node::CurrentCheckpoint);
+        Ok(())
+    }
+
+    fn materialized_tape(&self) -> Result<Vec<u8>, ErrorCode> {
+        let root = self
+            .knowledge
+            .root(TAPE_ROOT_NAME)
+            .map_err(map_knowledge_error)?;
+        self.knowledge
+            .read_bound_root(&root)
+            .map_err(map_knowledge_error)
     }
 }
 
@@ -470,7 +540,7 @@ impl FileServer for AgentFs {
     }
 
     async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
-        let (node, clone_id, stream) = {
+        let (node, clone_id, stream, tape_snapshot) = {
             let state = self.state.lock().await;
             // Reading needs read authority from a successful read-open (ROOT, the
             // pre-bound anchor, is always readable). A released/unknown fid is
@@ -484,11 +554,24 @@ impl FileServer for AgentFs {
             let clone_id = state.fids.get(&fid).and_then(|f| f.clone_id.clone());
             let node = state.node_of(fid)?;
             let stream = state.stream_for(&node);
-            (node, clone_id, stream)
+            let tape_snapshot = if matches!(node, Node::Tape) {
+                Some(state.materialized_tape()?)
+            } else {
+                None
+            };
+            (node, clone_id, stream, tape_snapshot)
         };
         // A clone fid reads back the allocated id.
         if let Some(id) = clone_id {
             return Ok(slice(id.into_bytes(), offset, count));
+        }
+        if let Some(bytes) = tape_snapshot {
+            if (offset as usize) < bytes.len() {
+                return Ok(slice(bytes, offset, count));
+            }
+            if let Some(stream) = stream {
+                return Ok(stream.read(offset, count).await);
+            }
         }
         if let Some(stream) = stream {
             return Ok(stream.read(offset, count).await);
@@ -518,6 +601,9 @@ impl FileServer for AgentFs {
                 } else {
                     format!("tape:{}\n", data.len())
                 };
+                if matches!(node, Node::Tape) {
+                    state.append_tape_block(data)?;
+                }
                 stream.append(data).await;
                 if is_output {
                     state.io_events.append(record.as_bytes()).await;
@@ -567,11 +653,11 @@ impl FileServer for AgentFs {
         let length = match &node {
             Node::Output
             | Node::Input
-            | Node::Tape
             | Node::Events
             | Node::IoEvents
             | Node::RequestsEvents
             | Node::ActionsEvents => state.stream_for(&node).expect("stream").len().await,
+            Node::Tape => state.materialized_tape()?.len() as u64,
             other => state
                 .computed_bytes(other)
                 .map(|b| b.len() as u64)
@@ -702,6 +788,7 @@ fn node_identity(node: &Node) -> (FileKind, u64) {
         Node::Root => (FileKind::Dir, "/".to_string()),
         Node::IoDir => (FileKind::Dir, "io".into()),
         Node::MachineDir => (FileKind::Dir, "machine".into()),
+        Node::CheckpointsDir => (FileKind::Dir, "machine/checkpoints".into()),
         Node::RequestsDir => (FileKind::Dir, "requests".into()),
         Node::ActionsDir => (FileKind::Dir, "actions".into()),
         Node::ContextDir => (FileKind::Dir, "context".into()),
@@ -719,6 +806,7 @@ fn node_identity(node: &Node) -> (FileKind, u64) {
         Node::Events => (FileKind::Stream, "events".into()),
         Node::Status => (FileKind::File, "machine/status".into()),
         Node::MachineCtl => (FileKind::File, "machine/ctl".into()),
+        Node::CurrentCheckpoint => (FileKind::File, "machine/checkpoints/current".into()),
         Node::RequestField(id, field) => (FileKind::File, format!("requests/{id}/{field}")),
         Node::ActionField(id, field) => (FileKind::File, format!("actions/{id}/{field}")),
     };
@@ -756,6 +844,27 @@ fn is_writable(node: &Node) -> bool {
         // read-only too (agent-file-layout-contract).
         Node::RequestField(_, field) => *field != "status",
         _ => false,
+    }
+}
+
+fn initial_tape_knowledge() -> (KnowledgeStore, ContentHash) {
+    let mut knowledge = KnowledgeStore::new();
+    let root = knowledge
+        .checkpoint_from_blocks(Vec::<ContentHash>::new())
+        .expect("empty tape checkpoint can be created");
+    knowledge
+        .bind_root(TAPE_ROOT_NAME, root.clone(), RootAccess::ReadWrite)
+        .expect("empty tape checkpoint can be bound");
+    (knowledge, root)
+}
+
+fn map_knowledge_error(error: KnowledgeError) -> ErrorCode {
+    match error {
+        KnowledgeError::NoAccess => ErrorCode::NoAccess,
+        KnowledgeError::MissingBlock(_)
+        | KnowledgeError::MissingNode(_)
+        | KnowledgeError::UnknownRoot(_) => ErrorCode::NotFound,
+        KnowledgeError::HashMismatch(_) | KnowledgeError::Cycle(_) => ErrorCode::Io,
     }
 }
 

--- a/crates/agentfs/src/lib.rs
+++ b/crates/agentfs/src/lib.rs
@@ -227,6 +227,14 @@ impl AgentFs {
             .verify_root_hash(&state.tape_root)
             .map_err(map_knowledge_error)
     }
+
+    pub(crate) async fn append_child_event(&self, child_pid: &str) {
+        let state = self.state.lock().await;
+        state
+            .events
+            .append(format!("child:{child_pid}\n").as_bytes())
+            .await;
+    }
 }
 
 impl State {
@@ -530,9 +538,22 @@ impl FileServer for AgentFs {
             }
             _ => None,
         };
+        let read_write_base = if matches!(mode, OpenMode::ReadWrite) {
+            match &node {
+                Node::RequestField(..) | Node::ActionField(..) => {
+                    Some(state.computed_bytes(&node)?)
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
         let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
         f.mode = Some(mode);
         f.clone_id = clone_id;
+        if let Some(bytes) = read_write_base {
+            f.write_buf = bytes;
+        }
         if is_tape_write {
             state.tape_writer = Some(fid);
         }

--- a/crates/agentfs/src/lib.rs
+++ b/crates/agentfs/src/lib.rs
@@ -235,6 +235,13 @@ impl AgentFs {
             .append(format!("child:{child_pid}\n").as_bytes())
             .await;
     }
+
+    pub(crate) async fn append_output_event(&self, count: u32) {
+        let state = self.state.lock().await;
+        let record = format!("output:{count}\n");
+        state.io_events.append(record.as_bytes()).await;
+        state.events.append(record.as_bytes()).await;
+    }
 }
 
 impl State {

--- a/crates/agentfs/src/lib.rs
+++ b/crates/agentfs/src/lib.rs
@@ -240,6 +240,13 @@ impl AgentFs {
         state.io_events.append(record.as_bytes()).await;
         state.events.append(record.as_bytes()).await;
     }
+
+    pub(crate) async fn append_input_event(&self, count: u32) {
+        let state = self.state.lock().await;
+        let record = format!("input:{count}\n");
+        state.io_events.append(record.as_bytes()).await;
+        state.events.append(record.as_bytes()).await;
+    }
 }
 
 impl State {

--- a/crates/agentfs/src/root.rs
+++ b/crates/agentfs/src/root.rs
@@ -55,11 +55,20 @@ enum Node {
     ProcFile {
         proc: Arc<dyn FileServer>,
         proc_fid: Fid,
+        pid: String,
+        names: Vec<String>,
     },
 }
 
 struct Entry {
     node: Node,
+}
+
+struct ProcCreateDir {
+    proc: Arc<dyn FileServer>,
+    dir_fid: Fid,
+    pid: String,
+    names: Vec<String>,
 }
 
 struct State {
@@ -311,6 +320,8 @@ impl AgentRootFs {
             Ok(_) => Ok(Node::ProcFile {
                 proc: self.proc.clone(),
                 proc_fid,
+                pid: pid.to_string(),
+                names: names.to_vec(),
             }),
             Err(e) => Err(e),
         }
@@ -320,11 +331,22 @@ impl AgentRootFs {
         &self,
         proc: Arc<dyn FileServer>,
         base_fid: Fid,
+        pid: String,
+        base_names: Vec<String>,
         names: &[String],
     ) -> Result<Node, ErrorCode> {
         let proc_fid = Fid(NEXT_PROC_FID.fetch_add(1, Ordering::Relaxed));
         match proc.walk(base_fid, proc_fid, names).await {
-            Ok(_) => Ok(Node::ProcFile { proc, proc_fid }),
+            Ok(_) => {
+                let mut child_names = base_names;
+                child_names.extend_from_slice(names);
+                Ok(Node::ProcFile {
+                    proc,
+                    proc_fid,
+                    pid,
+                    names: child_names,
+                })
+            }
             Err(e) => Err(e),
         }
     }
@@ -425,13 +447,12 @@ impl AgentRootFs {
     async fn create_proc_file(
         &self,
         newfid: Fid,
-        proc: Arc<dyn FileServer>,
-        dir_fid: Fid,
+        dir: ProcCreateDir,
         name: &str,
         kind: FileKind,
     ) -> Result<Qid, ErrorCode> {
         let proc_fid = Fid(NEXT_PROC_FID.fetch_add(1, Ordering::Relaxed));
-        let qid = match proc.create(dir_fid, proc_fid, name, kind).await {
+        let qid = match dir.proc.create(dir.dir_fid, proc_fid, name, kind).await {
             Ok(qid) => qid,
             Err(e) => return Err(e),
         };
@@ -439,13 +460,15 @@ impl AgentRootFs {
             .insert_fid(
                 newfid,
                 Node::ProcFile {
-                    proc: proc.clone(),
+                    proc: dir.proc.clone(),
                     proc_fid,
+                    pid: dir.pid,
+                    names: proc_child_names(dir.names, name),
                 },
             )
             .await
         {
-            rollback_created_fid(&proc, proc_fid).await;
+            rollback_created_fid(&dir.proc, proc_fid).await;
             return Err(e);
         }
         Ok(qid)
@@ -458,6 +481,14 @@ impl AgentRootFs {
         }
         state.fids.insert(fid, Entry { node });
         Ok(())
+    }
+
+    async fn agent_event_sink_for(&self, pid: &str) -> Option<Arc<AgentFs>> {
+        let state = self.state.lock().await;
+        state
+            .agents
+            .get(pid)
+            .and_then(|agent| agent.event_sink.clone())
     }
 }
 
@@ -532,8 +563,14 @@ impl FileServer for AgentRootFs {
                 self.bind_agent_walk(newfid, pid, backing, backing_fid, names)
                     .await?
             }
-            Node::ProcFile { proc, proc_fid } => {
-                self.bind_proc_relative_walk(proc, proc_fid, names).await?
+            Node::ProcFile {
+                proc,
+                proc_fid,
+                pid,
+                names: proc_names,
+            } => {
+                self.bind_proc_relative_walk(proc, proc_fid, pid, proc_names, names)
+                    .await?
             }
         };
         let qid = self.qid_for_node(&new_node).await?;
@@ -619,7 +656,20 @@ impl FileServer for AgentRootFs {
                 backing_fid,
                 ..
             } => backing.write(backing_fid, offset, data).await,
-            Node::ProcFile { proc, proc_fid, .. } => proc.write(proc_fid, offset, data).await,
+            Node::ProcFile {
+                proc,
+                proc_fid,
+                pid,
+                names,
+            } => {
+                let count = proc.write(proc_fid, offset, data).await?;
+                if is_proc_io_input_path(&names)
+                    && let Some(agent) = self.agent_event_sink_for(&pid).await
+                {
+                    agent.append_input_event(count).await;
+                }
+                Ok(count)
+            }
         }
     }
 
@@ -692,9 +742,19 @@ impl FileServer for AgentRootFs {
                 self.create_agent_file(newfid, pid, backing, backing_fid, name, kind)
                     .await
             }
-            Node::ProcFile { proc, proc_fid, .. } => {
-                self.create_proc_file(newfid, proc, proc_fid, name, kind)
-                    .await
+            Node::ProcFile {
+                proc,
+                proc_fid,
+                pid,
+                names,
+            } => {
+                let dir = ProcCreateDir {
+                    proc,
+                    dir_fid: proc_fid,
+                    pid,
+                    names,
+                };
+                self.create_proc_file(newfid, dir, name, kind).await
             }
         }
     }
@@ -839,6 +899,15 @@ fn is_proc_overlay_name(name: &str) -> bool {
         name,
         "status" | "parent" | "credentials" | "exit" | "ctl" | "namespace" | "io"
     )
+}
+
+fn is_proc_io_input_path(names: &[String]) -> bool {
+    names == ["io", "input"]
+}
+
+fn proc_child_names(mut names: Vec<String>, child: &str) -> Vec<String> {
+    names.push(child.to_string());
+    names
 }
 
 fn is_agent_overlay_reserved_name(name: &str) -> bool {

--- a/crates/agentfs/src/root.rs
+++ b/crates/agentfs/src/root.rs
@@ -29,6 +29,9 @@ enum Node {
         pid: String,
         backing: Arc<dyn FileServer>,
     },
+    AgentChildren {
+        pid: String,
+    },
     AgentFile {
         backing: Arc<dyn FileServer>,
         backing_fid: Fid,
@@ -168,8 +171,13 @@ impl AgentRootFs {
         if names.is_empty() && base_fid == Fid::ROOT {
             return Ok(Node::AgentRoot { pid, backing });
         }
-        if base_fid == Fid::ROOT && names.first().is_some_and(|name| is_proc_overlay_name(name)) {
-            return self.bind_proc_walk(newfid, &pid, names).await;
+        if base_fid == Fid::ROOT {
+            if names.first().is_some_and(|name| name == "children") {
+                return self.bind_agent_child_walk(newfid, &pid, &names[1..]).await;
+            }
+            if names.first().is_some_and(|name| is_proc_overlay_name(name)) {
+                return self.bind_proc_walk(newfid, &pid, names).await;
+            }
         }
         let backing_fid = Fid(NEXT_BACKING_FID.fetch_add(1, Ordering::Relaxed));
         match backing.walk(base_fid, backing_fid, names).await {
@@ -184,6 +192,28 @@ impl AgentRootFs {
                 Err(e)
             }
         }
+    }
+
+    async fn bind_agent_child_walk(
+        &self,
+        newfid: Fid,
+        parent_pid: &str,
+        names: &[String],
+    ) -> Result<Node, ErrorCode> {
+        if names.is_empty() {
+            return Ok(Node::AgentChildren {
+                pid: parent_pid.to_string(),
+            });
+        }
+        let child_pid = &names[0];
+        if child_pid == "root" {
+            return Err(ErrorCode::NotFound);
+        }
+        let (pid, backing) = self.entry_for_name(child_pid).await?;
+        if !self.proc_parent_matches(&pid, parent_pid).await? {
+            return Err(ErrorCode::NotFound);
+        }
+        Box::pin(self.bind_agent_walk(newfid, pid, backing, Fid::ROOT, &names[1..])).await
     }
 
     async fn bind_proc_walk(
@@ -210,6 +240,29 @@ impl AgentRootFs {
         }
     }
 
+    async fn proc_parent_matches(&self, pid: &str, parent_pid: &str) -> Result<bool, ErrorCode> {
+        Ok(self
+            .proc_parent_of(pid)
+            .await?
+            .is_some_and(|parent| parent == parent_pid))
+    }
+
+    async fn proc_parent_of(&self, pid: &str) -> Result<Option<String>, ErrorCode> {
+        let names = [pid.to_string(), "parent".to_string()];
+        match read_file_text(
+            self.proc.clone(),
+            &names,
+            NEXT_PROC_FID.fetch_add(1, Ordering::Relaxed),
+        )
+        .await
+        {
+            Ok(parent) if parent.is_empty() => Ok(None),
+            Ok(parent) => Ok(Some(parent)),
+            Err(ErrorCode::NotFound) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
     async fn agent_listing(
         &self,
         pid: &str,
@@ -223,6 +276,97 @@ impl AgentRootFs {
             }
         }
         Ok(names)
+    }
+
+    async fn agent_child_listing(&self, pid: &str) -> Result<Vec<String>, ErrorCode> {
+        let registered = {
+            let state = self.state.lock().await;
+            state.agents.keys().cloned().collect::<Vec<_>>()
+        };
+        let proc_pids = self.proc_pids().await?;
+        let mut names = Vec::new();
+        for child_pid in proc_pids {
+            if !registered.iter().any(|registered| registered == &child_pid) {
+                continue;
+            }
+            if self.proc_parent_matches(&child_pid, pid).await? {
+                names.push(child_pid);
+            }
+        }
+        Ok(names)
+    }
+
+    async fn create_agent_file(
+        &self,
+        newfid: Fid,
+        backing: Arc<dyn FileServer>,
+        dir_fid: Fid,
+        name: &str,
+        kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        let backing_fid = Fid(NEXT_BACKING_FID.fetch_add(1, Ordering::Relaxed));
+        let qid = match backing.create(dir_fid, backing_fid, name, kind).await {
+            Ok(qid) => qid,
+            Err(e) => {
+                let _ = backing.clunk(backing_fid).await;
+                return Err(e);
+            }
+        };
+        if let Err(e) = self
+            .insert_fid(
+                newfid,
+                Node::AgentFile {
+                    backing: backing.clone(),
+                    backing_fid,
+                },
+            )
+            .await
+        {
+            let _ = backing.clunk(backing_fid).await;
+            return Err(e);
+        }
+        Ok(qid)
+    }
+
+    async fn create_proc_file(
+        &self,
+        newfid: Fid,
+        proc: Arc<dyn FileServer>,
+        dir_fid: Fid,
+        name: &str,
+        kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        let proc_fid = Fid(NEXT_PROC_FID.fetch_add(1, Ordering::Relaxed));
+        let qid = match proc.create(dir_fid, proc_fid, name, kind).await {
+            Ok(qid) => qid,
+            Err(e) => {
+                let _ = proc.clunk(proc_fid).await;
+                return Err(e);
+            }
+        };
+        if let Err(e) = self
+            .insert_fid(
+                newfid,
+                Node::ProcFile {
+                    proc: proc.clone(),
+                    proc_fid,
+                },
+            )
+            .await
+        {
+            let _ = proc.clunk(proc_fid).await;
+            return Err(e);
+        }
+        Ok(qid)
+    }
+
+    async fn insert_fid(&self, fid: Fid, node: Node) -> Result<(), ErrorCode> {
+        let mut state = self.state.lock().await;
+        if fid == Fid::ROOT || state.fids.contains_key(&fid) {
+            return Err(ErrorCode::BadRequest);
+        }
+        state.fids.insert(fid, Entry { node });
+        Ok(())
     }
 }
 
@@ -254,6 +398,7 @@ impl FileServer for AgentRootFs {
                 self.bind_agent_walk(newfid, pid, backing, Fid::ROOT, names)
                     .await?
             }
+            Node::AgentChildren { pid } => self.bind_agent_child_walk(newfid, &pid, names).await?,
             Node::AgentFile {
                 backing,
                 backing_fid,
@@ -280,6 +425,12 @@ impl FileServer for AgentRootFs {
                 }
                 Ok(root_qid())
             }
+            Node::AgentChildren { .. } => {
+                if matches!(mode, OpenMode::Write | OpenMode::ReadWrite) {
+                    return Err(ErrorCode::NoAccess);
+                }
+                Ok(agent_children_qid())
+            }
             Node::AgentRoot { backing, .. } => backing.open(Fid::ROOT, mode).await,
             Node::AgentFile {
                 backing,
@@ -305,6 +456,14 @@ impl FileServer for AgentRootFs {
                 offset,
                 count,
             )),
+            Node::AgentChildren { pid } => Ok(slice(
+                self.agent_child_listing(&pid)
+                    .await?
+                    .join("\n")
+                    .into_bytes(),
+                offset,
+                count,
+            )),
             Node::AgentFile {
                 backing,
                 backing_fid,
@@ -317,6 +476,7 @@ impl FileServer for AgentRootFs {
     async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
         match self.node(fid).await? {
             Node::Root => Err(ErrorCode::NoAccess),
+            Node::AgentChildren { .. } => Err(ErrorCode::NoAccess),
             Node::AgentRoot { backing, .. } => backing.write(Fid::ROOT, offset, data).await,
             Node::AgentFile {
                 backing,
@@ -340,6 +500,12 @@ impl FileServer for AgentRootFs {
                 stat.length = self.agent_listing(&pid, backing).await?.join("\n").len() as u64;
                 Ok(stat)
             }
+            Node::AgentChildren { pid } => Ok(Stat {
+                name: "children".to_string(),
+                qid: agent_children_qid(),
+                length: self.agent_child_listing(&pid).await?.join("\n").len() as u64,
+                writable: false,
+            }),
             Node::AgentFile {
                 backing,
                 backing_fid,
@@ -356,21 +522,38 @@ impl FileServer for AgentRootFs {
         name: &str,
         kind: FileKind,
     ) -> Result<Qid, ErrorCode> {
+        {
+            let state = self.state.lock().await;
+            if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
+                return Err(ErrorCode::BadRequest);
+            }
+        }
         match self.node(fid).await? {
             Node::Root => Err(ErrorCode::Unsupported),
-            Node::AgentRoot { backing, .. } => backing.create(Fid::ROOT, newfid, name, kind).await,
+            Node::AgentChildren { .. } => Err(ErrorCode::Unsupported),
+            Node::AgentRoot { backing, .. } => {
+                self.create_agent_file(newfid, backing, Fid::ROOT, name, kind)
+                    .await
+            }
             Node::AgentFile {
                 backing,
                 backing_fid,
                 ..
-            } => backing.create(backing_fid, newfid, name, kind).await,
-            Node::ProcFile { proc, proc_fid } => proc.create(proc_fid, newfid, name, kind).await,
+            } => {
+                self.create_agent_file(newfid, backing, backing_fid, name, kind)
+                    .await
+            }
+            Node::ProcFile { proc, proc_fid } => {
+                self.create_proc_file(newfid, proc, proc_fid, name, kind)
+                    .await
+            }
         }
     }
 
     async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
         match self.node(fid).await? {
             Node::Root => Err(ErrorCode::Unsupported),
+            Node::AgentChildren { .. } => Err(ErrorCode::Unsupported),
             Node::AgentRoot { backing, .. } => backing.remove(Fid::ROOT).await,
             Node::AgentFile {
                 backing,
@@ -393,7 +576,7 @@ impl FileServer for AgentRootFs {
                 ..
             }) => backing.clunk(backing_fid).await,
             Some(Node::ProcFile { proc, proc_fid }) => proc.clunk(proc_fid).await,
-            Some(Node::Root | Node::AgentRoot { .. }) => Ok(()),
+            Some(Node::Root | Node::AgentRoot { .. } | Node::AgentChildren { .. }) => Ok(()),
             None => Err(ErrorCode::NotFound),
         }
     }
@@ -410,6 +593,7 @@ async fn qid_for_node(node: &Node) -> Result<Qid, ErrorCode> {
     match node {
         Node::Root => Ok(root_qid()),
         Node::AgentRoot { backing, .. } => backing.stat(Fid::ROOT).await.map(|stat| stat.qid),
+        Node::AgentChildren { .. } => Ok(agent_children_qid()),
         Node::AgentFile {
             backing,
             backing_fid,
@@ -417,6 +601,45 @@ async fn qid_for_node(node: &Node) -> Result<Qid, ErrorCode> {
         } => backing.stat(*backing_fid).await.map(|stat| stat.qid),
         Node::ProcFile { proc, proc_fid } => proc.stat(*proc_fid).await.map(|stat| stat.qid),
     }
+}
+
+async fn read_file_text(
+    server: Arc<dyn FileServer>,
+    names: &[String],
+    raw_fid: u64,
+) -> Result<String, ErrorCode> {
+    let fid = Fid(raw_fid);
+    if let Err(e) = server.walk(Fid::ROOT, fid, names).await {
+        let _ = server.clunk(fid).await;
+        return Err(e);
+    }
+    let result = match server.open(fid, OpenMode::Read).await {
+        Ok(_) => {
+            let length = match server.stat(fid).await {
+                Ok(stat) => stat.length,
+                Err(e) => {
+                    let _ = server.clunk(fid).await;
+                    return Err(e);
+                }
+            };
+            match server
+                .read(
+                    fid,
+                    0,
+                    u32::try_from(length.saturating_add(1)).unwrap_or(u32::MAX),
+                )
+                .await
+            {
+                Ok(bytes) => String::from_utf8(bytes).map_err(|_| ErrorCode::Io),
+                Err(e) => Err(e),
+            }
+        }
+        Err(e) => Err(e),
+    };
+    let clunk = server.clunk(fid).await;
+    let text = result?;
+    clunk?;
+    Ok(text)
 }
 
 async fn read_listing(
@@ -450,6 +673,14 @@ fn is_proc_overlay_name(name: &str) -> bool {
         name,
         "status" | "parent" | "credentials" | "exit" | "ctl" | "namespace"
     )
+}
+
+fn agent_children_qid() -> Qid {
+    Qid {
+        kind: FileKind::Dir,
+        version: 0,
+        path: 0xA6E7_C411D,
+    }
 }
 
 fn root_qid() -> Qid {

--- a/crates/agentfs/src/root.rs
+++ b/crates/agentfs/src/root.rs
@@ -551,6 +551,9 @@ impl FileServer for AgentRootFs {
     }
 
     async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
+        if fid == Fid::ROOT {
+            return Err(ErrorCode::Unsupported);
+        }
         match self.node(fid).await? {
             Node::Root => Err(ErrorCode::Unsupported),
             Node::AgentChildren { .. } => Err(ErrorCode::Unsupported),
@@ -561,7 +564,9 @@ impl FileServer for AgentRootFs {
                 ..
             } => backing.remove(backing_fid).await,
             Node::ProcFile { proc, proc_fid } => proc.remove(proc_fid).await,
-        }
+        }?;
+        self.state.lock().await.fids.remove(&fid);
+        Ok(())
     }
 
     async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {

--- a/crates/agentfs/src/root.rs
+++ b/crates/agentfs/src/root.rs
@@ -8,6 +8,7 @@
 //! separate.
 
 use std::{
+    any::Any,
     collections::HashMap,
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
@@ -21,8 +22,16 @@ use alan_ap::{ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat}
 use async_trait::async_trait;
 use tokio::sync::Mutex;
 
+use crate::AgentFs;
+
 static NEXT_BACKING_FID: AtomicU64 = AtomicU64::new(1_000_000);
 static NEXT_PROC_FID: AtomicU64 = AtomicU64::new(2_000_000);
+
+#[derive(Clone)]
+struct AgentRegistration {
+    backing: Arc<dyn FileServer>,
+    event_sink: Option<Arc<AgentFs>>,
+}
 
 #[derive(Clone)]
 enum Node {
@@ -50,7 +59,7 @@ struct Entry {
 }
 
 struct State {
-    agents: HashMap<String, Arc<dyn FileServer>>,
+    agents: HashMap<String, AgentRegistration>,
     root_pid: Option<String>,
     fids: HashMap<Fid, Entry>,
 }
@@ -78,8 +87,33 @@ impl AgentRootFs {
     }
 
     /// Register the agent-state backing tree for a committed process pid.
-    pub async fn bind_process(&self, pid: impl Into<String>, agent: Arc<dyn FileServer>) {
-        self.state.lock().await.agents.insert(pid.into(), agent);
+    pub async fn bind_process<T>(&self, pid: impl Into<String>, agent: Arc<T>)
+    where
+        T: FileServer + Any + 'static,
+    {
+        let pid = pid.into();
+        let event_sink = agent_event_sink(&agent);
+        let backing: Arc<dyn FileServer> = agent;
+        let parent_pid = self.proc_parent_of(&pid).await.ok().flatten();
+        let parent_events = {
+            let mut state = self.state.lock().await;
+            state.agents.insert(
+                pid.clone(),
+                AgentRegistration {
+                    backing,
+                    event_sink,
+                },
+            );
+            parent_pid.and_then(|parent_pid| {
+                state
+                    .agents
+                    .get(&parent_pid)
+                    .and_then(|agent| agent.event_sink.clone())
+            })
+        };
+        if let Some(parent) = parent_events {
+            parent.append_child_event(&pid).await;
+        }
     }
 
     /// Point `/agent/root` at the pid that embodies the Root Agent Process.
@@ -95,7 +129,11 @@ impl AgentRootFs {
             } else {
                 name.to_string()
             };
-            let backing = state.agents.get(&pid).cloned().ok_or(ErrorCode::NotFound)?;
+            let backing = state
+                .agents
+                .get(&pid)
+                .map(|agent| agent.backing.clone())
+                .ok_or(ErrorCode::NotFound)?;
             (pid, backing)
         };
         if self.proc_has_pid(&pid).await? {
@@ -191,8 +229,6 @@ impl AgentRootFs {
             }),
             Err(e) => {
                 let _ = backing.clunk(backing_fid).await;
-                let mut state = self.state.lock().await;
-                state.fids.remove(&newfid);
                 Err(e)
             }
         }
@@ -222,7 +258,7 @@ impl AgentRootFs {
 
     async fn bind_proc_walk(
         &self,
-        newfid: Fid,
+        _newfid: Fid,
         pid: &str,
         names: &[String],
     ) -> Result<Node, ErrorCode> {
@@ -237,8 +273,6 @@ impl AgentRootFs {
             }),
             Err(e) => {
                 let _ = self.proc.clunk(proc_fid).await;
-                let mut state = self.state.lock().await;
-                state.fids.remove(&newfid);
                 Err(e)
             }
         }
@@ -331,7 +365,7 @@ impl AgentRootFs {
             )
             .await
         {
-            let _ = backing.clunk(backing_fid).await;
+            rollback_created_fid(&backing, backing_fid).await;
             return Err(e);
         }
         Ok(namespace_agent_qid(&pid, qid))
@@ -363,7 +397,7 @@ impl AgentRootFs {
             )
             .await
         {
-            let _ = proc.clunk(proc_fid).await;
+            rollback_created_fid(&proc, proc_fid).await;
             return Err(e);
         }
         Ok(qid)
@@ -376,6 +410,20 @@ impl AgentRootFs {
         }
         state.fids.insert(fid, Entry { node });
         Ok(())
+    }
+}
+
+fn agent_event_sink<T>(agent: &Arc<T>) -> Option<Arc<AgentFs>>
+where
+    T: FileServer + Any + 'static,
+{
+    let erased: Arc<dyn Any + Send + Sync> = agent.clone();
+    Arc::downcast::<AgentFs>(erased).ok()
+}
+
+async fn rollback_created_fid(server: &Arc<dyn FileServer>, fid: Fid) {
+    if server.remove(fid).await.is_err() {
+        let _ = server.clunk(fid).await;
     }
 }
 

--- a/crates/agentfs/src/root.rs
+++ b/crates/agentfs/src/root.rs
@@ -9,6 +9,8 @@
 
 use std::{
     collections::HashMap,
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
@@ -33,6 +35,7 @@ enum Node {
         pid: String,
     },
     AgentFile {
+        pid: String,
         backing: Arc<dyn FileServer>,
         backing_fid: Fid,
     },
@@ -182,6 +185,7 @@ impl AgentRootFs {
         let backing_fid = Fid(NEXT_BACKING_FID.fetch_add(1, Ordering::Relaxed));
         match backing.walk(base_fid, backing_fid, names).await {
             Ok(_) => Ok(Node::AgentFile {
+                pid,
                 backing,
                 backing_fid,
             }),
@@ -299,6 +303,7 @@ impl AgentRootFs {
     async fn create_agent_file(
         &self,
         newfid: Fid,
+        pid: String,
         backing: Arc<dyn FileServer>,
         dir_fid: Fid,
         name: &str,
@@ -316,6 +321,7 @@ impl AgentRootFs {
             .insert_fid(
                 newfid,
                 Node::AgentFile {
+                    pid: pid.clone(),
                     backing: backing.clone(),
                     backing_fid,
                 },
@@ -325,7 +331,7 @@ impl AgentRootFs {
             let _ = backing.clunk(backing_fid).await;
             return Err(e);
         }
-        Ok(qid)
+        Ok(namespace_agent_qid(&pid, qid))
     }
 
     async fn create_proc_file(
@@ -400,15 +406,16 @@ impl FileServer for AgentRootFs {
             }
             Node::AgentChildren { pid } => self.bind_agent_child_walk(newfid, &pid, names).await?,
             Node::AgentFile {
+                pid,
                 backing,
                 backing_fid,
             } => {
-                self.bind_agent_walk(newfid, String::new(), backing, backing_fid, names)
+                self.bind_agent_walk(newfid, pid, backing, backing_fid, names)
                     .await?
             }
             Node::ProcFile { .. } => return Err(ErrorCode::NotDirectory),
         };
-        let qid = qid_for_node(&new_node).await?;
+        let qid = self.qid_for_node(&new_node).await?;
         self.state
             .lock()
             .await
@@ -425,18 +432,26 @@ impl FileServer for AgentRootFs {
                 }
                 Ok(root_qid())
             }
-            Node::AgentChildren { .. } => {
+            Node::AgentChildren { pid } => {
                 if matches!(mode, OpenMode::Write | OpenMode::ReadWrite) {
                     return Err(ErrorCode::NoAccess);
                 }
-                Ok(agent_children_qid())
+                let listing = self.agent_child_listing(&pid).await?;
+                Ok(agent_children_qid(&pid, &listing))
             }
-            Node::AgentRoot { backing, .. } => backing.open(Fid::ROOT, mode).await,
+            Node::AgentRoot { pid, backing } => backing
+                .open(Fid::ROOT, mode)
+                .await
+                .map(|qid| namespace_agent_qid(&pid, qid)),
             Node::AgentFile {
+                pid,
                 backing,
                 backing_fid,
                 ..
-            } => backing.open(backing_fid, mode).await,
+            } => backing
+                .open(backing_fid, mode)
+                .await
+                .map(|qid| namespace_agent_qid(&pid, qid)),
             Node::ProcFile { proc, proc_fid } => proc.open(proc_fid, mode).await,
         }
     }
@@ -497,20 +512,29 @@ impl FileServer for AgentRootFs {
             }),
             Node::AgentRoot { pid, backing } => {
                 let mut stat = backing.stat(Fid::ROOT).await?;
+                stat.qid = namespace_agent_qid(&pid, stat.qid);
                 stat.length = self.agent_listing(&pid, backing).await?.join("\n").len() as u64;
                 Ok(stat)
             }
-            Node::AgentChildren { pid } => Ok(Stat {
-                name: "children".to_string(),
-                qid: agent_children_qid(),
-                length: self.agent_child_listing(&pid).await?.join("\n").len() as u64,
-                writable: false,
-            }),
+            Node::AgentChildren { pid } => {
+                let listing = self.agent_child_listing(&pid).await?;
+                Ok(Stat {
+                    name: "children".to_string(),
+                    qid: agent_children_qid(&pid, &listing),
+                    length: listing.join("\n").len() as u64,
+                    writable: false,
+                })
+            }
             Node::AgentFile {
+                pid,
                 backing,
                 backing_fid,
                 ..
-            } => backing.stat(backing_fid).await,
+            } => {
+                let mut stat = backing.stat(backing_fid).await?;
+                stat.qid = namespace_agent_qid(&pid, stat.qid);
+                Ok(stat)
+            }
             Node::ProcFile { proc, proc_fid } => proc.stat(proc_fid).await,
         }
     }
@@ -531,16 +555,17 @@ impl FileServer for AgentRootFs {
         match self.node(fid).await? {
             Node::Root => Err(ErrorCode::Unsupported),
             Node::AgentChildren { .. } => Err(ErrorCode::Unsupported),
-            Node::AgentRoot { backing, .. } => {
-                self.create_agent_file(newfid, backing, Fid::ROOT, name, kind)
+            Node::AgentRoot { pid, backing } => {
+                self.create_agent_file(newfid, pid, backing, Fid::ROOT, name, kind)
                     .await
             }
             Node::AgentFile {
+                pid,
                 backing,
                 backing_fid,
                 ..
             } => {
-                self.create_agent_file(newfid, backing, backing_fid, name, kind)
+                self.create_agent_file(newfid, pid, backing, backing_fid, name, kind)
                     .await
             }
             Node::ProcFile { proc, proc_fid } => {
@@ -592,19 +617,29 @@ impl AgentRootFs {
         let state = self.state.lock().await;
         Self::node_of(&state, fid)
     }
-}
 
-async fn qid_for_node(node: &Node) -> Result<Qid, ErrorCode> {
-    match node {
-        Node::Root => Ok(root_qid()),
-        Node::AgentRoot { backing, .. } => backing.stat(Fid::ROOT).await.map(|stat| stat.qid),
-        Node::AgentChildren { .. } => Ok(agent_children_qid()),
-        Node::AgentFile {
-            backing,
-            backing_fid,
-            ..
-        } => backing.stat(*backing_fid).await.map(|stat| stat.qid),
-        Node::ProcFile { proc, proc_fid } => proc.stat(*proc_fid).await.map(|stat| stat.qid),
+    async fn qid_for_node(&self, node: &Node) -> Result<Qid, ErrorCode> {
+        match node {
+            Node::Root => Ok(root_qid()),
+            Node::AgentRoot { pid, backing } => backing
+                .stat(Fid::ROOT)
+                .await
+                .map(|stat| namespace_agent_qid(pid, stat.qid)),
+            Node::AgentChildren { pid } => {
+                let listing = self.agent_child_listing(pid).await?;
+                Ok(agent_children_qid(pid, &listing))
+            }
+            Node::AgentFile {
+                pid,
+                backing,
+                backing_fid,
+                ..
+            } => backing
+                .stat(*backing_fid)
+                .await
+                .map(|stat| namespace_agent_qid(pid, stat.qid)),
+            Node::ProcFile { proc, proc_fid } => proc.stat(*proc_fid).await.map(|stat| stat.qid),
+        }
     }
 }
 
@@ -680,11 +715,11 @@ fn is_proc_overlay_name(name: &str) -> bool {
     )
 }
 
-fn agent_children_qid() -> Qid {
+fn agent_children_qid(pid: &str, children: &[String]) -> Qid {
     Qid {
         kind: FileKind::Dir,
-        version: 0,
-        path: 0xA6E7_C411D,
+        version: hash_value(&("agent-children-version", pid, children)) as u32,
+        path: hash_value(&("agent-children", pid)),
     }
 }
 
@@ -694,6 +729,29 @@ fn root_qid() -> Qid {
         version: 0,
         path: 0xA6E7,
     }
+}
+
+fn namespace_agent_qid(pid: &str, qid: Qid) -> Qid {
+    Qid {
+        kind: qid.kind,
+        version: qid.version,
+        path: hash_value(&("agent-qid", pid, qid.path, file_kind_tag(qid.kind))),
+    }
+}
+
+fn file_kind_tag(kind: FileKind) -> u8 {
+    match kind {
+        FileKind::Dir => 1,
+        FileKind::File => 2,
+        FileKind::Stream => 3,
+        FileKind::Clone => 4,
+    }
+}
+
+fn hash_value<T: Hash>(value: &T) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
 }
 
 fn slice(bytes: Vec<u8>, offset: Offset, count: u32) -> Vec<u8> {

--- a/crates/agentfs/src/root.rs
+++ b/crates/agentfs/src/root.rs
@@ -47,11 +47,6 @@ enum Node {
     AgentChildren {
         pid: String,
     },
-    AgentIoDir {
-        pid: String,
-        backing: Arc<dyn FileServer>,
-        backing_fid: Fid,
-    },
     AgentFile {
         pid: String,
         backing: Arc<dyn FileServer>,
@@ -262,20 +257,12 @@ impl AgentRootFs {
             if names.first().is_some_and(|name| name == "children") {
                 return self.bind_agent_child_walk(newfid, &pid, &names[1..]).await;
             }
-            if is_proc_io_output_path(names) {
-                return self.bind_proc_walk(newfid, &pid, names).await;
-            }
             if names.first().is_some_and(|name| is_proc_overlay_name(name)) {
                 return self.bind_proc_walk(newfid, &pid, names).await;
             }
         }
         let backing_fid = Fid(NEXT_BACKING_FID.fetch_add(1, Ordering::Relaxed));
         match backing.walk(base_fid, backing_fid, names).await {
-            Ok(_) if is_agent_io_dir_path(base_fid, names) => Ok(Node::AgentIoDir {
-                pid,
-                backing,
-                backing_fid,
-            }),
             Ok(_) => Ok(Node::AgentFile {
                 pid,
                 backing,
@@ -325,6 +312,19 @@ impl AgentRootFs {
                 proc: self.proc.clone(),
                 proc_fid,
             }),
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn bind_proc_relative_walk(
+        &self,
+        proc: Arc<dyn FileServer>,
+        base_fid: Fid,
+        names: &[String],
+    ) -> Result<Node, ErrorCode> {
+        let proc_fid = Fid(NEXT_PROC_FID.fetch_add(1, Ordering::Relaxed));
+        match proc.walk(base_fid, proc_fid, names).await {
+            Ok(_) => Ok(Node::ProcFile { proc, proc_fid }),
             Err(e) => Err(e),
         }
     }
@@ -524,21 +524,6 @@ impl FileServer for AgentRootFs {
                     .await?
             }
             Node::AgentChildren { pid } => self.bind_agent_child_walk(newfid, &pid, names).await?,
-            Node::AgentIoDir {
-                pid,
-                backing,
-                backing_fid,
-            } => {
-                if names.first().is_some_and(|name| name == "output") {
-                    let mut proc_names = Vec::with_capacity(names.len() + 1);
-                    proc_names.push("io".to_string());
-                    proc_names.extend_from_slice(names);
-                    self.bind_proc_walk(newfid, &pid, &proc_names).await?
-                } else {
-                    self.bind_agent_walk(newfid, pid, backing, backing_fid, names)
-                        .await?
-                }
-            }
             Node::AgentFile {
                 pid,
                 backing,
@@ -547,7 +532,9 @@ impl FileServer for AgentRootFs {
                 self.bind_agent_walk(newfid, pid, backing, backing_fid, names)
                     .await?
             }
-            Node::ProcFile { .. } => return Err(ErrorCode::NotDirectory),
+            Node::ProcFile { proc, proc_fid } => {
+                self.bind_proc_relative_walk(proc, proc_fid, names).await?
+            }
         };
         let qid = self.qid_for_node(&new_node).await?;
         if let Err(error) = self.insert_fid(newfid, new_node.clone()).await {
@@ -575,15 +562,6 @@ impl FileServer for AgentRootFs {
             }
             Node::AgentRoot { pid, backing } => backing
                 .open(Fid::ROOT, mode)
-                .await
-                .map(|qid| namespace_agent_qid(&pid, qid)),
-            Node::AgentIoDir {
-                pid,
-                backing,
-                backing_fid,
-                ..
-            } => backing
-                .open(backing_fid, mode)
                 .await
                 .map(|qid| namespace_agent_qid(&pid, qid)),
             Node::AgentFile {
@@ -622,11 +600,6 @@ impl FileServer for AgentRootFs {
                 offset,
                 count,
             )),
-            Node::AgentIoDir {
-                backing,
-                backing_fid,
-                ..
-            } => backing.read(backing_fid, offset, count).await,
             Node::AgentFile {
                 backing,
                 backing_fid,
@@ -641,11 +614,6 @@ impl FileServer for AgentRootFs {
             Node::Root => Err(ErrorCode::NoAccess),
             Node::AgentChildren { .. } => Err(ErrorCode::NoAccess),
             Node::AgentRoot { backing, .. } => backing.write(Fid::ROOT, offset, data).await,
-            Node::AgentIoDir {
-                backing,
-                backing_fid,
-                ..
-            } => backing.write(backing_fid, offset, data).await,
             Node::AgentFile {
                 backing,
                 backing_fid,
@@ -681,16 +649,6 @@ impl FileServer for AgentRootFs {
                     writable: false,
                 })
             }
-            Node::AgentIoDir {
-                pid,
-                backing,
-                backing_fid,
-                ..
-            } => {
-                let mut stat = backing.stat(backing_fid).await?;
-                stat.qid = namespace_agent_qid(&pid, stat.qid);
-                Ok(stat)
-            }
             Node::AgentFile {
                 pid,
                 backing,
@@ -725,15 +683,6 @@ impl FileServer for AgentRootFs {
                 self.create_agent_file(newfid, pid, backing, Fid::ROOT, name, kind)
                     .await
             }
-            Node::AgentIoDir {
-                pid,
-                backing,
-                backing_fid,
-                ..
-            } => {
-                self.create_agent_file(newfid, pid, backing, backing_fid, name, kind)
-                    .await
-            }
             Node::AgentFile {
                 pid,
                 backing,
@@ -758,11 +707,6 @@ impl FileServer for AgentRootFs {
             Node::Root => Err(ErrorCode::Unsupported),
             Node::AgentChildren { .. } => Err(ErrorCode::Unsupported),
             Node::AgentRoot { backing, .. } => backing.remove(Fid::ROOT).await,
-            Node::AgentIoDir {
-                backing,
-                backing_fid,
-                ..
-            } => backing.remove(backing_fid).await,
             Node::AgentFile {
                 backing,
                 backing_fid,
@@ -780,11 +724,6 @@ impl FileServer for AgentRootFs {
         }
         let entry = self.state.lock().await.fids.remove(&fid);
         match entry.map(|entry| entry.node) {
-            Some(Node::AgentIoDir {
-                backing,
-                backing_fid,
-                ..
-            }) => backing.clunk(backing_fid).await,
             Some(Node::AgentFile {
                 backing,
                 backing_fid,
@@ -817,15 +756,6 @@ impl AgentRootFs {
                 let listing = self.agent_child_listing(pid).await?;
                 Ok(agent_children_qid(pid, &listing))
             }
-            Node::AgentIoDir {
-                pid,
-                backing,
-                backing_fid,
-                ..
-            } => backing
-                .stat(*backing_fid)
-                .await
-                .map(|stat| namespace_agent_qid(pid, stat.qid)),
             Node::AgentFile {
                 pid,
                 backing,
@@ -907,20 +837,12 @@ async fn read_listing(
 fn is_proc_overlay_name(name: &str) -> bool {
     matches!(
         name,
-        "status" | "parent" | "credentials" | "exit" | "ctl" | "namespace"
+        "status" | "parent" | "credentials" | "exit" | "ctl" | "namespace" | "io"
     )
 }
 
 fn is_agent_overlay_reserved_name(name: &str) -> bool {
     matches!(name, "children" | "io") || is_proc_overlay_name(name)
-}
-
-fn is_agent_io_dir_path(base_fid: Fid, names: &[String]) -> bool {
-    base_fid == Fid::ROOT && names.len() == 1 && names[0] == "io"
-}
-
-fn is_proc_io_output_path(names: &[String]) -> bool {
-    names.len() >= 2 && names[0] == "io" && names[1] == "output"
 }
 
 fn agent_children_qid(pid: &str, children: &[String]) -> Qid {
@@ -941,12 +863,7 @@ fn root_qid(listing: &[String]) -> Qid {
 
 async fn release_node(node: Node) {
     match node {
-        Node::AgentIoDir {
-            backing,
-            backing_fid,
-            ..
-        }
-        | Node::AgentFile {
+        Node::AgentFile {
             backing,
             backing_fid,
             ..

--- a/crates/agentfs/src/root.rs
+++ b/crates/agentfs/src/root.rs
@@ -20,8 +20,8 @@ use std::{
 };
 
 use alan_ap::{
-    ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, ProcessOutputEventSink,
-    ProcessOutputEventSource, Qid, Stat,
+    ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, ProcessInputEventSink,
+    ProcessInputEventSource, ProcessOutputEventSink, ProcessOutputEventSource, Qid, Stat,
 };
 use async_trait::async_trait;
 use tokio::sync::Mutex;
@@ -73,6 +73,7 @@ struct ProcCreateDir {
 
 struct State {
     agents: HashMap<String, AgentRegistration>,
+    input_event_pids: HashSet<String>,
     output_event_pids: HashSet<String>,
     root_pid: Option<String>,
     fids: HashMap<Fid, Entry>,
@@ -85,6 +86,7 @@ struct State {
 /// per-agent state is served by the registered backing `AgentFs` handles.
 pub struct AgentRootFs {
     proc: Arc<dyn FileServer>,
+    input_events: Option<Arc<dyn ProcessInputEventSource>>,
     output_events: Option<Arc<dyn ProcessOutputEventSource>>,
     state: Arc<Mutex<State>>,
 }
@@ -93,9 +95,11 @@ impl AgentRootFs {
     pub fn new(proc: Arc<dyn FileServer>) -> Self {
         Self {
             proc,
+            input_events: None,
             output_events: None,
             state: Arc::new(Mutex::new(State {
                 agents: HashMap::new(),
+                input_event_pids: HashSet::new(),
                 output_event_pids: HashSet::new(),
                 root_pid: None,
                 fids: HashMap::new(),
@@ -109,9 +113,30 @@ impl AgentRootFs {
     ) -> Self {
         Self {
             proc,
+            input_events: None,
             output_events: Some(output_events),
             state: Arc::new(Mutex::new(State {
                 agents: HashMap::new(),
+                input_event_pids: HashSet::new(),
+                output_event_pids: HashSet::new(),
+                root_pid: None,
+                fids: HashMap::new(),
+            })),
+        }
+    }
+
+    pub fn new_with_process_io_events(
+        proc: Arc<dyn FileServer>,
+        input_events: Arc<dyn ProcessInputEventSource>,
+        output_events: Arc<dyn ProcessOutputEventSource>,
+    ) -> Self {
+        Self {
+            proc,
+            input_events: Some(input_events),
+            output_events: Some(output_events),
+            state: Arc::new(Mutex::new(State {
+                agents: HashMap::new(),
+                input_event_pids: HashSet::new(),
                 output_event_pids: HashSet::new(),
                 root_pid: None,
                 fids: HashMap::new(),
@@ -129,7 +154,7 @@ impl AgentRootFs {
         let has_event_sink = event_sink.is_some();
         let backing: Arc<dyn FileServer> = agent;
         let parent_pid = self.proc_parent_of(&pid).await.ok().flatten();
-        let (parent_events, subscribe_output_events) = {
+        let (parent_events, subscribe_input_events, subscribe_output_events) = {
             let mut state = self.state.lock().await;
             state.agents.insert(
                 pid.clone(),
@@ -144,13 +169,32 @@ impl AgentRootFs {
                     .get(&parent_pid)
                     .and_then(|agent| agent.event_sink.clone())
             });
+            let subscribe_input_events = has_event_sink
+                && self.input_events.is_some()
+                && state.input_event_pids.insert(pid.clone());
             let subscribe_output_events = has_event_sink
                 && self.output_events.is_some()
                 && state.output_event_pids.insert(pid.clone());
-            (parent_events, subscribe_output_events)
+            (
+                parent_events,
+                subscribe_input_events,
+                subscribe_output_events,
+            )
         };
         if let Some(parent) = parent_events {
             parent.append_child_event(&pid).await;
+        }
+        if subscribe_input_events && let Some(input_events) = self.input_events.clone() {
+            let sink = Arc::new(AgentInputEventSink {
+                state: self.state.clone(),
+            });
+            if input_events
+                .subscribe_process_input(&pid, sink)
+                .await
+                .is_err()
+            {
+                self.state.lock().await.input_event_pids.remove(&pid);
+            }
         }
         if subscribe_output_events && let Some(output_events) = self.output_events.clone() {
             let sink = Arc::new(AgentOutputEventSink {
@@ -482,14 +526,6 @@ impl AgentRootFs {
         state.fids.insert(fid, Entry { node });
         Ok(())
     }
-
-    async fn agent_event_sink_for(&self, pid: &str) -> Option<Arc<AgentFs>> {
-        let state = self.state.lock().await;
-        state
-            .agents
-            .get(pid)
-            .and_then(|agent| agent.event_sink.clone())
-    }
 }
 
 fn agent_event_sink<T>(agent: &Arc<T>) -> Option<Arc<AgentFs>>
@@ -502,6 +538,26 @@ where
 
 struct AgentOutputEventSink {
     state: Arc<Mutex<State>>,
+}
+
+struct AgentInputEventSink {
+    state: Arc<Mutex<State>>,
+}
+
+#[async_trait]
+impl ProcessInputEventSink for AgentInputEventSink {
+    async fn input_appended(&self, pid: &str, count: u32) {
+        let event_sink = {
+            let state = self.state.lock().await;
+            state
+                .agents
+                .get(pid)
+                .and_then(|agent| agent.event_sink.clone())
+        };
+        if let Some(agent) = event_sink {
+            agent.append_input_event(count).await;
+        }
+    }
 }
 
 #[async_trait]
@@ -656,20 +712,7 @@ impl FileServer for AgentRootFs {
                 backing_fid,
                 ..
             } => backing.write(backing_fid, offset, data).await,
-            Node::ProcFile {
-                proc,
-                proc_fid,
-                pid,
-                names,
-            } => {
-                let count = proc.write(proc_fid, offset, data).await?;
-                if is_proc_io_input_path(&names)
-                    && let Some(agent) = self.agent_event_sink_for(&pid).await
-                {
-                    agent.append_input_event(count).await;
-                }
-                Ok(count)
-            }
+            Node::ProcFile { proc, proc_fid, .. } => proc.write(proc_fid, offset, data).await,
         }
     }
 
@@ -899,10 +942,6 @@ fn is_proc_overlay_name(name: &str) -> bool {
         name,
         "status" | "parent" | "credentials" | "exit" | "ctl" | "namespace" | "io"
     )
-}
-
-fn is_proc_io_input_path(names: &[String]) -> bool {
-    names == ["io", "input"]
 }
 
 fn proc_child_names(mut names: Vec<String>, child: &str) -> Vec<String> {

--- a/crates/agentfs/src/root.rs
+++ b/crates/agentfs/src/root.rs
@@ -10,6 +10,7 @@
 use std::{
     any::Any,
     collections::HashMap,
+    collections::HashSet,
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
     sync::{
@@ -18,7 +19,10 @@ use std::{
     },
 };
 
-use alan_ap::{ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat};
+use alan_ap::{
+    ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, ProcessOutputEventSink,
+    ProcessOutputEventSource, Qid, Stat,
+};
 use async_trait::async_trait;
 use tokio::sync::Mutex;
 
@@ -56,7 +60,6 @@ enum Node {
     ProcFile {
         proc: Arc<dyn FileServer>,
         proc_fid: Fid,
-        output_events: Option<Arc<AgentFs>>,
     },
 }
 
@@ -66,6 +69,7 @@ struct Entry {
 
 struct State {
     agents: HashMap<String, AgentRegistration>,
+    output_event_pids: HashSet<String>,
     root_pid: Option<String>,
     fids: HashMap<Fid, Entry>,
 }
@@ -77,18 +81,37 @@ struct State {
 /// per-agent state is served by the registered backing `AgentFs` handles.
 pub struct AgentRootFs {
     proc: Arc<dyn FileServer>,
-    state: Mutex<State>,
+    output_events: Option<Arc<dyn ProcessOutputEventSource>>,
+    state: Arc<Mutex<State>>,
 }
 
 impl AgentRootFs {
     pub fn new(proc: Arc<dyn FileServer>) -> Self {
         Self {
             proc,
-            state: Mutex::new(State {
+            output_events: None,
+            state: Arc::new(Mutex::new(State {
                 agents: HashMap::new(),
+                output_event_pids: HashSet::new(),
                 root_pid: None,
                 fids: HashMap::new(),
-            }),
+            })),
+        }
+    }
+
+    pub fn new_with_process_output_events(
+        proc: Arc<dyn FileServer>,
+        output_events: Arc<dyn ProcessOutputEventSource>,
+    ) -> Self {
+        Self {
+            proc,
+            output_events: Some(output_events),
+            state: Arc::new(Mutex::new(State {
+                agents: HashMap::new(),
+                output_event_pids: HashSet::new(),
+                root_pid: None,
+                fids: HashMap::new(),
+            })),
         }
     }
 
@@ -99,9 +122,10 @@ impl AgentRootFs {
     {
         let pid = pid.into();
         let event_sink = agent_event_sink(&agent);
+        let has_event_sink = event_sink.is_some();
         let backing: Arc<dyn FileServer> = agent;
         let parent_pid = self.proc_parent_of(&pid).await.ok().flatten();
-        let parent_events = {
+        let (parent_events, subscribe_output_events) = {
             let mut state = self.state.lock().await;
             state.agents.insert(
                 pid.clone(),
@@ -110,15 +134,31 @@ impl AgentRootFs {
                     event_sink,
                 },
             );
-            parent_pid.and_then(|parent_pid| {
+            let parent_events = parent_pid.and_then(|parent_pid| {
                 state
                     .agents
                     .get(&parent_pid)
                     .and_then(|agent| agent.event_sink.clone())
-            })
+            });
+            let subscribe_output_events = has_event_sink
+                && self.output_events.is_some()
+                && state.output_event_pids.insert(pid.clone());
+            (parent_events, subscribe_output_events)
         };
         if let Some(parent) = parent_events {
             parent.append_child_event(&pid).await;
+        }
+        if subscribe_output_events && let Some(output_events) = self.output_events.clone() {
+            let sink = Arc::new(AgentOutputEventSink {
+                state: self.state.clone(),
+            });
+            if output_events
+                .subscribe_process_output(&pid, sink)
+                .await
+                .is_err()
+            {
+                self.state.lock().await.output_event_pids.remove(&pid);
+            }
         }
     }
 
@@ -284,11 +324,6 @@ impl AgentRootFs {
             Ok(_) => Ok(Node::ProcFile {
                 proc: self.proc.clone(),
                 proc_fid,
-                output_events: if is_proc_io_output_path(names) {
-                    self.event_sink_for_pid(pid).await
-                } else {
-                    None
-                },
             }),
             Err(e) => {
                 let _ = self.proc.clunk(proc_fid).await;
@@ -353,15 +388,6 @@ impl AgentRootFs {
         Ok(names)
     }
 
-    async fn event_sink_for_pid(&self, pid: &str) -> Option<Arc<AgentFs>> {
-        self.state
-            .lock()
-            .await
-            .agents
-            .get(pid)
-            .and_then(|agent| agent.event_sink.clone())
-    }
-
     async fn create_agent_file(
         &self,
         newfid: Fid,
@@ -421,7 +447,6 @@ impl AgentRootFs {
                 Node::ProcFile {
                     proc: proc.clone(),
                     proc_fid,
-                    output_events: None,
                 },
             )
             .await
@@ -448,6 +473,26 @@ where
 {
     let erased: Arc<dyn Any + Send + Sync> = agent.clone();
     Arc::downcast::<AgentFs>(erased).ok()
+}
+
+struct AgentOutputEventSink {
+    state: Arc<Mutex<State>>,
+}
+
+#[async_trait]
+impl ProcessOutputEventSink for AgentOutputEventSink {
+    async fn output_appended(&self, pid: &str, count: u32) {
+        let event_sink = {
+            let state = self.state.lock().await;
+            state
+                .agents
+                .get(pid)
+                .and_then(|agent| agent.event_sink.clone())
+        };
+        if let Some(agent) = event_sink {
+            agent.append_output_event(count).await;
+        }
+    }
 }
 
 async fn rollback_created_fid(server: &Arc<dyn FileServer>, fid: Fid) {
@@ -612,17 +657,7 @@ impl FileServer for AgentRootFs {
                 backing_fid,
                 ..
             } => backing.write(backing_fid, offset, data).await,
-            Node::ProcFile {
-                proc,
-                proc_fid,
-                output_events,
-            } => {
-                let count = proc.write(proc_fid, offset, data).await?;
-                if let Some(events) = output_events {
-                    events.append_output_event(count).await;
-                }
-                Ok(count)
-            }
+            Node::ProcFile { proc, proc_fid, .. } => proc.write(proc_fid, offset, data).await,
         }
     }
 

--- a/crates/agentfs/src/root.rs
+++ b/crates/agentfs/src/root.rs
@@ -1,0 +1,467 @@
+//! `/agent` root view.
+//!
+//! `AgentFs` serves one agent process's state tree. `AgentRootFs` is the
+//! Plan-9-style view mounted at `/agent`: it lists only agent surfaces whose pid
+//! still exists in `/proc`, resolves `/agent/root` to the configured root agent
+//! pid, and forwards everything below `/agent/<pid>` to that pid's `AgentFs`.
+//! It observes `/proc` through aP, keeping kernel internals and agent files
+//! separate.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use alan_ap::{ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat};
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+static NEXT_BACKING_FID: AtomicU64 = AtomicU64::new(1_000_000);
+static NEXT_PROC_FID: AtomicU64 = AtomicU64::new(2_000_000);
+
+#[derive(Clone)]
+enum Node {
+    Root,
+    AgentRoot {
+        pid: String,
+        backing: Arc<dyn FileServer>,
+    },
+    AgentFile {
+        backing: Arc<dyn FileServer>,
+        backing_fid: Fid,
+    },
+    ProcFile {
+        proc: Arc<dyn FileServer>,
+        proc_fid: Fid,
+    },
+}
+
+struct Entry {
+    node: Node,
+}
+
+struct State {
+    agents: HashMap<String, Arc<dyn FileServer>>,
+    root_pid: Option<String>,
+    fids: HashMap<Fid, Entry>,
+}
+
+/// The `/agent` root view.
+///
+/// The view is intentionally thin: it owns no process table and no agent state.
+/// Process existence is checked by walking the configured `/proc` file server;
+/// per-agent state is served by the registered backing `AgentFs` handles.
+pub struct AgentRootFs {
+    proc: Arc<dyn FileServer>,
+    state: Mutex<State>,
+}
+
+impl AgentRootFs {
+    pub fn new(proc: Arc<dyn FileServer>) -> Self {
+        Self {
+            proc,
+            state: Mutex::new(State {
+                agents: HashMap::new(),
+                root_pid: None,
+                fids: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Register the agent-state backing tree for a committed process pid.
+    pub async fn bind_process(&self, pid: impl Into<String>, agent: Arc<dyn FileServer>) {
+        self.state.lock().await.agents.insert(pid.into(), agent);
+    }
+
+    /// Point `/agent/root` at the pid that embodies the Root Agent Process.
+    pub async fn set_root_process(&self, pid: impl Into<String>) {
+        self.state.lock().await.root_pid = Some(pid.into());
+    }
+
+    async fn entry_for_name(&self, name: &str) -> Result<(String, Arc<dyn FileServer>), ErrorCode> {
+        let (pid, backing) = {
+            let state = self.state.lock().await;
+            let pid = if name == "root" {
+                state.root_pid.clone().ok_or(ErrorCode::NotFound)?
+            } else {
+                name.to_string()
+            };
+            let backing = state.agents.get(&pid).cloned().ok_or(ErrorCode::NotFound)?;
+            (pid, backing)
+        };
+        if self.proc_has_pid(&pid).await? {
+            Ok((pid, backing))
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn proc_has_pid(&self, pid: &str) -> Result<bool, ErrorCode> {
+        let fid = Fid(NEXT_PROC_FID.fetch_add(1, Ordering::Relaxed));
+        match self.proc.walk(Fid::ROOT, fid, &[pid.to_string()]).await {
+            Ok(_) => {
+                let _ = self.proc.clunk(fid).await;
+                Ok(true)
+            }
+            Err(ErrorCode::NotFound) => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn proc_pids(&self) -> Result<Vec<String>, ErrorCode> {
+        let length = self.proc.stat(Fid::ROOT).await?.length;
+        let count = u32::try_from(length.saturating_add(1)).unwrap_or(u32::MAX);
+        let bytes = self.proc.read(Fid::ROOT, 0, count).await?;
+        let text = String::from_utf8(bytes).map_err(|_| ErrorCode::Io)?;
+        Ok(text
+            .lines()
+            .filter(|line| !line.is_empty() && *line != "clone")
+            .map(str::to_string)
+            .collect())
+    }
+
+    async fn root_listing(&self) -> Result<Vec<String>, ErrorCode> {
+        let (registered, root_pid) = {
+            let state = self.state.lock().await;
+            (
+                state.agents.keys().cloned().collect::<Vec<_>>(),
+                state.root_pid.clone(),
+            )
+        };
+        let proc_pids = self.proc_pids().await?;
+        let mut names = Vec::new();
+        for pid in proc_pids {
+            if registered.iter().any(|registered| registered == &pid) {
+                names.push(pid);
+            }
+        }
+        if let Some(root_pid) = root_pid
+            && names.iter().any(|name| name == &root_pid)
+        {
+            names.push("root".to_string());
+        }
+        Ok(names)
+    }
+
+    fn node_of(state: &State, fid: Fid) -> Result<Node, ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(Node::Root);
+        }
+        state
+            .fids
+            .get(&fid)
+            .map(|entry| entry.node.clone())
+            .ok_or(ErrorCode::NotFound)
+    }
+
+    async fn bind_agent_walk(
+        &self,
+        newfid: Fid,
+        pid: String,
+        backing: Arc<dyn FileServer>,
+        base_fid: Fid,
+        names: &[String],
+    ) -> Result<Node, ErrorCode> {
+        if names.is_empty() && base_fid == Fid::ROOT {
+            return Ok(Node::AgentRoot { pid, backing });
+        }
+        if base_fid == Fid::ROOT && names.first().is_some_and(|name| is_proc_overlay_name(name)) {
+            return self.bind_proc_walk(newfid, &pid, names).await;
+        }
+        let backing_fid = Fid(NEXT_BACKING_FID.fetch_add(1, Ordering::Relaxed));
+        match backing.walk(base_fid, backing_fid, names).await {
+            Ok(_) => Ok(Node::AgentFile {
+                backing,
+                backing_fid,
+            }),
+            Err(e) => {
+                let _ = backing.clunk(backing_fid).await;
+                let mut state = self.state.lock().await;
+                state.fids.remove(&newfid);
+                Err(e)
+            }
+        }
+    }
+
+    async fn bind_proc_walk(
+        &self,
+        newfid: Fid,
+        pid: &str,
+        names: &[String],
+    ) -> Result<Node, ErrorCode> {
+        let proc_fid = Fid(NEXT_PROC_FID.fetch_add(1, Ordering::Relaxed));
+        let mut proc_names = Vec::with_capacity(names.len() + 1);
+        proc_names.push(pid.to_string());
+        proc_names.extend_from_slice(names);
+        match self.proc.walk(Fid::ROOT, proc_fid, &proc_names).await {
+            Ok(_) => Ok(Node::ProcFile {
+                proc: self.proc.clone(),
+                proc_fid,
+            }),
+            Err(e) => {
+                let _ = self.proc.clunk(proc_fid).await;
+                let mut state = self.state.lock().await;
+                state.fids.remove(&newfid);
+                Err(e)
+            }
+        }
+    }
+
+    async fn agent_listing(
+        &self,
+        pid: &str,
+        backing: Arc<dyn FileServer>,
+    ) -> Result<Vec<String>, ErrorCode> {
+        let mut names = read_listing(backing, [].as_slice()).await?;
+        let proc_names = read_listing(self.proc.clone(), &[pid.to_string()]).await?;
+        for name in proc_names {
+            if !names.iter().any(|existing| existing == &name) {
+                names.push(name);
+            }
+        }
+        Ok(names)
+    }
+}
+
+#[async_trait]
+impl FileServer for AgentRootFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        {
+            let state = self.state.lock().await;
+            if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
+                return Err(ErrorCode::BadRequest);
+            }
+        }
+
+        let node = {
+            let state = self.state.lock().await;
+            Self::node_of(&state, fid)?
+        };
+        let new_node = match node {
+            Node::Root => {
+                if names.is_empty() {
+                    Node::Root
+                } else {
+                    let (pid, backing) = self.entry_for_name(&names[0]).await?;
+                    self.bind_agent_walk(newfid, pid, backing, Fid::ROOT, &names[1..])
+                        .await?
+                }
+            }
+            Node::AgentRoot { pid, backing } => {
+                self.bind_agent_walk(newfid, pid, backing, Fid::ROOT, names)
+                    .await?
+            }
+            Node::AgentFile {
+                backing,
+                backing_fid,
+            } => {
+                self.bind_agent_walk(newfid, String::new(), backing, backing_fid, names)
+                    .await?
+            }
+            Node::ProcFile { .. } => return Err(ErrorCode::NotDirectory),
+        };
+        let qid = qid_for_node(&new_node).await?;
+        self.state
+            .lock()
+            .await
+            .fids
+            .insert(newfid, Entry { node: new_node });
+        Ok(qid)
+    }
+
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
+        match self.node(fid).await? {
+            Node::Root => {
+                if matches!(mode, OpenMode::Write | OpenMode::ReadWrite) {
+                    return Err(ErrorCode::NoAccess);
+                }
+                Ok(root_qid())
+            }
+            Node::AgentRoot { backing, .. } => backing.open(Fid::ROOT, mode).await,
+            Node::AgentFile {
+                backing,
+                backing_fid,
+                ..
+            } => backing.open(backing_fid, mode).await,
+            Node::ProcFile { proc, proc_fid } => proc.open(proc_fid, mode).await,
+        }
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        match self.node(fid).await? {
+            Node::Root => Ok(slice(
+                self.root_listing().await?.join("\n").into_bytes(),
+                offset,
+                count,
+            )),
+            Node::AgentRoot { pid, backing } => Ok(slice(
+                self.agent_listing(&pid, backing)
+                    .await?
+                    .join("\n")
+                    .into_bytes(),
+                offset,
+                count,
+            )),
+            Node::AgentFile {
+                backing,
+                backing_fid,
+                ..
+            } => backing.read(backing_fid, offset, count).await,
+            Node::ProcFile { proc, proc_fid } => proc.read(proc_fid, offset, count).await,
+        }
+    }
+
+    async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        match self.node(fid).await? {
+            Node::Root => Err(ErrorCode::NoAccess),
+            Node::AgentRoot { backing, .. } => backing.write(Fid::ROOT, offset, data).await,
+            Node::AgentFile {
+                backing,
+                backing_fid,
+                ..
+            } => backing.write(backing_fid, offset, data).await,
+            Node::ProcFile { proc, proc_fid } => proc.write(proc_fid, offset, data).await,
+        }
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        match self.node(fid).await? {
+            Node::Root => Ok(Stat {
+                name: String::new(),
+                qid: root_qid(),
+                length: self.root_listing().await?.join("\n").len() as u64,
+                writable: false,
+            }),
+            Node::AgentRoot { pid, backing } => {
+                let mut stat = backing.stat(Fid::ROOT).await?;
+                stat.length = self.agent_listing(&pid, backing).await?.join("\n").len() as u64;
+                Ok(stat)
+            }
+            Node::AgentFile {
+                backing,
+                backing_fid,
+                ..
+            } => backing.stat(backing_fid).await,
+            Node::ProcFile { proc, proc_fid } => proc.stat(proc_fid).await,
+        }
+    }
+
+    async fn create(
+        &self,
+        fid: Fid,
+        newfid: Fid,
+        name: &str,
+        kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        match self.node(fid).await? {
+            Node::Root => Err(ErrorCode::Unsupported),
+            Node::AgentRoot { backing, .. } => backing.create(Fid::ROOT, newfid, name, kind).await,
+            Node::AgentFile {
+                backing,
+                backing_fid,
+                ..
+            } => backing.create(backing_fid, newfid, name, kind).await,
+            Node::ProcFile { proc, proc_fid } => proc.create(proc_fid, newfid, name, kind).await,
+        }
+    }
+
+    async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
+        match self.node(fid).await? {
+            Node::Root => Err(ErrorCode::Unsupported),
+            Node::AgentRoot { backing, .. } => backing.remove(Fid::ROOT).await,
+            Node::AgentFile {
+                backing,
+                backing_fid,
+                ..
+            } => backing.remove(backing_fid).await,
+            Node::ProcFile { proc, proc_fid } => proc.remove(proc_fid).await,
+        }
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(());
+        }
+        let entry = self.state.lock().await.fids.remove(&fid);
+        match entry.map(|entry| entry.node) {
+            Some(Node::AgentFile {
+                backing,
+                backing_fid,
+                ..
+            }) => backing.clunk(backing_fid).await,
+            Some(Node::ProcFile { proc, proc_fid }) => proc.clunk(proc_fid).await,
+            Some(Node::Root | Node::AgentRoot { .. }) => Ok(()),
+            None => Err(ErrorCode::NotFound),
+        }
+    }
+}
+
+impl AgentRootFs {
+    async fn node(&self, fid: Fid) -> Result<Node, ErrorCode> {
+        let state = self.state.lock().await;
+        Self::node_of(&state, fid)
+    }
+}
+
+async fn qid_for_node(node: &Node) -> Result<Qid, ErrorCode> {
+    match node {
+        Node::Root => Ok(root_qid()),
+        Node::AgentRoot { backing, .. } => backing.stat(Fid::ROOT).await.map(|stat| stat.qid),
+        Node::AgentFile {
+            backing,
+            backing_fid,
+            ..
+        } => backing.stat(*backing_fid).await.map(|stat| stat.qid),
+        Node::ProcFile { proc, proc_fid } => proc.stat(*proc_fid).await.map(|stat| stat.qid),
+    }
+}
+
+async fn read_listing(
+    server: Arc<dyn FileServer>,
+    names: &[String],
+) -> Result<Vec<String>, ErrorCode> {
+    let fid = Fid(NEXT_BACKING_FID.fetch_add(1, Ordering::Relaxed));
+    server.walk(Fid::ROOT, fid, names).await?;
+    server.open(fid, OpenMode::Read).await?;
+    let length = server.stat(fid).await?.length;
+    let bytes = server
+        .read(
+            fid,
+            0,
+            u32::try_from(length.saturating_add(1)).unwrap_or(u32::MAX),
+        )
+        .await;
+    let clunk = server.clunk(fid).await;
+    let bytes = bytes?;
+    clunk?;
+    let text = String::from_utf8(bytes).map_err(|_| ErrorCode::Io)?;
+    Ok(text
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+fn is_proc_overlay_name(name: &str) -> bool {
+    matches!(
+        name,
+        "status" | "parent" | "credentials" | "exit" | "ctl" | "namespace"
+    )
+}
+
+fn root_qid() -> Qid {
+    Qid {
+        kind: FileKind::Dir,
+        version: 0,
+        path: 0xA6E7,
+    }
+}
+
+fn slice(bytes: Vec<u8>, offset: Offset, count: u32) -> Vec<u8> {
+    let start = (offset as usize).min(bytes.len());
+    let end = bytes.len().min(start + count as usize);
+    bytes[start..end].to_vec()
+}

--- a/crates/agentfs/src/root.rs
+++ b/crates/agentfs/src/root.rs
@@ -309,6 +309,9 @@ impl AgentRootFs {
         name: &str,
         kind: FileKind,
     ) -> Result<Qid, ErrorCode> {
+        if dir_fid == Fid::ROOT && is_agent_overlay_reserved_name(name) {
+            return Err(ErrorCode::BadRequest);
+        }
         let backing_fid = Fid(NEXT_BACKING_FID.fetch_add(1, Ordering::Relaxed));
         let qid = match backing.create(dir_fid, backing_fid, name, kind).await {
             Ok(qid) => qid,
@@ -416,11 +419,10 @@ impl FileServer for AgentRootFs {
             Node::ProcFile { .. } => return Err(ErrorCode::NotDirectory),
         };
         let qid = self.qid_for_node(&new_node).await?;
-        self.state
-            .lock()
-            .await
-            .fids
-            .insert(newfid, Entry { node: new_node });
+        if let Err(error) = self.insert_fid(newfid, new_node.clone()).await {
+            release_node(new_node).await;
+            return Err(error);
+        }
         Ok(qid)
     }
 
@@ -430,7 +432,8 @@ impl FileServer for AgentRootFs {
                 if matches!(mode, OpenMode::Write | OpenMode::ReadWrite) {
                     return Err(ErrorCode::NoAccess);
                 }
-                Ok(root_qid())
+                let listing = self.root_listing().await?;
+                Ok(root_qid(&listing))
             }
             Node::AgentChildren { pid } => {
                 if matches!(mode, OpenMode::Write | OpenMode::ReadWrite) {
@@ -504,12 +507,15 @@ impl FileServer for AgentRootFs {
 
     async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
         match self.node(fid).await? {
-            Node::Root => Ok(Stat {
-                name: String::new(),
-                qid: root_qid(),
-                length: self.root_listing().await?.join("\n").len() as u64,
-                writable: false,
-            }),
+            Node::Root => {
+                let listing = self.root_listing().await?;
+                Ok(Stat {
+                    name: String::new(),
+                    qid: root_qid(&listing),
+                    length: listing.join("\n").len() as u64,
+                    writable: false,
+                })
+            }
             Node::AgentRoot { pid, backing } => {
                 let mut stat = backing.stat(Fid::ROOT).await?;
                 stat.qid = namespace_agent_qid(&pid, stat.qid);
@@ -620,7 +626,10 @@ impl AgentRootFs {
 
     async fn qid_for_node(&self, node: &Node) -> Result<Qid, ErrorCode> {
         match node {
-            Node::Root => Ok(root_qid()),
+            Node::Root => {
+                let listing = self.root_listing().await?;
+                Ok(root_qid(&listing))
+            }
             Node::AgentRoot { pid, backing } => backing
                 .stat(Fid::ROOT)
                 .await
@@ -715,6 +724,10 @@ fn is_proc_overlay_name(name: &str) -> bool {
     )
 }
 
+fn is_agent_overlay_reserved_name(name: &str) -> bool {
+    name == "children" || is_proc_overlay_name(name)
+}
+
 fn agent_children_qid(pid: &str, children: &[String]) -> Qid {
     Qid {
         kind: FileKind::Dir,
@@ -723,11 +736,27 @@ fn agent_children_qid(pid: &str, children: &[String]) -> Qid {
     }
 }
 
-fn root_qid() -> Qid {
+fn root_qid(listing: &[String]) -> Qid {
     Qid {
         kind: FileKind::Dir,
-        version: 0,
+        version: hash_value(&("agent-root-version", listing)) as u32,
         path: 0xA6E7,
+    }
+}
+
+async fn release_node(node: Node) {
+    match node {
+        Node::AgentFile {
+            backing,
+            backing_fid,
+            ..
+        } => {
+            let _ = backing.clunk(backing_fid).await;
+        }
+        Node::ProcFile { proc, proc_fid } => {
+            let _ = proc.clunk(proc_fid).await;
+        }
+        Node::Root | Node::AgentRoot { .. } | Node::AgentChildren { .. } => {}
     }
 }
 

--- a/crates/agentfs/src/root.rs
+++ b/crates/agentfs/src/root.rs
@@ -20,9 +20,10 @@ use std::{
 };
 
 use alan_ap::{
-    ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, ProcessInputEventSink,
-    ProcessInputEventSource, ProcessIoEventKind, ProcessIoEventSink, ProcessIoEventSource,
-    ProcessOutputEventSink, ProcessOutputEventSource, Qid, Stat,
+    ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, ProcessEvent, ProcessEventSink,
+    ProcessEventSource, ProcessInputEventSink, ProcessInputEventSource, ProcessIoEventKind,
+    ProcessIoEventSink, ProcessIoEventSource, ProcessOutputEventSink, ProcessOutputEventSource,
+    Qid, Stat,
 };
 use async_trait::async_trait;
 use tokio::sync::Mutex;
@@ -74,6 +75,7 @@ struct ProcCreateDir {
 
 struct State {
     agents: HashMap<String, AgentRegistration>,
+    process_event_pids: HashSet<String>,
     io_event_pids: HashSet<String>,
     input_event_pids: HashSet<String>,
     output_event_pids: HashSet<String>,
@@ -88,6 +90,7 @@ struct State {
 /// per-agent state is served by the registered backing `AgentFs` handles.
 pub struct AgentRootFs {
     proc: Arc<dyn FileServer>,
+    process_events: Option<Arc<dyn ProcessEventSource>>,
     io_events: Option<Arc<dyn ProcessIoEventSource>>,
     input_events: Option<Arc<dyn ProcessInputEventSource>>,
     output_events: Option<Arc<dyn ProcessOutputEventSource>>,
@@ -98,11 +101,13 @@ impl AgentRootFs {
     pub fn new(proc: Arc<dyn FileServer>) -> Self {
         Self {
             proc,
+            process_events: None,
             io_events: None,
             input_events: None,
             output_events: None,
             state: Arc::new(Mutex::new(State {
                 agents: HashMap::new(),
+                process_event_pids: HashSet::new(),
                 io_event_pids: HashSet::new(),
                 input_event_pids: HashSet::new(),
                 output_event_pids: HashSet::new(),
@@ -118,11 +123,13 @@ impl AgentRootFs {
     ) -> Self {
         Self {
             proc,
+            process_events: None,
             io_events: None,
             input_events: None,
             output_events: Some(output_events),
             state: Arc::new(Mutex::new(State {
                 agents: HashMap::new(),
+                process_event_pids: HashSet::new(),
                 io_event_pids: HashSet::new(),
                 input_event_pids: HashSet::new(),
                 output_event_pids: HashSet::new(),
@@ -139,11 +146,13 @@ impl AgentRootFs {
     ) -> Self {
         Self {
             proc,
+            process_events: None,
             io_events: None,
             input_events: Some(input_events),
             output_events: Some(output_events),
             state: Arc::new(Mutex::new(State {
                 agents: HashMap::new(),
+                process_event_pids: HashSet::new(),
                 io_event_pids: HashSet::new(),
                 input_event_pids: HashSet::new(),
                 output_event_pids: HashSet::new(),
@@ -159,11 +168,35 @@ impl AgentRootFs {
     ) -> Self {
         Self {
             proc,
+            process_events: None,
             io_events: Some(io_events),
             input_events: None,
             output_events: None,
             state: Arc::new(Mutex::new(State {
                 agents: HashMap::new(),
+                process_event_pids: HashSet::new(),
+                io_event_pids: HashSet::new(),
+                input_event_pids: HashSet::new(),
+                output_event_pids: HashSet::new(),
+                root_pid: None,
+                fids: HashMap::new(),
+            })),
+        }
+    }
+
+    pub fn new_with_process_events(
+        proc: Arc<dyn FileServer>,
+        process_events: Arc<dyn ProcessEventSource>,
+    ) -> Self {
+        Self {
+            proc,
+            process_events: Some(process_events),
+            io_events: None,
+            input_events: None,
+            output_events: None,
+            state: Arc::new(Mutex::new(State {
+                agents: HashMap::new(),
+                process_event_pids: HashSet::new(),
                 io_event_pids: HashSet::new(),
                 input_event_pids: HashSet::new(),
                 output_event_pids: HashSet::new(),
@@ -183,7 +216,13 @@ impl AgentRootFs {
         let has_event_sink = event_sink.is_some();
         let backing: Arc<dyn FileServer> = agent;
         let parent_pid = self.proc_parent_of(&pid).await.ok().flatten();
-        let (parent_events, subscribe_io_events, subscribe_input_events, subscribe_output_events) = {
+        let (
+            parent_events,
+            subscribe_process_events,
+            subscribe_io_events,
+            subscribe_input_events,
+            subscribe_output_events,
+        ) = {
             let mut state = self.state.lock().await;
             state.agents.insert(
                 pid.clone(),
@@ -198,19 +237,26 @@ impl AgentRootFs {
                     .get(&parent_pid)
                     .and_then(|agent| agent.event_sink.clone())
             });
+            let subscribe_process_events = has_event_sink
+                && self.process_events.is_some()
+                && state.process_event_pids.insert(pid.clone());
             let subscribe_io_events = has_event_sink
+                && self.process_events.is_none()
                 && self.io_events.is_some()
                 && state.io_event_pids.insert(pid.clone());
             let subscribe_input_events = has_event_sink
+                && self.process_events.is_none()
                 && self.io_events.is_none()
                 && self.input_events.is_some()
                 && state.input_event_pids.insert(pid.clone());
             let subscribe_output_events = has_event_sink
+                && self.process_events.is_none()
                 && self.io_events.is_none()
                 && self.output_events.is_some()
                 && state.output_event_pids.insert(pid.clone());
             (
                 parent_events,
+                subscribe_process_events,
                 subscribe_io_events,
                 subscribe_input_events,
                 subscribe_output_events,
@@ -218,6 +264,18 @@ impl AgentRootFs {
         };
         if let Some(parent) = parent_events {
             parent.append_child_event(&pid).await;
+        }
+        if subscribe_process_events && let Some(process_events) = self.process_events.clone() {
+            let sink = Arc::new(AgentProcessEventSink {
+                state: self.state.clone(),
+            });
+            if process_events
+                .subscribe_process_events(&pid, sink)
+                .await
+                .is_err()
+            {
+                self.state.lock().await.process_event_pids.remove(&pid);
+            }
         }
         if subscribe_io_events && let Some(io_events) = self.io_events.clone() {
             let sink = Arc::new(AgentIoEventSink {
@@ -586,6 +644,30 @@ struct AgentInputEventSink {
 
 struct AgentIoEventSink {
     state: Arc<Mutex<State>>,
+}
+
+struct AgentProcessEventSink {
+    state: Arc<Mutex<State>>,
+}
+
+#[async_trait]
+impl ProcessEventSink for AgentProcessEventSink {
+    async fn process_event(&self, pid: &str, event: ProcessEvent) {
+        let event_sink = {
+            let state = self.state.lock().await;
+            state
+                .agents
+                .get(pid)
+                .and_then(|agent| agent.event_sink.clone())
+        };
+        if let Some(agent) = event_sink {
+            match event {
+                ProcessEvent::Input { count } => agent.append_input_event(count).await,
+                ProcessEvent::Output { count } => agent.append_output_event(count).await,
+                ProcessEvent::Status { status } => agent.append_status_event(&status).await,
+            }
+        }
+    }
 }
 
 #[async_trait]

--- a/crates/agentfs/src/root.rs
+++ b/crates/agentfs/src/root.rs
@@ -43,6 +43,11 @@ enum Node {
     AgentChildren {
         pid: String,
     },
+    AgentIoDir {
+        pid: String,
+        backing: Arc<dyn FileServer>,
+        backing_fid: Fid,
+    },
     AgentFile {
         pid: String,
         backing: Arc<dyn FileServer>,
@@ -51,6 +56,7 @@ enum Node {
     ProcFile {
         proc: Arc<dyn FileServer>,
         proc_fid: Fid,
+        output_events: Option<Arc<AgentFs>>,
     },
 }
 
@@ -216,12 +222,20 @@ impl AgentRootFs {
             if names.first().is_some_and(|name| name == "children") {
                 return self.bind_agent_child_walk(newfid, &pid, &names[1..]).await;
             }
+            if is_proc_io_output_path(names) {
+                return self.bind_proc_walk(newfid, &pid, names).await;
+            }
             if names.first().is_some_and(|name| is_proc_overlay_name(name)) {
                 return self.bind_proc_walk(newfid, &pid, names).await;
             }
         }
         let backing_fid = Fid(NEXT_BACKING_FID.fetch_add(1, Ordering::Relaxed));
         match backing.walk(base_fid, backing_fid, names).await {
+            Ok(_) if is_agent_io_dir_path(base_fid, names) => Ok(Node::AgentIoDir {
+                pid,
+                backing,
+                backing_fid,
+            }),
             Ok(_) => Ok(Node::AgentFile {
                 pid,
                 backing,
@@ -270,6 +284,11 @@ impl AgentRootFs {
             Ok(_) => Ok(Node::ProcFile {
                 proc: self.proc.clone(),
                 proc_fid,
+                output_events: if is_proc_io_output_path(names) {
+                    self.event_sink_for_pid(pid).await
+                } else {
+                    None
+                },
             }),
             Err(e) => {
                 let _ = self.proc.clunk(proc_fid).await;
@@ -334,6 +353,15 @@ impl AgentRootFs {
         Ok(names)
     }
 
+    async fn event_sink_for_pid(&self, pid: &str) -> Option<Arc<AgentFs>> {
+        self.state
+            .lock()
+            .await
+            .agents
+            .get(pid)
+            .and_then(|agent| agent.event_sink.clone())
+    }
+
     async fn create_agent_file(
         &self,
         newfid: Fid,
@@ -393,6 +421,7 @@ impl AgentRootFs {
                 Node::ProcFile {
                     proc: proc.clone(),
                     proc_fid,
+                    output_events: None,
                 },
             )
             .await
@@ -456,6 +485,21 @@ impl FileServer for AgentRootFs {
                     .await?
             }
             Node::AgentChildren { pid } => self.bind_agent_child_walk(newfid, &pid, names).await?,
+            Node::AgentIoDir {
+                pid,
+                backing,
+                backing_fid,
+            } => {
+                if names.first().is_some_and(|name| name == "output") {
+                    let mut proc_names = Vec::with_capacity(names.len() + 1);
+                    proc_names.push("io".to_string());
+                    proc_names.extend_from_slice(names);
+                    self.bind_proc_walk(newfid, &pid, &proc_names).await?
+                } else {
+                    self.bind_agent_walk(newfid, pid, backing, backing_fid, names)
+                        .await?
+                }
+            }
             Node::AgentFile {
                 pid,
                 backing,
@@ -494,6 +538,15 @@ impl FileServer for AgentRootFs {
                 .open(Fid::ROOT, mode)
                 .await
                 .map(|qid| namespace_agent_qid(&pid, qid)),
+            Node::AgentIoDir {
+                pid,
+                backing,
+                backing_fid,
+                ..
+            } => backing
+                .open(backing_fid, mode)
+                .await
+                .map(|qid| namespace_agent_qid(&pid, qid)),
             Node::AgentFile {
                 pid,
                 backing,
@@ -503,7 +556,7 @@ impl FileServer for AgentRootFs {
                 .open(backing_fid, mode)
                 .await
                 .map(|qid| namespace_agent_qid(&pid, qid)),
-            Node::ProcFile { proc, proc_fid } => proc.open(proc_fid, mode).await,
+            Node::ProcFile { proc, proc_fid, .. } => proc.open(proc_fid, mode).await,
         }
     }
 
@@ -530,12 +583,17 @@ impl FileServer for AgentRootFs {
                 offset,
                 count,
             )),
+            Node::AgentIoDir {
+                backing,
+                backing_fid,
+                ..
+            } => backing.read(backing_fid, offset, count).await,
             Node::AgentFile {
                 backing,
                 backing_fid,
                 ..
             } => backing.read(backing_fid, offset, count).await,
-            Node::ProcFile { proc, proc_fid } => proc.read(proc_fid, offset, count).await,
+            Node::ProcFile { proc, proc_fid, .. } => proc.read(proc_fid, offset, count).await,
         }
     }
 
@@ -544,12 +602,27 @@ impl FileServer for AgentRootFs {
             Node::Root => Err(ErrorCode::NoAccess),
             Node::AgentChildren { .. } => Err(ErrorCode::NoAccess),
             Node::AgentRoot { backing, .. } => backing.write(Fid::ROOT, offset, data).await,
+            Node::AgentIoDir {
+                backing,
+                backing_fid,
+                ..
+            } => backing.write(backing_fid, offset, data).await,
             Node::AgentFile {
                 backing,
                 backing_fid,
                 ..
             } => backing.write(backing_fid, offset, data).await,
-            Node::ProcFile { proc, proc_fid } => proc.write(proc_fid, offset, data).await,
+            Node::ProcFile {
+                proc,
+                proc_fid,
+                output_events,
+            } => {
+                let count = proc.write(proc_fid, offset, data).await?;
+                if let Some(events) = output_events {
+                    events.append_output_event(count).await;
+                }
+                Ok(count)
+            }
         }
     }
 
@@ -579,6 +652,16 @@ impl FileServer for AgentRootFs {
                     writable: false,
                 })
             }
+            Node::AgentIoDir {
+                pid,
+                backing,
+                backing_fid,
+                ..
+            } => {
+                let mut stat = backing.stat(backing_fid).await?;
+                stat.qid = namespace_agent_qid(&pid, stat.qid);
+                Ok(stat)
+            }
             Node::AgentFile {
                 pid,
                 backing,
@@ -589,7 +672,7 @@ impl FileServer for AgentRootFs {
                 stat.qid = namespace_agent_qid(&pid, stat.qid);
                 Ok(stat)
             }
-            Node::ProcFile { proc, proc_fid } => proc.stat(proc_fid).await,
+            Node::ProcFile { proc, proc_fid, .. } => proc.stat(proc_fid).await,
         }
     }
 
@@ -613,6 +696,15 @@ impl FileServer for AgentRootFs {
                 self.create_agent_file(newfid, pid, backing, Fid::ROOT, name, kind)
                     .await
             }
+            Node::AgentIoDir {
+                pid,
+                backing,
+                backing_fid,
+                ..
+            } => {
+                self.create_agent_file(newfid, pid, backing, backing_fid, name, kind)
+                    .await
+            }
             Node::AgentFile {
                 pid,
                 backing,
@@ -622,7 +714,7 @@ impl FileServer for AgentRootFs {
                 self.create_agent_file(newfid, pid, backing, backing_fid, name, kind)
                     .await
             }
-            Node::ProcFile { proc, proc_fid } => {
+            Node::ProcFile { proc, proc_fid, .. } => {
                 self.create_proc_file(newfid, proc, proc_fid, name, kind)
                     .await
             }
@@ -637,12 +729,17 @@ impl FileServer for AgentRootFs {
             Node::Root => Err(ErrorCode::Unsupported),
             Node::AgentChildren { .. } => Err(ErrorCode::Unsupported),
             Node::AgentRoot { backing, .. } => backing.remove(Fid::ROOT).await,
+            Node::AgentIoDir {
+                backing,
+                backing_fid,
+                ..
+            } => backing.remove(backing_fid).await,
             Node::AgentFile {
                 backing,
                 backing_fid,
                 ..
             } => backing.remove(backing_fid).await,
-            Node::ProcFile { proc, proc_fid } => proc.remove(proc_fid).await,
+            Node::ProcFile { proc, proc_fid, .. } => proc.remove(proc_fid).await,
         }?;
         self.state.lock().await.fids.remove(&fid);
         Ok(())
@@ -654,12 +751,17 @@ impl FileServer for AgentRootFs {
         }
         let entry = self.state.lock().await.fids.remove(&fid);
         match entry.map(|entry| entry.node) {
+            Some(Node::AgentIoDir {
+                backing,
+                backing_fid,
+                ..
+            }) => backing.clunk(backing_fid).await,
             Some(Node::AgentFile {
                 backing,
                 backing_fid,
                 ..
             }) => backing.clunk(backing_fid).await,
-            Some(Node::ProcFile { proc, proc_fid }) => proc.clunk(proc_fid).await,
+            Some(Node::ProcFile { proc, proc_fid, .. }) => proc.clunk(proc_fid).await,
             Some(Node::Root | Node::AgentRoot { .. } | Node::AgentChildren { .. }) => Ok(()),
             None => Err(ErrorCode::NotFound),
         }
@@ -686,6 +788,15 @@ impl AgentRootFs {
                 let listing = self.agent_child_listing(pid).await?;
                 Ok(agent_children_qid(pid, &listing))
             }
+            Node::AgentIoDir {
+                pid,
+                backing,
+                backing_fid,
+                ..
+            } => backing
+                .stat(*backing_fid)
+                .await
+                .map(|stat| namespace_agent_qid(pid, stat.qid)),
             Node::AgentFile {
                 pid,
                 backing,
@@ -695,7 +806,9 @@ impl AgentRootFs {
                 .stat(*backing_fid)
                 .await
                 .map(|stat| namespace_agent_qid(pid, stat.qid)),
-            Node::ProcFile { proc, proc_fid } => proc.stat(*proc_fid).await.map(|stat| stat.qid),
+            Node::ProcFile { proc, proc_fid, .. } => {
+                proc.stat(*proc_fid).await.map(|stat| stat.qid)
+            }
         }
     }
 }
@@ -773,7 +886,15 @@ fn is_proc_overlay_name(name: &str) -> bool {
 }
 
 fn is_agent_overlay_reserved_name(name: &str) -> bool {
-    name == "children" || is_proc_overlay_name(name)
+    matches!(name, "children" | "io") || is_proc_overlay_name(name)
+}
+
+fn is_agent_io_dir_path(base_fid: Fid, names: &[String]) -> bool {
+    base_fid == Fid::ROOT && names.len() == 1 && names[0] == "io"
+}
+
+fn is_proc_io_output_path(names: &[String]) -> bool {
+    names.len() >= 2 && names[0] == "io" && names[1] == "output"
 }
 
 fn agent_children_qid(pid: &str, children: &[String]) -> Qid {
@@ -794,14 +915,19 @@ fn root_qid(listing: &[String]) -> Qid {
 
 async fn release_node(node: Node) {
     match node {
-        Node::AgentFile {
+        Node::AgentIoDir {
+            backing,
+            backing_fid,
+            ..
+        }
+        | Node::AgentFile {
             backing,
             backing_fid,
             ..
         } => {
             let _ = backing.clunk(backing_fid).await;
         }
-        Node::ProcFile { proc, proc_fid } => {
+        Node::ProcFile { proc, proc_fid, .. } => {
             let _ = proc.clunk(proc_fid).await;
         }
         Node::Root | Node::AgentRoot { .. } | Node::AgentChildren { .. } => {}

--- a/crates/agentfs/src/root.rs
+++ b/crates/agentfs/src/root.rs
@@ -321,10 +321,7 @@ impl AgentRootFs {
                 backing,
                 backing_fid,
             }),
-            Err(e) => {
-                let _ = backing.clunk(backing_fid).await;
-                Err(e)
-            }
+            Err(e) => Err(e),
         }
     }
 
@@ -629,7 +626,13 @@ impl FileServer for AgentRootFs {
                     .await?
             }
         };
-        let qid = self.qid_for_node(&new_node).await?;
+        let qid = match self.qid_for_node(&new_node).await {
+            Ok(qid) => qid,
+            Err(error) => {
+                release_node(new_node).await;
+                return Err(error);
+            }
+        };
         if let Err(error) = self.insert_fid(newfid, new_node.clone()).await {
             release_node(new_node).await;
             return Err(error);

--- a/crates/agentfs/src/root.rs
+++ b/crates/agentfs/src/root.rs
@@ -325,10 +325,7 @@ impl AgentRootFs {
                 proc: self.proc.clone(),
                 proc_fid,
             }),
-            Err(e) => {
-                let _ = self.proc.clunk(proc_fid).await;
-                Err(e)
-            }
+            Err(e) => Err(e),
         }
     }
 
@@ -436,10 +433,7 @@ impl AgentRootFs {
         let proc_fid = Fid(NEXT_PROC_FID.fetch_add(1, Ordering::Relaxed));
         let qid = match proc.create(dir_fid, proc_fid, name, kind).await {
             Ok(qid) => qid,
-            Err(e) => {
-                let _ = proc.clunk(proc_fid).await;
-                return Err(e);
-            }
+            Err(e) => return Err(e),
         };
         if let Err(e) = self
             .insert_fid(
@@ -854,10 +848,7 @@ async fn read_file_text(
     raw_fid: u64,
 ) -> Result<String, ErrorCode> {
     let fid = Fid(raw_fid);
-    if let Err(e) = server.walk(Fid::ROOT, fid, names).await {
-        let _ = server.clunk(fid).await;
-        return Err(e);
-    }
+    server.walk(Fid::ROOT, fid, names).await?;
     let result = match server.open(fid, OpenMode::Read).await {
         Ok(_) => {
             let length = match server.stat(fid).await {

--- a/crates/agentfs/src/root.rs
+++ b/crates/agentfs/src/root.rs
@@ -21,7 +21,8 @@ use std::{
 
 use alan_ap::{
     ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, ProcessInputEventSink,
-    ProcessInputEventSource, ProcessOutputEventSink, ProcessOutputEventSource, Qid, Stat,
+    ProcessInputEventSource, ProcessIoEventKind, ProcessIoEventSink, ProcessIoEventSource,
+    ProcessOutputEventSink, ProcessOutputEventSource, Qid, Stat,
 };
 use async_trait::async_trait;
 use tokio::sync::Mutex;
@@ -73,6 +74,7 @@ struct ProcCreateDir {
 
 struct State {
     agents: HashMap<String, AgentRegistration>,
+    io_event_pids: HashSet<String>,
     input_event_pids: HashSet<String>,
     output_event_pids: HashSet<String>,
     root_pid: Option<String>,
@@ -86,6 +88,7 @@ struct State {
 /// per-agent state is served by the registered backing `AgentFs` handles.
 pub struct AgentRootFs {
     proc: Arc<dyn FileServer>,
+    io_events: Option<Arc<dyn ProcessIoEventSource>>,
     input_events: Option<Arc<dyn ProcessInputEventSource>>,
     output_events: Option<Arc<dyn ProcessOutputEventSource>>,
     state: Arc<Mutex<State>>,
@@ -95,10 +98,12 @@ impl AgentRootFs {
     pub fn new(proc: Arc<dyn FileServer>) -> Self {
         Self {
             proc,
+            io_events: None,
             input_events: None,
             output_events: None,
             state: Arc::new(Mutex::new(State {
                 agents: HashMap::new(),
+                io_event_pids: HashSet::new(),
                 input_event_pids: HashSet::new(),
                 output_event_pids: HashSet::new(),
                 root_pid: None,
@@ -113,10 +118,12 @@ impl AgentRootFs {
     ) -> Self {
         Self {
             proc,
+            io_events: None,
             input_events: None,
             output_events: Some(output_events),
             state: Arc::new(Mutex::new(State {
                 agents: HashMap::new(),
+                io_event_pids: HashSet::new(),
                 input_event_pids: HashSet::new(),
                 output_event_pids: HashSet::new(),
                 root_pid: None,
@@ -132,10 +139,32 @@ impl AgentRootFs {
     ) -> Self {
         Self {
             proc,
+            io_events: None,
             input_events: Some(input_events),
             output_events: Some(output_events),
             state: Arc::new(Mutex::new(State {
                 agents: HashMap::new(),
+                io_event_pids: HashSet::new(),
+                input_event_pids: HashSet::new(),
+                output_event_pids: HashSet::new(),
+                root_pid: None,
+                fids: HashMap::new(),
+            })),
+        }
+    }
+
+    pub fn new_with_ordered_process_io_events(
+        proc: Arc<dyn FileServer>,
+        io_events: Arc<dyn ProcessIoEventSource>,
+    ) -> Self {
+        Self {
+            proc,
+            io_events: Some(io_events),
+            input_events: None,
+            output_events: None,
+            state: Arc::new(Mutex::new(State {
+                agents: HashMap::new(),
+                io_event_pids: HashSet::new(),
                 input_event_pids: HashSet::new(),
                 output_event_pids: HashSet::new(),
                 root_pid: None,
@@ -154,7 +183,7 @@ impl AgentRootFs {
         let has_event_sink = event_sink.is_some();
         let backing: Arc<dyn FileServer> = agent;
         let parent_pid = self.proc_parent_of(&pid).await.ok().flatten();
-        let (parent_events, subscribe_input_events, subscribe_output_events) = {
+        let (parent_events, subscribe_io_events, subscribe_input_events, subscribe_output_events) = {
             let mut state = self.state.lock().await;
             state.agents.insert(
                 pid.clone(),
@@ -169,20 +198,34 @@ impl AgentRootFs {
                     .get(&parent_pid)
                     .and_then(|agent| agent.event_sink.clone())
             });
+            let subscribe_io_events = has_event_sink
+                && self.io_events.is_some()
+                && state.io_event_pids.insert(pid.clone());
             let subscribe_input_events = has_event_sink
+                && self.io_events.is_none()
                 && self.input_events.is_some()
                 && state.input_event_pids.insert(pid.clone());
             let subscribe_output_events = has_event_sink
+                && self.io_events.is_none()
                 && self.output_events.is_some()
                 && state.output_event_pids.insert(pid.clone());
             (
                 parent_events,
+                subscribe_io_events,
                 subscribe_input_events,
                 subscribe_output_events,
             )
         };
         if let Some(parent) = parent_events {
             parent.append_child_event(&pid).await;
+        }
+        if subscribe_io_events && let Some(io_events) = self.io_events.clone() {
+            let sink = Arc::new(AgentIoEventSink {
+                state: self.state.clone(),
+            });
+            if io_events.subscribe_process_io(&pid, sink).await.is_err() {
+                self.state.lock().await.io_event_pids.remove(&pid);
+            }
         }
         if subscribe_input_events && let Some(input_events) = self.input_events.clone() {
             let sink = Arc::new(AgentInputEventSink {
@@ -539,6 +582,29 @@ struct AgentOutputEventSink {
 
 struct AgentInputEventSink {
     state: Arc<Mutex<State>>,
+}
+
+struct AgentIoEventSink {
+    state: Arc<Mutex<State>>,
+}
+
+#[async_trait]
+impl ProcessIoEventSink for AgentIoEventSink {
+    async fn io_appended(&self, pid: &str, kind: ProcessIoEventKind, count: u32) {
+        let event_sink = {
+            let state = self.state.lock().await;
+            state
+                .agents
+                .get(pid)
+                .and_then(|agent| agent.event_sink.clone())
+        };
+        if let Some(agent) = event_sink {
+            match kind {
+                ProcessIoEventKind::Input => agent.append_input_event(count).await,
+                ProcessIoEventKind::Output => agent.append_output_event(count).await,
+            }
+        }
+    }
 }
 
 #[async_trait]

--- a/crates/agentfs/tests/agent_files.rs
+++ b/crates/agentfs/tests/agent_files.rs
@@ -124,6 +124,32 @@ async fn tape_is_append_only_and_readable() {
 }
 
 #[tokio::test]
+async fn machine_tape_is_backed_by_a_content_addressed_checkpoint() {
+    let fs = AgentFs::new();
+    let empty_root = fs.current_tape_checkpoint().await;
+
+    write_doc(&fs, &["machine", "tape"], Fid(1), b"turn-1\n")
+        .await
+        .unwrap();
+    write_doc(&fs, &["machine", "tape"], Fid(2), b"turn-2\n")
+        .await
+        .unwrap();
+
+    let file_view = read_text(&fs, &["machine", "tape"], Fid(3)).await;
+    assert_eq!(file_view, "turn-1\nturn-2\n");
+    assert_eq!(
+        fs.materialize_tape_checkpoint().await.unwrap(),
+        file_view.as_bytes()
+    );
+    fs.verify_tape_checkpoint().await.unwrap();
+
+    let checkpoint = read_text(&fs, &["machine", "checkpoints", "current"], Fid(4)).await;
+    let current_root = fs.current_tape_checkpoint().await;
+    assert_ne!(current_root, empty_root);
+    assert_eq!(checkpoint.trim(), current_root.as_str());
+}
+
+#[tokio::test]
 async fn a_yield_is_a_request_opened_by_the_agent_and_answered_by_a_consumer() {
     let fs = AgentFs::new();
 
@@ -575,6 +601,94 @@ async fn machine_ctl_carries_runtime_tape_commands() {
         .unwrap();
     fs.open(Fid(5), OpenMode::Write).await.unwrap();
     assert_eq!(fs.write(Fid(5), 0, b"").await, Err(ErrorCode::BadRequest));
+}
+
+#[tokio::test]
+async fn ordinary_data_writes_do_not_invoke_control_semantics() {
+    let fs = AgentFs::new();
+
+    fs.walk(Fid::ROOT, Fid(1), &["requests".into(), "clone".into()])
+        .await
+        .unwrap();
+    fs.open(Fid(1), OpenMode::ReadWrite).await.unwrap();
+    let request_id = String::from_utf8(fs.read(Fid(1), 0, 64).await.unwrap()).unwrap();
+
+    fs.walk(Fid::ROOT, Fid(2), &["actions".into(), "clone".into()])
+        .await
+        .unwrap();
+    fs.open(Fid(2), OpenMode::ReadWrite).await.unwrap();
+    let action_id = String::from_utf8(fs.read(Fid(2), 0, 64).await.unwrap()).unwrap();
+
+    write_doc(&fs, &["io", "output"], Fid(3), b"assistant text")
+        .await
+        .unwrap();
+    write_doc(
+        &fs,
+        &["machine", "tape"],
+        Fid(4),
+        b"{\"role\":\"assistant\"}\n",
+    )
+    .await
+    .unwrap();
+    write_doc(
+        &fs,
+        &["requests", &request_id, "prompt"],
+        Fid(5),
+        b"need input",
+    )
+    .await
+    .unwrap();
+    write_doc(
+        &fs,
+        &["actions", &action_id, "status"],
+        Fid(6),
+        b"completed",
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        read_text(&fs, &["machine", "status"], Fid(7)).await,
+        "running"
+    );
+    assert_eq!(
+        read_text(&fs, &["requests", &request_id, "status"], Fid(8)).await,
+        "pending"
+    );
+    assert_eq!(
+        read_text(&fs, &["actions", &action_id, "status"], Fid(9)).await,
+        "completed"
+    );
+
+    let events = read_text(&fs, &["events"], Fid(10)).await;
+    assert!(
+        events.contains("output:"),
+        "output write recorded: {events:?}"
+    );
+    assert!(events.contains("tape:"), "tape write recorded: {events:?}");
+    assert!(
+        events.contains(&format!("request:{request_id}")),
+        "request write recorded in aggregate stream: {events:?}"
+    );
+    assert!(
+        events.contains(&format!("action:{action_id}")),
+        "action write recorded in aggregate stream: {events:?}"
+    );
+    assert!(
+        !events.contains("ctl:"),
+        "ordinary data writes must not be interpreted as control commands: {events:?}"
+    );
+
+    let request_events = read_text(&fs, &["requests", "events"], Fid(11)).await;
+    assert!(
+        request_events.contains(&format!("{request_id}:prompt")),
+        "request prompt write recorded: {request_events:?}"
+    );
+    let action_events = read_text(&fs, &["actions", "events"], Fid(12)).await;
+    assert!(
+        action_events.contains(&format!("{action_id}:status")),
+        "action status write recorded: {action_events:?}"
+    );
 }
 
 #[tokio::test]

--- a/crates/agentfs/tests/agent_files.rs
+++ b/crates/agentfs/tests/agent_files.rs
@@ -221,6 +221,61 @@ async fn a_tool_call_is_an_action_the_agent_records() {
 }
 
 #[tokio::test]
+async fn read_write_field_range_edits_preserve_existing_bytes() {
+    let fs = AgentFs::new();
+
+    fs.walk(Fid::ROOT, Fid(1), &["requests".into(), "clone".into()])
+        .await
+        .unwrap();
+    fs.open(Fid(1), OpenMode::ReadWrite).await.unwrap();
+    let request_id = String::from_utf8(fs.read(Fid(1), 0, 64).await.unwrap()).unwrap();
+    write_doc(&fs, &["requests", &request_id, "prompt"], Fid(2), b"abcdef")
+        .await
+        .unwrap();
+
+    fs.walk(
+        Fid::ROOT,
+        Fid(3),
+        &["requests".into(), request_id.clone(), "prompt".into()],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(3), OpenMode::ReadWrite).await.unwrap();
+    fs.write(Fid(3), 2, b"XY").await.unwrap();
+    fs.clunk(Fid(3)).await.unwrap();
+
+    assert_eq!(
+        read_text(&fs, &["requests", &request_id, "prompt"], Fid(4)).await,
+        "abXYef"
+    );
+
+    fs.walk(Fid::ROOT, Fid(5), &["actions".into(), "clone".into()])
+        .await
+        .unwrap();
+    fs.open(Fid(5), OpenMode::ReadWrite).await.unwrap();
+    let action_id = String::from_utf8(fs.read(Fid(5), 0, 64).await.unwrap()).unwrap();
+    write_doc(&fs, &["actions", &action_id, "output"], Fid(6), b"tool")
+        .await
+        .unwrap();
+
+    fs.walk(
+        Fid::ROOT,
+        Fid(7),
+        &["actions".into(), action_id.clone(), "output".into()],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(7), OpenMode::ReadWrite).await.unwrap();
+    fs.write(Fid(7), 4, b" output").await.unwrap();
+    fs.clunk(Fid(7)).await.unwrap();
+
+    assert_eq!(
+        read_text(&fs, &["actions", &action_id, "output"], Fid(8)).await,
+        "tool output"
+    );
+}
+
+#[tokio::test]
 async fn an_action_exposes_all_documented_fields() {
     let fs = AgentFs::new();
     fs.walk(Fid::ROOT, Fid(1), &["actions".into(), "clone".into()])

--- a/crates/agentfs/tests/agent_root_overlay.rs
+++ b/crates/agentfs/tests/agent_root_overlay.rs
@@ -7,7 +7,10 @@ use std::{
 };
 
 use alan_agentfs::{AgentFs, AgentRootFs};
-use alan_ap::{ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, Qid, Stat};
+use alan_ap::{
+    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, ProcessOutputEventSource,
+    Qid, Stat,
+};
 use alan_kernel::{Access, Credentials, MountFs, Namespace, Pid, ProcFs};
 use alan_memfs::MemFs;
 use alan_shell::Shell;
@@ -17,7 +20,11 @@ use tokio::sync::Notify;
 fn namespace_shell_with_agent_root() -> (InProcessTransport, Shell, Arc<AgentRootFs>, Arc<ProcFs>) {
     let proc = Arc::new(ProcFs::new());
     let proc_server: Arc<dyn FileServer> = proc.clone();
-    let agent_root = Arc::new(AgentRootFs::new(proc_server));
+    let proc_output_events: Arc<dyn ProcessOutputEventSource> = proc.clone();
+    let agent_root = Arc::new(AgentRootFs::new_with_process_output_events(
+        proc_server,
+        proc_output_events,
+    ));
 
     let mut namespace = Namespace::new();
     namespace.mount(
@@ -171,6 +178,46 @@ async fn agent_io_output_writes_to_the_proc_output_stream() {
             .unwrap()
             .contains("output:13")
     );
+}
+
+#[tokio::test]
+async fn direct_proc_output_writes_publish_agent_events() {
+    let (_, shell, agent_root, proc) = namespace_shell_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    agent_root
+        .bind_process(pid.clone(), Arc::new(AgentFs::new()))
+        .await;
+
+    let output_fid = Fid(9_200);
+    proc.walk(
+        Fid::ROOT,
+        output_fid,
+        &[pid.clone(), "io".to_string(), "output".to_string()],
+    )
+    .await
+    .unwrap();
+    proc.open(output_fid, OpenMode::Write).await.unwrap();
+    proc.write(output_fid, 0, b"direct proc").await.unwrap();
+    proc.clunk(output_fid).await.unwrap();
+
+    assert_eq!(
+        String::from_utf8(shell.cat(&format!("/agent/{pid}/io/output")).await.unwrap()).unwrap(),
+        "direct proc"
+    );
+    for path in [
+        format!("/agent/{pid}/events"),
+        format!("/agent/{pid}/io/events"),
+    ] {
+        assert!(
+            String::from_utf8(shell.cat(&path).await.unwrap())
+                .unwrap()
+                .contains("output:11"),
+            "{path} should publish a proc-owned output event"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/agentfs/tests/agent_root_overlay.rs
+++ b/crates/agentfs/tests/agent_root_overlay.rs
@@ -1,17 +1,22 @@
 use std::sync::Arc;
 
 use alan_agentfs::{AgentFs, AgentRootFs};
-use alan_ap::{ErrorCode, FileServer, InProcessTransport};
-use alan_kernel::{Access, MountFs, Namespace, ProcFs};
+use alan_ap::{ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode};
+use alan_kernel::{Access, Credentials, MountFs, Namespace, Pid, ProcFs};
+use alan_memfs::MemFs;
 use alan_shell::Shell;
 
-fn namespace_shell_with_agent_root() -> (Shell, Arc<AgentRootFs>) {
+fn namespace_shell_with_agent_root() -> (InProcessTransport, Shell, Arc<AgentRootFs>, Arc<ProcFs>) {
     let proc = Arc::new(ProcFs::new());
     let proc_server: Arc<dyn FileServer> = proc.clone();
     let agent_root = Arc::new(AgentRootFs::new(proc_server));
 
     let mut namespace = Namespace::new();
-    namespace.mount("/proc", InProcessTransport::new(proc), Access::ReadWrite);
+    namespace.mount(
+        "/proc",
+        InProcessTransport::new(proc.clone()),
+        Access::ReadWrite,
+    );
     namespace.mount(
         "/agent",
         InProcessTransport::new(agent_root.clone()),
@@ -19,12 +24,27 @@ fn namespace_shell_with_agent_root() -> (Shell, Arc<AgentRootFs>) {
     );
 
     let root = InProcessTransport::new(Arc::new(MountFs::new(namespace)));
-    (Shell::new(root), agent_root)
+    (root.clone(), Shell::new(root), agent_root, proc)
+}
+
+async fn spawn_on_proc(proc: &ProcFs, fid: Fid) -> String {
+    proc.walk(Fid::ROOT, fid, &["clone".into()])
+        .await
+        .expect("walk clone");
+    proc.open(fid, OpenMode::ReadWrite)
+        .await
+        .expect("open clone");
+    let pid = String::from_utf8(proc.read(fid, 0, 64).await.expect("read pid")).unwrap();
+    proc.write(fid, 0, br#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .expect("write exec");
+    proc.clunk(fid).await.expect("commit process");
+    pid
 }
 
 #[tokio::test]
 async fn agent_root_lists_only_proc_backed_agent_processes() {
-    let (shell, agent_root) = namespace_shell_with_agent_root();
+    let (_, shell, agent_root, _) = namespace_shell_with_agent_root();
 
     agent_root
         .bind_process("999", Arc::new(AgentFs::new()))
@@ -53,7 +73,7 @@ async fn agent_root_lists_only_proc_backed_agent_processes() {
 
 #[tokio::test]
 async fn agent_root_alias_forwards_to_the_root_agent_surface() {
-    let (shell, agent_root) = namespace_shell_with_agent_root();
+    let (_, shell, agent_root, _) = namespace_shell_with_agent_root();
     let pid = shell
         .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
         .await
@@ -76,4 +96,88 @@ async fn agent_root_alias_forwards_to_the_root_agent_surface() {
         shell.ls(&format!("/proc/{pid}/machine")).await,
         Err(ErrorCode::NotFound)
     ));
+}
+
+#[tokio::test]
+async fn agent_children_are_derived_from_proc_parentage() {
+    let (_, shell, agent_root, proc) = namespace_shell_with_agent_root();
+    let parent = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    let spawner = proc.for_spawner(
+        Some(Pid(parent.parse::<u64>().unwrap())),
+        Namespace::new(),
+        Credentials::user("alan"),
+    );
+    let child = spawn_on_proc(&spawner, Fid(10_000)).await;
+    let unbound_child = spawn_on_proc(&spawner, Fid(10_001)).await;
+
+    agent_root
+        .bind_process(parent.clone(), Arc::new(AgentFs::new()))
+        .await;
+    agent_root
+        .bind_process(child.clone(), Arc::new(AgentFs::new()))
+        .await;
+
+    let children = shell
+        .ls(&format!("/agent/{parent}/children"))
+        .await
+        .unwrap();
+    assert!(children.iter().any(|entry| entry == &child), "{children:?}");
+    assert!(
+        !children.iter().any(|entry| entry == &unbound_child),
+        "{children:?}"
+    );
+
+    shell
+        .write(
+            &format!("/agent/{parent}/children/{child}/io/output"),
+            b"hello child",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        String::from_utf8(
+            shell
+                .cat(&format!("/agent/{child}/io/output"))
+                .await
+                .unwrap()
+        )
+        .unwrap(),
+        "hello child"
+    );
+}
+
+#[tokio::test]
+async fn agent_root_tracks_created_fids_forwarded_to_backing() {
+    let (_, shell, agent_root, _) = namespace_shell_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    agent_root
+        .bind_process(pid.clone(), Arc::new(MemFs::new()))
+        .await;
+
+    let dir_fid = Fid(20_000);
+    let file_fid = Fid(20_001);
+    agent_root
+        .walk(Fid::ROOT, dir_fid, std::slice::from_ref(&pid))
+        .await
+        .unwrap();
+    let qid = agent_root
+        .create(dir_fid, file_fid, "facts", FileKind::File)
+        .await
+        .unwrap();
+    assert_eq!(qid.kind, FileKind::File);
+    agent_root.open(file_fid, OpenMode::Write).await.unwrap();
+    agent_root.write(file_fid, 0, b"alpha").await.unwrap();
+    agent_root.clunk(file_fid).await.unwrap();
+    agent_root.clunk(dir_fid).await.unwrap();
+
+    assert_eq!(
+        String::from_utf8(shell.cat(&format!("/agent/{pid}/facts")).await.unwrap()).unwrap(),
+        "alpha"
+    );
 }

--- a/crates/agentfs/tests/agent_root_overlay.rs
+++ b/crates/agentfs/tests/agent_root_overlay.rs
@@ -1,10 +1,18 @@
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
 use alan_agentfs::{AgentFs, AgentRootFs};
-use alan_ap::{ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode};
+use alan_ap::{ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, Qid, Stat};
 use alan_kernel::{Access, Credentials, MountFs, Namespace, Pid, ProcFs};
 use alan_memfs::MemFs;
 use alan_shell::Shell;
+use async_trait::async_trait;
+use tokio::sync::Notify;
 
 fn namespace_shell_with_agent_root() -> (InProcessTransport, Shell, Arc<AgentRootFs>, Arc<ProcFs>) {
     let proc = Arc::new(ProcFs::new());
@@ -69,6 +77,25 @@ async fn agent_root_lists_only_proc_backed_agent_processes() {
     assert!(listing.iter().any(|entry| entry == &pid), "{listing:?}");
     assert!(listing.iter().any(|entry| entry == "root"), "{listing:?}");
     assert!(!listing.iter().any(|entry| entry == "999"), "{listing:?}");
+}
+
+#[tokio::test]
+async fn agent_root_qid_version_changes_with_listing() {
+    let (_, shell, agent_root, _) = namespace_shell_with_agent_root();
+
+    let empty_qid = agent_root.stat(Fid::ROOT).await.unwrap().qid;
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    agent_root
+        .bind_process(pid.clone(), Arc::new(AgentFs::new()))
+        .await;
+
+    let populated_qid = agent_root.stat(Fid::ROOT).await.unwrap().qid;
+    assert_eq!(empty_qid.kind, FileKind::Dir);
+    assert_eq!(empty_qid.path, populated_qid.path);
+    assert_ne!(empty_qid.version, populated_qid.version);
 }
 
 #[tokio::test]
@@ -244,6 +271,81 @@ async fn agent_root_namespaces_backing_qids_by_pid() {
 }
 
 #[tokio::test]
+async fn agent_root_rejects_creates_for_overlay_reserved_names() {
+    let (_, shell, agent_root, _) = namespace_shell_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    agent_root
+        .bind_process(pid.clone(), Arc::new(MemFs::new()))
+        .await;
+
+    let dir_fid = Fid(13_000);
+    agent_root
+        .walk(Fid::ROOT, dir_fid, std::slice::from_ref(&pid))
+        .await
+        .unwrap();
+    for (idx, name) in ["children", "status", "ctl"].into_iter().enumerate() {
+        assert_eq!(
+            agent_root
+                .create(dir_fid, Fid(13_001 + idx as u64), name, FileKind::File)
+                .await,
+            Err(ErrorCode::BadRequest),
+            "{name} should stay reserved for the overlay"
+        );
+    }
+    agent_root.clunk(dir_fid).await.unwrap();
+}
+
+#[tokio::test]
+async fn concurrent_walk_rechecks_newfid_before_insert() {
+    let (_, shell, agent_root, _) = namespace_shell_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    let backing = Arc::new(RacingWalkFs::new());
+    agent_root.bind_process(pid.clone(), backing.clone()).await;
+
+    let shared_fid = Fid(14_000);
+    let first = {
+        let agent_root = agent_root.clone();
+        let pid = pid.clone();
+        tokio::spawn(async move {
+            agent_root
+                .walk(Fid::ROOT, shared_fid, &[pid, "file".to_string()])
+                .await
+        })
+    };
+    let second = {
+        let agent_root = agent_root.clone();
+        tokio::spawn(async move {
+            agent_root
+                .walk(Fid::ROOT, shared_fid, &[pid, "file".to_string()])
+                .await
+        })
+    };
+    let first = first.await.unwrap();
+    let second = second.await.unwrap();
+    let ok_count = [first, second].into_iter().filter(Result::is_ok).count();
+    let collision_count = [first, second]
+        .into_iter()
+        .filter(|result| matches!(result, Err(ErrorCode::BadRequest)))
+        .count();
+
+    assert_eq!(ok_count, 1);
+    assert_eq!(collision_count, 1);
+    assert_eq!(
+        backing.bound_fid_count(),
+        1,
+        "the backing fid allocated by the losing walk should be clunked"
+    );
+    agent_root.clunk(shared_fid).await.unwrap();
+    assert_eq!(backing.bound_fid_count(), 0);
+}
+
+#[tokio::test]
 async fn agent_root_tracks_created_fids_forwarded_to_backing() {
     let (_, shell, agent_root, _) = namespace_shell_with_agent_root();
     let pid = shell
@@ -315,4 +417,116 @@ async fn agent_root_releases_outer_fid_after_delegated_remove() {
         .walk(Fid::ROOT, remove_fid, std::slice::from_ref(&pid))
         .await
         .expect("remove releases the outer fid for reuse");
+}
+
+struct RacingWalkFs {
+    fids: Mutex<HashMap<Fid, ()>>,
+    started_walks: AtomicUsize,
+    release_walks: Notify,
+}
+
+impl RacingWalkFs {
+    fn new() -> Self {
+        Self {
+            fids: Mutex::new(HashMap::new()),
+            started_walks: AtomicUsize::new(0),
+            release_walks: Notify::new(),
+        }
+    }
+
+    fn bound_fid_count(&self) -> usize {
+        self.fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .len()
+    }
+
+    fn qid() -> Qid {
+        Qid {
+            kind: FileKind::File,
+            version: 0,
+            path: 0xF11E,
+        }
+    }
+}
+
+#[async_trait]
+impl FileServer for RacingWalkFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        if fid != Fid::ROOT || names.len() != 1 || names[0] != "file" {
+            return Err(ErrorCode::NotFound);
+        }
+        let started = self.started_walks.fetch_add(1, Ordering::SeqCst) + 1;
+        if started >= 2 {
+            self.release_walks.notify_waiters();
+        } else {
+            self.release_walks.notified().await;
+        }
+        self.fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .insert(newfid, ());
+        Ok(Self::qid())
+    }
+
+    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        if self
+            .fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .contains_key(&fid)
+        {
+            Ok(Self::qid())
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn read(&self, _fid: Fid, _offset: u64, _count: u32) -> Result<Vec<u8>, ErrorCode> {
+        Ok(Vec::new())
+    }
+
+    async fn write(&self, _fid: Fid, _offset: u64, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        if self
+            .fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .contains_key(&fid)
+        {
+            Ok(Stat {
+                name: "file".to_string(),
+                qid: Self::qid(),
+                length: 0,
+                writable: true,
+            })
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.clunk(fid).await
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .remove(&fid);
+        Ok(())
+    }
 }

--- a/crates/agentfs/tests/agent_root_overlay.rs
+++ b/crates/agentfs/tests/agent_root_overlay.rs
@@ -8,7 +8,7 @@ use std::{
 
 use alan_agentfs::{AgentFs, AgentRootFs};
 use alan_ap::{
-    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, ProcessIoEventSource, Qid,
+    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, ProcessEventSource, Qid,
     Stat,
 };
 use alan_kernel::{
@@ -29,10 +29,10 @@ fn namespace_shell_with_agent_root_for_proc(
     proc: Arc<ProcFs>,
 ) -> (InProcessTransport, Shell, Arc<AgentRootFs>, Arc<ProcFs>) {
     let proc_server: Arc<dyn FileServer> = proc.clone();
-    let proc_io_events: Arc<dyn ProcessIoEventSource> = proc.clone();
-    let agent_root = Arc::new(AgentRootFs::new_with_ordered_process_io_events(
+    let proc_events: Arc<dyn ProcessEventSource> = proc.clone();
+    let agent_root = Arc::new(AgentRootFs::new_with_process_events(
         proc_server,
-        proc_io_events,
+        proc_events,
     ));
 
     let mut namespace = Namespace::new();
@@ -374,6 +374,57 @@ async fn bind_process_replays_existing_proc_io_events() {
 }
 
 #[tokio::test]
+async fn bind_process_replays_existing_proc_lifecycle_events() {
+    let proc =
+        Arc::new(ProcFs::new().with_runner(Arc::new(ImmediateOutputRunner::new(Vec::new()))));
+    let (_, shell, agent_root, _) = namespace_shell_with_agent_root_for_proc(proc);
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    wait_for_file_contains(&shell, &format!("/proc/{pid}/status"), "exited").await;
+
+    agent_root
+        .bind_process(pid.clone(), Arc::new(AgentFs::new()))
+        .await;
+
+    let events =
+        String::from_utf8(shell.cat(&format!("/agent/{pid}/events")).await.unwrap()).unwrap();
+    assert!(
+        events.contains("status:exited"),
+        "late-bound agent aggregate should replay existing proc lifecycle events: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn direct_proc_cancel_publishes_agent_lifecycle_events() {
+    let (_, shell, agent_root, proc) = namespace_shell_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    agent_root
+        .bind_process(pid.clone(), Arc::new(AgentFs::new()))
+        .await;
+
+    let ctl_fid = Fid(9_274);
+    proc.walk(Fid::ROOT, ctl_fid, &[pid.clone(), "ctl".to_string()])
+        .await
+        .unwrap();
+    proc.open(ctl_fid, OpenMode::Write).await.unwrap();
+    proc.write(ctl_fid, 0, b"cancel").await.unwrap();
+    proc.clunk(ctl_fid).await.unwrap();
+    wait_for_file_contains(&shell, &format!("/proc/{pid}/status"), "exited").await;
+
+    let events =
+        String::from_utf8(shell.cat(&format!("/agent/{pid}/events")).await.unwrap()).unwrap();
+    assert!(
+        events.contains("status:exited"),
+        "agent aggregate should publish proc cancel lifecycle events: {events:?}"
+    );
+}
+
+#[tokio::test]
 async fn bind_process_replays_existing_proc_io_events_in_order() {
     let (_, shell, agent_root, proc) = namespace_shell_with_agent_root();
     let pid = shell
@@ -567,8 +618,10 @@ async fn child_registration_wakes_parent_events_stream() {
         .await
         .unwrap();
     agent_root.open(events_fid, OpenMode::Read).await.unwrap();
+    let events_offset = agent_root.stat(events_fid).await.unwrap().length;
     let reader_root = agent_root.clone();
-    let reader = tokio::spawn(async move { reader_root.read(events_fid, 0, 4096).await });
+    let reader =
+        tokio::spawn(async move { reader_root.read(events_fid, events_offset, 4096).await });
     tokio::time::sleep(Duration::from_millis(20)).await;
     assert!(
         !reader.is_finished(),

--- a/crates/agentfs/tests/agent_root_overlay.rs
+++ b/crates/agentfs/tests/agent_root_overlay.rs
@@ -221,6 +221,26 @@ async fn direct_proc_output_writes_publish_agent_events() {
 }
 
 #[tokio::test]
+async fn failed_proc_overlay_walk_does_not_clunk_unbound_proc_fid() {
+    let proc = Arc::new(ProcWalkCollisionFs::new());
+    let proc_server: Arc<dyn FileServer> = proc.clone();
+    let agent_root = AgentRootFs::new(proc_server);
+
+    agent_root.bind_process("1", Arc::new(AgentFs::new())).await;
+
+    assert_eq!(
+        agent_root
+            .walk(Fid::ROOT, Fid(9_300), &["1".into(), "status".into()])
+            .await,
+        Err(ErrorCode::BadRequest)
+    );
+    assert!(
+        !proc.clunked_failed_fid(),
+        "failed proc walks do not bind their newfid, so cleanup must not clunk it"
+    );
+}
+
+#[tokio::test]
 async fn agent_children_are_derived_from_proc_parentage() {
     let (_, shell, agent_root, proc) = namespace_shell_with_agent_root();
     let parent = shell
@@ -659,6 +679,105 @@ async fn agent_root_releases_outer_fid_after_delegated_remove() {
         .walk(Fid::ROOT, remove_fid, std::slice::from_ref(&pid))
         .await
         .expect("remove releases the outer fid for reuse");
+}
+
+struct ProcWalkCollisionFs {
+    failed_fids: Mutex<Vec<Fid>>,
+    clunked_fids: Mutex<Vec<Fid>>,
+}
+
+impl ProcWalkCollisionFs {
+    fn new() -> Self {
+        Self {
+            failed_fids: Mutex::new(Vec::new()),
+            clunked_fids: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn clunked_failed_fid(&self) -> bool {
+        let failed = self
+            .failed_fids
+            .lock()
+            .expect("failed fids lock should not be poisoned");
+        let clunked = self
+            .clunked_fids
+            .lock()
+            .expect("clunked fids lock should not be poisoned");
+        failed.iter().any(|fid| clunked.contains(fid))
+    }
+
+    fn qid() -> Qid {
+        Qid {
+            kind: FileKind::Dir,
+            version: 0,
+            path: 0xC011_1510,
+        }
+    }
+}
+
+#[async_trait]
+impl FileServer for ProcWalkCollisionFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        if fid != Fid::ROOT {
+            return Err(ErrorCode::NotFound);
+        }
+        match names {
+            [pid] if pid == "1" => Ok(Self::qid()),
+            [pid, name] if pid == "1" && name == "status" => {
+                self.failed_fids
+                    .lock()
+                    .expect("failed fids lock should not be poisoned")
+                    .push(newfid);
+                Err(ErrorCode::BadRequest)
+            }
+            [pid, name] if pid == "1" && name == "parent" => {
+                self.failed_fids
+                    .lock()
+                    .expect("failed fids lock should not be poisoned")
+                    .push(newfid);
+                Err(ErrorCode::NotFound)
+            }
+            _ => Err(ErrorCode::NotFound),
+        }
+    }
+
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn read(&self, _fid: Fid, _offset: u64, _count: u32) -> Result<Vec<u8>, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn write(&self, _fid: Fid, _offset: u64, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.clunked_fids
+            .lock()
+            .expect("clunked fids lock should not be poisoned")
+            .push(fid);
+        Ok(())
+    }
 }
 
 struct RacingWalkFs {

--- a/crates/agentfs/tests/agent_root_overlay.rs
+++ b/crates/agentfs/tests/agent_root_overlay.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeSet, HashMap},
     sync::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
@@ -177,6 +177,61 @@ async fn agent_children_are_derived_from_proc_parentage() {
 }
 
 #[tokio::test]
+async fn child_registration_wakes_parent_events_stream() {
+    use std::time::Duration;
+
+    let (_, shell, agent_root, proc) = namespace_shell_with_agent_root();
+    let parent = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    let spawner = proc.for_spawner(
+        Some(Pid(parent.parse::<u64>().unwrap())),
+        Namespace::new(),
+        Credentials::user("alan"),
+    );
+    let parent_agent = Arc::new(AgentFs::new());
+    agent_root
+        .bind_process(parent.clone(), parent_agent.clone())
+        .await;
+
+    let events_fid = Fid(10_100);
+    agent_root
+        .walk(
+            Fid::ROOT,
+            events_fid,
+            &[parent.clone(), "events".to_string()],
+        )
+        .await
+        .unwrap();
+    agent_root.open(events_fid, OpenMode::Read).await.unwrap();
+    let reader_root = agent_root.clone();
+    let reader = tokio::spawn(async move { reader_root.read(events_fid, 0, 4096).await });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(
+        !reader.is_finished(),
+        "events reader should block before the child is registered"
+    );
+
+    let child = spawn_on_proc(&spawner, Fid(10_101)).await;
+    agent_root
+        .bind_process(child.clone(), Arc::new(AgentFs::new()))
+        .await;
+
+    let record = tokio::time::timeout(Duration::from_millis(500), reader)
+        .await
+        .expect("child event should wake the parent events reader")
+        .unwrap()
+        .unwrap();
+    let record = String::from_utf8(record).unwrap();
+    assert!(
+        record.contains(&format!("child:{child}")),
+        "parent events should publish child registration: {record:?}"
+    );
+    agent_root.clunk(events_fid).await.unwrap();
+}
+
+#[tokio::test]
 async fn agent_children_qid_versions_change_with_listing() {
     let (_, shell, agent_root, proc) = namespace_shell_with_agent_root();
     let parent = shell
@@ -343,6 +398,98 @@ async fn concurrent_walk_rechecks_newfid_before_insert() {
     );
     agent_root.clunk(shared_fid).await.unwrap();
     assert_eq!(backing.bound_fid_count(), 0);
+}
+
+#[tokio::test]
+async fn failed_concurrent_walk_does_not_delete_winning_fid() {
+    let (_, shell, agent_root, _) = namespace_shell_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    let backing = Arc::new(DelayedFailWalkFs::new());
+    agent_root.bind_process(pid.clone(), backing.clone()).await;
+
+    let shared_fid = Fid(15_000);
+    let (tx, mut rx) = tokio::sync::mpsc::channel(2);
+    for _ in 0..2 {
+        let agent_root = agent_root.clone();
+        let pid = pid.clone();
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            let result = agent_root
+                .walk(Fid::ROOT, shared_fid, &[pid, "file".to_string()])
+                .await;
+            tx.send(result).await.unwrap();
+        });
+    }
+    drop(tx);
+
+    let winner = rx.recv().await.unwrap();
+    assert!(winner.is_ok(), "one concurrent walk should bind the fid");
+    backing.release_failure();
+    let loser = rx.recv().await.unwrap();
+    assert_eq!(loser, Err(ErrorCode::NotFound));
+
+    agent_root
+        .open(shared_fid, OpenMode::Read)
+        .await
+        .expect("failed concurrent walk must not remove the winning binding");
+    agent_root.clunk(shared_fid).await.unwrap();
+}
+
+#[tokio::test]
+async fn create_collision_rolls_back_the_losing_backing_file() {
+    let (_, shell, agent_root, _) = namespace_shell_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    let backing = Arc::new(RacingCreateFs::new());
+    agent_root.bind_process(pid.clone(), backing.clone()).await;
+
+    let dir_fid = Fid(16_000);
+    let shared_fid = Fid(16_001);
+    agent_root
+        .walk(Fid::ROOT, dir_fid, std::slice::from_ref(&pid))
+        .await
+        .unwrap();
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(2);
+    for name in ["alpha", "beta"] {
+        let agent_root = agent_root.clone();
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            let result = agent_root
+                .create(dir_fid, shared_fid, name, FileKind::File)
+                .await;
+            tx.send((name.to_string(), result)).await.unwrap();
+        });
+    }
+    drop(tx);
+
+    let first = rx.recv().await.unwrap();
+    let second = rx.recv().await.unwrap();
+    let results = [first, second];
+    let ok_names: BTreeSet<String> = results
+        .iter()
+        .filter(|(_, result)| result.is_ok())
+        .map(|(name, _)| name.clone())
+        .collect();
+    let collision_count = results
+        .iter()
+        .filter(|(_, result)| matches!(result, Err(ErrorCode::BadRequest)))
+        .count();
+
+    assert_eq!(ok_names.len(), 1);
+    assert_eq!(collision_count, 1);
+    assert_eq!(
+        backing.file_names(),
+        ok_names,
+        "a create that returns BadRequest must not leave a hidden backing file"
+    );
+    agent_root.clunk(shared_fid).await.unwrap();
+    agent_root.clunk(dir_fid).await.unwrap();
 }
 
 #[tokio::test]
@@ -520,6 +667,288 @@ impl FileServer for RacingWalkFs {
 
     async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
         self.clunk(fid).await
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .remove(&fid);
+        Ok(())
+    }
+}
+
+struct DelayedFailWalkFs {
+    fids: Mutex<HashMap<Fid, ()>>,
+    started_walks: AtomicUsize,
+    both_started: Notify,
+    release_failed_walk: Notify,
+}
+
+impl DelayedFailWalkFs {
+    fn new() -> Self {
+        Self {
+            fids: Mutex::new(HashMap::new()),
+            started_walks: AtomicUsize::new(0),
+            both_started: Notify::new(),
+            release_failed_walk: Notify::new(),
+        }
+    }
+
+    fn release_failure(&self) {
+        self.release_failed_walk.notify_waiters();
+    }
+
+    fn qid() -> Qid {
+        Qid {
+            kind: FileKind::File,
+            version: 0,
+            path: 0xF11E_0002,
+        }
+    }
+}
+
+#[async_trait]
+impl FileServer for DelayedFailWalkFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        if fid != Fid::ROOT || names.len() != 1 || names[0] != "file" {
+            return Err(ErrorCode::NotFound);
+        }
+        let started = self.started_walks.fetch_add(1, Ordering::SeqCst) + 1;
+        if started >= 2 {
+            self.both_started.notify_waiters();
+        }
+        while self.started_walks.load(Ordering::SeqCst) < 2 {
+            self.both_started.notified().await;
+        }
+        if started == 1 {
+            self.fids
+                .lock()
+                .expect("fid map lock should not be poisoned")
+                .insert(newfid, ());
+            Ok(Self::qid())
+        } else {
+            self.release_failed_walk.notified().await;
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        if self
+            .fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .contains_key(&fid)
+        {
+            Ok(Self::qid())
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn read(&self, _fid: Fid, _offset: u64, _count: u32) -> Result<Vec<u8>, ErrorCode> {
+        Ok(Vec::new())
+    }
+
+    async fn write(&self, _fid: Fid, _offset: u64, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        if self
+            .fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .contains_key(&fid)
+        {
+            Ok(Stat {
+                name: "file".to_string(),
+                qid: Self::qid(),
+                length: 0,
+                writable: false,
+            })
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.clunk(fid).await
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .remove(&fid);
+        Ok(())
+    }
+}
+
+struct RacingCreateFs {
+    fids: Mutex<HashMap<Fid, String>>,
+    files: Mutex<BTreeSet<String>>,
+    started_creates: AtomicUsize,
+    release_creates: Notify,
+}
+
+impl RacingCreateFs {
+    fn new() -> Self {
+        Self {
+            fids: Mutex::new(HashMap::new()),
+            files: Mutex::new(BTreeSet::new()),
+            started_creates: AtomicUsize::new(0),
+            release_creates: Notify::new(),
+        }
+    }
+
+    fn file_names(&self) -> BTreeSet<String> {
+        self.files
+            .lock()
+            .expect("file set lock should not be poisoned")
+            .clone()
+    }
+
+    fn qid(kind: FileKind) -> Qid {
+        Qid {
+            kind,
+            version: 0,
+            path: match kind {
+                FileKind::Dir => 0x0C0D_ED1A,
+                FileKind::File => 0xC0DE_F11E,
+                FileKind::Stream => 0xC0DE_57EA,
+                FileKind::Clone => 0xC0DE_C10E,
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl FileServer for RacingCreateFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        if fid != Fid::ROOT || names.len() != 1 {
+            return Err(ErrorCode::NotFound);
+        }
+        if self
+            .files
+            .lock()
+            .expect("file set lock should not be poisoned")
+            .contains(&names[0])
+        {
+            self.fids
+                .lock()
+                .expect("fid map lock should not be poisoned")
+                .insert(newfid, names[0].clone());
+            Ok(Self::qid(FileKind::File))
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        if fid == Fid::ROOT
+            || self
+                .fids
+                .lock()
+                .expect("fid map lock should not be poisoned")
+                .contains_key(&fid)
+        {
+            Ok(Self::qid(FileKind::File))
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn read(&self, fid: Fid, _offset: u64, _count: u32) -> Result<Vec<u8>, ErrorCode> {
+        if fid == Fid::ROOT {
+            Ok(self
+                .file_names()
+                .into_iter()
+                .collect::<Vec<_>>()
+                .join("\n")
+                .into_bytes())
+        } else {
+            Ok(Vec::new())
+        }
+    }
+
+    async fn write(&self, _fid: Fid, _offset: u64, data: &[u8]) -> Result<u32, ErrorCode> {
+        Ok(data.len() as u32)
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        if fid == Fid::ROOT
+            || self
+                .fids
+                .lock()
+                .expect("fid map lock should not be poisoned")
+                .contains_key(&fid)
+        {
+            Ok(Stat {
+                name: String::new(),
+                qid: Self::qid(if fid == Fid::ROOT {
+                    FileKind::Dir
+                } else {
+                    FileKind::File
+                }),
+                length: 0,
+                writable: true,
+            })
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn create(
+        &self,
+        fid: Fid,
+        newfid: Fid,
+        name: &str,
+        kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        if fid != Fid::ROOT || kind != FileKind::File {
+            return Err(ErrorCode::BadRequest);
+        }
+        let started = self.started_creates.fetch_add(1, Ordering::SeqCst) + 1;
+        if started >= 2 {
+            self.release_creates.notify_waiters();
+        }
+        while self.started_creates.load(Ordering::SeqCst) < 2 {
+            self.release_creates.notified().await;
+        }
+        self.files
+            .lock()
+            .expect("file set lock should not be poisoned")
+            .insert(name.to_string());
+        self.fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .insert(newfid, name.to_string());
+        Ok(Self::qid(FileKind::File))
+    }
+
+    async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
+        let name = self
+            .fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .remove(&fid)
+            .ok_or(ErrorCode::NotFound)?;
+        self.files
+            .lock()
+            .expect("file set lock should not be poisoned")
+            .remove(&name);
+        Ok(())
     }
 
     async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {

--- a/crates/agentfs/tests/agent_root_overlay.rs
+++ b/crates/agentfs/tests/agent_root_overlay.rs
@@ -8,8 +8,8 @@ use std::{
 
 use alan_agentfs::{AgentFs, AgentRootFs};
 use alan_ap::{
-    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, ProcessInputEventSource,
-    ProcessOutputEventSource, Qid, Stat,
+    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, ProcessIoEventSource, Qid,
+    Stat,
 };
 use alan_kernel::{
     Access, Credentials, MountFs, Namespace, Pid, ProcFs, ProcessInvocation, ProcessOutcome,
@@ -29,12 +29,10 @@ fn namespace_shell_with_agent_root_for_proc(
     proc: Arc<ProcFs>,
 ) -> (InProcessTransport, Shell, Arc<AgentRootFs>, Arc<ProcFs>) {
     let proc_server: Arc<dyn FileServer> = proc.clone();
-    let proc_input_events: Arc<dyn ProcessInputEventSource> = proc.clone();
-    let proc_output_events: Arc<dyn ProcessOutputEventSource> = proc.clone();
-    let agent_root = Arc::new(AgentRootFs::new_with_process_io_events(
+    let proc_io_events: Arc<dyn ProcessIoEventSource> = proc.clone();
+    let agent_root = Arc::new(AgentRootFs::new_with_ordered_process_io_events(
         proc_server,
-        proc_input_events,
-        proc_output_events,
+        proc_io_events,
     ));
 
     let mut namespace = Namespace::new();
@@ -372,6 +370,55 @@ async fn bind_process_replays_existing_proc_io_events() {
     assert!(
         events.contains("output:19"),
         "late-bound agent aggregate should replay existing proc IO events: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn bind_process_replays_existing_proc_io_events_in_order() {
+    let (_, shell, agent_root, proc) = namespace_shell_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+
+    let output_fid = Fid(9_275);
+    proc.walk(
+        Fid::ROOT,
+        output_fid,
+        &[pid.clone(), "io".to_string(), "output".to_string()],
+    )
+    .await
+    .unwrap();
+    proc.open(output_fid, OpenMode::Write).await.unwrap();
+    proc.write(output_fid, 0, b"early output").await.unwrap();
+    proc.clunk(output_fid).await.unwrap();
+
+    let input_fid = Fid(9_276);
+    proc.walk(
+        Fid::ROOT,
+        input_fid,
+        &[pid.clone(), "io".to_string(), "input".to_string()],
+    )
+    .await
+    .unwrap();
+    proc.open(input_fid, OpenMode::Write).await.unwrap();
+    proc.write(input_fid, 0, b"early input").await.unwrap();
+    proc.clunk(input_fid).await.unwrap();
+
+    agent_root
+        .bind_process(pid.clone(), Arc::new(AgentFs::new()))
+        .await;
+
+    let events =
+        String::from_utf8(shell.cat(&format!("/agent/{pid}/events")).await.unwrap()).unwrap();
+    let io_records = events
+        .lines()
+        .filter(|line| line.starts_with("input:") || line.starts_with("output:"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        io_records,
+        vec!["output:12", "input:11"],
+        "late-bound aggregate should preserve proc io/events order: {events:?}"
     );
 }
 

--- a/crates/agentfs/tests/agent_root_overlay.rs
+++ b/crates/agentfs/tests/agent_root_overlay.rs
@@ -181,3 +181,44 @@ async fn agent_root_tracks_created_fids_forwarded_to_backing() {
         "alpha"
     );
 }
+
+#[tokio::test]
+async fn agent_root_releases_outer_fid_after_delegated_remove() {
+    let (_, shell, agent_root, _) = namespace_shell_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    agent_root
+        .bind_process(pid.clone(), Arc::new(MemFs::new()))
+        .await;
+
+    let dir_fid = Fid(21_000);
+    let file_fid = Fid(21_001);
+    agent_root
+        .walk(Fid::ROOT, dir_fid, std::slice::from_ref(&pid))
+        .await
+        .unwrap();
+    agent_root
+        .create(dir_fid, file_fid, "scratch", FileKind::File)
+        .await
+        .unwrap();
+    agent_root.clunk(file_fid).await.unwrap();
+    agent_root.clunk(dir_fid).await.unwrap();
+
+    let remove_fid = Fid(21_002);
+    agent_root
+        .walk(Fid::ROOT, remove_fid, &[pid.clone(), "scratch".into()])
+        .await
+        .unwrap();
+    agent_root.remove(remove_fid).await.unwrap();
+    assert!(matches!(
+        shell.cat(&format!("/agent/{pid}/scratch")).await,
+        Err(ErrorCode::NotFound)
+    ));
+
+    agent_root
+        .walk(Fid::ROOT, remove_fid, std::slice::from_ref(&pid))
+        .await
+        .expect("remove releases the outer fid for reuse");
+}

--- a/crates/agentfs/tests/agent_root_overlay.rs
+++ b/crates/agentfs/tests/agent_root_overlay.rs
@@ -333,6 +333,51 @@ async fn failed_proc_overlay_walk_does_not_clunk_unbound_proc_fid() {
 }
 
 #[tokio::test]
+async fn failed_backing_walk_does_not_clunk_unbound_backing_fid() {
+    let (_, shell, agent_root, _) = namespace_shell_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    let backing = Arc::new(FailedBackingWalkFs::new());
+    agent_root.bind_process(pid.clone(), backing.clone()).await;
+
+    assert_eq!(
+        agent_root
+            .walk(Fid::ROOT, Fid(9_350), &[pid, "file".to_string()])
+            .await,
+        Err(ErrorCode::BadRequest)
+    );
+    assert!(
+        !backing.clunked_failed_fid(),
+        "failed backing walks do not bind their newfid, so cleanup must not clunk it"
+    );
+}
+
+#[tokio::test]
+async fn failed_stat_after_delegated_walk_releases_backing_fid() {
+    let (_, shell, agent_root, _) = namespace_shell_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    let backing = Arc::new(StatFailWalkFs::new());
+    agent_root.bind_process(pid.clone(), backing.clone()).await;
+
+    assert_eq!(
+        agent_root
+            .walk(Fid::ROOT, Fid(9_360), &[pid, "file".to_string()])
+            .await,
+        Err(ErrorCode::Io)
+    );
+    assert_eq!(
+        backing.bound_fid_count(),
+        0,
+        "a failed outer walk must release the delegated backing fid"
+    );
+}
+
+#[tokio::test]
 async fn agent_children_are_derived_from_proc_parentage() {
     let (_, shell, agent_root, proc) = namespace_shell_with_agent_root();
     let parent = shell
@@ -868,6 +913,173 @@ impl FileServer for ProcWalkCollisionFs {
             .lock()
             .expect("clunked fids lock should not be poisoned")
             .push(fid);
+        Ok(())
+    }
+}
+
+struct FailedBackingWalkFs {
+    failed_fids: Mutex<Vec<Fid>>,
+    clunked_fids: Mutex<Vec<Fid>>,
+}
+
+impl FailedBackingWalkFs {
+    fn new() -> Self {
+        Self {
+            failed_fids: Mutex::new(Vec::new()),
+            clunked_fids: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn clunked_failed_fid(&self) -> bool {
+        let failed = self
+            .failed_fids
+            .lock()
+            .expect("failed fids lock should not be poisoned");
+        let clunked = self
+            .clunked_fids
+            .lock()
+            .expect("clunked fids lock should not be poisoned");
+        failed.iter().any(|fid| clunked.contains(fid))
+    }
+}
+
+#[async_trait]
+impl FileServer for FailedBackingWalkFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        if fid == Fid::ROOT && names == ["file"] {
+            self.failed_fids
+                .lock()
+                .expect("failed fids lock should not be poisoned")
+                .push(newfid);
+            Err(ErrorCode::BadRequest)
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn read(&self, _fid: Fid, _offset: u64, _count: u32) -> Result<Vec<u8>, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn write(&self, _fid: Fid, _offset: u64, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.clunked_fids
+            .lock()
+            .expect("clunked fids lock should not be poisoned")
+            .push(fid);
+        Ok(())
+    }
+}
+
+struct StatFailWalkFs {
+    fids: Mutex<HashMap<Fid, ()>>,
+}
+
+impl StatFailWalkFs {
+    fn new() -> Self {
+        Self {
+            fids: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn bound_fid_count(&self) -> usize {
+        self.fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .len()
+    }
+
+    fn qid() -> Qid {
+        Qid {
+            kind: FileKind::File,
+            version: 0,
+            path: 0x57A7_F411,
+        }
+    }
+}
+
+#[async_trait]
+impl FileServer for StatFailWalkFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        if fid != Fid::ROOT || names != ["file"] {
+            return Err(ErrorCode::NotFound);
+        }
+        self.fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .insert(newfid, ());
+        Ok(Self::qid())
+    }
+
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn read(&self, _fid: Fid, _offset: u64, _count: u32) -> Result<Vec<u8>, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn write(&self, _fid: Fid, _offset: u64, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        if self
+            .fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .contains_key(&fid)
+        {
+            Err(ErrorCode::Io)
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.clunk(fid).await
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .remove(&fid);
         Ok(())
     }
 }

--- a/crates/agentfs/tests/agent_root_overlay.rs
+++ b/crates/agentfs/tests/agent_root_overlay.rs
@@ -11,7 +11,10 @@ use alan_ap::{
     ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, ProcessInputEventSource,
     ProcessOutputEventSource, Qid, Stat,
 };
-use alan_kernel::{Access, Credentials, MountFs, Namespace, Pid, ProcFs};
+use alan_kernel::{
+    Access, Credentials, MountFs, Namespace, Pid, ProcFs, ProcessInvocation, ProcessOutcome,
+    ProcessRunner,
+};
 use alan_memfs::MemFs;
 use alan_shell::Shell;
 use async_trait::async_trait;
@@ -19,6 +22,12 @@ use tokio::sync::Notify;
 
 fn namespace_shell_with_agent_root() -> (InProcessTransport, Shell, Arc<AgentRootFs>, Arc<ProcFs>) {
     let proc = Arc::new(ProcFs::new());
+    namespace_shell_with_agent_root_for_proc(proc)
+}
+
+fn namespace_shell_with_agent_root_for_proc(
+    proc: Arc<ProcFs>,
+) -> (InProcessTransport, Shell, Arc<AgentRootFs>, Arc<ProcFs>) {
     let proc_server: Arc<dyn FileServer> = proc.clone();
     let proc_input_events: Arc<dyn ProcessInputEventSource> = proc.clone();
     let proc_output_events: Arc<dyn ProcessOutputEventSource> = proc.clone();
@@ -44,6 +53,25 @@ fn namespace_shell_with_agent_root() -> (InProcessTransport, Shell, Arc<AgentRoo
     (root.clone(), Shell::new(root), agent_root, proc)
 }
 
+struct ImmediateOutputRunner {
+    output: Vec<u8>,
+}
+
+impl ImmediateOutputRunner {
+    fn new(output: impl Into<Vec<u8>>) -> Self {
+        Self {
+            output: output.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl ProcessRunner for ImmediateOutputRunner {
+    async fn run(&self, _invocation: ProcessInvocation) -> ProcessOutcome {
+        ProcessOutcome::exited(0, self.output.clone())
+    }
+}
+
 async fn spawn_on_proc(proc: &ProcFs, fid: Fid) -> String {
     proc.walk(Fid::ROOT, fid, &["clone".into()])
         .await
@@ -57,6 +85,17 @@ async fn spawn_on_proc(proc: &ProcFs, fid: Fid) -> String {
         .expect("write exec");
     proc.clunk(fid).await.expect("commit process");
     pid
+}
+
+async fn wait_for_file_contains(shell: &Shell, path: &str, needle: &str) {
+    for _ in 0..50 {
+        let text = String::from_utf8(shell.cat(path).await.unwrap()).unwrap();
+        if text.contains(needle) {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    panic!("{path} did not contain {needle:?}");
 }
 
 #[tokio::test]
@@ -310,6 +349,30 @@ async fn direct_proc_input_writes_publish_agent_events() {
             "{path} should publish a direct proc input event"
         );
     }
+}
+
+#[tokio::test]
+async fn bind_process_replays_existing_proc_io_events() {
+    let proc = Arc::new(
+        ProcFs::new().with_runner(Arc::new(ImmediateOutputRunner::new("early runner output"))),
+    );
+    let (_, shell, agent_root, _) = namespace_shell_with_agent_root_for_proc(proc);
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    wait_for_file_contains(&shell, &format!("/proc/{pid}/io/events"), "output:19").await;
+
+    agent_root
+        .bind_process(pid.clone(), Arc::new(AgentFs::new()))
+        .await;
+
+    let events =
+        String::from_utf8(shell.cat(&format!("/agent/{pid}/events")).await.unwrap()).unwrap();
+    assert!(
+        events.contains("output:19"),
+        "late-bound agent aggregate should replay existing proc IO events: {events:?}"
+    );
 }
 
 #[tokio::test]

--- a/crates/agentfs/tests/agent_root_overlay.rs
+++ b/crates/agentfs/tests/agent_root_overlay.rs
@@ -217,11 +217,17 @@ async fn agent_io_input_writes_to_the_proc_input_stream() {
         String::from_utf8(shell.cat(&format!("/agent/{pid}/io/input")).await.unwrap()).unwrap(),
         "shared input"
     );
-    assert!(
-        String::from_utf8(shell.cat(&format!("/agent/{pid}/io/events")).await.unwrap())
-            .unwrap()
-            .contains("input:12")
-    );
+    for path in [
+        format!("/agent/{pid}/io/events"),
+        format!("/agent/{pid}/events"),
+    ] {
+        assert!(
+            String::from_utf8(shell.cat(&path).await.unwrap())
+                .unwrap()
+                .contains("input:12"),
+            "{path} should publish a proc-owned input event"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/agentfs/tests/agent_root_overlay.rs
+++ b/crates/agentfs/tests/agent_root_overlay.rs
@@ -181,6 +181,50 @@ async fn agent_io_output_writes_to_the_proc_output_stream() {
 }
 
 #[tokio::test]
+async fn agent_io_input_writes_to_the_proc_input_stream() {
+    let (_, shell, agent_root, _) = namespace_shell_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    agent_root
+        .bind_process(pid.clone(), Arc::new(AgentFs::new()))
+        .await;
+
+    let io_fid = Fid(9_150);
+    let input_fid = Fid(9_151);
+    agent_root
+        .walk(Fid::ROOT, io_fid, &[pid.clone(), "io".to_string()])
+        .await
+        .unwrap();
+    agent_root
+        .walk(io_fid, input_fid, &["input".to_string()])
+        .await
+        .unwrap();
+    agent_root.open(input_fid, OpenMode::Write).await.unwrap();
+    agent_root
+        .write(input_fid, 0, b"shared input")
+        .await
+        .unwrap();
+    agent_root.clunk(input_fid).await.unwrap();
+    agent_root.clunk(io_fid).await.unwrap();
+
+    assert_eq!(
+        String::from_utf8(shell.cat(&format!("/proc/{pid}/io/input")).await.unwrap()).unwrap(),
+        "shared input"
+    );
+    assert_eq!(
+        String::from_utf8(shell.cat(&format!("/agent/{pid}/io/input")).await.unwrap()).unwrap(),
+        "shared input"
+    );
+    assert!(
+        String::from_utf8(shell.cat(&format!("/agent/{pid}/io/events")).await.unwrap())
+            .unwrap()
+            .contains("input:12")
+    );
+}
+
+#[tokio::test]
 async fn direct_proc_output_writes_publish_agent_events() {
     let (_, shell, agent_root, proc) = namespace_shell_with_agent_root();
     let pid = shell

--- a/crates/agentfs/tests/agent_root_overlay.rs
+++ b/crates/agentfs/tests/agent_root_overlay.rs
@@ -150,6 +150,100 @@ async fn agent_children_are_derived_from_proc_parentage() {
 }
 
 #[tokio::test]
+async fn agent_children_qid_versions_change_with_listing() {
+    let (_, shell, agent_root, proc) = namespace_shell_with_agent_root();
+    let parent = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    agent_root
+        .bind_process(parent.clone(), Arc::new(AgentFs::new()))
+        .await;
+
+    let empty_fid = Fid(11_000);
+    agent_root
+        .walk(
+            Fid::ROOT,
+            empty_fid,
+            &[parent.clone(), "children".to_string()],
+        )
+        .await
+        .unwrap();
+    let empty_qid = agent_root.stat(empty_fid).await.unwrap().qid;
+    agent_root.clunk(empty_fid).await.unwrap();
+
+    let spawner = proc.for_spawner(
+        Some(Pid(parent.parse::<u64>().unwrap())),
+        Namespace::new(),
+        Credentials::user("alan"),
+    );
+    let child = spawn_on_proc(&spawner, Fid(11_001)).await;
+    agent_root
+        .bind_process(child.clone(), Arc::new(AgentFs::new()))
+        .await;
+
+    let child_fid = Fid(11_002);
+    agent_root
+        .walk(Fid::ROOT, child_fid, &[parent, "children".to_string()])
+        .await
+        .unwrap();
+    let child_qid = agent_root.stat(child_fid).await.unwrap().qid;
+    agent_root.clunk(child_fid).await.unwrap();
+
+    assert_eq!(empty_qid.kind, FileKind::Dir);
+    assert_eq!(empty_qid.path, child_qid.path);
+    assert_ne!(empty_qid.version, child_qid.version);
+}
+
+#[tokio::test]
+async fn agent_root_namespaces_backing_qids_by_pid() {
+    let (_, shell, agent_root, _) = namespace_shell_with_agent_root();
+    let first = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    let second = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    agent_root
+        .bind_process(first.clone(), Arc::new(AgentFs::new()))
+        .await;
+    agent_root
+        .bind_process(second.clone(), Arc::new(AgentFs::new()))
+        .await;
+
+    let first_fid = Fid(12_000);
+    let first_qid = agent_root
+        .walk(
+            Fid::ROOT,
+            first_fid,
+            &[first, "io".to_string(), "output".to_string()],
+        )
+        .await
+        .unwrap();
+    let first_stat_qid = agent_root.stat(first_fid).await.unwrap().qid;
+
+    let second_fid = Fid(12_001);
+    let second_qid = agent_root
+        .walk(
+            Fid::ROOT,
+            second_fid,
+            &[second, "io".to_string(), "output".to_string()],
+        )
+        .await
+        .unwrap();
+    let second_stat_qid = agent_root.stat(second_fid).await.unwrap().qid;
+    agent_root.clunk(first_fid).await.unwrap();
+    agent_root.clunk(second_fid).await.unwrap();
+
+    assert_eq!(first_qid, first_stat_qid);
+    assert_eq!(second_qid, second_stat_qid);
+    assert_eq!(first_qid.kind, second_qid.kind);
+    assert_ne!(first_qid.path, second_qid.path);
+}
+
+#[tokio::test]
 async fn agent_root_tracks_created_fids_forwarded_to_backing() {
     let (_, shell, agent_root, _) = namespace_shell_with_agent_root();
     let pid = shell

--- a/crates/agentfs/tests/agent_root_overlay.rs
+++ b/crates/agentfs/tests/agent_root_overlay.rs
@@ -1,0 +1,79 @@
+use std::sync::Arc;
+
+use alan_agentfs::{AgentFs, AgentRootFs};
+use alan_ap::{ErrorCode, FileServer, InProcessTransport};
+use alan_kernel::{Access, MountFs, Namespace, ProcFs};
+use alan_shell::Shell;
+
+fn namespace_shell_with_agent_root() -> (Shell, Arc<AgentRootFs>) {
+    let proc = Arc::new(ProcFs::new());
+    let proc_server: Arc<dyn FileServer> = proc.clone();
+    let agent_root = Arc::new(AgentRootFs::new(proc_server));
+
+    let mut namespace = Namespace::new();
+    namespace.mount("/proc", InProcessTransport::new(proc), Access::ReadWrite);
+    namespace.mount(
+        "/agent",
+        InProcessTransport::new(agent_root.clone()),
+        Access::ReadWrite,
+    );
+
+    let root = InProcessTransport::new(Arc::new(MountFs::new(namespace)));
+    (Shell::new(root), agent_root)
+}
+
+#[tokio::test]
+async fn agent_root_lists_only_proc_backed_agent_processes() {
+    let (shell, agent_root) = namespace_shell_with_agent_root();
+
+    agent_root
+        .bind_process("999", Arc::new(AgentFs::new()))
+        .await;
+    agent_root.set_root_process("999").await;
+    assert_eq!(shell.ls("/agent").await.unwrap(), Vec::<String>::new());
+    assert!(matches!(
+        shell.ls("/agent/999").await,
+        Err(ErrorCode::NotFound)
+    ));
+
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    agent_root
+        .bind_process(pid.clone(), Arc::new(AgentFs::new()))
+        .await;
+    agent_root.set_root_process(pid.clone()).await;
+
+    let listing = shell.ls("/agent").await.unwrap();
+    assert!(listing.iter().any(|entry| entry == &pid), "{listing:?}");
+    assert!(listing.iter().any(|entry| entry == "root"), "{listing:?}");
+    assert!(!listing.iter().any(|entry| entry == "999"), "{listing:?}");
+}
+
+#[tokio::test]
+async fn agent_root_alias_forwards_to_the_root_agent_surface() {
+    let (shell, agent_root) = namespace_shell_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    agent_root
+        .bind_process(pid.clone(), Arc::new(AgentFs::new()))
+        .await;
+    agent_root.set_root_process(pid.clone()).await;
+
+    shell
+        .write("/agent/root/io/output", b"hello root")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        String::from_utf8(shell.cat(&format!("/agent/{pid}/io/output")).await.unwrap()).unwrap(),
+        "hello root"
+    );
+    assert!(matches!(
+        shell.ls(&format!("/proc/{pid}/machine")).await,
+        Err(ErrorCode::NotFound)
+    ));
+}

--- a/crates/agentfs/tests/agent_root_overlay.rs
+++ b/crates/agentfs/tests/agent_root_overlay.rs
@@ -8,8 +8,8 @@ use std::{
 
 use alan_agentfs::{AgentFs, AgentRootFs};
 use alan_ap::{
-    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, ProcessOutputEventSource,
-    Qid, Stat,
+    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, ProcessInputEventSource,
+    ProcessOutputEventSource, Qid, Stat,
 };
 use alan_kernel::{Access, Credentials, MountFs, Namespace, Pid, ProcFs};
 use alan_memfs::MemFs;
@@ -20,9 +20,11 @@ use tokio::sync::Notify;
 fn namespace_shell_with_agent_root() -> (InProcessTransport, Shell, Arc<AgentRootFs>, Arc<ProcFs>) {
     let proc = Arc::new(ProcFs::new());
     let proc_server: Arc<dyn FileServer> = proc.clone();
+    let proc_input_events: Arc<dyn ProcessInputEventSource> = proc.clone();
     let proc_output_events: Arc<dyn ProcessOutputEventSource> = proc.clone();
-    let agent_root = Arc::new(AgentRootFs::new_with_process_output_events(
+    let agent_root = Arc::new(AgentRootFs::new_with_process_io_events(
         proc_server,
+        proc_input_events,
         proc_output_events,
     ));
 
@@ -266,6 +268,46 @@ async fn direct_proc_output_writes_publish_agent_events() {
                 .unwrap()
                 .contains("output:11"),
             "{path} should publish a proc-owned output event"
+        );
+    }
+}
+
+#[tokio::test]
+async fn direct_proc_input_writes_publish_agent_events() {
+    let (_, shell, agent_root, proc) = namespace_shell_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    agent_root
+        .bind_process(pid.clone(), Arc::new(AgentFs::new()))
+        .await;
+
+    let input_fid = Fid(9_250);
+    proc.walk(
+        Fid::ROOT,
+        input_fid,
+        &[pid.clone(), "io".to_string(), "input".to_string()],
+    )
+    .await
+    .unwrap();
+    proc.open(input_fid, OpenMode::Write).await.unwrap();
+    proc.write(input_fid, 0, b"direct input").await.unwrap();
+    proc.clunk(input_fid).await.unwrap();
+
+    assert_eq!(
+        String::from_utf8(shell.cat(&format!("/agent/{pid}/io/input")).await.unwrap()).unwrap(),
+        "direct input"
+    );
+    for path in [
+        format!("/agent/{pid}/events"),
+        format!("/agent/{pid}/io/events"),
+    ] {
+        assert!(
+            String::from_utf8(shell.cat(&path).await.unwrap())
+                .unwrap()
+                .contains("input:12"),
+            "{path} should publish a direct proc input event"
         );
     }
 }

--- a/crates/agentfs/tests/agent_root_overlay.rs
+++ b/crates/agentfs/tests/agent_root_overlay.rs
@@ -119,10 +119,58 @@ async fn agent_root_alias_forwards_to_the_root_agent_surface() {
         String::from_utf8(shell.cat(&format!("/agent/{pid}/io/output")).await.unwrap()).unwrap(),
         "hello root"
     );
+    assert_eq!(
+        String::from_utf8(shell.cat(&format!("/proc/{pid}/io/output")).await.unwrap()).unwrap(),
+        "hello root"
+    );
     assert!(matches!(
         shell.ls(&format!("/proc/{pid}/machine")).await,
         Err(ErrorCode::NotFound)
     ));
+}
+
+#[tokio::test]
+async fn agent_io_output_writes_to_the_proc_output_stream() {
+    let (_, shell, agent_root, _) = namespace_shell_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    agent_root
+        .bind_process(pid.clone(), Arc::new(AgentFs::new()))
+        .await;
+
+    let io_fid = Fid(9_100);
+    let output_fid = Fid(9_101);
+    agent_root
+        .walk(Fid::ROOT, io_fid, &[pid.clone(), "io".to_string()])
+        .await
+        .unwrap();
+    agent_root
+        .walk(io_fid, output_fid, &["output".to_string()])
+        .await
+        .unwrap();
+    agent_root.open(output_fid, OpenMode::Write).await.unwrap();
+    agent_root
+        .write(output_fid, 0, b"shared output")
+        .await
+        .unwrap();
+    agent_root.clunk(output_fid).await.unwrap();
+    agent_root.clunk(io_fid).await.unwrap();
+
+    assert_eq!(
+        String::from_utf8(shell.cat(&format!("/proc/{pid}/io/output")).await.unwrap()).unwrap(),
+        "shared output"
+    );
+    assert_eq!(
+        String::from_utf8(shell.cat(&format!("/agent/{pid}/io/output")).await.unwrap()).unwrap(),
+        "shared output"
+    );
+    assert!(
+        String::from_utf8(shell.cat(&format!("/agent/{pid}/events")).await.unwrap())
+            .unwrap()
+            .contains("output:13")
+    );
 }
 
 #[tokio::test]
@@ -341,7 +389,7 @@ async fn agent_root_rejects_creates_for_overlay_reserved_names() {
         .walk(Fid::ROOT, dir_fid, std::slice::from_ref(&pid))
         .await
         .unwrap();
-    for (idx, name) in ["children", "status", "ctl"].into_iter().enumerate() {
+    for (idx, name) in ["children", "status", "ctl", "io"].into_iter().enumerate() {
         assert_eq!(
             agent_root
                 .create(dir_fid, Fid(13_001 + idx as u64), name, FileKind::File)

--- a/crates/agentfs/tests/conformance.rs
+++ b/crates/agentfs/tests/conformance.rs
@@ -6,7 +6,7 @@ use std::sync::{
 
 use alan_agentfs::{AgentConformanceChecker, AgentFs, AgentRootFs};
 use alan_ap::{
-    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, ProcessIoEventSource, Qid,
+    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, ProcessEventSource, Qid,
     Stat,
 };
 use alan_kernel::{Access, MountFs, Namespace, ProcFs};
@@ -16,10 +16,10 @@ use async_trait::async_trait;
 fn namespace_with_agent_root() -> (InProcessTransport, Shell, Arc<AgentRootFs>) {
     let proc = Arc::new(ProcFs::new());
     let proc_server: Arc<dyn FileServer> = proc.clone();
-    let proc_io_events: Arc<dyn ProcessIoEventSource> = proc.clone();
-    let agent_root = Arc::new(AgentRootFs::new_with_ordered_process_io_events(
+    let proc_events: Arc<dyn ProcessEventSource> = proc.clone();
+    let agent_root = Arc::new(AgentRootFs::new_with_process_events(
         proc_server,
-        proc_io_events,
+        proc_events,
     ));
 
     let mut namespace = Namespace::new();

--- a/crates/agentfs/tests/conformance.rs
+++ b/crates/agentfs/tests/conformance.rs
@@ -1,0 +1,76 @@
+use std::sync::Arc;
+
+use alan_agentfs::{AgentConformanceChecker, AgentFs, AgentRootFs};
+use alan_ap::{FileServer, InProcessTransport};
+use alan_kernel::{Access, MountFs, Namespace, ProcFs};
+use alan_shell::Shell;
+
+fn namespace_with_agent_root() -> (InProcessTransport, Shell, Arc<AgentRootFs>) {
+    let proc = Arc::new(ProcFs::new());
+    let proc_server: Arc<dyn FileServer> = proc.clone();
+    let agent_root = Arc::new(AgentRootFs::new(proc_server));
+
+    let mut namespace = Namespace::new();
+    namespace.mount("/proc", InProcessTransport::new(proc), Access::ReadWrite);
+    namespace.mount(
+        "/agent",
+        InProcessTransport::new(agent_root.clone()),
+        Access::ReadWrite,
+    );
+
+    let root = InProcessTransport::new(Arc::new(MountFs::new(namespace)));
+    (root.clone(), Shell::new(root), agent_root)
+}
+
+#[tokio::test]
+async fn conformance_checker_accepts_agent_overlay_process_layout() {
+    let (root, shell, agent_root) = namespace_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    agent_root
+        .bind_process(pid.clone(), Arc::new(AgentFs::new()))
+        .await;
+    agent_root.set_root_process(pid.clone()).await;
+
+    let checker = AgentConformanceChecker::new(root);
+    checker
+        .check_agent_process(&format!("/agent/{pid}"))
+        .await
+        .assert_ok();
+}
+
+#[tokio::test]
+async fn conformance_checker_verifies_dynamic_container_event_streams() {
+    let (root, shell, agent_root) = namespace_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    agent_root
+        .bind_process(pid.clone(), Arc::new(AgentFs::new()))
+        .await;
+
+    let checker = AgentConformanceChecker::new(root);
+    checker
+        .check_dynamic_container_events(&format!("/agent/{pid}"))
+        .await
+        .assert_ok();
+}
+
+#[tokio::test]
+async fn conformance_checker_verifies_root_alias_matches_current_pid() {
+    let (root, shell, agent_root) = namespace_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+    agent_root
+        .bind_process(pid.clone(), Arc::new(AgentFs::new()))
+        .await;
+    agent_root.set_root_process(pid.clone()).await;
+
+    let checker = AgentConformanceChecker::new(root);
+    checker.check_root_alias("/agent", &pid).await.assert_ok();
+}

--- a/crates/agentfs/tests/conformance.rs
+++ b/crates/agentfs/tests/conformance.rs
@@ -69,6 +69,33 @@ async fn conformance_checker_accepts_procfs_generic_process_layout() {
 }
 
 #[tokio::test]
+async fn conformance_checker_rejects_generic_process_missing_input_and_events() {
+    let checker = AgentConformanceChecker::new(InProcessTransport::new(Arc::new(
+        IncompleteGenericProcessFs::new(),
+    )));
+
+    let report = checker.check_generic_process("/proc/1").await;
+    let paths = report
+        .issues
+        .iter()
+        .map(|issue| issue.path.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(
+        paths.contains(&"/proc/1/io/input"),
+        "generic process checks must require io/input: {report:?}"
+    );
+    assert!(
+        paths.contains(&"/proc/1/io/events"),
+        "generic process checks must require io/events: {report:?}"
+    );
+    assert!(
+        !paths.contains(&"/proc/1/io/output"),
+        "the incomplete fixture still provides io/output: {report:?}"
+    );
+}
+
+#[tokio::test]
 async fn conformance_checker_verifies_dynamic_container_event_streams() {
     let (root, shell, agent_root) = namespace_with_agent_root();
     let pid = shell
@@ -228,6 +255,112 @@ impl FileServer for HangingContainerEventFs {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IncompleteGenericNode {
+    Proc,
+    Io,
+    Output,
+    Status,
+    Ctl,
+}
+
+struct IncompleteGenericProcessFs {
+    fids: Mutex<HashMap<Fid, IncompleteGenericNode>>,
+}
+
+impl IncompleteGenericProcessFs {
+    fn new() -> Self {
+        Self {
+            fids: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn node_for(&self, fid: Fid) -> Result<IncompleteGenericNode, ErrorCode> {
+        self.fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .get(&fid)
+            .copied()
+            .ok_or(ErrorCode::NotFound)
+    }
+}
+
+#[async_trait]
+impl FileServer for IncompleteGenericProcessFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        if fid != Fid::ROOT {
+            return Err(ErrorCode::NotFound);
+        }
+        let node = match names {
+            [proc, pid] if proc == "proc" && pid == "1" => IncompleteGenericNode::Proc,
+            [proc, pid, io] if proc == "proc" && pid == "1" && io == "io" => {
+                IncompleteGenericNode::Io
+            }
+            [proc, pid, io, output]
+                if proc == "proc" && pid == "1" && io == "io" && output == "output" =>
+            {
+                IncompleteGenericNode::Output
+            }
+            [proc, pid, status] if proc == "proc" && pid == "1" && status == "status" => {
+                IncompleteGenericNode::Status
+            }
+            [proc, pid, ctl] if proc == "proc" && pid == "1" && ctl == "ctl" => {
+                IncompleteGenericNode::Ctl
+            }
+            _ => return Err(ErrorCode::NotFound),
+        };
+        self.fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .insert(newfid, node);
+        Ok(qid_for_incomplete_generic_node(node))
+    }
+
+    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        self.node_for(fid).map(qid_for_incomplete_generic_node)
+    }
+
+    async fn read(&self, _fid: Fid, _offset: u64, _count: u32) -> Result<Vec<u8>, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn write(&self, _fid: Fid, _offset: u64, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        let node = self.node_for(fid)?;
+        Ok(Stat {
+            name: String::new(),
+            qid: qid_for_incomplete_generic_node(node),
+            length: 0,
+            writable: matches!(node, IncompleteGenericNode::Ctl),
+        })
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.clunk(fid).await
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .remove(&fid);
+        Ok(())
+    }
+}
+
 struct ActiveEventReadGuard {
     active_event_reads: Arc<AtomicUsize>,
 }
@@ -253,6 +386,21 @@ fn qid_for_hanging_node(node: HangingNode) -> Qid {
     let path = match node {
         HangingNode::EventStream => 1,
         HangingNode::CloneFile => 2,
+    };
+    Qid {
+        kind,
+        version: 0,
+        path,
+    }
+}
+
+fn qid_for_incomplete_generic_node(node: IncompleteGenericNode) -> Qid {
+    let (kind, path) = match node {
+        IncompleteGenericNode::Proc => (FileKind::Dir, 100),
+        IncompleteGenericNode::Io => (FileKind::Dir, 101),
+        IncompleteGenericNode::Output => (FileKind::Stream, 102),
+        IncompleteGenericNode::Status => (FileKind::File, 103),
+        IncompleteGenericNode::Ctl => (FileKind::File, 104),
     };
     Qid {
         kind,

--- a/crates/agentfs/tests/conformance.rs
+++ b/crates/agentfs/tests/conformance.rs
@@ -6,8 +6,8 @@ use std::sync::{
 
 use alan_agentfs::{AgentConformanceChecker, AgentFs, AgentRootFs};
 use alan_ap::{
-    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, ProcessInputEventSource,
-    ProcessOutputEventSource, Qid, Stat,
+    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, ProcessIoEventSource, Qid,
+    Stat,
 };
 use alan_kernel::{Access, MountFs, Namespace, ProcFs};
 use alan_shell::Shell;
@@ -16,12 +16,10 @@ use async_trait::async_trait;
 fn namespace_with_agent_root() -> (InProcessTransport, Shell, Arc<AgentRootFs>) {
     let proc = Arc::new(ProcFs::new());
     let proc_server: Arc<dyn FileServer> = proc.clone();
-    let proc_input_events: Arc<dyn ProcessInputEventSource> = proc.clone();
-    let proc_output_events: Arc<dyn ProcessOutputEventSource> = proc.clone();
-    let agent_root = Arc::new(AgentRootFs::new_with_process_io_events(
+    let proc_io_events: Arc<dyn ProcessIoEventSource> = proc.clone();
+    let agent_root = Arc::new(AgentRootFs::new_with_ordered_process_io_events(
         proc_server,
-        proc_input_events,
-        proc_output_events,
+        proc_io_events,
     ));
 
     let mut namespace = Namespace::new();
@@ -98,6 +96,25 @@ async fn conformance_checker_rejects_generic_process_missing_input_and_events() 
 }
 
 #[tokio::test]
+async fn conformance_checker_requires_current_checkpoint_file() {
+    let checker = AgentConformanceChecker::new(InProcessTransport::new(Arc::new(
+        MissingCheckpointAgentFs::new(),
+    )));
+
+    let report = checker.check_agent_process("/agent/1").await;
+    let paths = report
+        .issues
+        .iter()
+        .map(|issue| issue.path.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(
+        paths.contains(&"/agent/1/machine/checkpoints/current"),
+        "agent conformance checks must require machine/checkpoints/current: {report:?}"
+    );
+}
+
+#[tokio::test]
 async fn conformance_checker_verifies_dynamic_container_event_streams() {
     let (root, shell, agent_root) = namespace_with_agent_root();
     let pid = shell
@@ -148,6 +165,85 @@ async fn conformance_checker_aborts_timed_out_event_readers() {
         0,
         "timed-out event read tasks should be aborted before returning"
     );
+}
+
+struct MissingCheckpointAgentFs {
+    inner: AgentFs,
+}
+
+impl MissingCheckpointAgentFs {
+    fn new() -> Self {
+        Self {
+            inner: AgentFs::new(),
+        }
+    }
+
+    fn forwarded_names<'a>(
+        &self,
+        fid: Fid,
+        names: &'a [String],
+    ) -> Result<&'a [String], ErrorCode> {
+        if fid != Fid::ROOT {
+            return Ok(names);
+        }
+        match names {
+            [agent, pid, rest @ ..] if agent == "agent" && pid == "1" => Ok(rest),
+            _ => Err(ErrorCode::NotFound),
+        }
+    }
+
+    fn hides_current_checkpoint(names: &[String]) -> bool {
+        matches!(
+            names,
+            [machine, checkpoints, current]
+                if machine == "machine" && checkpoints == "checkpoints" && current == "current"
+        )
+    }
+}
+
+#[async_trait]
+impl FileServer for MissingCheckpointAgentFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        let names = self.forwarded_names(fid, names)?;
+        if Self::hides_current_checkpoint(names) {
+            return Err(ErrorCode::NotFound);
+        }
+        self.inner.walk(fid, newfid, names).await
+    }
+
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
+        self.inner.open(fid, mode).await
+    }
+
+    async fn read(&self, fid: Fid, offset: u64, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        self.inner.read(fid, offset, count).await
+    }
+
+    async fn write(&self, fid: Fid, offset: u64, data: &[u8]) -> Result<u32, ErrorCode> {
+        self.inner.write(fid, offset, data).await
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        self.inner.stat(fid).await
+    }
+
+    async fn create(
+        &self,
+        fid: Fid,
+        newfid: Fid,
+        name: &str,
+        kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        self.inner.create(fid, newfid, name, kind).await
+    }
+
+    async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.inner.remove(fid).await
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.inner.clunk(fid).await
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/agentfs/tests/conformance.rs
+++ b/crates/agentfs/tests/conformance.rs
@@ -6,8 +6,8 @@ use std::sync::{
 
 use alan_agentfs::{AgentConformanceChecker, AgentFs, AgentRootFs};
 use alan_ap::{
-    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, ProcessOutputEventSource,
-    Qid, Stat,
+    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, ProcessInputEventSource,
+    ProcessOutputEventSource, Qid, Stat,
 };
 use alan_kernel::{Access, MountFs, Namespace, ProcFs};
 use alan_shell::Shell;
@@ -16,9 +16,11 @@ use async_trait::async_trait;
 fn namespace_with_agent_root() -> (InProcessTransport, Shell, Arc<AgentRootFs>) {
     let proc = Arc::new(ProcFs::new());
     let proc_server: Arc<dyn FileServer> = proc.clone();
+    let proc_input_events: Arc<dyn ProcessInputEventSource> = proc.clone();
     let proc_output_events: Arc<dyn ProcessOutputEventSource> = proc.clone();
-    let agent_root = Arc::new(AgentRootFs::new_with_process_output_events(
+    let agent_root = Arc::new(AgentRootFs::new_with_process_io_events(
         proc_server,
+        proc_input_events,
         proc_output_events,
     ));
 

--- a/crates/agentfs/tests/conformance.rs
+++ b/crates/agentfs/tests/conformance.rs
@@ -1,9 +1,14 @@
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
 
 use alan_agentfs::{AgentConformanceChecker, AgentFs, AgentRootFs};
-use alan_ap::{FileServer, InProcessTransport};
+use alan_ap::{ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, Qid, Stat};
 use alan_kernel::{Access, MountFs, Namespace, ProcFs};
 use alan_shell::Shell;
+use async_trait::async_trait;
 
 fn namespace_with_agent_root() -> (InProcessTransport, Shell, Arc<AgentRootFs>) {
     let proc = Arc::new(ProcFs::new());
@@ -42,6 +47,21 @@ async fn conformance_checker_accepts_agent_overlay_process_layout() {
 }
 
 #[tokio::test]
+async fn conformance_checker_accepts_procfs_generic_process_layout() {
+    let (root, shell, _) = namespace_with_agent_root();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/alan-agent","args":[]}"#)
+        .await
+        .unwrap();
+
+    let checker = AgentConformanceChecker::new(root);
+    checker
+        .check_generic_process(&format!("/proc/{pid}"))
+        .await
+        .assert_ok();
+}
+
+#[tokio::test]
 async fn conformance_checker_verifies_dynamic_container_event_streams() {
     let (root, shell, agent_root) = namespace_with_agent_root();
     let pid = shell
@@ -73,4 +93,163 @@ async fn conformance_checker_verifies_root_alias_matches_current_pid() {
 
     let checker = AgentConformanceChecker::new(root);
     checker.check_root_alias("/agent", &pid).await.assert_ok();
+}
+
+#[tokio::test]
+async fn conformance_checker_aborts_timed_out_event_readers() {
+    let active_event_reads = Arc::new(AtomicUsize::new(0));
+    let fs = Arc::new(HangingContainerEventFs::new(active_event_reads.clone()));
+    let checker = AgentConformanceChecker::new(InProcessTransport::new(fs));
+
+    let report = checker.check_dynamic_container_events("/agent/1").await;
+
+    assert!(
+        !report.is_ok(),
+        "hanging event streams should report issues"
+    );
+    assert_eq!(
+        active_event_reads.load(Ordering::SeqCst),
+        0,
+        "timed-out event read tasks should be aborted before returning"
+    );
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HangingNode {
+    EventStream,
+    CloneFile,
+}
+
+struct HangingContainerEventFs {
+    fids: Mutex<HashMap<Fid, HangingNode>>,
+    active_event_reads: Arc<AtomicUsize>,
+}
+
+impl HangingContainerEventFs {
+    fn new(active_event_reads: Arc<AtomicUsize>) -> Self {
+        Self {
+            fids: Mutex::new(HashMap::new()),
+            active_event_reads,
+        }
+    }
+
+    fn node_for(&self, fid: Fid) -> Result<HangingNode, ErrorCode> {
+        self.fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .get(&fid)
+            .copied()
+            .ok_or(ErrorCode::NotFound)
+    }
+}
+
+#[async_trait]
+impl FileServer for HangingContainerEventFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        if fid != Fid::ROOT || names.len() != 4 || names[0] != "agent" || names[1] != "1" {
+            return Err(ErrorCode::NotFound);
+        }
+        let container = names[2].as_str();
+        if container != "requests" && container != "actions" {
+            return Err(ErrorCode::NotFound);
+        }
+        let node = match names[3].as_str() {
+            "events" => HangingNode::EventStream,
+            "clone" => HangingNode::CloneFile,
+            _ => return Err(ErrorCode::NotFound),
+        };
+        self.fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .insert(newfid, node);
+        Ok(qid_for_hanging_node(node))
+    }
+
+    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        self.node_for(fid).map(qid_for_hanging_node)
+    }
+
+    async fn read(&self, fid: Fid, _offset: u64, _count: u32) -> Result<Vec<u8>, ErrorCode> {
+        match self.node_for(fid)? {
+            HangingNode::CloneFile => Ok(b"1\n".to_vec()),
+            HangingNode::EventStream => {
+                let _guard = ActiveEventReadGuard::new(self.active_event_reads.clone());
+                std::future::pending::<()>().await;
+                unreachable!("pending event read should be cancelled by the checker")
+            }
+        }
+    }
+
+    async fn write(&self, _fid: Fid, _offset: u64, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        let node = self.node_for(fid)?;
+        let name = match node {
+            HangingNode::EventStream => "events",
+            HangingNode::CloneFile => "clone",
+        };
+        Ok(Stat {
+            name: name.to_string(),
+            qid: qid_for_hanging_node(node),
+            length: 0,
+            writable: true,
+        })
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.clunk(fid).await
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.fids
+            .lock()
+            .expect("fid map lock should not be poisoned")
+            .remove(&fid);
+        Ok(())
+    }
+}
+
+struct ActiveEventReadGuard {
+    active_event_reads: Arc<AtomicUsize>,
+}
+
+impl Drop for ActiveEventReadGuard {
+    fn drop(&mut self) {
+        self.active_event_reads.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+impl ActiveEventReadGuard {
+    fn new(active_event_reads: Arc<AtomicUsize>) -> Self {
+        active_event_reads.fetch_add(1, Ordering::SeqCst);
+        Self { active_event_reads }
+    }
+}
+
+fn qid_for_hanging_node(node: HangingNode) -> Qid {
+    let kind = match node {
+        HangingNode::EventStream => FileKind::Stream,
+        HangingNode::CloneFile => FileKind::Clone,
+    };
+    let path = match node {
+        HangingNode::EventStream => 1,
+        HangingNode::CloneFile => 2,
+    };
+    Qid {
+        kind,
+        version: 0,
+        path,
+    }
 }

--- a/crates/agentfs/tests/conformance.rs
+++ b/crates/agentfs/tests/conformance.rs
@@ -5,7 +5,10 @@ use std::sync::{
 };
 
 use alan_agentfs::{AgentConformanceChecker, AgentFs, AgentRootFs};
-use alan_ap::{ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, Qid, Stat};
+use alan_ap::{
+    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode, ProcessOutputEventSource,
+    Qid, Stat,
+};
 use alan_kernel::{Access, MountFs, Namespace, ProcFs};
 use alan_shell::Shell;
 use async_trait::async_trait;
@@ -13,7 +16,11 @@ use async_trait::async_trait;
 fn namespace_with_agent_root() -> (InProcessTransport, Shell, Arc<AgentRootFs>) {
     let proc = Arc::new(ProcFs::new());
     let proc_server: Arc<dyn FileServer> = proc.clone();
-    let agent_root = Arc::new(AgentRootFs::new(proc_server));
+    let proc_output_events: Arc<dyn ProcessOutputEventSource> = proc.clone();
+    let agent_root = Arc::new(AgentRootFs::new_with_process_output_events(
+        proc_server,
+        proc_output_events,
+    ));
 
     let mut namespace = Namespace::new();
     namespace.mount("/proc", InProcessTransport::new(proc), Access::ReadWrite);

--- a/crates/ap/src/lib.rs
+++ b/crates/ap/src/lib.rs
@@ -19,9 +19,9 @@ mod version;
 mod wire;
 
 pub use server::{
-    FileServer, InProcessTransport, ProcessInputEventSink, ProcessInputEventSource,
-    ProcessIoEventKind, ProcessIoEventSink, ProcessIoEventSource, ProcessOutputEventSink,
-    ProcessOutputEventSource,
+    FileServer, InProcessTransport, ProcessEvent, ProcessEventSink, ProcessEventSource,
+    ProcessInputEventSink, ProcessInputEventSource, ProcessIoEventKind, ProcessIoEventSink,
+    ProcessIoEventSource, ProcessOutputEventSink, ProcessOutputEventSource,
 };
 pub use stream::Stream;
 pub use types::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Stat};

--- a/crates/ap/src/lib.rs
+++ b/crates/ap/src/lib.rs
@@ -18,7 +18,9 @@ mod types;
 mod version;
 mod wire;
 
-pub use server::{FileServer, InProcessTransport};
+pub use server::{
+    FileServer, InProcessTransport, ProcessOutputEventSink, ProcessOutputEventSource,
+};
 pub use stream::Stream;
 pub use types::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Stat};
 pub use version::VersionTable;

--- a/crates/ap/src/lib.rs
+++ b/crates/ap/src/lib.rs
@@ -19,7 +19,8 @@ mod version;
 mod wire;
 
 pub use server::{
-    FileServer, InProcessTransport, ProcessOutputEventSink, ProcessOutputEventSource,
+    FileServer, InProcessTransport, ProcessInputEventSink, ProcessInputEventSource,
+    ProcessOutputEventSink, ProcessOutputEventSource,
 };
 pub use stream::Stream;
 pub use types::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Stat};

--- a/crates/ap/src/lib.rs
+++ b/crates/ap/src/lib.rs
@@ -20,7 +20,8 @@ mod wire;
 
 pub use server::{
     FileServer, InProcessTransport, ProcessInputEventSink, ProcessInputEventSource,
-    ProcessOutputEventSink, ProcessOutputEventSource,
+    ProcessIoEventKind, ProcessIoEventSink, ProcessIoEventSource, ProcessOutputEventSink,
+    ProcessOutputEventSource,
 };
 pub use stream::Stream;
 pub use types::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Stat};

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -80,6 +80,25 @@ pub trait ProcessOutputEventSource: Send + Sync {
     ) -> Result<(), ErrorCode>;
 }
 
+/// Receiver for process-input append notifications.
+///
+/// This mirrors process-output notifications so higher-level views can observe
+/// input delivered directly through `/proc/<pid>/io/input`.
+#[async_trait]
+pub trait ProcessInputEventSink: Send + Sync {
+    async fn input_appended(&self, pid: &str, count: u32);
+}
+
+/// Optional event source implemented by file servers that own process input.
+#[async_trait]
+pub trait ProcessInputEventSource: Send + Sync {
+    async fn subscribe_process_input(
+        &self,
+        pid: &str,
+        sink: Arc<dyn ProcessInputEventSink>,
+    ) -> Result<(), ErrorCode>;
+}
+
 /// The in-process fast path: dispatches a wire [`Request`] to a [`FileServer`]
 /// and returns its [`Response`] with no serialization (§5.6).
 #[derive(Clone)]

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -60,6 +60,26 @@ pub trait FileServer: Send + Sync {
     async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode>;
 }
 
+/// Receiver for process-output append notifications.
+///
+/// This is intentionally generic aP-adjacent plumbing: the kernel can publish
+/// `/proc/<pid>/io/output` stream changes without knowing which user-space file
+/// server, if any, projects those changes into a higher-level view.
+#[async_trait]
+pub trait ProcessOutputEventSink: Send + Sync {
+    async fn output_appended(&self, pid: &str, count: u32);
+}
+
+/// Optional event source implemented by file servers that own process output.
+#[async_trait]
+pub trait ProcessOutputEventSource: Send + Sync {
+    async fn subscribe_process_output(
+        &self,
+        pid: &str,
+        sink: Arc<dyn ProcessOutputEventSink>,
+    ) -> Result<(), ErrorCode>;
+}
+
 /// The in-process fast path: dispatches a wire [`Request`] to a [`FileServer`]
 /// and returns its [`Response`] with no serialization (§5.6).
 #[derive(Clone)]

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -99,6 +99,33 @@ pub trait ProcessInputEventSource: Send + Sync {
     ) -> Result<(), ErrorCode>;
 }
 
+/// Process IO event direction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessIoEventKind {
+    Input,
+    Output,
+}
+
+/// Receiver for ordered process IO append notifications.
+///
+/// This is the ordered form of the input/output-specific sinks above. A
+/// subscriber that binds after IO has already happened can replay retained
+/// `/proc/<pid>/io/events` history without grouping records by direction.
+#[async_trait]
+pub trait ProcessIoEventSink: Send + Sync {
+    async fn io_appended(&self, pid: &str, kind: ProcessIoEventKind, count: u32);
+}
+
+/// Optional ordered event source implemented by file servers that own process IO.
+#[async_trait]
+pub trait ProcessIoEventSource: Send + Sync {
+    async fn subscribe_process_io(
+        &self,
+        pid: &str,
+        sink: Arc<dyn ProcessIoEventSink>,
+    ) -> Result<(), ErrorCode>;
+}
+
 /// The in-process fast path: dispatches a wire [`Request`] to a [`FileServer`]
 /// and returns its [`Response`] with no serialization (§5.6).
 #[derive(Clone)]

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -126,6 +126,30 @@ pub trait ProcessIoEventSource: Send + Sync {
     ) -> Result<(), ErrorCode>;
 }
 
+/// Ordered process event retained by `/proc` and projected into aggregate views.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProcessEvent {
+    Input { count: u32 },
+    Output { count: u32 },
+    Status { status: String },
+}
+
+/// Receiver for ordered process lifecycle and IO notifications.
+#[async_trait]
+pub trait ProcessEventSink: Send + Sync {
+    async fn process_event(&self, pid: &str, event: ProcessEvent);
+}
+
+/// Optional ordered event source implemented by file servers that own process state.
+#[async_trait]
+pub trait ProcessEventSource: Send + Sync {
+    async fn subscribe_process_events(
+        &self,
+        pid: &str,
+        sink: Arc<dyn ProcessEventSink>,
+    ) -> Result<(), ErrorCode>;
+}
+
 /// The in-process fast path: dispatches a wire [`Request`] to a [`FileServer`]
 /// and returns its [`Response`] with no serialization (§5.6).
 #[derive(Clone)]

--- a/crates/kernel/src/procfs.rs
+++ b/crates/kernel/src/procfs.rs
@@ -34,7 +34,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use alan_ap::{
     ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode,
-    ProcessOutputEventSink, ProcessOutputEventSource, Qid, Stat, Stream,
+    ProcessInputEventSink, ProcessInputEventSource, ProcessOutputEventSink,
+    ProcessOutputEventSource, Qid, Stat, Stream,
 };
 use async_trait::async_trait;
 use tokio::sync::Mutex;
@@ -136,6 +137,7 @@ struct State {
     inputs: HashMap<Pid, Stream>,
     outputs: HashMap<Pid, Stream>,
     io_events: HashMap<Pid, Stream>,
+    input_observers: HashMap<Pid, Vec<Arc<dyn ProcessInputEventSink>>>,
     output_observers: HashMap<Pid, Vec<Arc<dyn ProcessOutputEventSink>>>,
 }
 
@@ -171,6 +173,7 @@ impl ProcFs {
                 inputs: HashMap::new(),
                 outputs: HashMap::new(),
                 io_events: HashMap::new(),
+                input_observers: HashMap::new(),
                 output_observers: HashMap::new(),
             })),
             view_id: next_view_id(),
@@ -286,6 +289,17 @@ impl ProcFs {
             observer.output_appended(&pid, count).await;
         }
     }
+
+    async fn notify_input_observers(&self, pid: Pid, count: u32) {
+        let observers = {
+            let state = self.state.lock().await;
+            state.input_observers.get(&pid).cloned().unwrap_or_default()
+        };
+        let pid = pid.0.to_string();
+        for observer in observers {
+            observer.input_appended(&pid, count).await;
+        }
+    }
 }
 
 #[async_trait]
@@ -301,6 +315,23 @@ impl ProcessOutputEventSource for ProcFs {
             return Err(ErrorCode::NotFound);
         }
         state.output_observers.entry(pid).or_default().push(sink);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ProcessInputEventSource for ProcFs {
+    async fn subscribe_process_input(
+        &self,
+        pid: &str,
+        sink: Arc<dyn ProcessInputEventSink>,
+    ) -> Result<(), ErrorCode> {
+        let pid = parse_pid(pid).ok_or(ErrorCode::BadRequest)?;
+        let mut state = self.state.lock().await;
+        if state.table.get(pid).is_none() {
+            return Err(ErrorCode::NotFound);
+        }
+        state.input_observers.entry(pid).or_default().push(sink);
         Ok(())
     }
 }
@@ -438,6 +469,7 @@ impl State {
 
 enum ProcStreamWrite {
     Input {
+        pid: Pid,
         stream: Stream,
         events: Stream,
     },
@@ -594,6 +626,7 @@ impl FileServer for ProcFs {
                         return Err(ErrorCode::NoAccess);
                     }
                     ProcStreamWrite::Input {
+                        pid,
                         stream: state.inputs.get(&pid).cloned().ok_or(ErrorCode::NotFound)?,
                         events: state
                             .io_events
@@ -627,9 +660,14 @@ impl FileServer for ProcFs {
         };
         let count = data.len() as u32;
         match stream_write {
-            ProcStreamWrite::Input { stream, events } => {
+            ProcStreamWrite::Input {
+                pid,
+                stream,
+                events,
+            } => {
                 stream.append(data).await;
                 append_io_event(&events, "input", count).await;
+                self.notify_input_observers(pid, count).await;
             }
             ProcStreamWrite::Output {
                 pid,

--- a/crates/kernel/src/procfs.rs
+++ b/crates/kernel/src/procfs.rs
@@ -34,8 +34,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use alan_ap::{
     ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode,
-    ProcessInputEventSink, ProcessInputEventSource, ProcessOutputEventSink,
-    ProcessOutputEventSource, Qid, Stat, Stream,
+    ProcessInputEventSink, ProcessInputEventSource, ProcessIoEventKind, ProcessIoEventSink,
+    ProcessIoEventSource, ProcessOutputEventSink, ProcessOutputEventSource, Qid, Stat, Stream,
 };
 use async_trait::async_trait;
 use tokio::sync::Mutex;
@@ -138,6 +138,7 @@ struct State {
     outputs: HashMap<Pid, Stream>,
     io_events: HashMap<Pid, Stream>,
     io_event_history: HashMap<Pid, Vec<ProcessIoEvent>>,
+    io_observers: HashMap<Pid, Vec<Arc<dyn ProcessIoEventSink>>>,
     input_observers: HashMap<Pid, Vec<Arc<dyn ProcessInputEventSink>>>,
     output_observers: HashMap<Pid, Vec<Arc<dyn ProcessOutputEventSink>>>,
 }
@@ -146,6 +147,21 @@ struct State {
 enum ProcessIoEvent {
     Input(u32),
     Output(u32),
+}
+
+impl ProcessIoEvent {
+    fn kind(self) -> ProcessIoEventKind {
+        match self {
+            Self::Input(_) => ProcessIoEventKind::Input,
+            Self::Output(_) => ProcessIoEventKind::Output,
+        }
+    }
+
+    fn count(self) -> u32 {
+        match self {
+            Self::Input(count) | Self::Output(count) => count,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -181,6 +197,7 @@ impl ProcFs {
                 outputs: HashMap::new(),
                 io_events: HashMap::new(),
                 io_event_history: HashMap::new(),
+                io_observers: HashMap::new(),
                 input_observers: HashMap::new(),
                 output_observers: HashMap::new(),
             })),
@@ -284,38 +301,54 @@ impl ProcFs {
     }
 
     async fn publish_output_event(&self, pid: Pid, count: u32) {
-        let observers = {
+        let (output_observers, io_observers) = {
             let mut state = self.state.lock().await;
             state
                 .io_event_history
                 .entry(pid)
                 .or_default()
                 .push(ProcessIoEvent::Output(count));
-            state
-                .output_observers
-                .get(&pid)
-                .cloned()
-                .unwrap_or_default()
+            (
+                state
+                    .output_observers
+                    .get(&pid)
+                    .cloned()
+                    .unwrap_or_default(),
+                state.io_observers.get(&pid).cloned().unwrap_or_default(),
+            )
         };
         let pid = pid.0.to_string();
-        for observer in observers {
+        for observer in output_observers {
             observer.output_appended(&pid, count).await;
+        }
+        for observer in io_observers {
+            observer
+                .io_appended(&pid, ProcessIoEventKind::Output, count)
+                .await;
         }
     }
 
     async fn publish_input_event(&self, pid: Pid, count: u32) {
-        let observers = {
+        let (input_observers, io_observers) = {
             let mut state = self.state.lock().await;
             state
                 .io_event_history
                 .entry(pid)
                 .or_default()
                 .push(ProcessIoEvent::Input(count));
-            state.input_observers.get(&pid).cloned().unwrap_or_default()
+            (
+                state.input_observers.get(&pid).cloned().unwrap_or_default(),
+                state.io_observers.get(&pid).cloned().unwrap_or_default(),
+            )
         };
         let pid = pid.0.to_string();
-        for observer in observers {
+        for observer in input_observers {
             observer.input_appended(&pid, count).await;
+        }
+        for observer in io_observers {
+            observer
+                .io_appended(&pid, ProcessIoEventKind::Input, count)
+                .await;
         }
     }
 }
@@ -389,6 +422,39 @@ impl ProcessInputEventSource for ProcFs {
         };
         for count in replay {
             sink.input_appended(&pid_text, count).await;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ProcessIoEventSource for ProcFs {
+    async fn subscribe_process_io(
+        &self,
+        pid: &str,
+        sink: Arc<dyn ProcessIoEventSink>,
+    ) -> Result<(), ErrorCode> {
+        let pid = parse_pid(pid).ok_or(ErrorCode::BadRequest)?;
+        let (pid_text, replay) = {
+            let mut state = self.state.lock().await;
+            if state.table.get(pid).is_none() {
+                return Err(ErrorCode::NotFound);
+            }
+            let replay = state
+                .io_event_history
+                .get(&pid)
+                .cloned()
+                .unwrap_or_default();
+            state
+                .io_observers
+                .entry(pid)
+                .or_default()
+                .push(sink.clone());
+            (pid.0.to_string(), replay)
+        };
+        for event in replay {
+            sink.io_appended(&pid_text, event.kind(), event.count())
+                .await;
         }
         Ok(())
     }

--- a/crates/kernel/src/procfs.rs
+++ b/crates/kernel/src/procfs.rs
@@ -31,7 +31,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use alan_ap::{
-    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode, Qid, Stat, Stream,
+    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode,
+    ProcessOutputEventSink, ProcessOutputEventSource, Qid, Stat, Stream,
 };
 use async_trait::async_trait;
 use tokio::sync::Mutex;
@@ -129,6 +130,7 @@ struct State {
     /// One output stream per committed process (the kernel owns the file; the
     /// process's execution, in user space, writes to it).
     outputs: HashMap<Pid, Stream>,
+    output_observers: HashMap<Pid, Vec<Arc<dyn ProcessOutputEventSink>>>,
 }
 
 #[derive(Clone)]
@@ -161,6 +163,7 @@ impl ProcFs {
                 table: ProcessTable::new(),
                 fids: HashMap::new(),
                 outputs: HashMap::new(),
+                output_observers: HashMap::new(),
             })),
             view_id: next_view_id(),
             root_node: Node::Root,
@@ -259,6 +262,38 @@ impl ProcFs {
             view_id: self.view_id,
             fid,
         }
+    }
+
+    async fn notify_output_observers(&self, pid: Pid, count: u32) {
+        let observers = {
+            let state = self.state.lock().await;
+            state
+                .output_observers
+                .get(&pid)
+                .cloned()
+                .unwrap_or_default()
+        };
+        let pid = pid.0.to_string();
+        for observer in observers {
+            observer.output_appended(&pid, count).await;
+        }
+    }
+}
+
+#[async_trait]
+impl ProcessOutputEventSource for ProcFs {
+    async fn subscribe_process_output(
+        &self,
+        pid: &str,
+        sink: Arc<dyn ProcessOutputEventSink>,
+    ) -> Result<(), ErrorCode> {
+        let pid = parse_pid(pid).ok_or(ErrorCode::BadRequest)?;
+        let mut state = self.state.lock().await;
+        if state.table.get(pid).is_none() {
+            return Err(ErrorCode::NotFound);
+        }
+        state.output_observers.entry(pid).or_default().push(sink);
+        Ok(())
     }
 }
 
@@ -476,7 +511,7 @@ impl FileServer for ProcFs {
     }
 
     async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
-        let output = {
+        let (pid, output) = {
             let mut state = self.state.lock().await;
             let fid_key = self.fid_key(fid);
             let node = state.node_of(fid_key, &self.root_node)?;
@@ -524,17 +559,22 @@ impl FileServer for ProcFs {
                     if !has_write_intent {
                         return Err(ErrorCode::NoAccess);
                     }
-                    state
-                        .outputs
-                        .get(&pid)
-                        .cloned()
-                        .ok_or(ErrorCode::NotFound)?
+                    (
+                        pid,
+                        state
+                            .outputs
+                            .get(&pid)
+                            .cloned()
+                            .ok_or(ErrorCode::NotFound)?,
+                    )
                 }
                 _ => return Err(ErrorCode::Unsupported),
             }
         };
         output.append(data).await;
-        Ok(data.len() as u32)
+        let count = data.len() as u32;
+        self.notify_output_observers(pid, count).await;
+        Ok(count)
     }
 
     async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
@@ -622,7 +662,7 @@ impl FileServer for ProcFs {
                         state.outputs.insert(committed, output.clone());
                         self.runner
                             .clone()
-                            .map(|runner| (runner, output, invocation))
+                            .map(|runner| (runner, output, invocation, self.clone()))
                     }
                     Err(_) => {
                         // Reject at commit and discard the fid-private slot — it was
@@ -635,12 +675,14 @@ impl FileServer for ProcFs {
                 None
             }
         };
-        if let Some((runner, output, invocation)) = runner_launch {
+        if let Some((runner, output, invocation, events)) = runner_launch {
             let state = self.state.clone();
             tokio::spawn(async move {
                 let outcome = runner.run(invocation.clone()).await;
                 if !outcome.output.is_empty() {
+                    let count = outcome.output.len() as u32;
                     output.append(&outcome.output).await;
+                    events.notify_output_observers(invocation.pid, count).await;
                 }
                 let mut state = state.lock().await;
                 state.table.exit(invocation.pid, outcome.exit_code);

--- a/crates/kernel/src/procfs.rs
+++ b/crates/kernel/src/procfs.rs
@@ -33,9 +33,10 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use alan_ap::{
-    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode,
-    ProcessInputEventSink, ProcessInputEventSource, ProcessIoEventKind, ProcessIoEventSink,
-    ProcessIoEventSource, ProcessOutputEventSink, ProcessOutputEventSource, Qid, Stat, Stream,
+    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode, ProcessEvent,
+    ProcessEventSink, ProcessEventSource, ProcessInputEventSink, ProcessInputEventSource,
+    ProcessIoEventKind, ProcessIoEventSink, ProcessIoEventSource, ProcessOutputEventSink,
+    ProcessOutputEventSource, Qid, Stat, Stream,
 };
 use async_trait::async_trait;
 use tokio::sync::Mutex;
@@ -137,30 +138,48 @@ struct State {
     inputs: HashMap<Pid, Stream>,
     outputs: HashMap<Pid, Stream>,
     io_events: HashMap<Pid, Stream>,
-    io_event_history: HashMap<Pid, Vec<ProcessIoEvent>>,
-    io_observers: HashMap<Pid, Vec<Arc<dyn ProcessIoEventSink>>>,
+    event_history: HashMap<Pid, Vec<ProcessEvent>>,
+    event_observers: HashMap<Pid, Vec<Arc<OrderedProcessEventObserver>>>,
+    io_observers: HashMap<Pid, Vec<Arc<OrderedProcessIoEventObserver>>>,
     input_observers: HashMap<Pid, Vec<Arc<dyn ProcessInputEventSink>>>,
     output_observers: HashMap<Pid, Vec<Arc<dyn ProcessOutputEventSink>>>,
 }
 
-#[derive(Clone, Copy)]
-enum ProcessIoEvent {
-    Input(u32),
-    Output(u32),
+struct OrderedProcessEventObserver {
+    sink: Arc<dyn ProcessEventSink>,
+    replay: Mutex<()>,
 }
 
-impl ProcessIoEvent {
-    fn kind(self) -> ProcessIoEventKind {
-        match self {
-            Self::Input(_) => ProcessIoEventKind::Input,
-            Self::Output(_) => ProcessIoEventKind::Output,
+impl OrderedProcessEventObserver {
+    fn new(sink: Arc<dyn ProcessEventSink>) -> Self {
+        Self {
+            sink,
+            replay: Mutex::new(()),
         }
     }
 
-    fn count(self) -> u32 {
-        match self {
-            Self::Input(count) | Self::Output(count) => count,
+    async fn deliver(&self, pid: &str, event: ProcessEvent) {
+        let _replay = self.replay.lock().await;
+        self.sink.process_event(pid, event).await;
+    }
+}
+
+struct OrderedProcessIoEventObserver {
+    sink: Arc<dyn ProcessIoEventSink>,
+    replay: Mutex<()>,
+}
+
+impl OrderedProcessIoEventObserver {
+    fn new(sink: Arc<dyn ProcessIoEventSink>) -> Self {
+        Self {
+            sink,
+            replay: Mutex::new(()),
         }
+    }
+
+    async fn deliver(&self, pid: &str, kind: ProcessIoEventKind, count: u32) {
+        let _replay = self.replay.lock().await;
+        self.sink.io_appended(pid, kind, count).await;
     }
 }
 
@@ -196,7 +215,8 @@ impl ProcFs {
                 inputs: HashMap::new(),
                 outputs: HashMap::new(),
                 io_events: HashMap::new(),
-                io_event_history: HashMap::new(),
+                event_history: HashMap::new(),
+                event_observers: HashMap::new(),
                 io_observers: HashMap::new(),
                 input_observers: HashMap::new(),
                 output_observers: HashMap::new(),
@@ -300,55 +320,51 @@ impl ProcFs {
         }
     }
 
-    async fn publish_output_event(&self, pid: Pid, count: u32) {
-        let (output_observers, io_observers) = {
+    async fn publish_process_event(&self, pid: Pid, event: ProcessEvent) {
+        let (event_observers, io_observers, input_observers, output_observers) = {
             let mut state = self.state.lock().await;
             state
-                .io_event_history
+                .event_history
                 .entry(pid)
                 .or_default()
-                .push(ProcessIoEvent::Output(count));
+                .push(event.clone());
             (
+                state.event_observers.get(&pid).cloned().unwrap_or_default(),
+                state.io_observers.get(&pid).cloned().unwrap_or_default(),
+                state.input_observers.get(&pid).cloned().unwrap_or_default(),
                 state
                     .output_observers
                     .get(&pid)
                     .cloned()
                     .unwrap_or_default(),
-                state.io_observers.get(&pid).cloned().unwrap_or_default(),
             )
         };
         let pid = pid.0.to_string();
-        for observer in output_observers {
-            observer.output_appended(&pid, count).await;
+        match &event {
+            ProcessEvent::Input { count } => {
+                for observer in input_observers {
+                    observer.input_appended(&pid, *count).await;
+                }
+                for observer in io_observers {
+                    observer
+                        .deliver(&pid, ProcessIoEventKind::Input, *count)
+                        .await;
+                }
+            }
+            ProcessEvent::Output { count } => {
+                for observer in output_observers {
+                    observer.output_appended(&pid, *count).await;
+                }
+                for observer in io_observers {
+                    observer
+                        .deliver(&pid, ProcessIoEventKind::Output, *count)
+                        .await;
+                }
+            }
+            ProcessEvent::Status { .. } => {}
         }
-        for observer in io_observers {
-            observer
-                .io_appended(&pid, ProcessIoEventKind::Output, count)
-                .await;
-        }
-    }
-
-    async fn publish_input_event(&self, pid: Pid, count: u32) {
-        let (input_observers, io_observers) = {
-            let mut state = self.state.lock().await;
-            state
-                .io_event_history
-                .entry(pid)
-                .or_default()
-                .push(ProcessIoEvent::Input(count));
-            (
-                state.input_observers.get(&pid).cloned().unwrap_or_default(),
-                state.io_observers.get(&pid).cloned().unwrap_or_default(),
-            )
-        };
-        let pid = pid.0.to_string();
-        for observer in input_observers {
-            observer.input_appended(&pid, count).await;
-        }
-        for observer in io_observers {
-            observer
-                .io_appended(&pid, ProcessIoEventKind::Input, count)
-                .await;
+        for observer in event_observers {
+            observer.deliver(&pid, event.clone()).await;
         }
     }
 }
@@ -367,13 +383,13 @@ impl ProcessOutputEventSource for ProcFs {
                 return Err(ErrorCode::NotFound);
             }
             let replay = state
-                .io_event_history
+                .event_history
                 .get(&pid)
                 .into_iter()
                 .flatten()
                 .filter_map(|event| match event {
-                    ProcessIoEvent::Input(_) => None,
-                    ProcessIoEvent::Output(count) => Some(*count),
+                    ProcessEvent::Input { .. } | ProcessEvent::Status { .. } => None,
+                    ProcessEvent::Output { count } => Some(*count),
                 })
                 .collect::<Vec<_>>();
             state
@@ -404,13 +420,13 @@ impl ProcessInputEventSource for ProcFs {
                 return Err(ErrorCode::NotFound);
             }
             let replay = state
-                .io_event_history
+                .event_history
                 .get(&pid)
                 .into_iter()
                 .flatten()
                 .filter_map(|event| match event {
-                    ProcessIoEvent::Input(count) => Some(*count),
-                    ProcessIoEvent::Output(_) => None,
+                    ProcessEvent::Input { count } => Some(*count),
+                    ProcessEvent::Output { .. } | ProcessEvent::Status { .. } => None,
                 })
                 .collect::<Vec<_>>();
             state
@@ -435,27 +451,70 @@ impl ProcessIoEventSource for ProcFs {
         sink: Arc<dyn ProcessIoEventSink>,
     ) -> Result<(), ErrorCode> {
         let pid = parse_pid(pid).ok_or(ErrorCode::BadRequest)?;
+        let observer = Arc::new(OrderedProcessIoEventObserver::new(sink));
+        let observer_for_state = observer.clone();
+        let replay_sink = observer.sink.clone();
+        let replay_guard = observer.replay.lock().await;
         let (pid_text, replay) = {
             let mut state = self.state.lock().await;
             if state.table.get(pid).is_none() {
                 return Err(ErrorCode::NotFound);
             }
             let replay = state
-                .io_event_history
+                .event_history
                 .get(&pid)
-                .cloned()
-                .unwrap_or_default();
+                .into_iter()
+                .flatten()
+                .filter_map(|event| match event {
+                    ProcessEvent::Input { count } => Some((ProcessIoEventKind::Input, *count)),
+                    ProcessEvent::Output { count } => Some((ProcessIoEventKind::Output, *count)),
+                    ProcessEvent::Status { .. } => None,
+                })
+                .collect::<Vec<_>>();
             state
                 .io_observers
                 .entry(pid)
                 .or_default()
-                .push(sink.clone());
+                .push(observer_for_state);
+            (pid.0.to_string(), replay)
+        };
+        for (kind, count) in replay {
+            replay_sink.io_appended(&pid_text, kind, count).await;
+        }
+        drop(replay_guard);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ProcessEventSource for ProcFs {
+    async fn subscribe_process_events(
+        &self,
+        pid: &str,
+        sink: Arc<dyn ProcessEventSink>,
+    ) -> Result<(), ErrorCode> {
+        let pid = parse_pid(pid).ok_or(ErrorCode::BadRequest)?;
+        let observer = Arc::new(OrderedProcessEventObserver::new(sink));
+        let observer_for_state = observer.clone();
+        let replay_sink = observer.sink.clone();
+        let replay_guard = observer.replay.lock().await;
+        let (pid_text, replay) = {
+            let mut state = self.state.lock().await;
+            if state.table.get(pid).is_none() {
+                return Err(ErrorCode::NotFound);
+            }
+            let replay = state.event_history.get(&pid).cloned().unwrap_or_default();
+            state
+                .event_observers
+                .entry(pid)
+                .or_default()
+                .push(observer_for_state);
             (pid.0.to_string(), replay)
         };
         for event in replay {
-            sink.io_appended(&pid_text, event.kind(), event.count())
-                .await;
+            replay_sink.process_event(&pid_text, event).await;
         }
+        drop(replay_guard);
         Ok(())
     }
 }
@@ -602,6 +661,9 @@ enum ProcStreamWrite {
         stream: Stream,
         events: Stream,
     },
+    Status {
+        pid: Pid,
+    },
 }
 
 #[async_trait]
@@ -741,7 +803,7 @@ impl FileServer for ProcFs {
                         b"cancel" | b"interrupt" => state.table.exit(pid, 130),
                         _ => return Err(ErrorCode::BadRequest),
                     }
-                    return Ok(data.len() as u32);
+                    ProcStreamWrite::Status { pid }
                 }
                 // Process input is a stream owned by `/proc`; parents, shells,
                 // and hosts write to it, and process descriptors read from it.
@@ -791,7 +853,8 @@ impl FileServer for ProcFs {
             } => {
                 stream.append(data).await;
                 append_io_event(&events, "input", count).await;
-                self.publish_input_event(pid, count).await;
+                self.publish_process_event(pid, ProcessEvent::Input { count })
+                    .await;
             }
             ProcStreamWrite::Output {
                 pid,
@@ -800,7 +863,17 @@ impl FileServer for ProcFs {
             } => {
                 stream.append(data).await;
                 append_io_event(&events, "output", count).await;
-                self.publish_output_event(pid, count).await;
+                self.publish_process_event(pid, ProcessEvent::Output { count })
+                    .await;
+            }
+            ProcStreamWrite::Status { pid } => {
+                self.publish_process_event(
+                    pid,
+                    ProcessEvent::Status {
+                        status: "exited".to_string(),
+                    },
+                )
+                .await;
             }
         }
         Ok(count)
@@ -854,7 +927,7 @@ impl FileServer for ProcFs {
         if fid == Fid::ROOT && !matches!(self.root_node, Node::Clone) {
             return Ok(());
         }
-        let runner_launch = {
+        let committed_process = {
             let mut state = self.state.lock().await;
             let Some(f) = state.fids.remove(&self.fid_key(fid)) else {
                 return Err(ErrorCode::NotFound);
@@ -901,10 +974,12 @@ impl FileServer for ProcFs {
                         state.inputs.insert(committed, input);
                         state.outputs.insert(committed, output.clone());
                         state.io_events.insert(committed, io_events.clone());
-                        state.io_event_history.insert(committed, Vec::new());
-                        self.runner
+                        state.event_history.insert(committed, Vec::new());
+                        let runner_launch = self
+                            .runner
                             .clone()
-                            .map(|runner| (runner, output, io_events, invocation, self.clone()))
+                            .map(|runner| (runner, output, io_events, invocation, self.clone()));
+                        Some((committed, runner_launch))
                     }
                     Err(_) => {
                         // Reject at commit and discard the fid-private slot — it was
@@ -917,19 +992,40 @@ impl FileServer for ProcFs {
                 None
             }
         };
-        if let Some((runner, output, io_events, invocation, events)) = runner_launch {
-            let state = self.state.clone();
-            tokio::spawn(async move {
-                let outcome = runner.run(invocation.clone()).await;
-                if !outcome.output.is_empty() {
-                    let count = outcome.output.len() as u32;
-                    output.append(&outcome.output).await;
-                    append_io_event(&io_events, "output", count).await;
-                    events.publish_output_event(invocation.pid, count).await;
-                }
-                let mut state = state.lock().await;
-                state.table.exit(invocation.pid, outcome.exit_code);
-            });
+        if let Some((committed, runner_launch)) = committed_process {
+            self.publish_process_event(
+                committed,
+                ProcessEvent::Status {
+                    status: "running".to_string(),
+                },
+            )
+            .await;
+            if let Some((runner, output, io_events, invocation, events)) = runner_launch {
+                let state = self.state.clone();
+                tokio::spawn(async move {
+                    let outcome = runner.run(invocation.clone()).await;
+                    if !outcome.output.is_empty() {
+                        let count = outcome.output.len() as u32;
+                        output.append(&outcome.output).await;
+                        append_io_event(&io_events, "output", count).await;
+                        events
+                            .publish_process_event(invocation.pid, ProcessEvent::Output { count })
+                            .await;
+                    }
+                    {
+                        let mut state = state.lock().await;
+                        state.table.exit(invocation.pid, outcome.exit_code);
+                    }
+                    events
+                        .publish_process_event(
+                            invocation.pid,
+                            ProcessEvent::Status {
+                                status: "exited".to_string(),
+                            },
+                        )
+                        .await;
+                });
+            }
         }
         Ok(())
     }

--- a/crates/kernel/src/procfs.rs
+++ b/crates/kernel/src/procfs.rs
@@ -13,7 +13,9 @@
 //!     credentials         # uname
 //!     exit                # exit code once exited, else ""
 //!     ctl                 # write "interrupt"/"cancel" (generic process control)
+//!     io/input            # the process's input stream
 //!     io/output           # the process's output stream
+//!     io/events           # IO-scoped input/output event stream
 //! ```
 //!
 //! Process creation is pure aP: opening `clone` allocates a fid-private pending
@@ -86,7 +88,9 @@ enum Node {
     Exit(Pid),
     Ctl(Pid),
     IoDir(Pid),
+    Input(Pid),
     Output(Pid),
+    IoEvents(Pid),
     NamespaceInfo(Pid),
 }
 
@@ -127,9 +131,11 @@ static NEXT_PROCFS_VIEW_ID: AtomicU64 = AtomicU64::new(1);
 struct State {
     table: ProcessTable,
     fids: HashMap<ProcFidKey, ProcFid>,
-    /// One output stream per committed process (the kernel owns the file; the
-    /// process's execution, in user space, writes to it).
+    /// Generic IO streams per committed process. The kernel owns the files; user
+    /// space supplies the execution semantics layered above them.
+    inputs: HashMap<Pid, Stream>,
     outputs: HashMap<Pid, Stream>,
+    io_events: HashMap<Pid, Stream>,
     output_observers: HashMap<Pid, Vec<Arc<dyn ProcessOutputEventSink>>>,
 }
 
@@ -162,7 +168,9 @@ impl ProcFs {
             state: Arc::new(Mutex::new(State {
                 table: ProcessTable::new(),
                 fids: HashMap::new(),
+                inputs: HashMap::new(),
                 outputs: HashMap::new(),
+                io_events: HashMap::new(),
                 output_observers: HashMap::new(),
             })),
             view_id: next_view_id(),
@@ -318,6 +326,7 @@ impl State {
         let version = match node {
             Node::Root => self.table.listing_generation(),
             Node::Clone | Node::Output(_) => 0,
+            Node::Input(_) | Node::IoEvents(_) => 0,
             Node::Proc(p)
             | Node::IoDir(p)
             | Node::Status(p)
@@ -356,7 +365,12 @@ impl State {
                 "namespace" => Ok(Node::NamespaceInfo(*pid)),
                 _ => Err(ErrorCode::NotFound),
             },
-            Node::IoDir(pid) if name == "output" => Ok(Node::Output(*pid)),
+            Node::IoDir(pid) => match name {
+                "input" => Ok(Node::Input(*pid)),
+                "output" => Ok(Node::Output(*pid)),
+                "events" => Ok(Node::IoEvents(*pid)),
+                _ => Err(ErrorCode::NotFound),
+            },
             _ => Err(ErrorCode::NotDirectory),
         }
     }
@@ -372,7 +386,7 @@ impl State {
             Node::Proc(_) => "status\nparent\ncredentials\nexit\nctl\nio\nnamespace"
                 .to_string()
                 .into_bytes(),
-            Node::IoDir(_) => b"output".to_vec(),
+            Node::IoDir(_) => b"input\noutput\nevents".to_vec(),
             Node::Status(pid) => match self.table.get(*pid).map(|p| p.status) {
                 Some(Status::Running) => b"running\n".to_vec(),
                 Some(Status::Exited) => b"exited\n".to_vec(),
@@ -412,12 +426,26 @@ impl State {
                     .join("\n")
                     .into_bytes()
             }
-            // `clone`/`ctl` are write surfaces; `output` is a stream served
-            // directly in `read`, not here.
-            Node::Clone | Node::Ctl(_) | Node::Output(_) => return Err(ErrorCode::Unsupported),
+            // `clone`/`ctl` are write surfaces; IO streams are served directly in
+            // `read`, not here.
+            Node::Clone | Node::Ctl(_) | Node::Input(_) | Node::Output(_) | Node::IoEvents(_) => {
+                return Err(ErrorCode::Unsupported);
+            }
         };
         Ok(bytes)
     }
+}
+
+enum ProcStreamWrite {
+    Input {
+        stream: Stream,
+        events: Stream,
+    },
+    Output {
+        pid: Pid,
+        stream: Stream,
+        events: Stream,
+    },
 }
 
 #[async_trait]
@@ -485,10 +513,10 @@ impl FileServer for ProcFs {
     }
 
     async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
-        // A process's output is a stream: clone it out and serve a blocking read
-        // without holding the state lock (so tailing one process never stalls
-        // the whole `/proc`).
-        let output = {
+        // A process's IO files are streams: clone them out and serve blocking
+        // reads without holding the state lock (so tailing one process never
+        // stalls the whole `/proc`).
+        let stream = {
             let state = self.state.lock().await;
             let fid_key = self.fid_key(fid);
             // An opened clone fid reads back its pending pid (the allocated name).
@@ -499,19 +527,25 @@ impl FileServer for ProcFs {
             }
             let node = state.node_of(fid_key, &self.root_node)?;
             match node {
+                Node::Input(pid) => state.inputs.get(&pid).cloned().ok_or(ErrorCode::NotFound)?,
                 Node::Output(pid) => state
                     .outputs
+                    .get(&pid)
+                    .cloned()
+                    .ok_or(ErrorCode::NotFound)?,
+                Node::IoEvents(pid) => state
+                    .io_events
                     .get(&pid)
                     .cloned()
                     .ok_or(ErrorCode::NotFound)?,
                 other => return Ok(slice(state.file_bytes(&other)?, offset, count)),
             }
         };
-        Ok(output.read(offset, count).await)
+        Ok(stream.read(offset, count).await)
     }
 
     async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
-        let (pid, output) = {
+        let stream_write = {
             let mut state = self.state.lock().await;
             let fid_key = self.fid_key(fid);
             let node = state.node_of(fid_key, &self.root_node)?;
@@ -553,27 +587,60 @@ impl FileServer for ProcFs {
                     }
                     return Ok(data.len() as u32);
                 }
+                // Process input is a stream owned by `/proc`; parents, shells,
+                // and hosts write to it, and process descriptors read from it.
+                Node::Input(pid) => {
+                    if !has_write_intent {
+                        return Err(ErrorCode::NoAccess);
+                    }
+                    ProcStreamWrite::Input {
+                        stream: state.inputs.get(&pid).cloned().ok_or(ErrorCode::NotFound)?,
+                        events: state
+                            .io_events
+                            .get(&pid)
+                            .cloned()
+                            .ok_or(ErrorCode::NotFound)?,
+                    }
+                }
                 // Process output is a stream owned by `/proc`; process descriptors
                 // write to it, and readers tail it through `io/output`.
                 Node::Output(pid) => {
                     if !has_write_intent {
                         return Err(ErrorCode::NoAccess);
                     }
-                    (
+                    ProcStreamWrite::Output {
                         pid,
-                        state
+                        stream: state
                             .outputs
                             .get(&pid)
                             .cloned()
                             .ok_or(ErrorCode::NotFound)?,
-                    )
+                        events: state
+                            .io_events
+                            .get(&pid)
+                            .cloned()
+                            .ok_or(ErrorCode::NotFound)?,
+                    }
                 }
                 _ => return Err(ErrorCode::Unsupported),
             }
         };
-        output.append(data).await;
         let count = data.len() as u32;
-        self.notify_output_observers(pid, count).await;
+        match stream_write {
+            ProcStreamWrite::Input { stream, events } => {
+                stream.append(data).await;
+                append_io_event(&events, "input", count).await;
+            }
+            ProcStreamWrite::Output {
+                pid,
+                stream,
+                events,
+            } => {
+                stream.append(data).await;
+                append_io_event(&events, "output", count).await;
+                self.notify_output_observers(pid, count).await;
+            }
+        }
         Ok(count)
     }
 
@@ -583,7 +650,15 @@ impl FileServer for ProcFs {
         // Report the readable byte length so clients can size reads; write-only
         // surfaces (clone/ctl) are 0, and a process output is its retained length.
         let length = match &node {
+            Node::Input(pid) => match state.inputs.get(pid) {
+                Some(stream) => stream.len().await,
+                None => 0,
+            },
             Node::Output(pid) => match state.outputs.get(pid) {
+                Some(stream) => stream.len().await,
+                None => 0,
+            },
+            Node::IoEvents(pid) => match state.io_events.get(pid) {
                 Some(stream) => stream.len().await,
                 None => 0,
             },
@@ -658,11 +733,15 @@ impl FileServer for ProcFs {
                             namespace: process.namespace.clone(),
                             exec: process.exec.clone(),
                         };
+                        let input = Stream::new();
                         let output = Stream::new();
+                        let io_events = Stream::new();
+                        state.inputs.insert(committed, input);
                         state.outputs.insert(committed, output.clone());
+                        state.io_events.insert(committed, io_events.clone());
                         self.runner
                             .clone()
-                            .map(|runner| (runner, output, invocation, self.clone()))
+                            .map(|runner| (runner, output, io_events, invocation, self.clone()))
                     }
                     Err(_) => {
                         // Reject at commit and discard the fid-private slot — it was
@@ -675,13 +754,14 @@ impl FileServer for ProcFs {
                 None
             }
         };
-        if let Some((runner, output, invocation, events)) = runner_launch {
+        if let Some((runner, output, io_events, invocation, events)) = runner_launch {
             let state = self.state.clone();
             tokio::spawn(async move {
                 let outcome = runner.run(invocation.clone()).await;
                 if !outcome.output.is_empty() {
                     let count = outcome.output.len() as u32;
                     output.append(&outcome.output).await;
+                    append_io_event(&io_events, "output", count).await;
                     events.notify_output_observers(invocation.pid, count).await;
                 }
                 let mut state = state.lock().await;
@@ -721,11 +801,16 @@ fn node_identity(node: &Node) -> (FileKind, u64) {
         Node::Exit(p) => (FileKind::File, tagged(7, *p)),
         Node::Ctl(p) => (FileKind::File, tagged(8, *p)),
         Node::NamespaceInfo(p) => (FileKind::File, tagged(9, *p)),
+        Node::Input(p) => (FileKind::Stream, tagged(10, *p)),
+        Node::IoEvents(p) => (FileKind::Stream, tagged(11, *p)),
     }
 }
 
 fn is_writable(node: &Node) -> bool {
-    matches!(node, Node::Clone | Node::Ctl(_) | Node::Output(_))
+    matches!(
+        node,
+        Node::Clone | Node::Ctl(_) | Node::Input(_) | Node::Output(_)
+    )
 }
 
 fn next_view_id() -> u64 {
@@ -740,4 +825,9 @@ fn slice(bytes: Vec<u8>, offset: Offset, count: u32) -> Vec<u8> {
     let start = (offset as usize).min(bytes.len());
     let end = bytes.len().min(start + count as usize);
     bytes[start..end].to_vec()
+}
+
+async fn append_io_event(events: &Stream, kind: &str, count: u32) {
+    let record = format!("{kind}:{count}\n");
+    events.append(record.as_bytes()).await;
 }

--- a/crates/kernel/src/procfs.rs
+++ b/crates/kernel/src/procfs.rs
@@ -137,8 +137,15 @@ struct State {
     inputs: HashMap<Pid, Stream>,
     outputs: HashMap<Pid, Stream>,
     io_events: HashMap<Pid, Stream>,
+    io_event_history: HashMap<Pid, Vec<ProcessIoEvent>>,
     input_observers: HashMap<Pid, Vec<Arc<dyn ProcessInputEventSink>>>,
     output_observers: HashMap<Pid, Vec<Arc<dyn ProcessOutputEventSink>>>,
+}
+
+#[derive(Clone, Copy)]
+enum ProcessIoEvent {
+    Input(u32),
+    Output(u32),
 }
 
 #[derive(Clone)]
@@ -173,6 +180,7 @@ impl ProcFs {
                 inputs: HashMap::new(),
                 outputs: HashMap::new(),
                 io_events: HashMap::new(),
+                io_event_history: HashMap::new(),
                 input_observers: HashMap::new(),
                 output_observers: HashMap::new(),
             })),
@@ -275,9 +283,14 @@ impl ProcFs {
         }
     }
 
-    async fn notify_output_observers(&self, pid: Pid, count: u32) {
+    async fn publish_output_event(&self, pid: Pid, count: u32) {
         let observers = {
-            let state = self.state.lock().await;
+            let mut state = self.state.lock().await;
+            state
+                .io_event_history
+                .entry(pid)
+                .or_default()
+                .push(ProcessIoEvent::Output(count));
             state
                 .output_observers
                 .get(&pid)
@@ -290,9 +303,14 @@ impl ProcFs {
         }
     }
 
-    async fn notify_input_observers(&self, pid: Pid, count: u32) {
+    async fn publish_input_event(&self, pid: Pid, count: u32) {
         let observers = {
-            let state = self.state.lock().await;
+            let mut state = self.state.lock().await;
+            state
+                .io_event_history
+                .entry(pid)
+                .or_default()
+                .push(ProcessIoEvent::Input(count));
             state.input_observers.get(&pid).cloned().unwrap_or_default()
         };
         let pid = pid.0.to_string();
@@ -310,11 +328,31 @@ impl ProcessOutputEventSource for ProcFs {
         sink: Arc<dyn ProcessOutputEventSink>,
     ) -> Result<(), ErrorCode> {
         let pid = parse_pid(pid).ok_or(ErrorCode::BadRequest)?;
-        let mut state = self.state.lock().await;
-        if state.table.get(pid).is_none() {
-            return Err(ErrorCode::NotFound);
+        let (pid_text, replay) = {
+            let mut state = self.state.lock().await;
+            if state.table.get(pid).is_none() {
+                return Err(ErrorCode::NotFound);
+            }
+            let replay = state
+                .io_event_history
+                .get(&pid)
+                .into_iter()
+                .flatten()
+                .filter_map(|event| match event {
+                    ProcessIoEvent::Input(_) => None,
+                    ProcessIoEvent::Output(count) => Some(*count),
+                })
+                .collect::<Vec<_>>();
+            state
+                .output_observers
+                .entry(pid)
+                .or_default()
+                .push(sink.clone());
+            (pid.0.to_string(), replay)
+        };
+        for count in replay {
+            sink.output_appended(&pid_text, count).await;
         }
-        state.output_observers.entry(pid).or_default().push(sink);
         Ok(())
     }
 }
@@ -327,11 +365,31 @@ impl ProcessInputEventSource for ProcFs {
         sink: Arc<dyn ProcessInputEventSink>,
     ) -> Result<(), ErrorCode> {
         let pid = parse_pid(pid).ok_or(ErrorCode::BadRequest)?;
-        let mut state = self.state.lock().await;
-        if state.table.get(pid).is_none() {
-            return Err(ErrorCode::NotFound);
+        let (pid_text, replay) = {
+            let mut state = self.state.lock().await;
+            if state.table.get(pid).is_none() {
+                return Err(ErrorCode::NotFound);
+            }
+            let replay = state
+                .io_event_history
+                .get(&pid)
+                .into_iter()
+                .flatten()
+                .filter_map(|event| match event {
+                    ProcessIoEvent::Input(count) => Some(*count),
+                    ProcessIoEvent::Output(_) => None,
+                })
+                .collect::<Vec<_>>();
+            state
+                .input_observers
+                .entry(pid)
+                .or_default()
+                .push(sink.clone());
+            (pid.0.to_string(), replay)
+        };
+        for count in replay {
+            sink.input_appended(&pid_text, count).await;
         }
-        state.input_observers.entry(pid).or_default().push(sink);
         Ok(())
     }
 }
@@ -667,7 +725,7 @@ impl FileServer for ProcFs {
             } => {
                 stream.append(data).await;
                 append_io_event(&events, "input", count).await;
-                self.notify_input_observers(pid, count).await;
+                self.publish_input_event(pid, count).await;
             }
             ProcStreamWrite::Output {
                 pid,
@@ -676,7 +734,7 @@ impl FileServer for ProcFs {
             } => {
                 stream.append(data).await;
                 append_io_event(&events, "output", count).await;
-                self.notify_output_observers(pid, count).await;
+                self.publish_output_event(pid, count).await;
             }
         }
         Ok(count)
@@ -777,6 +835,7 @@ impl FileServer for ProcFs {
                         state.inputs.insert(committed, input);
                         state.outputs.insert(committed, output.clone());
                         state.io_events.insert(committed, io_events.clone());
+                        state.io_event_history.insert(committed, Vec::new());
                         self.runner
                             .clone()
                             .map(|runner| (runner, output, io_events, invocation, self.clone()))
@@ -800,7 +859,7 @@ impl FileServer for ProcFs {
                     let count = outcome.output.len() as u32;
                     output.append(&outcome.output).await;
                     append_io_event(&io_events, "output", count).await;
-                    events.notify_output_observers(invocation.pid, count).await;
+                    events.publish_output_event(invocation.pid, count).await;
                 }
                 let mut state = state.lock().await;
                 state.table.exit(invocation.pid, outcome.exit_code);

--- a/crates/kernel/src/procfs.rs
+++ b/crates/kernel/src/procfs.rs
@@ -476,49 +476,65 @@ impl FileServer for ProcFs {
     }
 
     async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
-        let mut state = self.state.lock().await;
-        let fid_key = self.fid_key(fid);
-        let node = state.node_of(fid_key, &self.root_node)?;
-        // Write surfaces require write authority established at open.
-        let has_write_intent = state
-            .fids
-            .get(&fid_key)
-            .is_some_and(|f| matches!(f.mode, Some(OpenMode::Write | OpenMode::ReadWrite)));
-        match node {
-            // Exec-spec document for a clone fid: buffer at the given offset until
-            // clunk (commit-on-clunk; honor offsets, bound size, reject overflow).
-            Node::Clone => {
-                if !has_write_intent {
-                    return Err(ErrorCode::NoAccess);
+        let output = {
+            let mut state = self.state.lock().await;
+            let fid_key = self.fid_key(fid);
+            let node = state.node_of(fid_key, &self.root_node)?;
+            // Write surfaces require write authority established at open.
+            let has_write_intent = state
+                .fids
+                .get(&fid_key)
+                .is_some_and(|f| matches!(f.mode, Some(OpenMode::Write | OpenMode::ReadWrite)));
+            match node {
+                // Exec-spec document for a clone fid: buffer at the given offset until
+                // clunk (commit-on-clunk; honor offsets, bound size, reject overflow).
+                Node::Clone => {
+                    if !has_write_intent {
+                        return Err(ErrorCode::NoAccess);
+                    }
+                    let f = state.fids.get_mut(&fid_key).ok_or(ErrorCode::NotFound)?;
+                    if f.clone_pid.is_none() {
+                        return Err(ErrorCode::BadRequest);
+                    }
+                    let start = usize::try_from(offset).map_err(|_| ErrorCode::BadRequest)?;
+                    let end = start.checked_add(data.len()).ok_or(ErrorCode::BadRequest)?;
+                    if end > MAX_EXEC_SPEC_BYTES {
+                        return Err(ErrorCode::BadRequest);
+                    }
+                    if f.write_buf.len() < end {
+                        f.write_buf.resize(end, 0);
+                    }
+                    f.write_buf[start..end].copy_from_slice(data);
+                    return Ok(data.len() as u32);
                 }
-                let f = state.fids.get_mut(&fid_key).ok_or(ErrorCode::NotFound)?;
-                if f.clone_pid.is_none() {
-                    return Err(ErrorCode::BadRequest);
+                // Generic process control (interrupt/cancel) routes through ctl.
+                Node::Ctl(pid) => {
+                    if !has_write_intent {
+                        return Err(ErrorCode::NoAccess);
+                    }
+                    match data {
+                        b"cancel" | b"interrupt" => state.table.exit(pid, 130),
+                        _ => return Err(ErrorCode::BadRequest),
+                    }
+                    return Ok(data.len() as u32);
                 }
-                let start = usize::try_from(offset).map_err(|_| ErrorCode::BadRequest)?;
-                let end = start.checked_add(data.len()).ok_or(ErrorCode::BadRequest)?;
-                if end > MAX_EXEC_SPEC_BYTES {
-                    return Err(ErrorCode::BadRequest);
+                // Process output is a stream owned by `/proc`; process descriptors
+                // write to it, and readers tail it through `io/output`.
+                Node::Output(pid) => {
+                    if !has_write_intent {
+                        return Err(ErrorCode::NoAccess);
+                    }
+                    state
+                        .outputs
+                        .get(&pid)
+                        .cloned()
+                        .ok_or(ErrorCode::NotFound)?
                 }
-                if f.write_buf.len() < end {
-                    f.write_buf.resize(end, 0);
-                }
-                f.write_buf[start..end].copy_from_slice(data);
-                Ok(data.len() as u32)
+                _ => return Err(ErrorCode::Unsupported),
             }
-            // Generic process control (interrupt/cancel) routes through ctl.
-            Node::Ctl(pid) => {
-                if !has_write_intent {
-                    return Err(ErrorCode::NoAccess);
-                }
-                match data {
-                    b"cancel" | b"interrupt" => state.table.exit(pid, 130),
-                    _ => return Err(ErrorCode::BadRequest),
-                }
-                Ok(data.len() as u32)
-            }
-            _ => Err(ErrorCode::Unsupported),
-        }
+        };
+        output.append(data).await;
+        Ok(data.len() as u32)
     }
 
     async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
@@ -667,7 +683,7 @@ fn node_identity(node: &Node) -> (FileKind, u64) {
 }
 
 fn is_writable(node: &Node) -> bool {
-    matches!(node, Node::Clone | Node::Ctl(_))
+    matches!(node, Node::Clone | Node::Ctl(_) | Node::Output(_))
 }
 
 fn next_view_id() -> u64 {

--- a/crates/kernel/tests/procfs.rs
+++ b/crates/kernel/tests/procfs.rs
@@ -351,6 +351,48 @@ async fn child_namespace_rebinds_proc_clone_to_the_child_spawn_context() {
 }
 
 #[tokio::test]
+async fn late_io_event_subscribers_replay_existing_events() {
+    let fs = proc();
+    let pid = spawn(&fs, Fid(10)).await;
+
+    let input_fid = Fid(11);
+    fs.walk(
+        Fid::ROOT,
+        input_fid,
+        &[pid.clone(), "io".to_string(), "input".to_string()],
+    )
+    .await
+    .unwrap();
+    fs.open(input_fid, OpenMode::Write).await.unwrap();
+    fs.write(input_fid, 0, b"early input").await.unwrap();
+    fs.clunk(input_fid).await.unwrap();
+
+    let output_fid = Fid(12);
+    fs.walk(
+        Fid::ROOT,
+        output_fid,
+        &[pid.clone(), "io".to_string(), "output".to_string()],
+    )
+    .await
+    .unwrap();
+    fs.open(output_fid, OpenMode::Write).await.unwrap();
+    fs.write(output_fid, 0, b"early output").await.unwrap();
+    fs.clunk(output_fid).await.unwrap();
+
+    let input_sink = Arc::new(RecordingInputSink::new());
+    fs.subscribe_process_input(&pid, input_sink.clone())
+        .await
+        .unwrap();
+    assert_eq!(input_sink.wait_for(1).await, vec![(pid.clone(), 11)]);
+
+    let output_sink = Arc::new(RecordingOutputSink::new());
+    fs.subscribe_process_output(&pid, output_sink.clone())
+        .await
+        .unwrap();
+    assert_eq!(output_sink.wait_for(1).await, vec![(pid, 12)]);
+}
+
+#[tokio::test]
 async fn delegated_proc_clone_mount_rebinds_to_the_child_spawn_context() {
     let runner = Arc::new(CaptureRunner::new());
     let fs = ProcFs::new().with_runner(runner.clone());

--- a/crates/kernel/tests/procfs.rs
+++ b/crates/kernel/tests/procfs.rs
@@ -6,8 +6,8 @@
 //! needs no side API to launch a process.
 
 use alan_ap::{
-    ErrorCode, Fid, FileServer, InProcessTransport, OpenMode, ProcessOutputEventSink,
-    ProcessOutputEventSource, Request, Response,
+    ErrorCode, Fid, FileServer, InProcessTransport, OpenMode, ProcessInputEventSink,
+    ProcessInputEventSource, ProcessOutputEventSink, ProcessOutputEventSource, Request, Response,
 };
 use alan_kernel::{
     Access, Credentials, Namespace, Pid, ProcFs, ProcessInvocation, ProcessOutcome, ProcessRunner,
@@ -140,6 +140,51 @@ impl ProcessOutputEventSink for RecordingOutputSink {
         self.records
             .lock()
             .expect("output records lock should not be poisoned")
+            .push((pid.to_string(), count));
+        self.notify.notify_waiters();
+    }
+}
+
+struct RecordingInputSink {
+    records: Mutex<Vec<(String, u32)>>,
+    notify: Notify,
+}
+
+impl RecordingInputSink {
+    fn new() -> Self {
+        Self {
+            records: Mutex::new(Vec::new()),
+            notify: Notify::new(),
+        }
+    }
+
+    async fn wait_for(&self, expected: usize) -> Vec<(String, u32)> {
+        for _ in 0..50 {
+            let records = self
+                .records
+                .lock()
+                .expect("input records lock should not be poisoned")
+                .clone();
+            if records.len() >= expected {
+                return records;
+            }
+            let _ =
+                tokio::time::timeout(std::time::Duration::from_millis(10), self.notify.notified())
+                    .await;
+        }
+        self.records
+            .lock()
+            .expect("input records lock should not be poisoned")
+            .clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl ProcessInputEventSink for RecordingInputSink {
+    async fn input_appended(&self, pid: &str, count: u32) {
+        self.records
+            .lock()
+            .expect("input records lock should not be poisoned")
             .push((pid.to_string(), count));
         self.notify.notify_waiters();
     }
@@ -604,6 +649,29 @@ async fn proc_output_observers_see_direct_writes() {
         Fid::ROOT,
         Fid(11),
         &[pid.clone(), "io".into(), "output".into()],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(11), OpenMode::Write).await.unwrap();
+    fs.write(Fid(11), 0, b"hello proc").await.unwrap();
+    fs.clunk(Fid(11)).await.unwrap();
+
+    assert_eq!(sink.wait_for(1).await, vec![(pid, 10)]);
+}
+
+#[tokio::test]
+async fn proc_input_observers_see_direct_writes() {
+    let fs = proc();
+    let pid = spawn(&fs, Fid(10)).await;
+    let sink = Arc::new(RecordingInputSink::new());
+    fs.subscribe_process_input(&pid, sink.clone())
+        .await
+        .unwrap();
+
+    fs.walk(
+        Fid::ROOT,
+        Fid(11),
+        &[pid.clone(), "io".to_string(), "input".to_string()],
     )
     .await
     .unwrap();

--- a/crates/kernel/tests/procfs.rs
+++ b/crates/kernel/tests/procfs.rs
@@ -512,6 +512,50 @@ async fn proc_output_serves_the_stream() {
 }
 
 #[tokio::test]
+async fn proc_io_lists_generic_streams() {
+    let fs = proc();
+    let pid = spawn(&fs, Fid(10)).await;
+
+    let listing = String::from_utf8(read_at(&fs, &[&pid, "io"], Fid(11)).await.unwrap()).unwrap();
+
+    assert_eq!(
+        listing.lines().collect::<Vec<_>>(),
+        vec!["input", "output", "events"]
+    );
+}
+
+#[tokio::test]
+async fn proc_input_accepts_write_intent_and_records_io_event() {
+    let fs = proc();
+    let pid = spawn(&fs, Fid(10)).await;
+
+    fs.walk(
+        Fid::ROOT,
+        Fid(11),
+        &[pid.clone(), "io".into(), "input".into()],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(11), OpenMode::Write).await.unwrap();
+    fs.write(Fid(11), 0, b"hello proc").await.unwrap();
+    fs.clunk(Fid(11)).await.unwrap();
+
+    assert_eq!(
+        String::from_utf8(read_at(&fs, &[&pid, "io", "input"], Fid(12)).await.unwrap()).unwrap(),
+        "hello proc"
+    );
+    assert_eq!(
+        String::from_utf8(
+            read_at(&fs, &[&pid, "io", "events"], Fid(13))
+                .await
+                .unwrap()
+        )
+        .unwrap(),
+        "input:10\n"
+    );
+}
+
+#[tokio::test]
 async fn proc_output_accepts_write_intent() {
     let fs = proc();
     let pid = spawn(&fs, Fid(10)).await;
@@ -535,6 +579,15 @@ async fn proc_output_accepts_write_intent() {
         )
         .unwrap(),
         "hello proc"
+    );
+    assert_eq!(
+        String::from_utf8(
+            read_at(&fs, &[&pid, "io", "events"], Fid(13))
+                .await
+                .unwrap()
+        )
+        .unwrap(),
+        "output:10\n"
     );
 }
 
@@ -595,6 +648,13 @@ async fn registered_runner_writes_process_output_and_exit() {
             )
             .unwrap();
             assert_eq!(output, "hello tool\n");
+            let io_events = String::from_utf8(
+                read_at(&fs, &[&pid, "io", "events"], Fid(202))
+                    .await
+                    .unwrap(),
+            )
+            .unwrap();
+            assert_eq!(io_events, "output:11\n");
             let exit =
                 String::from_utf8(read_at(&fs, &[&pid, "exit"], Fid(201)).await.unwrap()).unwrap();
             assert_eq!(exit, "0");

--- a/crates/kernel/tests/procfs.rs
+++ b/crates/kernel/tests/procfs.rs
@@ -437,6 +437,33 @@ async fn proc_output_serves_the_stream() {
 }
 
 #[tokio::test]
+async fn proc_output_accepts_write_intent() {
+    let fs = proc();
+    let pid = spawn(&fs, Fid(10)).await;
+
+    fs.walk(
+        Fid::ROOT,
+        Fid(11),
+        &[pid.clone(), "io".into(), "output".into()],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(11), OpenMode::Write).await.unwrap();
+    fs.write(Fid(11), 0, b"hello proc").await.unwrap();
+    fs.clunk(Fid(11)).await.unwrap();
+
+    assert_eq!(
+        String::from_utf8(
+            read_at(&fs, &[&pid, "io", "output"], Fid(12))
+                .await
+                .unwrap()
+        )
+        .unwrap(),
+        "hello proc"
+    );
+}
+
+#[tokio::test]
 async fn registered_runner_writes_process_output_and_exit() {
     let fs = ProcFs::new().with_runner(Arc::new(EchoRunner));
     let mut namespace = Namespace::new();

--- a/crates/kernel/tests/procfs.rs
+++ b/crates/kernel/tests/procfs.rs
@@ -6,13 +6,17 @@
 //! needs no side API to launch a process.
 
 use alan_ap::{
-    ErrorCode, Fid, FileServer, InProcessTransport, OpenMode, ProcessInputEventSink,
-    ProcessInputEventSource, ProcessOutputEventSink, ProcessOutputEventSource, Request, Response,
+    ErrorCode, Fid, FileServer, InProcessTransport, OpenMode, ProcessEvent, ProcessEventSink,
+    ProcessEventSource, ProcessInputEventSink, ProcessInputEventSource, ProcessOutputEventSink,
+    ProcessOutputEventSource, Request, Response,
 };
 use alan_kernel::{
     Access, Credentials, Namespace, Pid, ProcFs, ProcessInvocation, ProcessOutcome, ProcessRunner,
 };
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
 use tokio::sync::Notify;
 
 fn proc() -> ProcFs {
@@ -186,6 +190,74 @@ impl ProcessInputEventSink for RecordingInputSink {
             .lock()
             .expect("input records lock should not be poisoned")
             .push((pid.to_string(), count));
+        self.notify.notify_waiters();
+    }
+}
+
+struct BlockingProcessEventSink {
+    records: Mutex<Vec<ProcessEvent>>,
+    first_started: AtomicBool,
+    first_entered: Notify,
+    release_first: Notify,
+    notify: Notify,
+}
+
+impl BlockingProcessEventSink {
+    fn new() -> Self {
+        Self {
+            records: Mutex::new(Vec::new()),
+            first_started: AtomicBool::new(false),
+            first_entered: Notify::new(),
+            release_first: Notify::new(),
+            notify: Notify::new(),
+        }
+    }
+
+    async fn wait_for(&self, expected: usize) -> Vec<ProcessEvent> {
+        for _ in 0..50 {
+            let records = self
+                .records
+                .lock()
+                .expect("process event records lock should not be poisoned")
+                .clone();
+            if records.len() >= expected {
+                return records;
+            }
+            let _ =
+                tokio::time::timeout(std::time::Duration::from_millis(10), self.notify.notified())
+                    .await;
+        }
+        self.records
+            .lock()
+            .expect("process event records lock should not be poisoned")
+            .clone()
+    }
+
+    async fn wait_until_first_replay_enters(&self) {
+        tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            self.first_entered.notified(),
+        )
+        .await
+        .expect("first replay event should enter the sink");
+    }
+
+    fn release_first_replay(&self) {
+        self.release_first.notify_one();
+    }
+}
+
+#[async_trait::async_trait]
+impl ProcessEventSink for BlockingProcessEventSink {
+    async fn process_event(&self, _pid: &str, event: ProcessEvent) {
+        if !self.first_started.swap(true, Ordering::SeqCst) {
+            self.first_entered.notify_waiters();
+            self.release_first.notified().await;
+        }
+        self.records
+            .lock()
+            .expect("process event records lock should not be poisoned")
+            .push(event);
         self.notify.notify_waiters();
     }
 }
@@ -390,6 +462,73 @@ async fn late_io_event_subscribers_replay_existing_events() {
         .await
         .unwrap();
     assert_eq!(output_sink.wait_for(1).await, vec![(pid, 12)]);
+}
+
+#[tokio::test]
+async fn process_event_replay_precedes_live_events_for_late_subscribers() {
+    let fs = proc();
+    let pid = spawn(&fs, Fid(10)).await;
+
+    let output_fid = Fid(11);
+    fs.walk(
+        Fid::ROOT,
+        output_fid,
+        &[pid.clone(), "io".to_string(), "output".to_string()],
+    )
+    .await
+    .unwrap();
+    fs.open(output_fid, OpenMode::Write).await.unwrap();
+    fs.write(output_fid, 0, b"early output").await.unwrap();
+    fs.clunk(output_fid).await.unwrap();
+
+    let sink = Arc::new(BlockingProcessEventSink::new());
+    let subscribe_fs = fs.clone();
+    let subscribe_pid = pid.clone();
+    let subscribe_sink = sink.clone();
+    let subscription = tokio::spawn(async move {
+        subscribe_fs
+            .subscribe_process_events(&subscribe_pid, subscribe_sink)
+            .await
+            .unwrap();
+    });
+    sink.wait_until_first_replay_enters().await;
+
+    let live_fs = fs.clone();
+    let live_pid = pid.clone();
+    let live_write = tokio::spawn(async move {
+        let input_fid = Fid(12);
+        live_fs
+            .walk(
+                Fid::ROOT,
+                input_fid,
+                &[live_pid, "io".to_string(), "input".to_string()],
+            )
+            .await
+            .unwrap();
+        live_fs.open(input_fid, OpenMode::Write).await.unwrap();
+        live_fs.write(input_fid, 0, b"live input").await.unwrap();
+        live_fs.clunk(input_fid).await.unwrap();
+    });
+    tokio::task::yield_now().await;
+    assert!(
+        !live_write.is_finished(),
+        "live event delivery should wait while retained event replay is active"
+    );
+
+    sink.release_first_replay();
+    subscription.await.unwrap();
+    live_write.await.unwrap();
+
+    assert_eq!(
+        sink.wait_for(3).await,
+        vec![
+            ProcessEvent::Status {
+                status: "running".to_string()
+            },
+            ProcessEvent::Output { count: 12 },
+            ProcessEvent::Input { count: 10 },
+        ]
+    );
 }
 
 #[tokio::test]

--- a/crates/kernel/tests/procfs.rs
+++ b/crates/kernel/tests/procfs.rs
@@ -5,11 +5,15 @@
 //! public), write the exec spec, and `clunk` to commit — so an aP-only client
 //! needs no side API to launch a process.
 
-use alan_ap::{ErrorCode, Fid, FileServer, InProcessTransport, OpenMode, Request, Response};
+use alan_ap::{
+    ErrorCode, Fid, FileServer, InProcessTransport, OpenMode, ProcessOutputEventSink,
+    ProcessOutputEventSource, Request, Response,
+};
 use alan_kernel::{
     Access, Credentials, Namespace, Pid, ProcFs, ProcessInvocation, ProcessOutcome, ProcessRunner,
 };
 use std::sync::{Arc, Mutex};
+use tokio::sync::Notify;
 
 fn proc() -> ProcFs {
     ProcFs::new()
@@ -67,6 +71,77 @@ impl ProcessRunner for EchoRunner {
         let mut output = invocation.exec.args.join(" ").into_bytes();
         output.push(b'\n');
         ProcessOutcome::exited(0, output)
+    }
+}
+
+struct DelayedOutputRunner {
+    output: Vec<u8>,
+    release: Notify,
+}
+
+impl DelayedOutputRunner {
+    fn new(output: impl Into<Vec<u8>>) -> Self {
+        Self {
+            output: output.into(),
+            release: Notify::new(),
+        }
+    }
+
+    fn release(&self) {
+        self.release.notify_one();
+    }
+}
+
+#[async_trait::async_trait]
+impl ProcessRunner for DelayedOutputRunner {
+    async fn run(&self, _invocation: ProcessInvocation) -> ProcessOutcome {
+        self.release.notified().await;
+        ProcessOutcome::exited(0, self.output.clone())
+    }
+}
+
+struct RecordingOutputSink {
+    records: Mutex<Vec<(String, u32)>>,
+    notify: Notify,
+}
+
+impl RecordingOutputSink {
+    fn new() -> Self {
+        Self {
+            records: Mutex::new(Vec::new()),
+            notify: Notify::new(),
+        }
+    }
+
+    async fn wait_for(&self, expected: usize) -> Vec<(String, u32)> {
+        for _ in 0..50 {
+            let records = self
+                .records
+                .lock()
+                .expect("output records lock should not be poisoned")
+                .clone();
+            if records.len() >= expected {
+                return records;
+            }
+            let _ =
+                tokio::time::timeout(std::time::Duration::from_millis(10), self.notify.notified())
+                    .await;
+        }
+        self.records
+            .lock()
+            .expect("output records lock should not be poisoned")
+            .clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl ProcessOutputEventSink for RecordingOutputSink {
+    async fn output_appended(&self, pid: &str, count: u32) {
+        self.records
+            .lock()
+            .expect("output records lock should not be poisoned")
+            .push((pid.to_string(), count));
+        self.notify.notify_waiters();
     }
 }
 
@@ -464,6 +539,29 @@ async fn proc_output_accepts_write_intent() {
 }
 
 #[tokio::test]
+async fn proc_output_observers_see_direct_writes() {
+    let fs = proc();
+    let pid = spawn(&fs, Fid(10)).await;
+    let sink = Arc::new(RecordingOutputSink::new());
+    fs.subscribe_process_output(&pid, sink.clone())
+        .await
+        .unwrap();
+
+    fs.walk(
+        Fid::ROOT,
+        Fid(11),
+        &[pid.clone(), "io".into(), "output".into()],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(11), OpenMode::Write).await.unwrap();
+    fs.write(Fid(11), 0, b"hello proc").await.unwrap();
+    fs.clunk(Fid(11)).await.unwrap();
+
+    assert_eq!(sink.wait_for(1).await, vec![(pid, 10)]);
+}
+
+#[tokio::test]
 async fn registered_runner_writes_process_output_and_exit() {
     let fs = ProcFs::new().with_runner(Arc::new(EchoRunner));
     let mut namespace = Namespace::new();
@@ -505,6 +603,21 @@ async fn registered_runner_writes_process_output_and_exit() {
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
     panic!("runner did not exit process {pid}");
+}
+
+#[tokio::test]
+async fn proc_output_observers_see_runner_output() {
+    let runner = Arc::new(DelayedOutputRunner::new("runner output\n"));
+    let fs = ProcFs::new().with_runner(runner.clone());
+    let pid = spawn(&fs, Fid(10)).await;
+    let sink = Arc::new(RecordingOutputSink::new());
+    fs.subscribe_process_output(&pid, sink.clone())
+        .await
+        .unwrap();
+
+    runner.release();
+
+    assert_eq!(sink.wait_for(1).await, vec![(pid, 14)]);
 }
 
 // Spawning requires write intent: opening /proc/clone read-only is rejected, and

--- a/crates/knowledge/Cargo.toml
+++ b/crates/knowledge/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "alan-knowledge"
+description = "Content-addressed knowledge store backing Alan agent tape, memory, and checkpoint roots."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+hex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+thiserror.workspace = true

--- a/crates/knowledge/src/lib.rs
+++ b/crates/knowledge/src/lib.rs
@@ -1,0 +1,497 @@
+//! Content-addressed knowledge store.
+//!
+//! This crate is the backing model for Ring 3's Venti-inspired knowledge layer:
+//! immutable hash-named blocks, Merkle checkpoints, cheap forks, and
+//! reachability-based retention. It deliberately does not change the agent-facing
+//! file surfaces; `machine/tape`, memory, and context remain file views above
+//! this store.
+
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// A SHA-256 content address.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ContentHash(String);
+
+impl ContentHash {
+    /// The stable textual representation, currently `sha256:<hex>`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ContentHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Access granted by a namespace-bound root.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootAccess {
+    /// Read and verify the rooted state, but do not mutate the root binding.
+    ReadOnly,
+    /// Read and update the root binding.
+    ReadWrite,
+}
+
+/// Retention policy for garbage collection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetentionPolicy {
+    /// Keep unreachable blocks for now.
+    KeepUnreachable,
+    /// Collect every block and node not reachable from a live or pinned root.
+    CollectUnreachable,
+}
+
+/// Summary of one GC pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GcReport {
+    /// Number of removed raw content blocks.
+    pub removed_blocks: usize,
+    /// Number of removed Merkle DAG nodes.
+    pub removed_nodes: usize,
+}
+
+/// A root bound into an agent namespace.
+///
+/// Possessing a [`ContentHash`] is not enough to read; callers need one of these
+/// bindings, issued by the store after the root is made reachable in the
+/// namespace model above it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoundRoot {
+    name: String,
+    root: ContentHash,
+    access: RootAccess,
+}
+
+impl BoundRoot {
+    /// Namespace-local root name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Checkpoint root hash this binding reaches.
+    pub fn root_hash(&self) -> &ContentHash {
+        &self.root
+    }
+
+    /// Access rights granted by the binding.
+    pub fn access(&self) -> RootAccess {
+        self.access
+    }
+}
+
+/// Errors returned by the knowledge store.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum KnowledgeError {
+    /// The requested raw block is not present.
+    #[error("missing block {0}")]
+    MissingBlock(ContentHash),
+    /// The requested DAG node is not present.
+    #[error("missing node {0}")]
+    MissingNode(ContentHash),
+    /// The caller did not present a live namespace-bound root.
+    #[error("root is not reachable through an authorized namespace binding")]
+    NoAccess,
+    /// Stored bytes no longer match their recorded content hash.
+    #[error("content hash mismatch for {0}")]
+    HashMismatch(ContentHash),
+    /// A root name was not found.
+    #[error("unknown root {0}")]
+    UnknownRoot(String),
+    /// A referenced node cycle was detected.
+    #[error("cycle detected at {0}")]
+    Cycle(ContentHash),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct DagNodeV1 {
+    version: u8,
+    #[serde(flatten)]
+    kind: DagNodeKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum DagNodeKind {
+    Sequence { entries: Vec<DagEntry> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "hash", rename_all = "snake_case")]
+enum DagEntry {
+    Block(ContentHash),
+    Node(ContentHash),
+}
+
+/// In-memory content-addressed knowledge store.
+#[derive(Default)]
+pub struct KnowledgeStore {
+    blocks: HashMap<ContentHash, Vec<u8>>,
+    nodes: HashMap<ContentHash, DagNodeV1>,
+    roots: HashMap<String, BoundRoot>,
+    pinned_roots: HashSet<ContentHash>,
+}
+
+impl KnowledgeStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Store a raw block under the hash of its bytes.
+    ///
+    /// Re-writing identical content is idempotent and keeps one physical copy.
+    pub fn put_block(&mut self, bytes: impl AsRef<[u8]>) -> ContentHash {
+        let bytes = bytes.as_ref();
+        let hash = hash_bytes(bytes);
+        self.blocks
+            .entry(hash.clone())
+            .or_insert_with(|| bytes.to_vec());
+        hash
+    }
+
+    /// Number of stored raw blocks.
+    pub fn block_count(&self) -> usize {
+        self.blocks.len()
+    }
+
+    /// Number of stored DAG nodes.
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Whether a raw block is present.
+    pub fn contains_block(&self, hash: &ContentHash) -> bool {
+        self.blocks.contains_key(hash)
+    }
+
+    /// Whether a DAG node is present.
+    pub fn contains_node(&self, hash: &ContentHash) -> bool {
+        self.nodes.contains_key(hash)
+    }
+
+    /// Build a checkpoint from existing raw block hashes.
+    pub fn checkpoint_from_blocks<I>(&mut self, blocks: I) -> Result<ContentHash, KnowledgeError>
+    where
+        I: IntoIterator<Item = ContentHash>,
+    {
+        let entries = blocks
+            .into_iter()
+            .map(|hash| {
+                if self.blocks.contains_key(&hash) {
+                    Ok(DagEntry::Block(hash))
+                } else {
+                    Err(KnowledgeError::MissingBlock(hash))
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        self.put_node(DagNodeV1 {
+            version: 1,
+            kind: DagNodeKind::Sequence { entries },
+        })
+    }
+
+    /// Store blocks and build a checkpoint over them.
+    pub fn checkpoint_from_bytes<I, B>(&mut self, blocks: I) -> Result<ContentHash, KnowledgeError>
+    where
+        I: IntoIterator<Item = B>,
+        B: AsRef<[u8]>,
+    {
+        let hashes = blocks
+            .into_iter()
+            .map(|block| self.put_block(block))
+            .collect::<Vec<_>>();
+        self.checkpoint_from_blocks(hashes)
+    }
+
+    /// Fork from `base_root` and append existing raw blocks as the divergent
+    /// suffix. The fork references the base node, so unchanged blocks are shared.
+    pub fn fork_append_blocks<I>(
+        &mut self,
+        base_root: &ContentHash,
+        blocks: I,
+    ) -> Result<ContentHash, KnowledgeError>
+    where
+        I: IntoIterator<Item = ContentHash>,
+    {
+        if !self.nodes.contains_key(base_root) {
+            return Err(KnowledgeError::MissingNode(base_root.clone()));
+        }
+        let mut entries = vec![DagEntry::Node(base_root.clone())];
+        for hash in blocks {
+            if !self.blocks.contains_key(&hash) {
+                return Err(KnowledgeError::MissingBlock(hash));
+            }
+            entries.push(DagEntry::Block(hash));
+        }
+        self.put_node(DagNodeV1 {
+            version: 1,
+            kind: DagNodeKind::Sequence { entries },
+        })
+    }
+
+    /// Store new blocks and fork from `base_root` with those blocks appended.
+    pub fn fork_append_bytes<I, B>(
+        &mut self,
+        base_root: &ContentHash,
+        blocks: I,
+    ) -> Result<ContentHash, KnowledgeError>
+    where
+        I: IntoIterator<Item = B>,
+        B: AsRef<[u8]>,
+    {
+        let hashes = blocks
+            .into_iter()
+            .map(|block| self.put_block(block))
+            .collect::<Vec<_>>();
+        self.fork_append_blocks(base_root, hashes)
+    }
+
+    /// Bind a checkpoint root into the namespace model above the store.
+    pub fn bind_root(
+        &mut self,
+        name: impl Into<String>,
+        root: ContentHash,
+        access: RootAccess,
+    ) -> Result<BoundRoot, KnowledgeError> {
+        if !self.nodes.contains_key(&root) {
+            return Err(KnowledgeError::MissingNode(root));
+        }
+        let bound = BoundRoot {
+            name: name.into(),
+            root,
+            access,
+        };
+        self.roots.insert(bound.name.clone(), bound.clone());
+        Ok(bound)
+    }
+
+    /// Remove a namespace-bound root.
+    pub fn unbind_root(&mut self, name: &str) -> Result<(), KnowledgeError> {
+        self.roots
+            .remove(name)
+            .map(|_| ())
+            .ok_or_else(|| KnowledgeError::UnknownRoot(name.to_string()))
+    }
+
+    /// Resolve a live root by its namespace-local name.
+    pub fn root(&self, name: &str) -> Result<BoundRoot, KnowledgeError> {
+        self.roots
+            .get(name)
+            .cloned()
+            .ok_or_else(|| KnowledgeError::UnknownRoot(name.to_string()))
+    }
+
+    /// Authorize by root hash only if that hash is already reachable through a
+    /// live namespace binding.
+    pub fn authorize_reachable_hash(
+        &self,
+        root: &ContentHash,
+    ) -> Result<BoundRoot, KnowledgeError> {
+        self.roots
+            .values()
+            .find(|bound| &bound.root == root)
+            .cloned()
+            .ok_or(KnowledgeError::NoAccess)
+    }
+
+    /// Read a materialized file view through an authorized root.
+    pub fn read_bound_root(&self, root: &BoundRoot) -> Result<Vec<u8>, KnowledgeError> {
+        match self.roots.get(root.name()) {
+            Some(current) if current == root => {
+                self.verify_root_hash(root.root_hash())?;
+                self.materialize_node(root.root_hash(), &mut HashSet::new())
+            }
+            _ => Err(KnowledgeError::NoAccess),
+        }
+    }
+
+    /// Pin a root so retention GC keeps its reachable history.
+    pub fn pin_root(&mut self, root: &ContentHash) -> Result<(), KnowledgeError> {
+        if !self.nodes.contains_key(root) {
+            return Err(KnowledgeError::MissingNode(root.clone()));
+        }
+        self.pinned_roots.insert(root.clone());
+        Ok(())
+    }
+
+    /// Remove an audit pin.
+    pub fn unpin_root(&mut self, root: &ContentHash) {
+        self.pinned_roots.remove(root);
+    }
+
+    /// Verify the Merkle DAG rooted at `root`.
+    pub fn verify_root_hash(&self, root: &ContentHash) -> Result<(), KnowledgeError> {
+        self.verify_node(root, &mut HashSet::new())
+    }
+
+    /// Collect unreachable content according to `policy`.
+    pub fn collect_garbage(&mut self, policy: RetentionPolicy) -> GcReport {
+        if policy == RetentionPolicy::KeepUnreachable {
+            return GcReport {
+                removed_blocks: 0,
+                removed_nodes: 0,
+            };
+        }
+
+        let mut reachable_nodes = HashSet::new();
+        let mut reachable_blocks = HashSet::new();
+        let roots = self
+            .roots
+            .values()
+            .map(|root| root.root.clone())
+            .chain(self.pinned_roots.iter().cloned())
+            .collect::<Vec<_>>();
+        for root in roots {
+            self.mark_reachable(&root, &mut reachable_nodes, &mut reachable_blocks);
+        }
+
+        let before_blocks = self.blocks.len();
+        let before_nodes = self.nodes.len();
+        self.blocks
+            .retain(|hash, _| reachable_blocks.contains(hash));
+        self.nodes.retain(|hash, _| reachable_nodes.contains(hash));
+
+        GcReport {
+            removed_blocks: before_blocks - self.blocks.len(),
+            removed_nodes: before_nodes - self.nodes.len(),
+        }
+    }
+
+    fn put_node(&mut self, node: DagNodeV1) -> Result<ContentHash, KnowledgeError> {
+        let bytes = node_bytes(&node);
+        let hash = hash_bytes(&bytes);
+        self.nodes.entry(hash.clone()).or_insert(node);
+        Ok(hash)
+    }
+
+    fn materialize_node(
+        &self,
+        root: &ContentHash,
+        visiting: &mut HashSet<ContentHash>,
+    ) -> Result<Vec<u8>, KnowledgeError> {
+        if !visiting.insert(root.clone()) {
+            return Err(KnowledgeError::Cycle(root.clone()));
+        }
+        let node = self
+            .nodes
+            .get(root)
+            .ok_or_else(|| KnowledgeError::MissingNode(root.clone()))?;
+        let mut out = Vec::new();
+        match &node.kind {
+            DagNodeKind::Sequence { entries } => {
+                for entry in entries {
+                    match entry {
+                        DagEntry::Block(hash) => {
+                            let bytes = self
+                                .blocks
+                                .get(hash)
+                                .ok_or_else(|| KnowledgeError::MissingBlock(hash.clone()))?;
+                            out.extend_from_slice(bytes);
+                        }
+                        DagEntry::Node(hash) => {
+                            out.extend(self.materialize_node(hash, visiting)?);
+                        }
+                    }
+                }
+            }
+        }
+        visiting.remove(root);
+        Ok(out)
+    }
+
+    fn verify_node(
+        &self,
+        root: &ContentHash,
+        visiting: &mut HashSet<ContentHash>,
+    ) -> Result<(), KnowledgeError> {
+        if !visiting.insert(root.clone()) {
+            return Err(KnowledgeError::Cycle(root.clone()));
+        }
+        let node = self
+            .nodes
+            .get(root)
+            .ok_or_else(|| KnowledgeError::MissingNode(root.clone()))?;
+        let actual = hash_bytes(&node_bytes(node));
+        if &actual != root {
+            return Err(KnowledgeError::HashMismatch(root.clone()));
+        }
+        match &node.kind {
+            DagNodeKind::Sequence { entries } => {
+                for entry in entries {
+                    match entry {
+                        DagEntry::Block(hash) => {
+                            let bytes = self
+                                .blocks
+                                .get(hash)
+                                .ok_or_else(|| KnowledgeError::MissingBlock(hash.clone()))?;
+                            if hash_bytes(bytes) != *hash {
+                                return Err(KnowledgeError::HashMismatch(hash.clone()));
+                            }
+                        }
+                        DagEntry::Node(hash) => self.verify_node(hash, visiting)?,
+                    }
+                }
+            }
+        }
+        visiting.remove(root);
+        Ok(())
+    }
+
+    fn mark_reachable(
+        &self,
+        root: &ContentHash,
+        nodes: &mut HashSet<ContentHash>,
+        blocks: &mut HashSet<ContentHash>,
+    ) {
+        if !nodes.insert(root.clone()) {
+            return;
+        }
+        let Some(node) = self.nodes.get(root) else {
+            return;
+        };
+        match &node.kind {
+            DagNodeKind::Sequence { entries } => {
+                for entry in entries {
+                    match entry {
+                        DagEntry::Block(hash) => {
+                            blocks.insert(hash.clone());
+                        }
+                        DagEntry::Node(hash) => self.mark_reachable(hash, nodes, blocks),
+                    }
+                }
+            }
+        }
+    }
+
+    /// Corrupt a raw block for verification tests.
+    #[doc(hidden)]
+    pub fn replace_block_for_test(
+        &mut self,
+        hash: &ContentHash,
+        bytes: impl Into<Vec<u8>>,
+    ) -> Result<(), KnowledgeError> {
+        let block = self
+            .blocks
+            .get_mut(hash)
+            .ok_or_else(|| KnowledgeError::MissingBlock(hash.clone()))?;
+        *block = bytes.into();
+        Ok(())
+    }
+}
+
+fn node_bytes(node: &DagNodeV1) -> Vec<u8> {
+    serde_json::to_vec(node).expect("DAG node serialization is infallible")
+}
+
+fn hash_bytes(bytes: &[u8]) -> ContentHash {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    ContentHash(format!("sha256:{}", hex::encode(hasher.finalize())))
+}

--- a/crates/knowledge/tests/store.rs
+++ b/crates/knowledge/tests/store.rs
@@ -1,0 +1,114 @@
+use alan_knowledge::{KnowledgeError, KnowledgeStore, RetentionPolicy, RootAccess};
+
+#[test]
+fn identical_blocks_are_deduplicated_by_content_hash() {
+    let mut store = KnowledgeStore::new();
+
+    let first = store.put_block(b"same context");
+    let second = store.put_block(b"same context");
+
+    assert_eq!(first, second);
+    assert_eq!(store.block_count(), 1);
+    assert!(first.as_str().starts_with("sha256:"));
+}
+
+#[test]
+fn checkpoint_materializes_and_verifies_root_hash() {
+    let mut store = KnowledgeStore::new();
+    let root = store
+        .checkpoint_from_bytes([b"record-1\n".as_slice(), b"record-2\n".as_slice()])
+        .unwrap();
+    let bound = store
+        .bind_root("agent/root/machine", root.clone(), RootAccess::ReadOnly)
+        .unwrap();
+
+    assert_eq!(
+        store.read_bound_root(&bound).unwrap(),
+        b"record-1\nrecord-2\n"
+    );
+    store.verify_root_hash(&root).unwrap();
+}
+
+#[test]
+fn fork_shares_unchanged_blocks_and_writes_only_delta() {
+    let mut store = KnowledgeStore::new();
+    let base = store
+        .checkpoint_from_bytes([b"a\n".as_slice(), b"b\n".as_slice()])
+        .unwrap();
+    let initial_blocks = store.block_count();
+    let initial_nodes = store.node_count();
+
+    let fork = store.fork_append_bytes(&base, [b"c\n".as_slice()]).unwrap();
+    let base_bound = store.bind_root("base", base, RootAccess::ReadOnly).unwrap();
+    let fork_bound = store.bind_root("fork", fork, RootAccess::ReadOnly).unwrap();
+
+    assert_eq!(store.block_count(), initial_blocks + 1);
+    assert_eq!(store.node_count(), initial_nodes + 1);
+    assert_eq!(store.read_bound_root(&base_bound).unwrap(), b"a\nb\n");
+    assert_eq!(store.read_bound_root(&fork_bound).unwrap(), b"a\nb\nc\n");
+}
+
+#[test]
+fn content_hash_does_not_authorize_reads_without_reachable_root() {
+    let mut store = KnowledgeStore::new();
+    let root = store
+        .checkpoint_from_bytes([b"private\n".as_slice()])
+        .unwrap();
+
+    assert_eq!(
+        store.authorize_reachable_hash(&root),
+        Err(KnowledgeError::NoAccess)
+    );
+
+    let bound = store
+        .bind_root("agent/private", root.clone(), RootAccess::ReadOnly)
+        .unwrap();
+    assert_eq!(store.authorize_reachable_hash(&root).unwrap(), bound);
+    assert_eq!(store.read_bound_root(&bound).unwrap(), b"private\n");
+
+    store.unbind_root("agent/private").unwrap();
+    assert_eq!(store.read_bound_root(&bound), Err(KnowledgeError::NoAccess));
+}
+
+#[test]
+fn tampering_with_a_block_is_detected_by_verification() {
+    let mut store = KnowledgeStore::new();
+    let block = store.put_block(b"original");
+    let root = store.checkpoint_from_blocks([block.clone()]).unwrap();
+
+    store.replace_block_for_test(&block, b"rewritten").unwrap();
+
+    assert_eq!(
+        store.verify_root_hash(&root),
+        Err(KnowledgeError::HashMismatch(block))
+    );
+}
+
+#[test]
+fn gc_collects_unreachable_blocks_but_keeps_live_and_pinned_roots() {
+    let mut store = KnowledgeStore::new();
+    let live = store.checkpoint_from_bytes([b"live".as_slice()]).unwrap();
+    let pinned = store.checkpoint_from_bytes([b"pinned".as_slice()]).unwrap();
+    let garbage = store
+        .checkpoint_from_bytes([b"garbage".as_slice()])
+        .unwrap();
+
+    store
+        .bind_root("live", live.clone(), RootAccess::ReadOnly)
+        .unwrap();
+    store.pin_root(&pinned).unwrap();
+
+    let report = store.collect_garbage(RetentionPolicy::CollectUnreachable);
+
+    assert_eq!(report.removed_blocks, 1);
+    assert_eq!(report.removed_nodes, 1);
+    assert!(store.contains_node(&live));
+    assert!(store.contains_node(&pinned));
+    assert!(!store.contains_node(&garbage));
+
+    store.unbind_root("live").unwrap();
+    store.unpin_root(&pinned);
+    let report = store.collect_garbage(RetentionPolicy::CollectUnreachable);
+    assert_eq!(report.removed_nodes, 2);
+    assert_eq!(report.removed_blocks, 2);
+}

--- a/crates/memfs/Cargo.toml
+++ b/crates/memfs/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "alan-memfs"
+description = "Memory Store file server backed by Alan content-addressed knowledge checkpoints."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+alan-ap = { path = "../ap" }
+alan-knowledge.workspace = true
+async-trait.workspace = true
+tokio = { workspace = true }

--- a/crates/memfs/src/lib.rs
+++ b/crates/memfs/src/lib.rs
@@ -91,10 +91,7 @@ impl MemFs {
         if !valid_name(&name) {
             return Err(ErrorCode::BadRequest);
         }
-        let generation = match state.files.get(&name) {
-            Some(file) => file.generation,
-            None => state.next_generation(),
-        };
+        let generation = state.next_generation();
         state.bind_file_root(name, root, generation)?;
         Ok(())
     }

--- a/crates/memfs/src/lib.rs
+++ b/crates/memfs/src/lib.rs
@@ -1,0 +1,365 @@
+//! alan-memfs — Memory Store file server backed by content-addressed knowledge.
+//!
+//! The server is intentionally small: callers see ordinary files under the
+//! mounted tree (for example `/mnt/mem/facts`). File bytes are stored as immutable
+//! knowledge blocks behind a namespace-bound checkpoint root, so memory/context
+//! reads stay file-shaped while persistence can deduplicate, verify, and garbage
+//! collect by reachability.
+
+use std::collections::{BTreeMap, HashMap};
+use std::hash::{Hash, Hasher};
+
+use alan_ap::{ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat, VersionTable};
+use alan_knowledge::{BoundRoot, ContentHash, KnowledgeError, KnowledgeStore, RootAccess};
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+const MAX_DOC_BYTES: usize = 1 << 20; // 1 MiB
+
+/// A memory/context file server backed by content-addressed checkpoint roots.
+pub struct MemFs {
+    state: Mutex<State>,
+}
+
+struct State {
+    store: KnowledgeStore,
+    files: BTreeMap<String, MemoryFile>,
+    versions: VersionTable,
+    fids: HashMap<Fid, MemFid>,
+}
+
+struct MemoryFile {
+    root: BoundRoot,
+}
+
+struct MemFid {
+    node: Node,
+    mode: Option<OpenMode>,
+    write_buf: Vec<u8>,
+    wrote: bool,
+}
+
+#[derive(Clone)]
+enum Node {
+    Root,
+    File(String),
+}
+
+impl Default for MemFs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MemFs {
+    /// Create an empty memory file server.
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(State {
+                store: KnowledgeStore::new(),
+                files: BTreeMap::new(),
+                versions: VersionTable::new(),
+                fids: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Return the current checkpoint root for a named file.
+    pub async fn checkpoint_root(&self, name: &str) -> Result<ContentHash, ErrorCode> {
+        let state = self.state.lock().await;
+        let file = state.files.get(name).ok_or(ErrorCode::NotFound)?;
+        Ok(file.root.root_hash().clone())
+    }
+
+    /// Bind an existing checkpoint root back into this memory tree.
+    ///
+    /// This is the durable-home resume primitive for the in-process v1 store: a
+    /// storage-backed home keeps blocks/nodes after a file is unbound, so the
+    /// checkpoint root can be rebound later. A fresh ephemeral store lacks those
+    /// nodes and rejects the same root.
+    pub async fn restore_checkpoint(
+        &self,
+        name: impl Into<String>,
+        root: ContentHash,
+    ) -> Result<(), ErrorCode> {
+        let mut state = self.state.lock().await;
+        let name = name.into();
+        if !valid_name(&name) {
+            return Err(ErrorCode::BadRequest);
+        }
+        let binding = state
+            .store
+            .bind_root(root_name(&name), root, RootAccess::ReadWrite)
+            .map_err(map_knowledge_error)?;
+        state
+            .files
+            .insert(name.clone(), MemoryFile { root: binding });
+        state.versions.bump(node_identity(&Node::Root).1);
+        state.versions.bump(node_identity(&Node::File(name)).1);
+        Ok(())
+    }
+
+    /// Verify and materialize a named file through its namespace-bound root.
+    pub async fn materialize(&self, name: &str) -> Result<Vec<u8>, ErrorCode> {
+        let state = self.state.lock().await;
+        state.materialize(name)
+    }
+}
+
+impl State {
+    fn node_of(&self, fid: Fid) -> Result<Node, ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(Node::Root);
+        }
+        self.fids
+            .get(&fid)
+            .map(|f| f.node.clone())
+            .ok_or(ErrorCode::NotFound)
+    }
+
+    fn qid(&self, node: &Node) -> Qid {
+        let (kind, path) = node_identity(node);
+        Qid {
+            kind,
+            version: self.versions.get(path),
+            path,
+        }
+    }
+
+    fn materialize(&self, name: &str) -> Result<Vec<u8>, ErrorCode> {
+        let file = self.files.get(name).ok_or(ErrorCode::NotFound)?;
+        self.store
+            .read_bound_root(&file.root)
+            .map_err(map_knowledge_error)
+    }
+
+    fn put_file(&mut self, name: String, bytes: &[u8]) -> Result<(), ErrorCode> {
+        let root = self
+            .store
+            .checkpoint_from_bytes([bytes])
+            .map_err(map_knowledge_error)?;
+        let binding = self
+            .store
+            .bind_root(root_name(&name), root, RootAccess::ReadWrite)
+            .map_err(map_knowledge_error)?;
+        self.files
+            .insert(name.clone(), MemoryFile { root: binding });
+        self.versions.bump(node_identity(&Node::Root).1);
+        self.versions.bump(node_identity(&Node::File(name)).1);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl FileServer for MemFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        let mut state = self.state.lock().await;
+        if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
+            return Err(ErrorCode::BadRequest);
+        }
+        let node = match state.node_of(fid)? {
+            Node::Root if names.is_empty() => Node::Root,
+            Node::Root if names.len() == 1 && state.files.contains_key(&names[0]) => {
+                Node::File(names[0].clone())
+            }
+            Node::Root if names.len() == 1 => return Err(ErrorCode::NotFound),
+            Node::Root => return Err(ErrorCode::NotDirectory),
+            Node::File(_) => return Err(ErrorCode::NotDirectory),
+        };
+        let qid = state.qid(&node);
+        state.fids.insert(
+            newfid,
+            MemFid {
+                node,
+                mode: None,
+                write_buf: Vec::new(),
+                wrote: false,
+            },
+        );
+        Ok(qid)
+    }
+
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
+        let mut state = self.state.lock().await;
+        let node = state.node_of(fid)?;
+        if fid != Fid::ROOT && state.fids.get(&fid).is_some_and(|f| f.mode.is_some()) {
+            return Err(ErrorCode::BadRequest);
+        }
+        if matches!(node, Node::Root) && matches!(mode, OpenMode::Write | OpenMode::ReadWrite) {
+            return Err(ErrorCode::NoAccess);
+        }
+        if let Node::File(name) = &node
+            && !state.files.contains_key(name)
+        {
+            return Err(ErrorCode::NotFound);
+        }
+        if fid != Fid::ROOT {
+            let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
+            f.mode = Some(mode);
+        }
+        Ok(state.qid(&node))
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let state = self.state.lock().await;
+        if fid != Fid::ROOT {
+            let f = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+            if !matches!(f.mode, Some(OpenMode::Read | OpenMode::ReadWrite)) {
+                return Err(ErrorCode::NoAccess);
+            }
+        }
+        let bytes = match state.node_of(fid)? {
+            Node::Root => state
+                .files
+                .keys()
+                .cloned()
+                .collect::<Vec<_>>()
+                .join("\n")
+                .into_bytes(),
+            Node::File(name) => state.materialize(&name)?,
+        };
+        Ok(slice(bytes, offset, count))
+    }
+
+    async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        let mut state = self.state.lock().await;
+        let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
+        if !matches!(f.mode, Some(OpenMode::Write | OpenMode::ReadWrite)) {
+            return Err(ErrorCode::NoAccess);
+        }
+        if !matches!(f.node, Node::File(_)) {
+            return Err(ErrorCode::Unsupported);
+        }
+        let start = usize::try_from(offset).map_err(|_| ErrorCode::BadRequest)?;
+        let end = start.checked_add(data.len()).ok_or(ErrorCode::BadRequest)?;
+        if end > MAX_DOC_BYTES {
+            return Err(ErrorCode::BadRequest);
+        }
+        if f.write_buf.len() < end {
+            f.write_buf.resize(end, 0);
+        }
+        f.write_buf[start..end].copy_from_slice(data);
+        f.wrote = true;
+        Ok(data.len() as u32)
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        let state = self.state.lock().await;
+        let node = state.node_of(fid)?;
+        let length = match &node {
+            Node::Root => state
+                .files
+                .keys()
+                .cloned()
+                .collect::<Vec<_>>()
+                .join("\n")
+                .len() as u64,
+            Node::File(name) => state.materialize(name)?.len() as u64,
+        };
+        Ok(Stat {
+            name: String::new(),
+            qid: state.qid(&node),
+            length,
+            writable: matches!(node, Node::File(_)),
+        })
+    }
+
+    async fn create(
+        &self,
+        fid: Fid,
+        newfid: Fid,
+        name: &str,
+        kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        if kind != FileKind::File || !valid_name(name) {
+            return Err(ErrorCode::BadRequest);
+        }
+        let mut state = self.state.lock().await;
+        if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
+            return Err(ErrorCode::BadRequest);
+        }
+        if !matches!(state.node_of(fid)?, Node::Root) {
+            return Err(ErrorCode::NotDirectory);
+        }
+        if state.files.contains_key(name) {
+            return Err(ErrorCode::BadRequest);
+        }
+        let node = Node::File(name.to_string());
+        state.put_file(name.to_string(), b"")?;
+        let qid = state.qid(&node);
+        state.fids.insert(
+            newfid,
+            MemFid {
+                node,
+                mode: None,
+                write_buf: Vec::new(),
+                wrote: false,
+            },
+        );
+        Ok(qid)
+    }
+
+    async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
+        let mut state = self.state.lock().await;
+        let node = state.node_of(fid)?;
+        let Node::File(name) = node else {
+            return Err(ErrorCode::Unsupported);
+        };
+        state.files.remove(&name).ok_or(ErrorCode::NotFound)?;
+        state
+            .store
+            .unbind_root(&root_name(&name))
+            .map_err(map_knowledge_error)?;
+        state.versions.bump(node_identity(&Node::Root).1);
+        state.fids.remove(&fid);
+        Ok(())
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(());
+        }
+        let mut state = self.state.lock().await;
+        let f = state.fids.remove(&fid).ok_or(ErrorCode::NotFound)?;
+        if let Node::File(name) = f.node
+            && f.wrote
+        {
+            state.put_file(name, &f.write_buf)?;
+        }
+        Ok(())
+    }
+}
+
+fn valid_name(name: &str) -> bool {
+    !name.is_empty() && !name.contains('/') && !name.contains('\n')
+}
+
+fn root_name(name: &str) -> String {
+    format!("mem/{name}")
+}
+
+fn node_identity(node: &Node) -> (FileKind, u64) {
+    let (kind, key) = match node {
+        Node::Root => (FileKind::Dir, "/".to_string()),
+        Node::File(name) => (FileKind::File, name.clone()),
+    };
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut h);
+    (kind, h.finish())
+}
+
+fn map_knowledge_error(error: KnowledgeError) -> ErrorCode {
+    match error {
+        KnowledgeError::NoAccess => ErrorCode::NoAccess,
+        KnowledgeError::MissingBlock(_)
+        | KnowledgeError::MissingNode(_)
+        | KnowledgeError::UnknownRoot(_) => ErrorCode::NotFound,
+        KnowledgeError::HashMismatch(_) | KnowledgeError::Cycle(_) => ErrorCode::Io,
+    }
+}
+
+fn slice(bytes: Vec<u8>, offset: Offset, count: u32) -> Vec<u8> {
+    let start = (offset as usize).min(bytes.len());
+    let end = bytes.len().min(start + count as usize);
+    bytes[start..end].to_vec()
+}

--- a/crates/memfs/src/lib.rs
+++ b/crates/memfs/src/lib.rs
@@ -26,10 +26,12 @@ struct State {
     files: BTreeMap<String, MemoryFile>,
     versions: VersionTable,
     fids: HashMap<Fid, MemFid>,
+    next_file_generation: u64,
 }
 
 struct MemoryFile {
     root: BoundRoot,
+    generation: u64,
 }
 
 struct MemFid {
@@ -37,6 +39,7 @@ struct MemFid {
     mode: Option<OpenMode>,
     write_buf: Vec<u8>,
     wrote: bool,
+    file_generation: Option<u64>,
 }
 
 #[derive(Clone)]
@@ -60,6 +63,7 @@ impl MemFs {
                 files: BTreeMap::new(),
                 versions: VersionTable::new(),
                 fids: HashMap::new(),
+                next_file_generation: 1,
             }),
         }
     }
@@ -87,15 +91,11 @@ impl MemFs {
         if !valid_name(&name) {
             return Err(ErrorCode::BadRequest);
         }
-        let binding = state
-            .store
-            .bind_root(root_name(&name), root, RootAccess::ReadWrite)
-            .map_err(map_knowledge_error)?;
-        state
-            .files
-            .insert(name.clone(), MemoryFile { root: binding });
-        state.versions.bump(node_identity(&Node::Root).1);
-        state.versions.bump(node_identity(&Node::File(name)).1);
+        let generation = match state.files.get(&name) {
+            Some(file) => file.generation,
+            None => state.next_generation(),
+        };
+        state.bind_file_root(name, root, generation)?;
         Ok(())
     }
 
@@ -133,17 +133,64 @@ impl State {
             .map_err(map_knowledge_error)
     }
 
-    fn put_file(&mut self, name: String, bytes: &[u8]) -> Result<(), ErrorCode> {
+    fn next_generation(&mut self) -> u64 {
+        let generation = self.next_file_generation;
+        self.next_file_generation = self.next_file_generation.wrapping_add(1);
+        generation
+    }
+
+    fn put_file(&mut self, name: String, bytes: &[u8]) -> Result<u64, ErrorCode> {
+        let generation = match self.files.get(&name) {
+            Some(file) => file.generation,
+            None => self.next_generation(),
+        };
+        self.put_file_at_generation(name, bytes, generation)?;
+        Ok(generation)
+    }
+
+    fn put_existing_file(
+        &mut self,
+        name: String,
+        expected_generation: u64,
+        bytes: &[u8],
+    ) -> Result<(), ErrorCode> {
+        let file = self.files.get(&name).ok_or(ErrorCode::NotFound)?;
+        if file.generation != expected_generation {
+            return Err(ErrorCode::NotFound);
+        }
+        self.put_file_at_generation(name, bytes, expected_generation)
+    }
+
+    fn put_file_at_generation(
+        &mut self,
+        name: String,
+        bytes: &[u8],
+        generation: u64,
+    ) -> Result<(), ErrorCode> {
         let root = self
             .store
             .checkpoint_from_bytes([bytes])
             .map_err(map_knowledge_error)?;
+        self.bind_file_root(name, root, generation)
+    }
+
+    fn bind_file_root(
+        &mut self,
+        name: String,
+        root: ContentHash,
+        generation: u64,
+    ) -> Result<(), ErrorCode> {
         let binding = self
             .store
             .bind_root(root_name(&name), root, RootAccess::ReadWrite)
             .map_err(map_knowledge_error)?;
-        self.files
-            .insert(name.clone(), MemoryFile { root: binding });
+        self.files.insert(
+            name.clone(),
+            MemoryFile {
+                root: binding,
+                generation,
+            },
+        );
         self.versions.bump(node_identity(&Node::Root).1);
         self.versions.bump(node_identity(&Node::File(name)).1);
         Ok(())
@@ -166,6 +213,10 @@ impl FileServer for MemFs {
             Node::Root => return Err(ErrorCode::NotDirectory),
             Node::File(_) => return Err(ErrorCode::NotDirectory),
         };
+        let file_generation = match &node {
+            Node::Root => None,
+            Node::File(name) => Some(state.files.get(name).ok_or(ErrorCode::NotFound)?.generation),
+        };
         let qid = state.qid(&node);
         state.fids.insert(
             newfid,
@@ -174,6 +225,7 @@ impl FileServer for MemFs {
                 mode: None,
                 write_buf: Vec::new(),
                 wrote: false,
+                file_generation,
             },
         );
         Ok(qid)
@@ -296,7 +348,7 @@ impl FileServer for MemFs {
             return Err(ErrorCode::BadRequest);
         }
         let node = Node::File(name.to_string());
-        state.put_file(name.to_string(), b"")?;
+        let file_generation = state.put_file(name.to_string(), b"")?;
         let qid = state.qid(&node);
         state.fids.insert(
             newfid,
@@ -305,6 +357,7 @@ impl FileServer for MemFs {
                 mode: None,
                 write_buf: Vec::new(),
                 wrote: false,
+                file_generation: Some(file_generation),
             },
         );
         Ok(qid)
@@ -322,6 +375,7 @@ impl FileServer for MemFs {
             .unbind_root(&root_name(&name))
             .map_err(map_knowledge_error)?;
         state.versions.bump(node_identity(&Node::Root).1);
+        state.versions.bump(node_identity(&Node::File(name)).1);
         state.fids.remove(&fid);
         Ok(())
     }
@@ -335,7 +389,8 @@ impl FileServer for MemFs {
         if let Node::File(name) = f.node
             && f.wrote
         {
-            state.put_file(name, &f.write_buf)?;
+            let generation = f.file_generation.ok_or(ErrorCode::NotFound)?;
+            state.put_existing_file(name, generation, &f.write_buf)?;
         }
         Ok(())
     }

--- a/crates/memfs/src/lib.rs
+++ b/crates/memfs/src/lib.rs
@@ -193,9 +193,20 @@ impl FileServer for MemFs {
         {
             return Err(ErrorCode::NotFound);
         }
+        let read_write_base = if matches!(mode, OpenMode::ReadWrite) {
+            match &node {
+                Node::File(name) => Some(state.materialize(name)?),
+                Node::Root => None,
+            }
+        } else {
+            None
+        };
         if fid != Fid::ROOT {
             let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
             f.mode = Some(mode);
+            if let Some(bytes) = read_write_base {
+                f.write_buf = bytes;
+            }
         }
         Ok(state.qid(&node))
     }

--- a/crates/memfs/tests/memfs.rs
+++ b/crates/memfs/tests/memfs.rs
@@ -60,6 +60,19 @@ async fn removing_a_memory_file_removes_its_namespace_authority() {
 }
 
 #[tokio::test]
+async fn read_write_range_writes_preserve_unwritten_bytes() {
+    let fs = MemFs::new();
+    create_file(&fs, "facts", Fid(1), b"abcdef").await;
+
+    fs.walk(Fid::ROOT, Fid(2), &["facts".into()]).await.unwrap();
+    fs.open(Fid(2), OpenMode::ReadWrite).await.unwrap();
+    fs.write(Fid(2), 2, b"XY").await.unwrap();
+    fs.clunk(Fid(2)).await.unwrap();
+
+    assert_eq!(read_file(&fs, "facts", Fid(3)).await, b"abXYef");
+}
+
+#[tokio::test]
 async fn durable_home_can_resume_a_file_from_its_root_hash() {
     let fs = MemFs::new();
     create_file(&fs, "continuity", Fid(1), b"remember this").await;

--- a/crates/memfs/tests/memfs.rs
+++ b/crates/memfs/tests/memfs.rs
@@ -134,6 +134,27 @@ async fn durable_home_can_resume_a_file_from_its_root_hash() {
 }
 
 #[tokio::test]
+async fn stale_writer_clunk_after_restore_does_not_overwrite_checkpoint() {
+    let fs = MemFs::new();
+    create_file(&fs, "continuity", Fid(1), b"old").await;
+    create_file(&fs, "snapshot", Fid(2), b"restored").await;
+    let restored_root = fs.checkpoint_root("snapshot").await.unwrap();
+
+    fs.walk(Fid::ROOT, Fid(3), &["continuity".into()])
+        .await
+        .unwrap();
+    fs.open(Fid(3), OpenMode::Write).await.unwrap();
+    fs.write(Fid(3), 0, b"stale").await.unwrap();
+
+    fs.restore_checkpoint("continuity", restored_root)
+        .await
+        .unwrap();
+
+    assert_eq!(fs.clunk(Fid(3)).await, Err(ErrorCode::NotFound));
+    assert_eq!(read_file(&fs, "continuity", Fid(4)).await, b"restored");
+}
+
+#[tokio::test]
 async fn ephemeral_home_does_not_resume_roots_it_did_not_persist() {
     let durable = MemFs::new();
     create_file(&durable, "continuity", Fid(1), b"remember this").await;

--- a/crates/memfs/tests/memfs.rs
+++ b/crates/memfs/tests/memfs.rs
@@ -60,6 +60,51 @@ async fn removing_a_memory_file_removes_its_namespace_authority() {
 }
 
 #[tokio::test]
+async fn stale_writer_clunk_after_remove_does_not_resurrect_file() {
+    let fs = MemFs::new();
+    create_file(&fs, "scratch", Fid(1), b"temporary").await;
+
+    fs.walk(Fid::ROOT, Fid(2), &["scratch".into()])
+        .await
+        .unwrap();
+    fs.open(Fid(2), OpenMode::Write).await.unwrap();
+    fs.write(Fid(2), 0, b"stale").await.unwrap();
+
+    fs.walk(Fid::ROOT, Fid(3), &["scratch".into()])
+        .await
+        .unwrap();
+    fs.remove(Fid(3)).await.unwrap();
+
+    assert_eq!(fs.clunk(Fid(2)).await, Err(ErrorCode::NotFound));
+    assert_eq!(
+        fs.walk(Fid::ROOT, Fid(4), &["scratch".into()]).await,
+        Err(ErrorCode::NotFound)
+    );
+    assert_eq!(fs.materialize("scratch").await, Err(ErrorCode::NotFound));
+}
+
+#[tokio::test]
+async fn stale_writer_clunk_after_recreate_does_not_overwrite_new_file() {
+    let fs = MemFs::new();
+    create_file(&fs, "scratch", Fid(1), b"temporary").await;
+
+    fs.walk(Fid::ROOT, Fid(2), &["scratch".into()])
+        .await
+        .unwrap();
+    fs.open(Fid(2), OpenMode::Write).await.unwrap();
+    fs.write(Fid(2), 0, b"stale").await.unwrap();
+
+    fs.walk(Fid::ROOT, Fid(3), &["scratch".into()])
+        .await
+        .unwrap();
+    fs.remove(Fid(3)).await.unwrap();
+    create_file(&fs, "scratch", Fid(4), b"fresh").await;
+
+    assert_eq!(fs.clunk(Fid(2)).await, Err(ErrorCode::NotFound));
+    assert_eq!(read_file(&fs, "scratch", Fid(5)).await, b"fresh");
+}
+
+#[tokio::test]
 async fn read_write_range_writes_preserve_unwritten_bytes() {
     let fs = MemFs::new();
     create_file(&fs, "facts", Fid(1), b"abcdef").await;

--- a/crates/memfs/tests/memfs.rs
+++ b/crates/memfs/tests/memfs.rs
@@ -1,0 +1,89 @@
+use alan_ap::{ErrorCode, Fid, FileKind, FileServer, OpenMode};
+use alan_memfs::MemFs;
+
+async fn create_file(fs: &MemFs, name: &str, fid: Fid, bytes: &[u8]) {
+    fs.create(Fid::ROOT, fid, name, FileKind::File)
+        .await
+        .expect("create");
+    fs.open(fid, OpenMode::Write).await.expect("open");
+    fs.write(fid, 0, bytes).await.expect("write");
+    fs.clunk(fid).await.expect("clunk");
+}
+
+async fn read_file(fs: &MemFs, name: &str, fid: Fid) -> Vec<u8> {
+    fs.walk(Fid::ROOT, fid, &[name.to_string()])
+        .await
+        .expect("walk");
+    fs.open(fid, OpenMode::Read).await.expect("open");
+    fs.read(fid, 0, 4096).await.expect("read")
+}
+
+#[tokio::test]
+async fn memory_files_are_plain_file_views_over_checkpoint_roots() {
+    let fs = MemFs::new();
+    create_file(&fs, "facts", Fid(1), b"alpha\nbeta\n").await;
+
+    assert_eq!(read_file(&fs, "facts", Fid(2)).await, b"alpha\nbeta\n");
+    assert_eq!(fs.materialize("facts").await.unwrap(), b"alpha\nbeta\n");
+
+    let root = fs.checkpoint_root("facts").await.unwrap();
+    assert!(root.as_str().starts_with("sha256:"));
+}
+
+#[tokio::test]
+async fn identical_memory_content_gets_the_same_checkpoint_root() {
+    let fs = MemFs::new();
+    create_file(&fs, "a", Fid(1), b"shared").await;
+    create_file(&fs, "b", Fid(2), b"shared").await;
+
+    assert_eq!(
+        fs.checkpoint_root("a").await.unwrap(),
+        fs.checkpoint_root("b").await.unwrap()
+    );
+}
+
+#[tokio::test]
+async fn removing_a_memory_file_removes_its_namespace_authority() {
+    let fs = MemFs::new();
+    create_file(&fs, "scratch", Fid(1), b"temporary").await;
+
+    fs.walk(Fid::ROOT, Fid(2), &["scratch".into()])
+        .await
+        .unwrap();
+    fs.remove(Fid(2)).await.unwrap();
+
+    assert_eq!(
+        fs.walk(Fid::ROOT, Fid(3), &["scratch".into()]).await,
+        Err(ErrorCode::NotFound)
+    );
+    assert_eq!(fs.materialize("scratch").await, Err(ErrorCode::NotFound));
+}
+
+#[tokio::test]
+async fn durable_home_can_resume_a_file_from_its_root_hash() {
+    let fs = MemFs::new();
+    create_file(&fs, "continuity", Fid(1), b"remember this").await;
+    let root = fs.checkpoint_root("continuity").await.unwrap();
+
+    fs.walk(Fid::ROOT, Fid(2), &["continuity".into()])
+        .await
+        .unwrap();
+    fs.remove(Fid(2)).await.unwrap();
+    assert_eq!(fs.materialize("continuity").await, Err(ErrorCode::NotFound));
+
+    fs.restore_checkpoint("continuity", root).await.unwrap();
+    assert_eq!(read_file(&fs, "continuity", Fid(3)).await, b"remember this");
+}
+
+#[tokio::test]
+async fn ephemeral_home_does_not_resume_roots_it_did_not_persist() {
+    let durable = MemFs::new();
+    create_file(&durable, "continuity", Fid(1), b"remember this").await;
+    let root = durable.checkpoint_root("continuity").await.unwrap();
+
+    let ephemeral = MemFs::new();
+    assert_eq!(
+        ephemeral.restore_checkpoint("continuity", root).await,
+        Err(ErrorCode::NotFound)
+    );
+}

--- a/openspec/changes/add-content-addressed-knowledge/tasks.md
+++ b/openspec/changes/add-content-addressed-knowledge/tasks.md
@@ -1,33 +1,74 @@
 ## 1. Content-addressed store
 
-- [ ] 1.1 Implement a content-addressed block store (hash-named blocks,
+- [x] 1.1 Implement a content-addressed block store (hash-named blocks,
   write-once, idempotent writes, dedup).
-- [ ] 1.2 Implement Merkle DAG assembly with root-hash checkpoints and
+  Done 2026-07-02: added `alan-knowledge`, with `KnowledgeStore::put_block`
+  storing raw blocks under `sha256:<hex>` content hashes. Re-writing identical
+  bytes is idempotent and keeps one stored copy; tests cover cross-write dedup.
+- [x] 1.2 Implement Merkle DAG assembly with root-hash checkpoints and
   block-sharing forks.
-- [ ] 1.3 Retrieve state through an authorized, namespace-bound root (gated by
+  Done 2026-07-02: `KnowledgeStore` builds Merkle DAG checkpoints from block
+  hashes and forks by referencing the base checkpoint node plus delta blocks, so
+  unchanged blocks are shared. Tests cover checkpoint materialization,
+  verification, and fork block/node counts.
+- [x] 1.3 Retrieve state through an authorized, namespace-bound root (gated by
   reachability + access rights, ADR-0024 D6), then use the root hash only for
   integrity verification — possessing a hash is never the authority to read.
+  Done 2026-07-02: reads require a private `BoundRoot` created by
+  `KnowledgeStore::bind_root`; `authorize_reachable_hash` rejects a bare hash
+  until that root is live in the namespace model. Stale bindings fail after
+  unbind, while `verify_root_hash` uses hashes only for integrity.
 
 ## 2. Retention and GC
 
-- [ ] 2.1 Implement reachability GC from live roots with a retention policy.
-- [ ] 2.2 Support pinning audited roots so GC does not drop them.
+- [x] 2.1 Implement reachability GC from live roots with a retention policy.
+  Done 2026-07-02: `KnowledgeStore::collect_garbage` walks live root bindings
+  plus pinned roots and, under `RetentionPolicy::CollectUnreachable`, removes
+  unreachable DAG nodes and raw blocks. `RetentionPolicy::KeepUnreachable`
+  preserves deferred retention behavior.
+- [x] 2.2 Support pinning audited roots so GC does not drop them.
+  Done 2026-07-02: `pin_root` and `unpin_root` keep audited checkpoint roots
+  alive independently from namespace root bindings; tests verify pinned roots
+  survive GC and become collectible after unpinning.
 
 ## 3. Backing the agent surfaces
 
-- [ ] 3.1 Back `memfs` (`/mnt/mem`) and the agent `machine/` surface with the
+- [x] 3.1 Back `memfs` (`/mnt/mem`) and the agent `machine/` surface with the
   store; expose tape/memory/context as file views over the DAG.
-- [ ] 3.2 Back the durable home (ADR-0024 D7): resume from a root hash; ephemeral
+  Done 2026-07-02: added `alan-memfs`, a Memory Store file server whose ordinary
+  files materialize from namespace-bound `alan-knowledge` checkpoint roots, and
+  backed `agentfs` `machine/tape` writes with content-addressed blocks plus a
+  current checkpoint root exposed at `machine/checkpoints/current`. Existing tape
+  reads remain file-shaped and are verified against the checkpoint in tests.
+- [x] 3.2 Back the durable home (ADR-0024 D7): resume from a root hash; ephemeral
   homes persist no roots.
-- [ ] 3.3 Map current tape/rollout/checkpoint persistence onto root-hash
+  Done 2026-07-02: `alan-memfs` can rebind an existing checkpoint root into the
+  same storage-backed home after the file's namespace authority is removed,
+  while a fresh ephemeral store rejects the same root because it did not persist
+  the backing blocks/nodes. Tests cover both durable resume and ephemeral
+  non-resume behavior.
+- [x] 3.3 Map current tape/rollout/checkpoint persistence onto root-hash
   checkpoints in the `introduce-alan-kernel-runtime` projection.
+  Done 2026-07-02: `NamespaceTurnRuntime`/`NamespaceRuntimeEnvironment` can read
+  the current `machine/tape` root hash from `machine/checkpoints/current`, and
+  rollout `CheckpointRecord`s now carry an optional `knowledge_root` while
+  preserving legacy JSON compatibility when absent. Tests cover namespace turn
+  root lookup and checkpoint persistence with a root hash.
 
 ## 4. Verification
 
-- [ ] 4.1 Tests: dedup, cheap fork (block sharing), checkpoint restore, tamper
+- [x] 4.1 Tests: dedup, cheap fork (block sharing), checkpoint restore, tamper
   detection, GC reachability + pinning.
-- [ ] 4.2 Run `just verify`.
-- [ ] 4.3 Run `openspec validate add-content-addressed-knowledge --strict`.
+  Done 2026-07-02: `crates/knowledge/tests/store.rs` covers identical-content
+  dedup, checkpoint materialization/restore, block-sharing forks, hash-is-not-
+  authority behavior, tamper detection by rehashing, and GC reachability plus
+  audit pinning.
+- [x] 4.2 Run `just verify`.
+  Done 2026-07-02: `just verify` passed after the content-addressed knowledge,
+  memfs, agentfs checkpoint backing, and rollout checkpoint-root mapping changes.
+- [x] 4.3 Run `openspec validate add-content-addressed-knowledge --strict`.
+  Done 2026-07-02: strict validation passed after the implementation and task
+  updates.
 
 ## 5. Follow-up (separate change)
 

--- a/openspec/changes/add-content-addressed-knowledge/tasks.md
+++ b/openspec/changes/add-content-addressed-knowledge/tasks.md
@@ -47,13 +47,14 @@
   while a fresh ephemeral store rejects the same root because it did not persist
   the backing blocks/nodes. Tests cover both durable resume and ephemeral
   non-resume behavior.
-- [x] 3.3 Map current tape/rollout/checkpoint persistence onto root-hash
+- [ ] 3.3 Map current tape/rollout/checkpoint persistence onto root-hash
   checkpoints in the `introduce-alan-kernel-runtime` projection.
-  Done 2026-07-02: `NamespaceTurnRuntime`/`NamespaceRuntimeEnvironment` can read
-  the current `machine/tape` root hash from `machine/checkpoints/current`, and
-  rollout `CheckpointRecord`s now carry an optional `knowledge_root` while
-  preserving legacy JSON compatibility when absent. Tests cover namespace turn
-  root lookup and checkpoint persistence with a root hash.
+  Partial 2026-07-02: `agentfs` exposes the current `machine/tape` root hash at
+  `machine/checkpoints/current`, and rollout `CheckpointRecord`s carry an
+  optional `knowledge_root` while preserving legacy JSON compatibility when
+  absent. Remaining: production checkpoint recording still needs to read the
+  namespace-native current checkpoint root and call the knowledge-root recorder
+  path instead of `record_checkpoint_nowait`.
 
 ## 4. Verification
 

--- a/openspec/changes/define-agent-file-layout-contract/design.md
+++ b/openspec/changes/define-agent-file-layout-contract/design.md
@@ -14,11 +14,14 @@ resources through directory conventions and `ctl` files.
 - Define `ctl`-based control and `/agent` as an overlay over `/proc`.
 - Define the LLM-stream consumer model and namespace-assembled requests.
 - Define requests/responses as files and the durable home tree.
+- Define the reference boundary for LLM provider, memory, tool, and skill file
+  servers consumed by the agent layout.
 
 **Non-Goals:**
 
-- Specify the LLM provider, memory, tool, or skill file servers themselves
-  (separate changes); this contract only references how an agent consumes them.
+- Specify the full LLM provider, memory, tool, or skill file-server protocols
+  (separate changes); this contract only names their mount boundaries and how an
+  agent consumes them.
 - Specify wire formats for any provider (provider-local per ADR-0024 D2).
 - Re-introduce any retired noun (Session, Workspace, AgentInstance,
   Subscription, Context Grant, Result Contract).
@@ -38,6 +41,9 @@ Implements [ADR-0024](../../../docs/adr/0024-plan9-kernel-model.md):
   vs ephemeral is decided by where the home is mounted.
 - D8 (agent-facing) → dynamic containers (`requests/`, `actions/`) expose an
   events stream watched by blocking read.
+- ADR-0025 D3 → external capability trees are reached through named file-server
+  mounts: `/mnt/llm`, `/mnt/mem`, `/bin` plus `/lib/exec` and `/man/1`, and
+  `/lib/skill` plus `/man/skill`.
 
 ## Risks / Trade-offs
 
@@ -56,3 +62,6 @@ Implements [ADR-0024](../../../docs/adr/0024-plan9-kernel-model.md):
 2. Map existing session / tape / yield / tool-call behavior onto this layout in
    the agent-runtime implementation change (a separate change), keeping current
    transport as compatibility only.
+3. Keep the detailed LLM, memory, tool, and skill protocols in their owning
+   OpenSpec capabilities while this contract remains the shared consumer
+   boundary.

--- a/openspec/changes/define-agent-file-layout-contract/proposal.md
+++ b/openspec/changes/define-agent-file-layout-contract/proposal.md
@@ -30,6 +30,9 @@ already provide.
 - Define the request as a view assembled from namespace files, tape compaction
   as a view over `machine/tape`, and an agent's tools as the `/bin` visible in
   its namespace.
+- Define the referenced external file-server boundaries for LLM provider access,
+  Memory Stores, Tools, and Skills, without taking ownership of their detailed
+  protocols.
 - Define requests and responses as files, and the durable agent identity (home
   tree) that makes a restarted agent resume.
 - Define the namespace's **access discipline** — consolidated here as the single
@@ -46,9 +49,10 @@ already provide.
 - `agent-file-layout-contract`: the OS-level file-layout convention for agents —
   process layout, agent superset, `ctl` control, `/agent` as a `/proc` view, the
   LLM-stream consumer model, namespace-assembled requests, tools-as-`/bin`,
-  request/response files, the durable home tree, and the namespace access
-  discipline (ctl scoping, the generation tape lease, actor-keyed authority +
-  interpose, the external-writer protocol-layer prerequisite, self-description).
+  referenced LLM/memory/tool/skill file-server boundaries, request/response
+  files, the durable home tree, and the namespace access discipline (ctl
+  scoping, the generation tape lease, actor-keyed authority + interpose, the
+  external-writer protocol-layer prerequisite, self-description).
 
 ### Modified Capabilities
 
@@ -79,6 +83,7 @@ and its access discipline. Two overlapping efforts are folded in here:
   conforms to this contract; conformance — not a kernel flag — is what makes its
   processes operable as agents.
 - Affected planning: LLM providers, memory, tools, and skills are separate
-  user-space file servers referenced by this contract but specified elsewhere.
+  user-space file servers referenced here at their mount/descriptor boundaries
+  but specified in detail by their owning OpenSpec capabilities.
 - Affected ADRs: implements ADR-0024 D1, D2, D4, and the agent-facing parts of
   D6, D7, and D8. Depends on `define-plan9-kernel-substrate`.

--- a/openspec/changes/define-agent-file-layout-contract/specs/agent-file-layout-contract/spec.md
+++ b/openspec/changes/define-agent-file-layout-contract/specs/agent-file-layout-contract/spec.md
@@ -183,6 +183,52 @@ the request's tool list.
   model-callable tools
 - **AND** there is no separate tool registry granting tools outside the namespace
 
+### Requirement: Referenced capability file servers have explicit mount boundaries
+Alan OS SHALL treat the LLM provider, Memory Store, Tool, and Skill capabilities
+referenced by this contract as external file-server surfaces, not fields on the
+agent runtime. The referenced surfaces are:
+
+- LLM provider access: `alan-llmfs` posts `/srv/llm` and serves `/mnt/llm`;
+  Providers are introspection surfaces under `/mnt/llm/providers/<provider>`,
+  while callable Connections live under `/mnt/llm/connections/<connection>`.
+- Memory Stores: storage-backed Memory Store file servers post handles such as
+  `/srv/mem` and are mounted for process use under `/mnt/mem` or passed as
+  narrower descriptors/binds. They own memory authority; memory kinds describe
+  usage, not ownership.
+- Tools: Tool file servers contribute executable command files unioned into
+  `/bin`, with machine-readable manifests at `/lib/exec/<tool>/manifest` and
+  manuals under `/man/1`.
+- Skills: package file servers expose manual-like Skill packages under
+  `/lib/skill/<name>` and documentation under `/man/skill/<name>`. Skills are
+  passed by descriptor and do not execute or grant authority by themselves.
+
+The agent file layout MAY project references to these surfaces, but it SHALL NOT
+own their global registries, provider wire formats, memory authority, tool
+catalog implementation, or skill package resolution. Those detailed protocols
+belong to their own OpenSpec capabilities.
+
+#### Scenario: A spawner assembles an agent's capabilities
+- **WHEN** an agent process is spawned
+- **THEN** the spawner binds only the selected LLM Connection, Memory Store
+  descriptors, Tool command files, and Skill package descriptors into the
+  process namespace
+- **AND** any unbound provider, store, tool, or skill is structurally absent from
+  the agent's world rather than denied by a side-channel API
+
+#### Scenario: Memory is read or written
+- **WHEN** an agent recalls, flushes, or promotes memory
+- **THEN** it does so through a Memory Store path or descriptor in its namespace
+- **AND** the agent runtime does not use a global memory registry outside the
+  namespace to grant authority
+
+#### Scenario: Tool and Skill packages are both present
+- **WHEN** a Skill package includes instructions and package-local executables
+- **THEN** the Skill contributes knowledge through its descriptor, while any
+  executable effect is available to the agent only if a Tool command is bound
+  into `/bin` or another explicit execution path
+- **AND** a Skill package does not become an executable Tool merely by being
+  discovered
+
 ### Requirement: Requests and actions are files with events
 Alan OS SHALL represent agent yield, confirmation, approval, credential,
 selection, and structured-input requests as file trees under `requests/<id>/`,

--- a/openspec/changes/define-agent-file-layout-contract/tasks.md
+++ b/openspec/changes/define-agent-file-layout-contract/tasks.md
@@ -47,23 +47,56 @@
 
 ## 3. Conformance test-kit
 
-- [ ] 3.1 Provide a conformance checker that, given a process directory, verifies
+- [x] 3.1 Provide a conformance checker that, given a process directory, verifies
   the generic process layout (`io/input`, `io/output`, `io/events`, `status`,
   `ctl`) and, for agents, the full superset (`requests/`, `actions/`, `machine/`,
   `context/`, `children/`, and the top-level aggregate `events` stream). This
   gives the convention teeth without a kernel type.
-- [ ] 3.2 Verify dynamic containers (`requests/`, `actions/`) expose an `events`
+  Done 2026-07-02: `alan-agentfs` now exports `AgentConformanceChecker`, an
+  aP-only checker over an arbitrary `InProcessTransport`. It verifies the
+  generic process files plus the agent superset under a supplied process path,
+  so agent-ness is tested by walking files rather than consulting a kernel type.
+  Coverage runs it against the current `/agent/<pid>` overlay.
+- [x] 3.2 Verify dynamic containers (`requests/`, `actions/`) expose an `events`
   stream observable by blocking read (D8).
-- [ ] 3.3 Verify `/agent` resolves as an overlay over `/proc` and that `/agent/root`
+  Done 2026-07-02: the checker opens `requests/events` and `actions/events`,
+  records the current stream offset, clone-opens a child in the corresponding
+  container, and proves the events stream unblocks with new bytes. This is
+  covered by `conformance_checker_verifies_dynamic_container_event_streams`.
+- [x] 3.3 Verify `/agent` resolves as an overlay over `/proc` and that `/agent/root`
   follows the current root pid while durable identity stays the home path (D4/D7).
-- [ ] 3.4 Make the checker runnable by any third-party runtime against its own
+  Done 2026-07-02: `AgentRootFs` now unions proc-owned generic files
+  (`status`, `ctl`, `parent`, `credentials`, `exit`, `namespace`) into
+  `/agent/<pid>` while keeping agent-owned surfaces (`io`, `machine`,
+  `requests`, `actions`, `context`, `children`, `events`) backed by AgentFS.
+  The checker proves `/agent/root` has the same conforming surface as the
+  current root pid.
+- [x] 3.4 Make the checker runnable by any third-party runtime against its own
   exported tree, so conformance — not a kernel flag — is what makes a runtime's
   agents operable.
+  Done 2026-07-02: the checker API takes only an aP transport and paths; it has
+  no dependency on `alan-kernel`, `alan-agent-engine`, or Alan process types.
+  Any third-party runtime that exports a compatible aP tree can run the same
+  checker against its own process directory.
 
 ## 4. Follow-up (separate changes)
 
-- [ ] 4.1 Map current session / tape / yield / tool-call behavior onto this
+- [x] 4.1 Map current session / tape / yield / tool-call behavior onto this
   layout in `introduce-alan-kernel-runtime` (the projection file server) and run
   the conformance test-kit against it.
-- [ ] 4.2 Specify the LLM provider, memory, tool, and skill file servers that
+  Done 2026-07-02: the superseding `refactor-engine-namespace-native` path maps
+  session IO, tape, yielded requests, and tool/action records onto AgentFS. The
+  namespace-native M2 test now runs through the real `/agent` overlay (not a
+  direct `/agent/1` mount), then runs `AgentConformanceChecker` against the live
+  process tree. The request/action file test also runs against the overlay and
+  verifies the same conformance after writing `requests/<id>/` and
+  `actions/<id>/` state.
+- [x] 4.2 Specify the LLM provider, memory, tool, and skill file servers that
   this contract references.
+  Done 2026-07-02: the contract now names the referenced external file-server
+  boundaries: `alan-llmfs` at `/srv/llm` and `/mnt/llm`, Memory Stores through
+  `/srv/mem` handles and `/mnt/mem` mounts/descriptors, Tools through `/bin`
+  plus `/lib/exec/<tool>/manifest` and `/man/1`, and Skills through
+  `/lib/skill/<name>` plus `/man/skill/<name>`. It also states that the agent
+  layout consumes these surfaces by namespace/descriptors while their detailed
+  protocols remain owned by separate OpenSpec capabilities.


### PR DESCRIPTION
Stack 3/4. Base: #587 / feat/northstar-llmfs-shell.

Adds the AgentFS overlay/conformance layer and the Ring 3 content-addressed knowledge slice: alan-knowledge, alan-memfs, machine/tape checkpoint backing, durable/ephemeral root resume behavior, and rollout checkpoint knowledge_root metadata.

Verification: just verify passed on the top of the stack after all four branches.