### PR TITLE
North Star 5/5: add routefs message routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "alan-kernel",
  "alan-llm",
  "alan-llmfs",
+ "alan-routefs",
  "alan-shell",
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "alan-routefs"
+version = "0.1.0"
+dependencies = [
+ "alan-ap",
+ "alan-kernel",
+ "alan-shell",
+ "async-trait",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "alan-shell"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/kernel",
     "crates/knowledge",
     "crates/memfs",
+    "crates/routefs",
     "crates/agent-protocol",
     "crates/llm",
     "crates/llmfs",
@@ -120,6 +121,7 @@ alan-llm = { path = "crates/llm" }
 alan-agent-engine = { path = "crates/agent-engine" }
 alan-knowledge = { path = "crates/knowledge" }
 alan-memfs = { path = "crates/memfs" }
+alan-routefs = { path = "crates/routefs" }
 alan-swebench-tooling = { path = "crates/agent-engine/skills/swebench/tooling" }
 alan-shell-core = { path = "crates/shell-core" }
 alan-shell-core-ffi = { path = "crates/shell-core-ffi" }

--- a/crates/agent-engine/Cargo.toml
+++ b/crates/agent-engine/Cargo.toml
@@ -11,6 +11,7 @@ alan-agent-protocol.workspace = true
 alan-kernel = { path = "../kernel" }
 alan-llm.workspace = true
 alan-llmfs = { path = "../llmfs" }
+alan-routefs.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 serde.workspace = true

--- a/crates/agent-engine/src/runtime/agent_loop/namespace_environment.rs
+++ b/crates/agent-engine/src/runtime/agent_loop/namespace_environment.rs
@@ -174,6 +174,11 @@ impl NamespaceRuntimeEnvironment {
         &self.llm_connection
     }
 
+    #[cfg(test)]
+    pub(crate) fn root_transport(&self) -> InProcessTransport {
+        self.root.clone()
+    }
+
     pub async fn read_llm_connection_capabilities(&self) -> Result<NamespaceLlmCapabilities> {
         let path = format!("/mnt/llm/connections/{}/capabilities", self.llm_connection);
         let client = self.client();

--- a/crates/agent-engine/src/runtime/agent_loop/namespace_environment.rs
+++ b/crates/agent-engine/src/runtime/agent_loop/namespace_environment.rs
@@ -140,7 +140,14 @@ pub struct NamespaceRuntimeEnvironment {
     root: InProcessTransport,
     agent_path: String,
     llm_connection: String,
+    shared_services: Option<NamespaceSharedServices>,
     input_offset: Arc<AtomicU64>,
+}
+
+#[derive(Clone)]
+pub(crate) struct NamespaceSharedServices {
+    pub(crate) srv: InProcessTransport,
+    pub(crate) route: InProcessTransport,
 }
 
 impl std::fmt::Debug for NamespaceRuntimeEnvironment {
@@ -148,6 +155,7 @@ impl std::fmt::Debug for NamespaceRuntimeEnvironment {
         f.debug_struct("NamespaceRuntimeEnvironment")
             .field("agent_path", &self.agent_path)
             .field("llm_connection", &self.llm_connection)
+            .field("has_shared_services", &self.shared_services.is_some())
             .finish_non_exhaustive()
     }
 }
@@ -162,8 +170,22 @@ impl NamespaceRuntimeEnvironment {
             root,
             agent_path: agent_path.into(),
             llm_connection: llm_connection.into(),
+            shared_services: None,
             input_offset: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    pub(crate) fn with_shared_services(
+        mut self,
+        srv: InProcessTransport,
+        route: InProcessTransport,
+    ) -> Self {
+        self.shared_services = Some(NamespaceSharedServices { srv, route });
+        self
+    }
+
+    pub(crate) fn shared_services(&self) -> Option<NamespaceSharedServices> {
+        self.shared_services.clone()
     }
 
     pub fn agent_path(&self) -> &str {

--- a/crates/agent-engine/src/runtime/child_agents.rs
+++ b/crates/agent-engine/src/runtime/child_agents.rs
@@ -367,28 +367,8 @@ where
         &child_namespace_plan.llm_connection_name()?,
         Box::new(ChildLlmProvider::new(llm_client)),
     );
-    let routefs = Arc::new(alan_routefs::RouteFs::new());
-    let srvfs = Arc::new(alan_kernel::SrvFs::new());
-    srvfs
-        .post(
-            alan_routefs::SRV_HANDLE,
-            InProcessTransport::new(routefs.clone()),
-            alan_kernel::Access::ReadWrite,
-        )
-        .await;
-    let (route_tree, route_access) = srvfs
-        .lookup(alan_routefs::SRV_HANDLE)
-        .await
-        .context("lookup child routefs handle after posting /srv/route")?;
-    if route_access != alan_kernel::Access::ReadWrite {
-        bail!("child routefs handle must be mounted read-write");
-    }
-    let mut handles = ChildNamespaceLaunchHandles::new(
-        agentfs,
-        InProcessTransport::new(llmfs),
-        InProcessTransport::new(srvfs),
-        route_tree,
-    );
+    let mut handles = child_namespace_launch_handles_from_parent(parent, agentfs, llmfs)
+        .context("Failed to assemble child-agent shared namespace handles")?;
     for mount in &child_namespace_plan.bin_tool_mounts {
         handles = handles.with_bin_tool(
             mount.clone(),
@@ -1411,6 +1391,23 @@ impl ChildNamespaceLaunchHandles {
     }
 }
 
+fn child_namespace_launch_handles_from_parent(
+    parent: &RuntimeLoopState,
+    agent_tree: Arc<alan_agentfs::AgentFs>,
+    llm_connection: Arc<alan_llmfs::LlmFs>,
+) -> Result<ChildNamespaceLaunchHandles> {
+    let shared_services = parent
+        .namespace_environment()
+        .shared_services()
+        .context("parent namespace missing shared service handles for child-agent launch")?;
+    Ok(ChildNamespaceLaunchHandles::new(
+        agent_tree,
+        InProcessTransport::new(llm_connection),
+        shared_services.srv,
+        shared_services.route,
+    ))
+}
+
 #[cfg_attr(not(test), allow(dead_code))]
 struct ChildNamespaceRuntimeLaunch {
     pid: String,
@@ -1491,7 +1488,8 @@ async fn spawn_child_namespace_runtime_environment(
         root,
         format!("/agent/{pid}"),
         plan.llm_connection_name()?,
-    );
+    )
+    .with_shared_services(handles.srv.clone(), handles.route.clone());
 
     Ok(ChildNamespaceRuntimeLaunch {
         pid,
@@ -2038,11 +2036,18 @@ mod tests {
     }
 
     fn namespace_environment_for_parent_test() -> RuntimeEnvironment {
+        namespace_environment_for_parent_test_with_route(Arc::new(alan_routefs::RouteFs::new()))
+    }
+
+    fn namespace_environment_for_parent_test_with_route(
+        routefs: Arc<alan_routefs::RouteFs>,
+    ) -> RuntimeEnvironment {
         let root =
             InProcessTransport::new(Arc::new(alan_kernel::MountFs::new(KernelNamespace::new())));
-        RuntimeEnvironment::namespace(crate::runtime::NamespaceRuntimeEnvironment::new(
-            root, "/agent/1", "default",
-        ))
+        let namespace =
+            crate::runtime::NamespaceRuntimeEnvironment::new(root, "/agent/1", "default")
+                .with_shared_services(memfs_transport(), InProcessTransport::new(routefs));
+        RuntimeEnvironment::namespace(namespace)
     }
 
     #[derive(Clone, Default)]
@@ -2985,6 +2990,83 @@ Body
             tool_namespace.lines().any(|line| line == "/bin/alpha ro"),
             "child-spawned processes inherit mounted tools: {tool_namespace:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn child_namespace_launch_handles_share_parent_routefs() {
+        let temp = TempDir::new().unwrap();
+        let requests = RecordedRequests::default();
+        let response = completed_response("Child finished cleanly.");
+        let routefs = Arc::new(alan_routefs::RouteFs::new());
+        routefs
+            .install_rule(
+                "10-results",
+                alan_routefs::RuleSpec::for_type("result", "review"),
+            )
+            .await
+            .unwrap();
+        let mut parent = make_parent_state(&temp, requests, response);
+        parent.environment = namespace_environment_for_parent_test_with_route(routefs.clone());
+
+        let root_dir = temp.path().join("repo/.alan/agents/grader");
+        let mut spec = launch_spec(root_dir);
+        spec.handles = vec![SpawnHandle::Workspace];
+        let plan =
+            build_child_namespace_assembly_plan(&parent, &spec, &parent.core_config).unwrap();
+        let child_tools = build_child_tool_registry_from_namespace_plan(
+            &parent,
+            &spec,
+            &parent.core_config,
+            &plan,
+        )
+        .unwrap();
+        let launch_procfs = KernelProcFs::new();
+        let runtime_procfs = launch_procfs
+            .clone()
+            .with_runner(Arc::new(ChildToolProcessRunner::new(child_tools)));
+        let llmfs = Arc::new(alan_llmfs::LlmFs::new());
+        llmfs.register_connection(
+            &plan.llm_connection_name().unwrap(),
+            Box::new(ChildLlmProvider::new(LlmClient::new(
+                RecordingProvider::new(RecordedRequests::default(), completed_response("unused")),
+            ))),
+        );
+        let handles = child_namespace_launch_handles_from_parent(
+            &parent,
+            Arc::new(alan_agentfs::AgentFs::new()),
+            llmfs,
+        )
+        .unwrap()
+        .with_bin_tool("/bin/alpha", memfs_transport())
+        .with_bin_tool("/bin/beta", memfs_transport());
+
+        let launch = spawn_child_namespace_runtime_environment(
+            &launch_procfs,
+            &runtime_procfs,
+            &plan,
+            handles,
+            "/bin/alan-agent",
+        )
+        .await
+        .unwrap();
+
+        let child_shell = alan_shell::Shell::new(launch.environment.root_transport());
+        let message = serde_json::to_vec(&json!({
+            "version": 1,
+            "type": "result",
+            "content": "child result"
+        }))
+        .unwrap();
+        child_shell
+            .write("/mnt/route/send", &message)
+            .await
+            .unwrap();
+
+        let parent_route_shell = alan_shell::Shell::new(InProcessTransport::new(routefs));
+        let routed =
+            String::from_utf8(parent_route_shell.cat("/ports/review").await.unwrap()).unwrap();
+        assert!(routed.contains(r#""type":"result""#), "{routed}");
+        assert!(routed.contains(r#""content":"child result""#), "{routed}");
     }
 
     #[tokio::test]

--- a/crates/agent-engine/src/runtime/child_agents.rs
+++ b/crates/agent-engine/src/runtime/child_agents.rs
@@ -367,7 +367,28 @@ where
         &child_namespace_plan.llm_connection_name()?,
         Box::new(ChildLlmProvider::new(llm_client)),
     );
-    let mut handles = ChildNamespaceLaunchHandles::new(agentfs, InProcessTransport::new(llmfs));
+    let routefs = Arc::new(alan_routefs::RouteFs::new());
+    let srvfs = Arc::new(alan_kernel::SrvFs::new());
+    srvfs
+        .post(
+            alan_routefs::SRV_HANDLE,
+            InProcessTransport::new(routefs.clone()),
+            alan_kernel::Access::ReadWrite,
+        )
+        .await;
+    let (route_tree, route_access) = srvfs
+        .lookup(alan_routefs::SRV_HANDLE)
+        .await
+        .context("lookup child routefs handle after posting /srv/route")?;
+    if route_access != alan_kernel::Access::ReadWrite {
+        bail!("child routefs handle must be mounted read-write");
+    }
+    let mut handles = ChildNamespaceLaunchHandles::new(
+        agentfs,
+        InProcessTransport::new(llmfs),
+        InProcessTransport::new(srvfs),
+        route_tree,
+    );
     for mount in &child_namespace_plan.bin_tool_mounts {
         handles = handles.with_bin_tool(
             mount.clone(),
@@ -1291,6 +1312,8 @@ struct ChildNamespaceAssemblyPlan {
     agent_mount: String,
     llm_mount: String,
     llm_connection_name: String,
+    srv_mount: String,
+    route_mount: String,
     bin_tool_mounts: Vec<String>,
     workspace_root: Option<PathBuf>,
     cwd: Option<PathBuf>,
@@ -1326,6 +1349,8 @@ impl ChildNamespaceAssemblyPlan {
         let mut mounts = vec![
             ExecNamespaceMount::new(self.agent_mount.clone(), ExecNamespaceAccess::ReadWrite),
             ExecNamespaceMount::new(self.llm_mount.clone(), ExecNamespaceAccess::ReadWrite),
+            ExecNamespaceMount::new(self.route_mount.clone(), ExecNamespaceAccess::ReadWrite),
+            ExecNamespaceMount::new(self.srv_mount.clone(), ExecNamespaceAccess::ReadOnly),
         ];
         mounts.extend(
             self.bin_tool_mounts
@@ -1358,15 +1383,24 @@ impl ChildNamespaceAssemblyPlan {
 struct ChildNamespaceLaunchHandles {
     agent_tree: Arc<alan_agentfs::AgentFs>,
     llm_connection: InProcessTransport,
+    srv: InProcessTransport,
+    route: InProcessTransport,
     bin_tools: Vec<(String, InProcessTransport)>,
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
 impl ChildNamespaceLaunchHandles {
-    fn new(agent_tree: Arc<alan_agentfs::AgentFs>, llm_connection: InProcessTransport) -> Self {
+    fn new(
+        agent_tree: Arc<alan_agentfs::AgentFs>,
+        llm_connection: InProcessTransport,
+        srv: InProcessTransport,
+        route: InProcessTransport,
+    ) -> Self {
         Self {
             agent_tree,
             llm_connection,
+            srv,
+            route,
             bin_tools: Vec::new(),
         }
     }
@@ -1533,6 +1567,16 @@ fn child_namespace_from_launch_handles(
         handles.llm_connection.clone(),
         alan_kernel::Access::ReadWrite,
     );
+    namespace.mount(
+        &plan.srv_mount,
+        handles.srv.clone(),
+        alan_kernel::Access::ReadOnly,
+    );
+    namespace.mount(
+        &plan.route_mount,
+        handles.route.clone(),
+        alan_kernel::Access::ReadWrite,
+    );
     for (mount, tree) in &handles.bin_tools {
         namespace.mount(mount, tree.clone(), alan_kernel::Access::ReadOnly);
     }
@@ -1564,6 +1608,8 @@ fn build_child_namespace_assembly_plan(
         agent_mount: "/agent".to_string(),
         llm_mount: "/mnt/llm".to_string(),
         llm_connection_name: llm_connection.to_string(),
+        srv_mount: "/srv".to_string(),
+        route_mount: alan_routefs::MOUNT_PATH.to_string(),
         bin_tool_mounts: Vec::new(),
         workspace_root: workspace_root.clone(),
         cwd,
@@ -2381,6 +2427,12 @@ Body
             KernelAccess::ReadWrite,
         );
         namespace.mount(&plan.llm_mount, memfs_transport(), KernelAccess::ReadWrite);
+        namespace.mount(&plan.srv_mount, memfs_transport(), KernelAccess::ReadOnly);
+        namespace.mount(
+            &plan.route_mount,
+            memfs_transport(),
+            KernelAccess::ReadWrite,
+        );
         for mount in &plan.bin_tool_mounts {
             namespace.mount(mount, memfs_transport(), KernelAccess::ReadOnly);
         }
@@ -2663,6 +2715,8 @@ Body
         assert_eq!(plan.agent_mount, "/agent");
         assert_eq!(plan.llm_mount, "/mnt/llm");
         assert_eq!(plan.llm_connection_name().unwrap(), "child-main");
+        assert_eq!(plan.srv_mount, "/srv");
+        assert_eq!(plan.route_mount, "/mnt/route");
         assert!(plan.bin_tool_mounts.is_empty());
         assert_eq!(plan.workspace_root, None);
     }
@@ -2685,6 +2739,8 @@ Body
 
         assert_eq!(plan.llm_mount, "/mnt/llm");
         assert_eq!(plan.llm_connection_name().unwrap(), "default");
+        assert_eq!(plan.srv_mount, "/srv");
+        assert_eq!(plan.route_mount, "/mnt/route");
         assert_eq!(plan.workspace_root, Some(temp.path().join("repo")));
         assert_eq!(plan.cwd, Some(temp.path().join("repo")));
         assert_eq!(plan.bin_tool_mounts, vec!["/bin/alpha"]);
@@ -2712,7 +2768,9 @@ Body
                 "namespace": {
                     "mounts": [
                         {"path": "/agent", "access": "rw"},
-                        {"path": "/mnt/llm", "access": "rw"}
+                        {"path": "/mnt/llm", "access": "rw"},
+                        {"path": "/mnt/route", "access": "rw"},
+                        {"path": "/srv", "access": "ro"}
                     ]
                 }
             })
@@ -2745,7 +2803,9 @@ Body
                 "mounts": [
                     {"path": "/agent", "access": "rw"},
                     {"path": "/bin/alpha", "access": "ro"},
-                    {"path": "/mnt/llm", "access": "rw"}
+                    {"path": "/mnt/llm", "access": "rw"},
+                    {"path": "/mnt/route", "access": "rw"},
+                    {"path": "/srv", "access": "ro"}
                 ]
             })
         );
@@ -2831,6 +2891,8 @@ Body
         let handles = ChildNamespaceLaunchHandles::new(
             Arc::new(alan_agentfs::AgentFs::new()),
             memfs_transport(),
+            memfs_transport(),
+            memfs_transport(),
         )
         .with_bin_tool("/bin/alpha", memfs_transport());
 
@@ -2877,6 +2939,14 @@ Body
             "llm connection is present: {namespace:?}"
         );
         assert!(
+            namespace.lines().any(|line| line == "/mnt/route rw"),
+            "routefs tree is present: {namespace:?}"
+        );
+        assert!(
+            namespace.lines().any(|line| line == "/srv ro"),
+            "service handle registry is present: {namespace:?}"
+        );
+        assert!(
             namespace.lines().any(|line| line == "/bin/alpha ro"),
             "allowed tool mount is present: {namespace:?}"
         );
@@ -2902,6 +2972,14 @@ Body
         assert!(
             tool_namespace.lines().any(|line| line == "/mnt/llm rw"),
             "child-spawned processes inherit the llm connection: {tool_namespace:?}"
+        );
+        assert!(
+            tool_namespace.lines().any(|line| line == "/mnt/route rw"),
+            "child-spawned processes inherit routefs: {tool_namespace:?}"
+        );
+        assert!(
+            tool_namespace.lines().any(|line| line == "/srv ro"),
+            "child-spawned processes inherit /srv handles: {tool_namespace:?}"
         );
         assert!(
             tool_namespace.lines().any(|line| line == "/bin/alpha ro"),

--- a/crates/agent-engine/src/runtime/engine.rs
+++ b/crates/agent-engine/src/runtime/engine.rs
@@ -1168,7 +1168,8 @@ async fn build_root_namespace_environment(
         alan_kernel::Access::ReadWrite,
     );
     mount_llmfs_standard_handles(&mut process_namespace, srvfs.clone(), llmfs).await?;
-    mount_routefs_standard_handles(&mut process_namespace, srvfs, routefs).await?;
+    let route_tree =
+        mount_routefs_standard_handles(&mut process_namespace, srvfs.clone(), routefs).await?;
     for tool_name in &tool_names {
         process_namespace.mount(
             &format!("/bin/{tool_name}"),
@@ -1200,8 +1201,11 @@ async fn build_root_namespace_environment(
         alan_kernel::Access::ReadWrite,
     );
     let root = InProcessTransport::new(Arc::new(alan_kernel::MountFs::new(process_namespace)));
+    let namespace =
+        super::NamespaceRuntimeEnvironment::new(root, format!("/agent/{root_pid}"), "default")
+            .with_shared_services(InProcessTransport::new(srvfs), route_tree);
     Ok(RuntimeEnvironment::namespace_with_tool_definitions(
-        super::NamespaceRuntimeEnvironment::new(root, format!("/agent/{root_pid}"), "default"),
+        namespace,
         tool_definitions,
     ))
 }
@@ -1235,7 +1239,7 @@ async fn mount_routefs_standard_handles(
     namespace: &mut alan_kernel::Namespace,
     srvfs: Arc<alan_kernel::SrvFs>,
     routefs: Arc<alan_routefs::RouteFs>,
-) -> Result<()> {
+) -> Result<InProcessTransport> {
     srvfs
         .post(
             alan_routefs::SRV_HANDLE,
@@ -1252,8 +1256,8 @@ async fn mount_routefs_standard_handles(
         .lookup(alan_routefs::SRV_HANDLE)
         .await
         .context("lookup routefs handle after posting /srv/route")?;
-    namespace.mount(alan_routefs::MOUNT_PATH, route_tree, route_access);
-    Ok(())
+    namespace.mount(alan_routefs::MOUNT_PATH, route_tree.clone(), route_access);
+    Ok(route_tree)
 }
 
 async fn spawn_root_agent_process(

--- a/crates/agent-engine/src/runtime/engine.rs
+++ b/crates/agent-engine/src/runtime/engine.rs
@@ -1154,6 +1154,8 @@ async fn build_root_namespace_environment(
     let agentfs = Arc::new(alan_agentfs::AgentFs::new());
     let llmfs = Arc::new(alan_llmfs::LlmFs::new());
     llmfs.register_connection("default", Box::new(RuntimeLlmProvider::new(llm_client)));
+    let routefs = Arc::new(alan_routefs::RouteFs::new());
+    let srvfs = Arc::new(alan_kernel::SrvFs::new());
 
     let procfs = alan_kernel::ProcFs::new();
     let agent_root = Arc::new(alan_agentfs::AgentRootFs::new(Arc::new(procfs.clone())));
@@ -1165,12 +1167,8 @@ async fn build_root_namespace_environment(
         agent_root_tree.clone(),
         alan_kernel::Access::ReadWrite,
     );
-    mount_llmfs_standard_handles(
-        &mut process_namespace,
-        Arc::new(alan_kernel::SrvFs::new()),
-        llmfs,
-    )
-    .await?;
+    mount_llmfs_standard_handles(&mut process_namespace, srvfs.clone(), llmfs).await?;
+    mount_routefs_standard_handles(&mut process_namespace, srvfs, routefs).await?;
     for tool_name in &tool_names {
         process_namespace.mount(
             &format!("/bin/{tool_name}"),
@@ -1230,6 +1228,31 @@ async fn mount_llmfs_standard_handles(
         .await
         .context("lookup llmfs handle after posting /srv/llm")?;
     namespace.mount(LLM_MOUNT, llm_tree, llm_access);
+    Ok(())
+}
+
+async fn mount_routefs_standard_handles(
+    namespace: &mut alan_kernel::Namespace,
+    srvfs: Arc<alan_kernel::SrvFs>,
+    routefs: Arc<alan_routefs::RouteFs>,
+) -> Result<()> {
+    srvfs
+        .post(
+            alan_routefs::SRV_HANDLE,
+            InProcessTransport::new(routefs),
+            alan_kernel::Access::ReadWrite,
+        )
+        .await;
+    namespace.mount(
+        SRV_MOUNT,
+        InProcessTransport::new(srvfs.clone()),
+        alan_kernel::Access::ReadOnly,
+    );
+    let (route_tree, route_access) = srvfs
+        .lookup(alan_routefs::SRV_HANDLE)
+        .await
+        .context("lookup routefs handle after posting /srv/route")?;
+    namespace.mount(alan_routefs::MOUNT_PATH, route_tree, route_access);
     Ok(())
 }
 
@@ -1923,6 +1946,51 @@ mod tests {
         assert!(llm_root.iter().any(|entry| entry == "providers"));
         let connections = shell.ls("/mnt/llm/connections").await.unwrap();
         assert_eq!(connections, vec!["default".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn root_namespace_environment_posts_routefs_and_mounts_route_tree() {
+        let environment = build_root_namespace_environment(
+            LlmClient::new(MockLlmProvider::new()),
+            crate::tools::ToolRegistry::new(),
+        )
+        .await
+        .unwrap();
+        let RuntimeEnvironment::Namespace { namespace, .. } = environment;
+        let shell = alan_shell::Shell::new(namespace.root_transport());
+
+        let srv_entries = shell.ls("/srv").await.unwrap();
+        assert!(srv_entries.iter().any(|entry| entry == "llm"));
+        assert!(srv_entries.iter().any(|entry| entry == "route"));
+        assert_eq!(shell.cat("/srv/route").await.unwrap(), b"route");
+        assert_eq!(
+            shell.ls("/srv/route").await,
+            Err(alan_ap::ErrorCode::NotDirectory),
+            "/srv/route is the rendezvous handle, not the routefs state tree"
+        );
+
+        let route_root = shell.ls("/mnt/route").await.unwrap();
+        for entry in ["send", "rules", "ports", "log"] {
+            assert!(
+                route_root.iter().any(|mounted| mounted == entry),
+                "{route_root:?}"
+            );
+        }
+
+        let message = serde_json::to_vec(&serde_json::json!({
+            "version": 1,
+            "type": "status",
+            "content": "ready"
+        }))
+        .unwrap();
+        shell.write("/mnt/route/send", &message).await.unwrap();
+        let dead_letter =
+            String::from_utf8(shell.cat("/mnt/route/ports/dead-letter").await.unwrap()).unwrap();
+        assert!(
+            dead_letter.contains(r#""rule":"dead-letter""#),
+            "{dead_letter}"
+        );
+        assert!(dead_letter.contains(r#""type":"status""#), "{dead_letter}");
     }
 
     #[test]

--- a/crates/kernel/src/mountfs.rs
+++ b/crates/kernel/src/mountfs.rs
@@ -380,14 +380,74 @@ impl FileServer for MountFs {
 
     async fn create(
         &self,
-        _fid: Fid,
-        _newfid: Fid,
-        _name: &str,
-        _kind: FileKind,
+        fid: Fid,
+        newfid: Fid,
+        name: &str,
+        kind: FileKind,
     ) -> Result<Qid, ErrorCode> {
-        // v1 does not multiplex create across a mount (the newfid mapping is a
-        // later slice); the backing servers do not support it either.
-        Err(ErrorCode::Unsupported)
+        let (resolved, backing_fid, parent_path) = {
+            let state = self.state.lock().await;
+            if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
+                return Err(ErrorCode::BadRequest);
+            }
+            let entry = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+            let Some(backing) = &entry.backing else {
+                return Err(ErrorCode::Unsupported);
+            };
+            if !backing.is_dir {
+                return Err(ErrorCode::NotDirectory);
+            }
+            (
+                backing.resolved.clone(),
+                backing.backing_fid,
+                entry.path.clone(),
+            )
+        };
+
+        let backing_newfid = Fid(NEXT_BACKING.fetch_add(1, Ordering::Relaxed));
+        let qid = match resolved
+            .call(Request::Create {
+                fid: backing_fid,
+                newfid: backing_newfid,
+                name: name.to_string(),
+                kind,
+            })
+            .await?
+        {
+            Response::Create { qid } => qid,
+            _ => return Err(ErrorCode::Io),
+        };
+
+        let mut path = parent_path;
+        path.push(name.to_string());
+        let inserted = {
+            let mut state = self.state.lock().await;
+            if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
+                false
+            } else {
+                state.fids.insert(
+                    newfid,
+                    Entry {
+                        path,
+                        backing: Some(Backing {
+                            resolved: resolved.clone(),
+                            backing_fid: backing_newfid,
+                            is_dir: qid.kind == FileKind::Dir,
+                        }),
+                    },
+                );
+                true
+            }
+        };
+        if !inserted {
+            let _ = resolved
+                .call(Request::Clunk {
+                    fid: backing_newfid,
+                })
+                .await;
+            return Err(ErrorCode::BadRequest);
+        }
+        Ok(qid)
     }
 
     async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {

--- a/crates/kernel/src/mountfs.rs
+++ b/crates/kernel/src/mountfs.rs
@@ -64,6 +64,10 @@ struct Entry {
     path: Vec<String>,
     /// `Some` when the path is at/below a mount; `None` for a synthetic directory.
     backing: Option<Backing>,
+    /// Temporarily reserves a caller-visible fid while a backing create is in
+    /// flight. Normal operations cannot use it until the backing tree succeeds and
+    /// this entry is replaced with a real backing fid.
+    reserved: bool,
 }
 
 struct State {
@@ -86,6 +90,7 @@ impl MountFs {
             Entry {
                 path: Vec::new(),
                 backing: None,
+                reserved: false,
             },
         );
         Self {
@@ -181,6 +186,9 @@ impl MountFs {
     async fn target(&self, fid: Fid) -> Result<Target, ErrorCode> {
         let state = self.state.lock().await;
         let entry = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+        if entry.reserved {
+            return Err(ErrorCode::BadRequest);
+        }
         Ok(match &entry.backing {
             Some(b) => Target::Backing {
                 resolved: b.resolved.clone(),
@@ -201,6 +209,9 @@ impl FileServer for MountFs {
             return Err(ErrorCode::BadRequest);
         }
         let base = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+        if base.reserved {
+            return Err(ErrorCode::BadRequest);
+        }
         // A non-empty walk descends into a child, so the base must be a directory.
         // A backing *file* base is rejected here rather than re-resolving the
         // absolute path (which could otherwise traverse a non-directory into a
@@ -236,6 +247,7 @@ impl FileServer for MountFs {
                             backing_fid,
                             is_dir: qid.kind == FileKind::Dir,
                         }),
+                        reserved: false,
                     },
                 );
                 return Ok(qid);
@@ -254,6 +266,7 @@ impl FileServer for MountFs {
                 Entry {
                     path,
                     backing: None,
+                    reserved: false,
                 },
             );
             return Ok(qid);
@@ -385,46 +398,60 @@ impl FileServer for MountFs {
         name: &str,
         kind: FileKind,
     ) -> Result<Qid, ErrorCode> {
-        let (resolved, backing_fid, parent_path) = {
-            let state = self.state.lock().await;
+        let (resolved, backing_fid, path) = {
+            let mut state = self.state.lock().await;
             if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
                 return Err(ErrorCode::BadRequest);
             }
             let entry = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+            if entry.reserved {
+                return Err(ErrorCode::BadRequest);
+            }
             let Some(backing) = &entry.backing else {
                 return Err(ErrorCode::Unsupported);
             };
             if !backing.is_dir {
                 return Err(ErrorCode::NotDirectory);
             }
-            (
-                backing.resolved.clone(),
-                backing.backing_fid,
-                entry.path.clone(),
-            )
+            let resolved = backing.resolved.clone();
+            let backing_fid = backing.backing_fid;
+            let mut path = entry.path.clone();
+            path.push(name.to_string());
+            state.fids.insert(
+                newfid,
+                Entry {
+                    path: path.clone(),
+                    backing: None,
+                    reserved: true,
+                },
+            );
+            (resolved, backing_fid, path)
         };
 
         let backing_newfid = Fid(NEXT_BACKING.fetch_add(1, Ordering::Relaxed));
-        let qid = match resolved
+        let create = resolved
             .call(Request::Create {
                 fid: backing_fid,
                 newfid: backing_newfid,
                 name: name.to_string(),
                 kind,
             })
-            .await?
-        {
-            Response::Create { qid } => qid,
-            _ => return Err(ErrorCode::Io),
+            .await;
+        let qid = match create {
+            Ok(Response::Create { qid }) => qid,
+            Ok(_) => {
+                self.state.lock().await.fids.remove(&newfid);
+                return Err(ErrorCode::Io);
+            }
+            Err(err) => {
+                self.state.lock().await.fids.remove(&newfid);
+                return Err(err);
+            }
         };
 
-        let mut path = parent_path;
-        path.push(name.to_string());
         let inserted = {
             let mut state = self.state.lock().await;
-            if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
-                false
-            } else {
+            if matches!(state.fids.get(&newfid), Some(entry) if entry.reserved) {
                 state.fids.insert(
                     newfid,
                     Entry {
@@ -434,9 +461,12 @@ impl FileServer for MountFs {
                             backing_fid: backing_newfid,
                             is_dir: qid.kind == FileKind::Dir,
                         }),
+                        reserved: false,
                     },
                 );
                 true
+            } else {
+                false
             }
         };
         if !inserted {
@@ -459,6 +489,10 @@ impl FileServer for MountFs {
         // Drop the entry under the lock, then forward without it held.
         let backing = {
             let mut state = self.state.lock().await;
+            let entry = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+            if entry.reserved {
+                return Err(ErrorCode::BadRequest);
+            }
             state.fids.remove(&fid).ok_or(ErrorCode::NotFound)?.backing
         };
         match backing {
@@ -481,6 +515,12 @@ impl FileServer for MountFs {
         // lock held (a commit-on-clunk commit must not serialize the namespace).
         let backing = {
             let mut state = self.state.lock().await;
+            let Some(entry) = state.fids.get(&fid) else {
+                return Err(ErrorCode::NotFound);
+            };
+            if entry.reserved {
+                return Err(ErrorCode::BadRequest);
+            }
             let Some(entry) = state.fids.remove(&fid) else {
                 return Err(ErrorCode::NotFound);
             };

--- a/crates/kernel/tests/mountfs.rs
+++ b/crates/kernel/tests/mountfs.rs
@@ -22,6 +22,10 @@ fn procfs() -> InProcessTransport {
     InProcessTransport::new(Arc::new(ProcFs::new()))
 }
 
+fn createfs() -> InProcessTransport {
+    InProcessTransport::new(Arc::new(CreateFs::default()))
+}
+
 /// A namespace with `/proc` (ProcFs) and `/data` (MemFs), both read-write.
 fn ns() -> Namespace {
     let mut ns = Namespace::new();
@@ -40,6 +44,174 @@ async fn read_lines(fs: &MountFs, path: &[&str], fid: Fid) -> Vec<String> {
         .lines()
         .map(str::to_string)
         .collect()
+}
+
+#[derive(Clone)]
+enum CreateNode {
+    Root,
+    File(String),
+}
+
+#[derive(Default)]
+struct CreateFs {
+    files: tokio::sync::Mutex<HashMap<String, Vec<u8>>>,
+    fids: tokio::sync::Mutex<HashMap<Fid, CreateNode>>,
+}
+
+#[async_trait::async_trait]
+impl FileServer for CreateFs {
+    async fn walk(&self, _fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        let node = match names {
+            [] => CreateNode::Root,
+            [name] if self.files.lock().await.contains_key(name) => CreateNode::File(name.clone()),
+            _ => return Err(ErrorCode::NotFound),
+        };
+        let kind = match node {
+            CreateNode::Root => FileKind::Dir,
+            CreateNode::File(_) => FileKind::File,
+        };
+        self.fids.lock().await.insert(newfid, node);
+        Ok(Qid {
+            kind,
+            version: 0,
+            path: 0,
+        })
+    }
+
+    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        let kind = match self.fids.lock().await.get(&fid) {
+            Some(CreateNode::Root) => FileKind::Dir,
+            Some(CreateNode::File(_)) => FileKind::File,
+            None if fid == Fid::ROOT => FileKind::Dir,
+            None => return Err(ErrorCode::NotFound),
+        };
+        Ok(Qid {
+            kind,
+            version: 0,
+            path: 0,
+        })
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let bytes = match self.fids.lock().await.get(&fid) {
+            Some(CreateNode::Root) => {
+                let mut names = self.files.lock().await.keys().cloned().collect::<Vec<_>>();
+                names.sort();
+                names.join("\n").into_bytes()
+            }
+            None if fid == Fid::ROOT => {
+                let mut names = self.files.lock().await.keys().cloned().collect::<Vec<_>>();
+                names.sort();
+                names.join("\n").into_bytes()
+            }
+            Some(CreateNode::File(name)) => self
+                .files
+                .lock()
+                .await
+                .get(name)
+                .cloned()
+                .ok_or(ErrorCode::NotFound)?,
+            None => return Err(ErrorCode::NotFound),
+        };
+        let start = (offset as usize).min(bytes.len());
+        let end = bytes.len().min(start + count as usize);
+        Ok(bytes[start..end].to_vec())
+    }
+
+    async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        let name = match self.fids.lock().await.get(&fid) {
+            Some(CreateNode::File(name)) => name.clone(),
+            Some(CreateNode::Root) => return Err(ErrorCode::IsDirectory),
+            None => return Err(ErrorCode::NotFound),
+        };
+        let start = usize::try_from(offset).map_err(|_| ErrorCode::BadRequest)?;
+        let end = start.checked_add(data.len()).ok_or(ErrorCode::BadRequest)?;
+        let mut files = self.files.lock().await;
+        let bytes = files.get_mut(&name).ok_or(ErrorCode::NotFound)?;
+        if bytes.len() < end {
+            bytes.resize(end, 0);
+        }
+        bytes[start..end].copy_from_slice(data);
+        Ok(data.len() as u32)
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        let (kind, length, writable) = match self.fids.lock().await.get(&fid) {
+            Some(CreateNode::Root) => (FileKind::Dir, 0, true),
+            None if fid == Fid::ROOT => (FileKind::Dir, 0, true),
+            Some(CreateNode::File(name)) => {
+                let length = self
+                    .files
+                    .lock()
+                    .await
+                    .get(name)
+                    .map(|bytes| bytes.len() as u64)
+                    .ok_or(ErrorCode::NotFound)?;
+                (FileKind::File, length, true)
+            }
+            None => return Err(ErrorCode::NotFound),
+        };
+        Ok(Stat {
+            name: String::new(),
+            qid: Qid {
+                kind,
+                version: 0,
+                path: 0,
+            },
+            length,
+            writable,
+        })
+    }
+
+    async fn create(
+        &self,
+        fid: Fid,
+        newfid: Fid,
+        name: &str,
+        kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        if kind != FileKind::File || name.is_empty() || name.contains('/') || name.contains('\n') {
+            return Err(ErrorCode::BadRequest);
+        }
+        let is_root =
+            matches!(self.fids.lock().await.get(&fid), Some(CreateNode::Root)) || fid == Fid::ROOT;
+        if !is_root {
+            return Err(ErrorCode::NotDirectory);
+        }
+        let mut files = self.files.lock().await;
+        if files.contains_key(name) {
+            return Err(ErrorCode::BadRequest);
+        }
+        files.insert(name.to_string(), Vec::new());
+        self.fids
+            .lock()
+            .await
+            .insert(newfid, CreateNode::File(name.to_string()));
+        Ok(Qid {
+            kind: FileKind::File,
+            version: 0,
+            path: 0,
+        })
+    }
+
+    async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
+        let Some(CreateNode::File(name)) = self.fids.lock().await.remove(&fid) else {
+            return Err(ErrorCode::Unsupported);
+        };
+        self.files
+            .lock()
+            .await
+            .remove(&name)
+            .ok_or(ErrorCode::NotFound)?;
+        Ok(())
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        if fid != Fid::ROOT {
+            self.fids.lock().await.remove(&fid);
+        }
+        Ok(())
+    }
 }
 
 #[tokio::test]
@@ -69,6 +241,39 @@ async fn read_delegates_to_the_backing_file() {
         .unwrap();
     fs.open(Fid(1), OpenMode::Read).await.unwrap();
     assert_eq!(fs.read(Fid(1), 0, 64).await.unwrap(), b"hi");
+}
+
+#[tokio::test]
+async fn create_delegates_to_the_backing_tree_and_binds_newfid() {
+    let mut ns = Namespace::new();
+    ns.mount("/create", createfs(), Access::ReadWrite);
+    let fs = MountFs::new(ns);
+    fs.walk(Fid::ROOT, Fid(1), &["create".into()])
+        .await
+        .unwrap();
+    let qid = fs
+        .create(Fid(1), Fid(2), "created", FileKind::File)
+        .await
+        .unwrap();
+    assert_eq!(qid.kind, FileKind::File);
+    fs.open(Fid(2), OpenMode::Write).await.unwrap();
+    fs.write(Fid(2), 0, b"created through mount").await.unwrap();
+    fs.clunk(Fid(2)).await.unwrap();
+    fs.clunk(Fid(1)).await.unwrap();
+
+    let entries = read_lines(&fs, &["create"], Fid(3)).await;
+    assert!(
+        entries.iter().any(|entry| entry == "created"),
+        "{entries:?}"
+    );
+    fs.walk(Fid::ROOT, Fid(4), &["create".into(), "created".into()])
+        .await
+        .unwrap();
+    fs.open(Fid(4), OpenMode::Read).await.unwrap();
+    assert_eq!(
+        fs.read(Fid(4), 0, 64).await.unwrap(),
+        b"created through mount"
+    );
 }
 
 #[tokio::test]
@@ -111,6 +316,18 @@ async fn a_read_only_mount_denies_a_write_open() {
         .unwrap();
     assert_eq!(
         fs.open(Fid(1), OpenMode::Write).await,
+        Err(ErrorCode::NoAccess)
+    );
+}
+
+#[tokio::test]
+async fn a_read_only_mount_denies_create() {
+    let mut ns = Namespace::new();
+    ns.mount("/ro", createfs(), Access::ReadOnly);
+    let fs = MountFs::new(ns);
+    fs.walk(Fid::ROOT, Fid(1), &["ro".into()]).await.unwrap();
+    assert_eq!(
+        fs.create(Fid(1), Fid(2), "created", FileKind::File).await,
         Err(ErrorCode::NoAccess)
     );
 }

--- a/crates/kernel/tests/mountfs.rs
+++ b/crates/kernel/tests/mountfs.rs
@@ -6,13 +6,17 @@
 //! that list their child mount points.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 
 use alan_ap::reference::MemFs;
 use alan_ap::{
     ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode, Qid, Stat, Stream,
 };
 use alan_kernel::{Access, MountFs, Namespace, ProcFs};
+use tokio::sync::Notify;
 
 fn memfs() -> InProcessTransport {
     InProcessTransport::new(Arc::new(MemFs::new()))
@@ -56,6 +60,18 @@ enum CreateNode {
 struct CreateFs {
     files: tokio::sync::Mutex<HashMap<String, Vec<u8>>>,
     fids: tokio::sync::Mutex<HashMap<Fid, CreateNode>>,
+    create_gate: Option<Arc<Notify>>,
+    create_started: Option<Arc<AtomicUsize>>,
+}
+
+impl CreateFs {
+    fn gated(create_gate: Arc<Notify>, create_started: Arc<AtomicUsize>) -> Self {
+        Self {
+            create_gate: Some(create_gate),
+            create_started: Some(create_started),
+            ..Self::default()
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -178,6 +194,12 @@ impl FileServer for CreateFs {
         if !is_root {
             return Err(ErrorCode::NotDirectory);
         }
+        if let Some(started) = &self.create_started {
+            started.fetch_add(1, Ordering::SeqCst);
+        }
+        if let Some(gate) = &self.create_gate {
+            gate.notified().await;
+        }
         let mut files = self.files.lock().await;
         if files.contains_key(name) {
             return Err(ErrorCode::BadRequest);
@@ -273,6 +295,51 @@ async fn create_delegates_to_the_backing_tree_and_binds_newfid() {
     assert_eq!(
         fs.read(Fid(4), 0, 64).await.unwrap(),
         b"created through mount"
+    );
+}
+
+#[tokio::test]
+async fn create_reserves_newfid_before_forwarding_to_the_backing_tree() {
+    let gate = Arc::new(Notify::new());
+    let started = Arc::new(AtomicUsize::new(0));
+    let backing = Arc::new(CreateFs::gated(gate.clone(), started.clone()));
+    let mut ns = Namespace::new();
+    ns.mount(
+        "/create",
+        InProcessTransport::new(backing),
+        Access::ReadWrite,
+    );
+    let fs = Arc::new(MountFs::new(ns));
+    fs.walk(Fid::ROOT, Fid(1), &["create".into()])
+        .await
+        .unwrap();
+
+    let first = {
+        let fs = fs.clone();
+        tokio::spawn(async move { fs.create(Fid(1), Fid(2), "first", FileKind::File).await })
+    };
+    while started.load(Ordering::SeqCst) == 0 {
+        tokio::task::yield_now().await;
+    }
+
+    assert_eq!(
+        fs.create(Fid(1), Fid(2), "second", FileKind::File).await,
+        Err(ErrorCode::BadRequest),
+        "the caller-visible newfid is reserved before backing create runs"
+    );
+    assert_eq!(
+        started.load(Ordering::SeqCst),
+        1,
+        "the failed create must not reach the backing file server"
+    );
+
+    gate.notify_waiters();
+    first.await.unwrap().unwrap();
+    let entries = read_lines(&fs, &["create"], Fid(3)).await;
+    assert!(entries.iter().any(|entry| entry == "first"), "{entries:?}");
+    assert!(
+        !entries.iter().any(|entry| entry == "second"),
+        "the failed create must not leave a backing child behind: {entries:?}"
     );
 }
 

--- a/crates/routefs/Cargo.toml
+++ b/crates/routefs/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "alan-routefs"
+description = "Message routing file server for typed, rule-routed Alan OS handoff."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+alan-ap = { path = "../ap" }
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true }
+
+[dev-dependencies]
+alan-kernel = { path = "../kernel" }
+alan-shell = { path = "../shell" }

--- a/crates/routefs/src/lib.rs
+++ b/crates/routefs/src/lib.rs
@@ -505,8 +505,13 @@ impl FileServer for RouteFs {
         match f.node {
             Node::Send if f.wrote => state.route_message(&f.write_buf).await,
             Node::Rule(name) if f.wrote => {
-                let spec: RuleSpec =
-                    serde_json::from_slice(&f.write_buf).map_err(|_| ErrorCode::BadRequest)?;
+                let spec: RuleSpec = match serde_json::from_slice(&f.write_buf) {
+                    Ok(spec) => spec,
+                    Err(_) => {
+                        state.abandon_pending_rule(&name);
+                        return Err(ErrorCode::BadRequest);
+                    }
+                };
                 state.commit_pending_rule(name, spec)
             }
             Node::Rule(name) => {

--- a/crates/routefs/src/lib.rs
+++ b/crates/routefs/src/lib.rs
@@ -1,0 +1,525 @@
+//! alan-routefs — typed message routing as an aP file server.
+//!
+//! A sender writes one typed message document to `send` and commits it by
+//! clunking the fid. Routefs matches the complete message against plain rule
+//! files in deterministic name order, delivers it to a destination port stream,
+//! and appends the routing decision to `log`. The sender emits a result type; it
+//! does not name the receiving actor.
+
+use std::collections::{BTreeMap, HashMap};
+use std::hash::{Hash, Hasher};
+
+use alan_ap::{
+    ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat, Stream, VersionTable,
+};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+/// Canonical `/srv` handle name for the routefs server.
+pub const SRV_HANDLE: &str = "route";
+/// Canonical mount path for routefs.
+pub const MOUNT_PATH: &str = "/mnt/route";
+/// Default port for unrouted messages.
+pub const DEAD_LETTER_PORT: &str = "dead-letter";
+
+const MAX_DOC_BYTES: usize = 1 << 20; // 1 MiB
+
+/// A plain JSON rule file.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuleSpec {
+    pub version: u16,
+    /// Message type to match. If omitted, any type matches.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub match_type: Option<String>,
+    /// Substring required in the message content. If omitted, content is ignored.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_contains: Option<String>,
+    /// Destination port name under `ports/`.
+    pub port: String,
+    /// Human-readable reason, retained in the log.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl RuleSpec {
+    /// Rule matching a message type.
+    pub fn for_type(message_type: impl Into<String>, port: impl Into<String>) -> Self {
+        Self {
+            version: 1,
+            match_type: Some(message_type.into()),
+            content_contains: None,
+            port: port.into(),
+            reason: None,
+        }
+    }
+
+    /// Attach a content substring condition.
+    pub fn with_content_contains(mut self, content: impl Into<String>) -> Self {
+        self.content_contains = Some(content.into());
+        self
+    }
+
+    /// Attach an inspectable reason.
+    pub fn with_reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason = Some(reason.into());
+        self
+    }
+
+    fn validate(&self) -> Result<(), ErrorCode> {
+        if self.version != 1 || !valid_name(&self.port) {
+            return Err(ErrorCode::BadRequest);
+        }
+        if self.match_type.as_deref().is_some_and(str::is_empty)
+            || self.content_contains.as_deref().is_some_and(str::is_empty)
+        {
+            return Err(ErrorCode::BadRequest);
+        }
+        Ok(())
+    }
+
+    fn matches(&self, message: &WireMessage) -> bool {
+        let type_matches = self
+            .match_type
+            .as_deref()
+            .is_none_or(|expected| expected == message.message_type);
+        let content_matches = self
+            .content_contains
+            .as_deref()
+            .is_none_or(|needle| message.content.contains(needle));
+        type_matches && content_matches
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+struct WireMessage {
+    version: u16,
+    #[serde(rename = "type")]
+    message_type: String,
+    content: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+}
+
+#[derive(Serialize)]
+struct RoutedRecord<'a> {
+    version: u16,
+    port: &'a str,
+    rule: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'a str>,
+    message: &'a WireMessage,
+}
+
+#[derive(Debug, Clone)]
+struct RuleEntry {
+    spec: RuleSpec,
+    source: Vec<u8>,
+}
+
+struct State {
+    rules: BTreeMap<String, RuleEntry>,
+    ports: BTreeMap<String, Stream>,
+    log: Stream,
+    versions: VersionTable,
+    fids: HashMap<Fid, RouteFid>,
+}
+
+struct RouteFid {
+    node: Node,
+    mode: Option<OpenMode>,
+    write_buf: Vec<u8>,
+    wrote: bool,
+}
+
+#[derive(Debug, Clone)]
+enum Node {
+    Root,
+    Send,
+    RulesDir,
+    Rule(String),
+    PortsDir,
+    Port(String),
+    Log,
+}
+
+/// The message routing file server.
+pub struct RouteFs {
+    state: Mutex<State>,
+}
+
+impl Default for RouteFs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RouteFs {
+    /// Create an empty routefs with only the dead-letter port.
+    pub fn new() -> Self {
+        let mut ports = BTreeMap::new();
+        ports.insert(DEAD_LETTER_PORT.to_string(), Stream::new());
+        Self {
+            state: Mutex::new(State {
+                rules: BTreeMap::new(),
+                ports,
+                log: Stream::new(),
+                versions: VersionTable::new(),
+                fids: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Install or replace a rule without going through the aP file surface.
+    /// Tests and bootstrap code may use this; the rule remains readable as
+    /// `rules/<name>`.
+    pub async fn install_rule(
+        &self,
+        name: impl Into<String>,
+        spec: RuleSpec,
+    ) -> Result<(), ErrorCode> {
+        let mut state = self.state.lock().await;
+        let name = name.into();
+        state.install_rule(name, spec)
+    }
+}
+
+impl State {
+    fn node_of(&self, fid: Fid) -> Result<Node, ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(Node::Root);
+        }
+        self.fids
+            .get(&fid)
+            .map(|f| f.node.clone())
+            .ok_or(ErrorCode::NotFound)
+    }
+
+    fn qid(&self, node: &Node) -> Qid {
+        let (kind, path) = node_identity(node);
+        Qid {
+            kind,
+            version: self.versions.get(path),
+            path,
+        }
+    }
+
+    fn child(&self, node: &Node, name: &str) -> Result<Node, ErrorCode> {
+        match node {
+            Node::Root => match name {
+                "send" => Ok(Node::Send),
+                "rules" => Ok(Node::RulesDir),
+                "ports" => Ok(Node::PortsDir),
+                "log" => Ok(Node::Log),
+                _ => Err(ErrorCode::NotFound),
+            },
+            Node::RulesDir => {
+                if self.rules.contains_key(name) {
+                    Ok(Node::Rule(name.to_string()))
+                } else {
+                    Err(ErrorCode::NotFound)
+                }
+            }
+            Node::PortsDir => {
+                if self.ports.contains_key(name) {
+                    Ok(Node::Port(name.to_string()))
+                } else {
+                    Err(ErrorCode::NotFound)
+                }
+            }
+            _ => Err(ErrorCode::NotDirectory),
+        }
+    }
+
+    fn computed_bytes(&self, node: &Node) -> Result<Vec<u8>, ErrorCode> {
+        let bytes = match node {
+            Node::Root => b"send\nrules\nports\nlog".to_vec(),
+            Node::Send => b"# routefs send: write one message JSON document, then clunk\n".to_vec(),
+            Node::RulesDir => listing(self.rules.keys()),
+            Node::PortsDir => listing(self.ports.keys()),
+            Node::Rule(name) => self
+                .rules
+                .get(name)
+                .ok_or(ErrorCode::NotFound)?
+                .source
+                .clone(),
+            Node::Port(_) | Node::Log => return Err(ErrorCode::Unsupported),
+        };
+        Ok(bytes)
+    }
+
+    fn stream_for(&self, node: &Node) -> Option<Stream> {
+        match node {
+            Node::Port(name) => self.ports.get(name).cloned(),
+            Node::Log => Some(self.log.clone()),
+            _ => None,
+        }
+    }
+
+    fn install_rule(&mut self, name: String, spec: RuleSpec) -> Result<(), ErrorCode> {
+        if !valid_name(&name) {
+            return Err(ErrorCode::BadRequest);
+        }
+        spec.validate()?;
+        let source = rule_source(&spec)?;
+        let port = spec.port.clone();
+        self.rules.insert(name.clone(), RuleEntry { spec, source });
+        self.ensure_port(&port);
+        self.versions.bump(node_identity(&Node::RulesDir).1);
+        self.versions.bump(node_identity(&Node::Rule(name)).1);
+        Ok(())
+    }
+
+    fn ensure_port(&mut self, port: &str) {
+        if !self.ports.contains_key(port) {
+            self.ports.insert(port.to_string(), Stream::new());
+            self.versions.bump(node_identity(&Node::PortsDir).1);
+        }
+    }
+
+    async fn route_message(&mut self, bytes: &[u8]) -> Result<(), ErrorCode> {
+        let message: WireMessage =
+            serde_json::from_slice(bytes).map_err(|_| ErrorCode::BadRequest)?;
+        if message.version != 1 || message.message_type.is_empty() {
+            return Err(ErrorCode::BadRequest);
+        }
+
+        let decision = self
+            .rules
+            .iter()
+            .find(|(_, rule)| rule.spec.matches(&message))
+            .map(|(name, rule)| {
+                (
+                    rule.spec.port.clone(),
+                    name.clone(),
+                    rule.spec.reason.clone(),
+                )
+            })
+            .unwrap_or_else(|| {
+                (
+                    DEAD_LETTER_PORT.to_string(),
+                    "dead-letter".to_string(),
+                    Some("no matching rule".to_string()),
+                )
+            });
+        let (port, rule_name, reason) = decision;
+        self.ensure_port(&port);
+        let record = RoutedRecord {
+            version: 1,
+            port: &port,
+            rule: &rule_name,
+            reason: reason.as_deref(),
+            message: &message,
+        };
+        let bytes = routed_record_bytes(&record)?;
+        let stream = self.ports.get(&port).ok_or(ErrorCode::NotFound)?.clone();
+        stream.append(&bytes).await;
+        self.log.append(&bytes).await;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl FileServer for RouteFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        let mut state = self.state.lock().await;
+        if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
+            return Err(ErrorCode::BadRequest);
+        }
+        let mut node = state.node_of(fid)?;
+        for name in names {
+            node = state.child(&node, name)?;
+        }
+        let qid = state.qid(&node);
+        state.fids.insert(newfid, RouteFid::at(node));
+        Ok(qid)
+    }
+
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
+        let mut state = self.state.lock().await;
+        let node = state.node_of(fid)?;
+        if fid != Fid::ROOT && state.fids.get(&fid).is_some_and(|f| f.mode.is_some()) {
+            return Err(ErrorCode::BadRequest);
+        }
+        if matches!(mode, OpenMode::Write | OpenMode::ReadWrite) && !is_writable(&node) {
+            return Err(ErrorCode::NoAccess);
+        }
+        if fid != Fid::ROOT {
+            let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
+            f.mode = Some(mode);
+        }
+        Ok(state.qid(&node))
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let (node, stream) = {
+            let state = self.state.lock().await;
+            if fid != Fid::ROOT {
+                let f = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+                if !matches!(f.mode, Some(OpenMode::Read | OpenMode::ReadWrite)) {
+                    return Err(ErrorCode::NoAccess);
+                }
+            }
+            let node = state.node_of(fid)?;
+            let stream = state.stream_for(&node);
+            (node, stream)
+        };
+        if let Some(stream) = stream {
+            return Ok(stream.read(offset, count).await);
+        }
+        let state = self.state.lock().await;
+        Ok(slice(state.computed_bytes(&node)?, offset, count))
+    }
+
+    async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        let mut state = self.state.lock().await;
+        let node = state.node_of(fid)?;
+        let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
+        if !matches!(f.mode, Some(OpenMode::Write | OpenMode::ReadWrite)) {
+            return Err(ErrorCode::NoAccess);
+        }
+        if !matches!(node, Node::Send | Node::Rule(_)) {
+            return Err(ErrorCode::Unsupported);
+        }
+        let start = usize::try_from(offset).map_err(|_| ErrorCode::BadRequest)?;
+        let end = start.checked_add(data.len()).ok_or(ErrorCode::BadRequest)?;
+        if end > MAX_DOC_BYTES {
+            return Err(ErrorCode::BadRequest);
+        }
+        if f.write_buf.len() < end {
+            f.write_buf.resize(end, 0);
+        }
+        f.write_buf[start..end].copy_from_slice(data);
+        f.wrote = true;
+        Ok(data.len() as u32)
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        let state = self.state.lock().await;
+        let node = state.node_of(fid)?;
+        let length = match &node {
+            Node::Port(_) | Node::Log => {
+                state
+                    .stream_for(&node)
+                    .ok_or(ErrorCode::NotFound)?
+                    .len()
+                    .await
+            }
+            other => state.computed_bytes(other)?.len() as u64,
+        };
+        Ok(Stat {
+            name: String::new(),
+            qid: state.qid(&node),
+            length,
+            writable: is_writable(&node),
+        })
+    }
+
+    async fn create(
+        &self,
+        fid: Fid,
+        newfid: Fid,
+        name: &str,
+        kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        if kind != FileKind::File || !valid_name(name) {
+            return Err(ErrorCode::BadRequest);
+        }
+        let mut state = self.state.lock().await;
+        if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
+            return Err(ErrorCode::BadRequest);
+        }
+        if !matches!(state.node_of(fid)?, Node::RulesDir) || state.rules.contains_key(name) {
+            return Err(ErrorCode::BadRequest);
+        }
+        let node = Node::Rule(name.to_string());
+        let qid = state.qid(&node);
+        state.fids.insert(newfid, RouteFid::at(node));
+        Ok(qid)
+    }
+
+    async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
+        let mut state = self.state.lock().await;
+        let node = state.node_of(fid)?;
+        let Node::Rule(name) = node else {
+            return Err(ErrorCode::Unsupported);
+        };
+        state.rules.remove(&name).ok_or(ErrorCode::NotFound)?;
+        state.versions.bump(node_identity(&Node::RulesDir).1);
+        state.fids.remove(&fid);
+        Ok(())
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(());
+        }
+        let mut state = self.state.lock().await;
+        let f = state.fids.remove(&fid).ok_or(ErrorCode::NotFound)?;
+        match f.node {
+            Node::Send if f.wrote => state.route_message(&f.write_buf).await,
+            Node::Rule(name) if f.wrote => {
+                let spec: RuleSpec =
+                    serde_json::from_slice(&f.write_buf).map_err(|_| ErrorCode::BadRequest)?;
+                state.install_rule(name, spec)
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+impl RouteFid {
+    fn at(node: Node) -> Self {
+        Self {
+            node,
+            mode: None,
+            write_buf: Vec::new(),
+            wrote: false,
+        }
+    }
+}
+
+fn is_writable(node: &Node) -> bool {
+    matches!(node, Node::Send | Node::Rule(_))
+}
+
+fn valid_name(name: &str) -> bool {
+    !name.is_empty() && !name.contains('/') && !name.contains('\n')
+}
+
+fn listing<'a>(names: impl Iterator<Item = &'a String>) -> Vec<u8> {
+    names.cloned().collect::<Vec<_>>().join("\n").into_bytes()
+}
+
+fn rule_source(spec: &RuleSpec) -> Result<Vec<u8>, ErrorCode> {
+    let mut bytes = serde_json::to_vec(spec).map_err(|_| ErrorCode::BadRequest)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn routed_record_bytes(record: &RoutedRecord<'_>) -> Result<Vec<u8>, ErrorCode> {
+    let mut bytes = serde_json::to_vec(record).map_err(|_| ErrorCode::BadRequest)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn node_identity(node: &Node) -> (FileKind, u64) {
+    let (kind, key) = match node {
+        Node::Root => (FileKind::Dir, "/".to_string()),
+        Node::Send => (FileKind::File, "send".to_string()),
+        Node::RulesDir => (FileKind::Dir, "rules".to_string()),
+        Node::Rule(name) => (FileKind::File, format!("rules/{name}")),
+        Node::PortsDir => (FileKind::Dir, "ports".to_string()),
+        Node::Port(name) => (FileKind::Stream, format!("ports/{name}")),
+        Node::Log => (FileKind::Stream, "log".to_string()),
+    };
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut h);
+    (kind, h.finish())
+}
+
+fn slice(bytes: Vec<u8>, offset: Offset, count: u32) -> Vec<u8> {
+    let start = (offset as usize).min(bytes.len());
+    let end = bytes.len().min(start + count as usize);
+    bytes[start..end].to_vec()
+}

--- a/crates/routefs/src/lib.rs
+++ b/crates/routefs/src/lib.rs
@@ -6,7 +6,7 @@
 //! and appends the routing decision to `log`. The sender emits a result type; it
 //! does not name the receiving actor.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::hash::{Hash, Hasher};
 
 use alan_ap::{
@@ -147,6 +147,7 @@ struct RuleEntry {
 
 struct State {
     rules: BTreeMap<String, RuleEntry>,
+    pending_rules: BTreeSet<String>,
     ports: BTreeMap<String, Stream>,
     log: Stream,
     versions: VersionTable,
@@ -190,6 +191,7 @@ impl RouteFs {
         Self {
             state: Mutex::new(State {
                 rules: BTreeMap::new(),
+                pending_rules: BTreeSet::new(),
                 ports,
                 log: Stream::new(),
                 versions: VersionTable::new(),
@@ -288,6 +290,9 @@ impl State {
         if !valid_name(&name) {
             return Err(ErrorCode::BadRequest);
         }
+        if self.pending_rules.contains(&name) {
+            return Err(ErrorCode::BadRequest);
+        }
         spec.validate()?;
         let source = rule_source(&spec)?;
         let port = spec.port.clone();
@@ -340,6 +345,15 @@ impl State {
         stream.append(&bytes).await;
         self.log.append(&bytes).await;
         Ok(())
+    }
+
+    fn commit_pending_rule(&mut self, name: String, spec: RuleSpec) -> Result<(), ErrorCode> {
+        self.pending_rules.remove(&name);
+        self.install_rule(name, spec)
+    }
+
+    fn abandon_pending_rule(&mut self, name: &str) {
+        self.pending_rules.remove(name);
     }
 }
 
@@ -453,9 +467,13 @@ impl FileServer for RouteFs {
         if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
             return Err(ErrorCode::BadRequest);
         }
-        if !matches!(state.node_of(fid)?, Node::RulesDir) || state.rules.contains_key(name) {
+        if !matches!(state.node_of(fid)?, Node::RulesDir)
+            || state.rules.contains_key(name)
+            || state.pending_rules.contains(name)
+        {
             return Err(ErrorCode::BadRequest);
         }
+        state.pending_rules.insert(name.to_string());
         let node = Node::Rule(name.to_string());
         let qid = state.qid(&node);
         state.fids.insert(newfid, RouteFid::at(node));
@@ -468,7 +486,11 @@ impl FileServer for RouteFs {
         let Node::Rule(name) = node else {
             return Err(ErrorCode::Unsupported);
         };
-        state.rules.remove(&name).ok_or(ErrorCode::NotFound)?;
+        let removed = state.rules.remove(&name).is_some();
+        let reserved = state.pending_rules.remove(&name);
+        if !removed && !reserved {
+            return Err(ErrorCode::NotFound);
+        }
         state.versions.bump(node_identity(&Node::RulesDir).1);
         state.fids.remove(&fid);
         Ok(())
@@ -485,7 +507,11 @@ impl FileServer for RouteFs {
             Node::Rule(name) if f.wrote => {
                 let spec: RuleSpec =
                     serde_json::from_slice(&f.write_buf).map_err(|_| ErrorCode::BadRequest)?;
-                state.install_rule(name, spec)
+                state.commit_pending_rule(name, spec)
+            }
+            Node::Rule(name) => {
+                state.abandon_pending_rule(&name);
+                Ok(())
             }
             _ => Ok(()),
         }

--- a/crates/routefs/src/lib.rs
+++ b/crates/routefs/src/lib.rs
@@ -160,6 +160,7 @@ struct RouteFid {
     write_buf: Vec<u8>,
     wrote: bool,
     pending_rule_create: bool,
+    observed_rule_version: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -287,6 +288,25 @@ impl State {
         }
     }
 
+    fn current_rule_version(&self, name: &str) -> Option<u32> {
+        self.rules.contains_key(name).then(|| {
+            self.versions
+                .get(node_identity(&Node::Rule(name.to_string())).1)
+        })
+    }
+
+    fn ensure_current_rule_fid(&self, f: &RouteFid, name: &str) -> Result<(), ErrorCode> {
+        if f.pending_rule_create {
+            return Ok(());
+        }
+        let observed = f.observed_rule_version.ok_or(ErrorCode::BadRequest)?;
+        let current = self.current_rule_version(name).ok_or(ErrorCode::NotFound)?;
+        if observed != current {
+            return Err(ErrorCode::BadRequest);
+        }
+        Ok(())
+    }
+
     fn install_rule(&mut self, name: String, spec: RuleSpec) -> Result<(), ErrorCode> {
         if !valid_name(&name) {
             return Err(ErrorCode::BadRequest);
@@ -370,7 +390,7 @@ impl FileServer for RouteFs {
             node = state.child(&node, name)?;
         }
         let qid = state.qid(&node);
-        state.fids.insert(newfid, RouteFid::at(node));
+        state.fids.insert(newfid, RouteFid::at(node, qid));
         Ok(qid)
     }
 
@@ -382,6 +402,12 @@ impl FileServer for RouteFs {
         }
         if matches!(mode, OpenMode::Write | OpenMode::ReadWrite) && !is_writable(&node) {
             return Err(ErrorCode::NoAccess);
+        }
+        if matches!(mode, OpenMode::Write | OpenMode::ReadWrite)
+            && let Node::Rule(name) = &node
+        {
+            let f = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+            state.ensure_current_rule_fid(f, name)?;
         }
         if fid != Fid::ROOT {
             let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
@@ -413,18 +439,22 @@ impl FileServer for RouteFs {
     async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
         let mut state = self.state.lock().await;
         let node = state.node_of(fid)?;
-        let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
+        let f = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
         if !matches!(f.mode, Some(OpenMode::Write | OpenMode::ReadWrite)) {
             return Err(ErrorCode::NoAccess);
         }
         if !matches!(node, Node::Send | Node::Rule(_)) {
             return Err(ErrorCode::Unsupported);
         }
+        if let Node::Rule(name) = &node {
+            state.ensure_current_rule_fid(f, name)?;
+        }
         let start = usize::try_from(offset).map_err(|_| ErrorCode::BadRequest)?;
         let end = start.checked_add(data.len()).ok_or(ErrorCode::BadRequest)?;
         if end > MAX_DOC_BYTES {
             return Err(ErrorCode::BadRequest);
         }
+        let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
         if f.write_buf.len() < end {
             f.write_buf.resize(end, 0);
         }
@@ -483,14 +513,18 @@ impl FileServer for RouteFs {
 
     async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
         let mut state = self.state.lock().await;
-        let node = state.node_of(fid)?;
+        let f = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+        let node = f.node.clone();
         let Node::Rule(name) = node else {
             return Err(ErrorCode::Unsupported);
         };
-        let removed = state.rules.remove(&name).is_some();
-        let reserved = state.pending_rules.remove(&name);
-        if !removed && !reserved {
-            return Err(ErrorCode::NotFound);
+        if f.pending_rule_create {
+            if !state.pending_rules.remove(&name) {
+                return Err(ErrorCode::NotFound);
+            }
+        } else {
+            state.ensure_current_rule_fid(f, &name)?;
+            state.rules.remove(&name).ok_or(ErrorCode::NotFound)?;
         }
         state.versions.bump(node_identity(&Node::RulesDir).1);
         state.fids.remove(&fid);
@@ -515,10 +549,11 @@ impl FileServer for RouteFs {
                 };
                 state.commit_pending_rule(name, spec)
             }
-            Node::Rule(name) if f.wrote => {
+            Node::Rule(ref name) if f.wrote => {
+                state.ensure_current_rule_fid(&f, name)?;
                 let spec: RuleSpec =
                     serde_json::from_slice(&f.write_buf).map_err(|_| ErrorCode::BadRequest)?;
-                state.install_rule(name, spec)
+                state.install_rule(name.clone(), spec)
             }
             Node::Rule(name) if f.pending_rule_create => {
                 state.abandon_pending_rule(&name);
@@ -530,13 +565,15 @@ impl FileServer for RouteFs {
 }
 
 impl RouteFid {
-    fn at(node: Node) -> Self {
+    fn at(node: Node, qid: Qid) -> Self {
+        let observed_rule_version = matches!(node, Node::Rule(_)).then_some(qid.version);
         Self {
             node,
             mode: None,
             write_buf: Vec::new(),
             wrote: false,
             pending_rule_create: false,
+            observed_rule_version,
         }
     }
 
@@ -547,6 +584,7 @@ impl RouteFid {
             write_buf: Vec::new(),
             wrote: false,
             pending_rule_create: true,
+            observed_rule_version: None,
         }
     }
 }

--- a/crates/routefs/src/lib.rs
+++ b/crates/routefs/src/lib.rs
@@ -159,6 +159,7 @@ struct RouteFid {
     mode: Option<OpenMode>,
     write_buf: Vec<u8>,
     wrote: bool,
+    pending_rule_create: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -476,7 +477,7 @@ impl FileServer for RouteFs {
         state.pending_rules.insert(name.to_string());
         let node = Node::Rule(name.to_string());
         let qid = state.qid(&node);
-        state.fids.insert(newfid, RouteFid::at(node));
+        state.fids.insert(newfid, RouteFid::pending_rule(node));
         Ok(qid)
     }
 
@@ -504,7 +505,7 @@ impl FileServer for RouteFs {
         let f = state.fids.remove(&fid).ok_or(ErrorCode::NotFound)?;
         match f.node {
             Node::Send if f.wrote => state.route_message(&f.write_buf).await,
-            Node::Rule(name) if f.wrote => {
+            Node::Rule(name) if f.wrote && f.pending_rule_create => {
                 let spec: RuleSpec = match serde_json::from_slice(&f.write_buf) {
                     Ok(spec) => spec,
                     Err(_) => {
@@ -514,7 +515,12 @@ impl FileServer for RouteFs {
                 };
                 state.commit_pending_rule(name, spec)
             }
-            Node::Rule(name) => {
+            Node::Rule(name) if f.wrote => {
+                let spec: RuleSpec =
+                    serde_json::from_slice(&f.write_buf).map_err(|_| ErrorCode::BadRequest)?;
+                state.install_rule(name, spec)
+            }
+            Node::Rule(name) if f.pending_rule_create => {
                 state.abandon_pending_rule(&name);
                 Ok(())
             }
@@ -530,6 +536,17 @@ impl RouteFid {
             mode: None,
             write_buf: Vec::new(),
             wrote: false,
+            pending_rule_create: false,
+        }
+    }
+
+    fn pending_rule(node: Node) -> Self {
+        Self {
+            node,
+            mode: None,
+            write_buf: Vec::new(),
+            wrote: false,
+            pending_rule_create: true,
         }
     }
 }

--- a/crates/routefs/src/lib.rs
+++ b/crates/routefs/src/lib.rs
@@ -78,7 +78,7 @@ impl RuleSpec {
         Ok(())
     }
 
-    fn matches(&self, message: &WireMessage) -> bool {
+    fn matches(&self, message: &MessageDocument) -> bool {
         let type_matches = self
             .match_type
             .as_deref()
@@ -91,14 +91,42 @@ impl RuleSpec {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-struct WireMessage {
-    version: u16,
-    #[serde(rename = "type")]
+#[derive(Debug, Clone)]
+struct MessageDocument {
     message_type: String,
     content: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    title: Option<String>,
+    raw: serde_json::Value,
+}
+
+impl MessageDocument {
+    fn parse(bytes: &[u8]) -> Result<Self, ErrorCode> {
+        let raw: serde_json::Value =
+            serde_json::from_slice(bytes).map_err(|_| ErrorCode::BadRequest)?;
+        let object = raw.as_object().ok_or(ErrorCode::BadRequest)?;
+        let version = object
+            .get("version")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|value| u16::try_from(value).ok())
+            .ok_or(ErrorCode::BadRequest)?;
+        let message_type = object
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .ok_or(ErrorCode::BadRequest)?
+            .to_string();
+        let content = object
+            .get("content")
+            .and_then(serde_json::Value::as_str)
+            .ok_or(ErrorCode::BadRequest)?
+            .to_string();
+        if version != 1 || message_type.is_empty() {
+            return Err(ErrorCode::BadRequest);
+        }
+        Ok(Self {
+            message_type,
+            content,
+            raw,
+        })
+    }
 }
 
 #[derive(Serialize)]
@@ -108,7 +136,7 @@ struct RoutedRecord<'a> {
     rule: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     reason: Option<&'a str>,
-    message: &'a WireMessage,
+    message: &'a serde_json::Value,
 }
 
 #[derive(Debug, Clone)]
@@ -278,11 +306,7 @@ impl State {
     }
 
     async fn route_message(&mut self, bytes: &[u8]) -> Result<(), ErrorCode> {
-        let message: WireMessage =
-            serde_json::from_slice(bytes).map_err(|_| ErrorCode::BadRequest)?;
-        if message.version != 1 || message.message_type.is_empty() {
-            return Err(ErrorCode::BadRequest);
-        }
+        let message = MessageDocument::parse(bytes)?;
 
         let decision = self
             .rules
@@ -309,7 +333,7 @@ impl State {
             port: &port,
             rule: &rule_name,
             reason: reason.as_deref(),
-            message: &message,
+            message: &message.raw,
         };
         let bytes = routed_record_bytes(&record)?;
         let stream = self.ports.get(&port).ok_or(ErrorCode::NotFound)?.clone();

--- a/crates/routefs/tests/routefs.rs
+++ b/crates/routefs/tests/routefs.rs
@@ -291,6 +291,53 @@ async fn stale_rule_fid_does_not_release_a_replacement_reservation() {
 }
 
 #[tokio::test]
+async fn stale_rule_fid_writes_after_recreate_are_rejected() {
+    let fs = RouteFs::new();
+    create_rule(
+        &fs,
+        "10-results",
+        Fid(1),
+        json!({"version":1,"match_type":"result","port":"old"}),
+    )
+    .await;
+
+    fs.walk(Fid::ROOT, Fid(2), &["rules".into(), "10-results".into()])
+        .await
+        .unwrap();
+    fs.open(Fid(2), OpenMode::Write).await.unwrap();
+    let stale_rule =
+        serde_json::to_vec(&json!({"version":1,"match_type":"result","port":"stale"})).unwrap();
+    fs.write(Fid(2), 0, &stale_rule).await.unwrap();
+
+    fs.walk(Fid::ROOT, Fid(3), &["rules".into(), "10-results".into()])
+        .await
+        .unwrap();
+    fs.walk(Fid::ROOT, Fid(4), &["rules".into(), "10-results".into()])
+        .await
+        .unwrap();
+    fs.remove(Fid(4)).await.unwrap();
+    create_rule(
+        &fs,
+        "10-results",
+        Fid(5),
+        json!({"version":1,"match_type":"result","port":"fresh"}),
+    )
+    .await;
+
+    assert_eq!(
+        fs.open(Fid(3), OpenMode::Write).await,
+        Err(ErrorCode::BadRequest)
+    );
+    assert_eq!(fs.clunk(Fid(2)).await, Err(ErrorCode::BadRequest));
+
+    write_doc(&fs, &["send"], Fid(6), &[&message("result", "done")])
+        .await
+        .unwrap();
+    let fresh = read_text(&fs, &["ports", "fresh"], Fid(7)).await;
+    assert!(fresh.contains(r#""port":"fresh""#), "{fresh}");
+}
+
+#[tokio::test]
 async fn no_match_routes_to_dead_letter_and_log_records_decision() {
     let fs = RouteFs::new();
     write_doc(&fs, &["send"], Fid(1), &[&message("citation", "source")])

--- a/crates/routefs/tests/routefs.rs
+++ b/crates/routefs/tests/routefs.rs
@@ -256,6 +256,41 @@ async fn invalid_rule_json_releases_the_reserved_name() {
 }
 
 #[tokio::test]
+async fn stale_rule_fid_does_not_release_a_replacement_reservation() {
+    let fs = RouteFs::new();
+    create_rule(
+        &fs,
+        "10-results",
+        Fid(1),
+        json!({"version":1,"match_type":"result","port":"review"}),
+    )
+    .await;
+
+    fs.walk(Fid::ROOT, Fid(2), &["rules".into(), "10-results".into()])
+        .await
+        .unwrap();
+    fs.walk(Fid::ROOT, Fid(3), &["rules".into(), "10-results".into()])
+        .await
+        .unwrap();
+    fs.remove(Fid(3)).await.unwrap();
+
+    fs.walk(Fid::ROOT, Fid(4), &["rules".into()]).await.unwrap();
+    fs.create(Fid(4), Fid(5), "10-results", FileKind::File)
+        .await
+        .unwrap();
+    fs.clunk(Fid(2)).await.unwrap();
+
+    assert_eq!(
+        fs.create(Fid(4), Fid(6), "10-results", FileKind::File)
+            .await,
+        Err(ErrorCode::BadRequest),
+        "only the pending create fid may release its reservation"
+    );
+    fs.clunk(Fid(5)).await.unwrap();
+    fs.clunk(Fid(4)).await.unwrap();
+}
+
+#[tokio::test]
 async fn no_match_routes_to_dead_letter_and_log_records_decision() {
     let fs = RouteFs::new();
     write_doc(&fs, &["send"], Fid(1), &[&message("citation", "source")])

--- a/crates/routefs/tests/routefs.rs
+++ b/crates/routefs/tests/routefs.rs
@@ -249,3 +249,50 @@ async fn routefs_posts_under_srv_and_mounts_at_canonical_path() {
         assert!(root.lines().any(|line| line == entry), "{root}");
     }
 }
+
+#[tokio::test]
+async fn mounted_routefs_allows_rule_creation_through_mnt_route() {
+    let srv = Arc::new(SrvFs::new());
+    let routefs = Arc::new(RouteFs::new());
+    srv.post(
+        SRV_HANDLE,
+        InProcessTransport::new(routefs),
+        Access::ReadWrite,
+    )
+    .await;
+    let (handle, access) = srv.lookup(SRV_HANDLE).await.expect("route handle");
+    let mut ns = Namespace::new();
+    ns.mount("/srv", InProcessTransport::new(srv), Access::ReadOnly);
+    ns.mount(MOUNT_PATH, handle, access);
+    let fs = Arc::new(MountFs::new(ns));
+
+    fs.walk(
+        Fid::ROOT,
+        Fid(1),
+        &["mnt".into(), "route".into(), "rules".into()],
+    )
+    .await
+    .unwrap();
+    fs.create(Fid(1), Fid(2), "10-results", FileKind::File)
+        .await
+        .unwrap();
+    let rule = serde_json::to_vec(&json!({
+        "version": 1,
+        "match_type": "result",
+        "port": "review"
+    }))
+    .unwrap();
+    fs.open(Fid(2), OpenMode::Write).await.unwrap();
+    fs.write(Fid(2), 0, &rule).await.unwrap();
+    fs.clunk(Fid(2)).await.unwrap();
+    fs.clunk(Fid(1)).await.unwrap();
+
+    let shell = Shell::new(InProcessTransport::new(fs));
+    shell
+        .write("/mnt/route/send", &message("result", "needs review"))
+        .await
+        .unwrap();
+    let routed = String::from_utf8(shell.cat("/mnt/route/ports/review").await.unwrap()).unwrap();
+    assert!(routed.contains(r#""rule":"10-results""#), "{routed}");
+    assert!(routed.contains(r#""type":"result""#), "{routed}");
+}

--- a/crates/routefs/tests/routefs.rs
+++ b/crates/routefs/tests/routefs.rs
@@ -1,0 +1,206 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use alan_ap::{ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode};
+use alan_kernel::{Access, MountFs, Namespace, SrvFs};
+use alan_routefs::{DEAD_LETTER_PORT, MOUNT_PATH, RouteFs, RuleSpec, SRV_HANDLE};
+use alan_shell::Shell;
+use serde_json::json;
+
+async fn read_text(fs: &RouteFs, path: &[&str], fid: Fid) -> String {
+    let names = path.iter().map(|name| name.to_string()).collect::<Vec<_>>();
+    fs.walk(Fid::ROOT, fid, &names).await.expect("walk");
+    fs.open(fid, OpenMode::Read).await.expect("open");
+    let bytes = fs.read(fid, 0, 4096).await.expect("read");
+    fs.clunk(fid).await.expect("clunk");
+    String::from_utf8(bytes).expect("utf8")
+}
+
+async fn write_doc(
+    fs: &RouteFs,
+    path: &[&str],
+    fid: Fid,
+    chunks: &[&[u8]],
+) -> Result<(), ErrorCode> {
+    let names = path.iter().map(|name| name.to_string()).collect::<Vec<_>>();
+    fs.walk(Fid::ROOT, fid, &names).await?;
+    fs.open(fid, OpenMode::Write).await?;
+    let mut offset = 0;
+    for chunk in chunks {
+        fs.write(fid, offset, chunk).await?;
+        offset += chunk.len() as u64;
+    }
+    fs.clunk(fid).await
+}
+
+async fn create_rule(fs: &RouteFs, name: &str, fid: Fid, rule: serde_json::Value) {
+    fs.walk(Fid::ROOT, fid, &["rules".into()])
+        .await
+        .expect("walk rules");
+    fs.create(fid, Fid(fid.0 + 100), name, FileKind::File)
+        .await
+        .expect("create rule");
+    let bytes = serde_json::to_vec(&rule).expect("serialize rule");
+    fs.open(Fid(fid.0 + 100), OpenMode::Write)
+        .await
+        .expect("open rule");
+    fs.write(Fid(fid.0 + 100), 0, &bytes)
+        .await
+        .expect("write rule");
+    fs.clunk(Fid(fid.0 + 100)).await.expect("commit rule");
+    fs.clunk(fid).await.expect("clunk rules dir");
+}
+
+fn message(message_type: &str, content: &str) -> Vec<u8> {
+    serde_json::to_vec(&json!({
+        "version": 1,
+        "type": message_type,
+        "content": content,
+    }))
+    .expect("serialize message")
+}
+
+#[tokio::test]
+async fn typed_message_routes_by_rule_on_send_clunk() {
+    let fs = RouteFs::new();
+    create_rule(
+        &fs,
+        "10-patches",
+        Fid(1),
+        json!({"version":1,"match_type":"patch","port":"review"}),
+    )
+    .await;
+
+    let message = message("patch", "diff --git");
+    let split = message.split_at(12);
+    write_doc(&fs, &["send"], Fid(2), &[split.0, split.1])
+        .await
+        .unwrap();
+
+    let routed = read_text(&fs, &["ports", "review"], Fid(3)).await;
+    assert!(routed.contains(r#""port":"review""#), "{routed}");
+    assert!(routed.contains(r#""rule":"10-patches""#), "{routed}");
+    assert!(routed.contains(r#""type":"patch""#), "{routed}");
+}
+
+#[tokio::test]
+async fn send_does_not_route_before_clunk() {
+    let fs = Arc::new(RouteFs::new());
+    fs.install_rule("10-patches", RuleSpec::for_type("patch", "review"))
+        .await
+        .unwrap();
+
+    fs.walk(Fid::ROOT, Fid(1), &["send".into()]).await.unwrap();
+    fs.open(Fid(1), OpenMode::Write).await.unwrap();
+    fs.write(Fid(1), 0, &message("patch", "diff"))
+        .await
+        .unwrap();
+
+    let reader = {
+        let fs = fs.clone();
+        tokio::spawn(async move { read_text(&fs, &["ports", "review"], Fid(2)).await })
+    };
+    assert!(
+        tokio::time::timeout(Duration::from_millis(30), reader)
+            .await
+            .is_err(),
+        "port read should block until send fid is clunked"
+    );
+
+    fs.clunk(Fid(1)).await.unwrap();
+    let routed = read_text(&fs, &["ports", "review"], Fid(3)).await;
+    assert!(routed.contains(r#""type":"patch""#), "{routed}");
+}
+
+#[tokio::test]
+async fn rule_files_are_cat_readable_and_match_by_content() {
+    let fs = RouteFs::new();
+    create_rule(
+        &fs,
+        "00-human-review",
+        Fid(1),
+        json!({
+            "version":1,
+            "match_type":"result",
+            "content_contains":"needs_human_judgment",
+            "port":"human-inbox",
+            "reason":"approval remains explicit through requests/<id>/response"
+        }),
+    )
+    .await;
+
+    let rule_text = read_text(&fs, &["rules", "00-human-review"], Fid(2)).await;
+    assert!(rule_text.contains("needs_human_judgment"), "{rule_text}");
+    assert!(rule_text.contains("human-inbox"), "{rule_text}");
+
+    write_doc(
+        &fs,
+        &["send"],
+        Fid(3),
+        &[&message("result", "status=needs_human_judgment")],
+    )
+    .await
+    .unwrap();
+    let routed = read_text(&fs, &["ports", "human-inbox"], Fid(4)).await;
+    assert!(routed.contains("approval remains explicit"), "{routed}");
+}
+
+#[tokio::test]
+async fn no_match_routes_to_dead_letter_and_log_records_decision() {
+    let fs = RouteFs::new();
+    write_doc(&fs, &["send"], Fid(1), &[&message("citation", "source")])
+        .await
+        .unwrap();
+
+    let dead = read_text(&fs, &["ports", DEAD_LETTER_PORT], Fid(2)).await;
+    assert!(dead.contains(r#""port":"dead-letter""#), "{dead}");
+    assert!(dead.contains(r#""rule":"dead-letter""#), "{dead}");
+
+    let log = read_text(&fs, &["log"], Fid(3)).await;
+    assert_eq!(log, dead);
+}
+
+#[tokio::test]
+async fn deterministic_rule_order_picks_lexically_first_match() {
+    let fs = RouteFs::new();
+    fs.install_rule("20-generic", RuleSpec::for_type("patch", "apply-tool"))
+        .await
+        .unwrap();
+    fs.install_rule(
+        "10-review",
+        RuleSpec::for_type("patch", "review-agent").with_reason("review first"),
+    )
+    .await
+    .unwrap();
+
+    write_doc(&fs, &["send"], Fid(1), &[&message("patch", "diff")])
+        .await
+        .unwrap();
+
+    let routed = read_text(&fs, &["ports", "review-agent"], Fid(2)).await;
+    assert!(routed.contains(r#""rule":"10-review""#), "{routed}");
+}
+
+#[tokio::test]
+async fn routefs_posts_under_srv_and_mounts_at_canonical_path() {
+    let srv = Arc::new(SrvFs::new());
+    let routefs = Arc::new(RouteFs::new());
+    srv.post(
+        SRV_HANDLE,
+        InProcessTransport::new(routefs.clone()),
+        Access::ReadWrite,
+    )
+    .await;
+
+    let (handle, access) = srv.lookup(SRV_HANDLE).await.expect("route handle");
+    assert_eq!(access, Access::ReadWrite);
+
+    let mut ns = Namespace::new();
+    ns.mount(MOUNT_PATH, handle, access);
+    let shell = Shell::new(InProcessTransport::new(Arc::new(MountFs::new(ns))));
+
+    let root = String::from_utf8(shell.cat(MOUNT_PATH).await.unwrap()).unwrap();
+    for entry in ["send", "rules", "ports", "log"] {
+        assert!(root.lines().any(|line| line == entry), "{root}");
+    }
+}

--- a/crates/routefs/tests/routefs.rs
+++ b/crates/routefs/tests/routefs.rs
@@ -191,6 +191,53 @@ async fn rule_files_are_cat_readable_and_match_by_content() {
 }
 
 #[tokio::test]
+async fn rule_create_reserves_the_name_until_clunk() {
+    let fs = RouteFs::new();
+    fs.walk(Fid::ROOT, Fid(1), &["rules".into()]).await.unwrap();
+    fs.create(Fid(1), Fid(2), "10-results", FileKind::File)
+        .await
+        .unwrap();
+    assert_eq!(
+        fs.create(Fid(1), Fid(3), "10-results", FileKind::File)
+            .await,
+        Err(ErrorCode::BadRequest),
+        "a pending rule create reserves its name"
+    );
+
+    let rule = serde_json::to_vec(&json!({
+        "version": 1,
+        "match_type": "result",
+        "port": "review"
+    }))
+    .unwrap();
+    fs.open(Fid(2), OpenMode::Write).await.unwrap();
+    fs.write(Fid(2), 0, &rule).await.unwrap();
+    fs.clunk(Fid(2)).await.unwrap();
+    assert_eq!(
+        fs.create(Fid(1), Fid(4), "10-results", FileKind::File)
+            .await,
+        Err(ErrorCode::BadRequest),
+        "a committed rule keeps the name reserved"
+    );
+    fs.clunk(Fid(1)).await.unwrap();
+}
+
+#[tokio::test]
+async fn abandoned_rule_create_releases_the_reserved_name() {
+    let fs = RouteFs::new();
+    fs.walk(Fid::ROOT, Fid(1), &["rules".into()]).await.unwrap();
+    fs.create(Fid(1), Fid(2), "10-results", FileKind::File)
+        .await
+        .unwrap();
+    fs.clunk(Fid(2)).await.unwrap();
+    fs.create(Fid(1), Fid(3), "10-results", FileKind::File)
+        .await
+        .unwrap();
+    fs.clunk(Fid(3)).await.unwrap();
+    fs.clunk(Fid(1)).await.unwrap();
+}
+
+#[tokio::test]
 async fn no_match_routes_to_dead_letter_and_log_records_decision() {
     let fs = RouteFs::new();
     write_doc(&fs, &["send"], Fid(1), &[&message("citation", "source")])

--- a/crates/routefs/tests/routefs.rs
+++ b/crates/routefs/tests/routefs.rs
@@ -238,6 +238,24 @@ async fn abandoned_rule_create_releases_the_reserved_name() {
 }
 
 #[tokio::test]
+async fn invalid_rule_json_releases_the_reserved_name() {
+    let fs = RouteFs::new();
+    fs.walk(Fid::ROOT, Fid(1), &["rules".into()]).await.unwrap();
+    fs.create(Fid(1), Fid(2), "10-results", FileKind::File)
+        .await
+        .unwrap();
+    fs.open(Fid(2), OpenMode::Write).await.unwrap();
+    fs.write(Fid(2), 0, b"{not-json").await.unwrap();
+    assert_eq!(fs.clunk(Fid(2)).await, Err(ErrorCode::BadRequest));
+
+    fs.create(Fid(1), Fid(3), "10-results", FileKind::File)
+        .await
+        .unwrap();
+    fs.clunk(Fid(3)).await.unwrap();
+    fs.clunk(Fid(1)).await.unwrap();
+}
+
+#[tokio::test]
 async fn no_match_routes_to_dead_letter_and_log_records_decision() {
     let fs = RouteFs::new();
     write_doc(&fs, &["send"], Fid(1), &[&message("citation", "source")])

--- a/crates/routefs/tests/routefs.rs
+++ b/crates/routefs/tests/routefs.rs
@@ -84,6 +84,51 @@ async fn typed_message_routes_by_rule_on_send_clunk() {
 }
 
 #[tokio::test]
+async fn routed_record_preserves_the_full_message_document() {
+    let fs = RouteFs::new();
+    fs.install_rule("10-results", RuleSpec::for_type("result", "review"))
+        .await
+        .unwrap();
+
+    write_doc(
+        &fs,
+        &["send"],
+        Fid(1),
+        &[&serde_json::to_vec(&json!({
+            "version": 1,
+            "type": "result",
+            "content": "needs_human_judgment",
+            "result_id": "res-42",
+            "payload": {
+                "status": "blocked",
+                "artifacts": ["patch.diff", "report.json"]
+            },
+            "metadata": {
+                "producer": "root-agent",
+                "confidence": 0.62
+            }
+        }))
+        .unwrap()],
+    )
+    .await
+    .unwrap();
+
+    let routed = read_text(&fs, &["ports", "review"], Fid(2)).await;
+    let record: serde_json::Value = serde_json::from_str(routed.trim()).unwrap();
+    assert_eq!(record["message"]["result_id"], json!("res-42"));
+    assert_eq!(record["message"]["payload"]["status"], json!("blocked"));
+    assert_eq!(
+        record["message"]["payload"]["artifacts"][1],
+        json!("report.json")
+    );
+    assert_eq!(
+        record["message"]["metadata"]["producer"],
+        json!("root-agent")
+    );
+    assert_eq!(record["message"]["metadata"]["confidence"], json!(0.62));
+}
+
+#[tokio::test]
 async fn send_does_not_route_before_clunk() {
     let fs = Arc::new(RouteFs::new());
     fs.install_rule("10-patches", RuleSpec::for_type("patch", "review"))

--- a/openspec/changes/add-message-routing/tasks.md
+++ b/openspec/changes/add-message-routing/tasks.md
@@ -18,8 +18,10 @@
 - [x] 1.3 Implement rule files (content/type match) with deterministic match
   order and a default dead-letter port.
   Done 2026-07-02: `rules/<name>` are plain JSON files, matched in lexical
-  `BTreeMap` order by message type and optional content substring; unmatched
-  messages go to the built-in `dead-letter` port.
+  `BTreeMap` order by message type and optional content substring. Create
+  reserves rule names until clunk, so concurrent same-name creates cannot both
+  succeed and silently overwrite each other. Unmatched messages go to the
+  built-in `dead-letter` port.
 - [x] 1.4 Implement destination ports as blocking-read streams.
   Done 2026-07-02: `ports/<name>` and `log` are aP `Stream`s with blocking-read
   semantics; port delivery appends one routed JSON record per message.
@@ -57,7 +59,8 @@
   and child namespace launch manifests include `/srv` plus `/mnt/route`. Kernel
   `MountFs` coverage verifies create forwarding and read-only create denial,
   and routefs coverage creates a rule through `/mnt/route/rules/<name>` before
-  routing a message through that mounted namespace.
+  routing a message through that mounted namespace. Routefs also covers
+  same-name create reservation and reservation release for abandoned creates.
 - [x] 4.2 Run `just verify`.
   Done 2026-07-02: `just verify` passed, including workspace fmt, clippy,
   tests, and smoke verification.

--- a/openspec/changes/add-message-routing/tasks.md
+++ b/openspec/changes/add-message-routing/tasks.md
@@ -5,10 +5,12 @@
   Done 2026-07-02: added `alan-routefs`, an aP file server with `send`, `rules`,
   `ports`, and `log`; the root runtime namespace posts it under `/srv/route`
   and mounts the handle at `/mnt/route`, and child-agent namespace manifests
-  inherit `/srv` plus `/mnt/route` alongside `/agent`, `/mnt/llm`, and mounted
-  `/bin` tools. `MountFs` now forwards create requests to backing trees, so
-  rules can be installed through the advertised `/mnt/route/rules/<name>` file
-  path rather than only through direct test helpers.
+  inherit `/srv` plus the session's shared `/mnt/route` handle alongside
+  `/agent`, `/mnt/llm`, and mounted `/bin` tools. `MountFs` now forwards create
+  requests to backing trees and reserves caller-visible `newfid`s before
+  forwarding, so rules can be installed through the advertised
+  `/mnt/route/rules/<name>` file path rather than only through direct test
+  helpers.
 - [x] 1.2 Implement the `send` write entry point for typed messages; frame a
   message across multiple writes and match/route only on clunk of the `send` fid
   (commit-on-clunk), never on a partial write.
@@ -56,12 +58,12 @@
   port reads, complete JSON message preservation, and `/srv/route` to
   `/mnt/route` mounting. `alan-agent-engine` regression coverage verifies the
   production root namespace exposes `/srv/route` and writable `/mnt/route/send`,
-  and child namespace launch manifests include `/srv` plus `/mnt/route`. Kernel
-  `MountFs` coverage verifies create forwarding and read-only create denial,
-  and routefs coverage creates a rule through `/mnt/route/rules/<name>` before
-  routing a message through that mounted namespace. Routefs also covers
-  same-name create reservation and reservation release for abandoned or invalid
-  creates.
+  and child namespace launch manifests include `/srv` plus a shared
+  `/mnt/route`. Kernel `MountFs` coverage verifies create forwarding, read-only
+  create denial, and `newfid` reservation before backing create forwarding; and
+  routefs coverage creates a rule through `/mnt/route/rules/<name>` before
+  routing a message through that mounted namespace. Routefs also covers same-name
+  create reservation and reservation release for abandoned or invalid creates.
 - [x] 4.2 Run `just verify`.
   Done 2026-07-02: `just verify` passed, including workspace fmt, clippy,
   tests, and smoke verification.

--- a/openspec/changes/add-message-routing/tasks.md
+++ b/openspec/changes/add-message-routing/tasks.md
@@ -3,8 +3,10 @@
 - [x] 1.1 Add `routefs` as a user-space aP file server; post a handle at
   `/srv/route` and serve its tree (send, rules, ports, log) at `/mnt/route`.
   Done 2026-07-02: added `alan-routefs`, an aP file server with `send`, `rules`,
-  `ports`, and `log`; tests post it under `/srv/route` and mount the handle at
-  `/mnt/route`.
+  `ports`, and `log`; the root runtime namespace posts it under `/srv/route`
+  and mounts the handle at `/mnt/route`, and child-agent namespace manifests
+  inherit `/srv` plus `/mnt/route` alongside `/agent`, `/mnt/llm`, and mounted
+  `/bin` tools.
 - [x] 1.2 Implement the `send` write entry point for typed messages; frame a
   message across multiple writes and match/route only on clunk of the `send` fid
   (commit-on-clunk), never on a partial write.
@@ -47,7 +49,10 @@
   Done 2026-07-02: `crates/routefs/tests/routefs.rs` covers type routing, split
   send writes, no route before clunk, content-match governance routing,
   deterministic rule order, dead-letter logging, readable rule files, blocking
-  port reads, and `/srv/route` to `/mnt/route` mounting.
+  port reads, complete JSON message preservation, and `/srv/route` to
+  `/mnt/route` mounting. `alan-agent-engine` regression coverage verifies the
+  production root namespace exposes `/srv/route` and writable `/mnt/route/send`,
+  and child namespace launch manifests include `/srv` plus `/mnt/route`.
 - [x] 4.2 Run `just verify`.
   Done 2026-07-02: `just verify` passed, including workspace fmt, clippy,
   tests, and smoke verification.

--- a/openspec/changes/add-message-routing/tasks.md
+++ b/openspec/changes/add-message-routing/tasks.md
@@ -1,28 +1,56 @@
 ## 1. Routefs file server
 
-- [ ] 1.1 Add `routefs` as a user-space aP file server; post a handle at
+- [x] 1.1 Add `routefs` as a user-space aP file server; post a handle at
   `/srv/route` and serve its tree (send, rules, ports, log) at `/mnt/route`.
-- [ ] 1.2 Implement the `send` write entry point for typed messages; frame a
+  Done 2026-07-02: added `alan-routefs`, an aP file server with `send`, `rules`,
+  `ports`, and `log`; tests post it under `/srv/route` and mount the handle at
+  `/mnt/route`.
+- [x] 1.2 Implement the `send` write entry point for typed messages; frame a
   message across multiple writes and match/route only on clunk of the `send` fid
   (commit-on-clunk), never on a partial write.
-- [ ] 1.3 Implement rule files (content/type match) with deterministic match
+  Done 2026-07-02: `send` buffers writes by offset and routes only when the fid
+  is clunked; tests verify split writes and that no port delivery happens before
+  clunk.
+- [x] 1.3 Implement rule files (content/type match) with deterministic match
   order and a default dead-letter port.
-- [ ] 1.4 Implement destination ports as blocking-read streams.
+  Done 2026-07-02: `rules/<name>` are plain JSON files, matched in lexical
+  `BTreeMap` order by message type and optional content substring; unmatched
+  messages go to the built-in `dead-letter` port.
+- [x] 1.4 Implement destination ports as blocking-read streams.
+  Done 2026-07-02: `ports/<name>` and `log` are aP `Stream`s with blocking-read
+  semantics; port delivery appends one routed JSON record per message.
 
 ## 2. Auditability
 
-- [ ] 2.1 Append every message (and its routing decision) to an observable log
+- [x] 2.1 Append every message (and its routing decision) to an observable log
   stream; keep rules as plain `cat`-able files.
+  Done 2026-07-02: routefs appends the same routed record to the destination port
+  and `log`, including `port`, `rule`, optional `reason`, and the message; tests
+  read both the log and `rules/<name>` files.
 
 ## 3. Use cases
 
-- [ ] 3.1 Human-in-the-loop governance: route results needing judgment to a human
+- [x] 3.1 Human-in-the-loop governance: route results needing judgment to a human
   inbox port (approval stays an explicit request/response).
-- [ ] 3.2 Agent→tool/agent handoff by result type.
+  Done 2026-07-02: tests install an inspectable `result` rule with
+  `content_contains = "needs_human_judgment"` routing to `human-inbox`, while the
+  rule reason states approval remains explicit via the agent file-layout
+  request/response path.
+- [x] 3.2 Agent→tool/agent handoff by result type.
+  Done 2026-07-02: type rules route `patch` messages to review/apply ports
+  without the sender naming a receiving actor.
 
 ## 4. Verification
 
-- [ ] 4.1 Tests: routing by type, dead-letter on no match, message log
+- [x] 4.1 Tests: routing by type, dead-letter on no match, message log
   completeness, port blocking-read.
-- [ ] 4.2 Run `just verify`.
-- [ ] 4.3 Run `openspec validate add-message-routing --strict`.
+  Done 2026-07-02: `crates/routefs/tests/routefs.rs` covers type routing, split
+  send writes, no route before clunk, content-match governance routing,
+  deterministic rule order, dead-letter logging, readable rule files, blocking
+  port reads, and `/srv/route` to `/mnt/route` mounting.
+- [x] 4.2 Run `just verify`.
+  Done 2026-07-02: `just verify` passed, including workspace fmt, clippy,
+  tests, and smoke verification.
+- [x] 4.3 Run `openspec validate add-message-routing --strict`.
+  Done 2026-07-02: strict OpenSpec validation passed for
+  `add-message-routing`.

--- a/openspec/changes/add-message-routing/tasks.md
+++ b/openspec/changes/add-message-routing/tasks.md
@@ -6,7 +6,9 @@
   `ports`, and `log`; the root runtime namespace posts it under `/srv/route`
   and mounts the handle at `/mnt/route`, and child-agent namespace manifests
   inherit `/srv` plus `/mnt/route` alongside `/agent`, `/mnt/llm`, and mounted
-  `/bin` tools.
+  `/bin` tools. `MountFs` now forwards create requests to backing trees, so
+  rules can be installed through the advertised `/mnt/route/rules/<name>` file
+  path rather than only through direct test helpers.
 - [x] 1.2 Implement the `send` write entry point for typed messages; frame a
   message across multiple writes and match/route only on clunk of the `send` fid
   (commit-on-clunk), never on a partial write.
@@ -52,7 +54,10 @@
   port reads, complete JSON message preservation, and `/srv/route` to
   `/mnt/route` mounting. `alan-agent-engine` regression coverage verifies the
   production root namespace exposes `/srv/route` and writable `/mnt/route/send`,
-  and child namespace launch manifests include `/srv` plus `/mnt/route`.
+  and child namespace launch manifests include `/srv` plus `/mnt/route`. Kernel
+  `MountFs` coverage verifies create forwarding and read-only create denial,
+  and routefs coverage creates a rule through `/mnt/route/rules/<name>` before
+  routing a message through that mounted namespace.
 - [x] 4.2 Run `just verify`.
   Done 2026-07-02: `just verify` passed, including workspace fmt, clippy,
   tests, and smoke verification.

--- a/openspec/changes/add-message-routing/tasks.md
+++ b/openspec/changes/add-message-routing/tasks.md
@@ -63,7 +63,8 @@
   create denial, and `newfid` reservation before backing create forwarding; and
   routefs coverage creates a rule through `/mnt/route/rules/<name>` before
   routing a message through that mounted namespace. Routefs also covers same-name
-  create reservation and reservation release for abandoned or invalid creates.
+  create reservation, reservation release for abandoned or invalid creates, and
+  stale rule fids not releasing replacement reservations.
 - [x] 4.2 Run `just verify`.
   Done 2026-07-02: `just verify` passed, including workspace fmt, clippy,
   tests, and smoke verification.

--- a/openspec/changes/add-message-routing/tasks.md
+++ b/openspec/changes/add-message-routing/tasks.md
@@ -60,7 +60,8 @@
   `MountFs` coverage verifies create forwarding and read-only create denial,
   and routefs coverage creates a rule through `/mnt/route/rules/<name>` before
   routing a message through that mounted namespace. Routefs also covers
-  same-name create reservation and reservation release for abandoned creates.
+  same-name create reservation and reservation release for abandoned or invalid
+  creates.
 - [x] 4.2 Run `just verify`.
   Done 2026-07-02: `just verify` passed, including workspace fmt, clippy,
   tests, and smoke verification.


### PR DESCRIPTION
Stack: 5/5, stacked on #589 / feat/northstar-namespace-engine.

This adds the add-message-routing slice from ADR-0027: a new alan-routefs aP file server with /srv/route, /mnt/route, send/rules/ports/log, commit-on-clunk routing, deterministic rule matching, dead-letter handling, and observable route logs.

Verification:
- just verify
- cargo test -p alan-routefs -- --nocapture
- cargo clippy -p alan-routefs --all-targets --all-features -- -D warnings
- openspec validate add-message-routing --strict
- git diff --check