### PR TITLE
North Star 6/6: add aP wire import/export transport

### DIFF
--- a/crates/ap/src/lib.rs
+++ b/crates/ap/src/lib.rs
@@ -28,7 +28,7 @@ pub use stream::Stream;
 pub use types::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Stat};
 pub use version::VersionTable;
 pub use wire::{
-    Request, Response, WireError, WireRequestFrame, WireResponseFrame, decode_request_frame,
-    decode_response_frame, encode_request_frame, encode_response_frame, read_request_frame,
-    read_response_frame, write_request_frame, write_response_frame,
+    MAX_WIRE_FRAME_BYTES, Request, Response, WireError, WireRequestFrame, WireResponseFrame,
+    decode_request_frame, decode_response_frame, encode_request_frame, encode_response_frame,
+    read_request_frame, read_response_frame, write_request_frame, write_response_frame,
 };

--- a/crates/ap/src/lib.rs
+++ b/crates/ap/src/lib.rs
@@ -19,11 +19,16 @@ mod version;
 mod wire;
 
 pub use server::{
-    FileServer, InProcessTransport, ProcessEvent, ProcessEventSink, ProcessEventSource,
-    ProcessInputEventSink, ProcessInputEventSource, ProcessIoEventKind, ProcessIoEventSink,
-    ProcessIoEventSource, ProcessOutputEventSink, ProcessOutputEventSource,
+    FileServer, ImportedFileServer, InProcessTransport, ProcessEvent, ProcessEventSink,
+    ProcessEventSource, ProcessInputEventSink, ProcessInputEventSource, ProcessIoEventKind,
+    ProcessIoEventSink, ProcessIoEventSource, ProcessOutputEventSink, ProcessOutputEventSource,
+    WireTransportClient, export_file_server,
 };
 pub use stream::Stream;
 pub use types::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Stat};
 pub use version::VersionTable;
-pub use wire::{Request, Response};
+pub use wire::{
+    Request, Response, WireError, WireRequestFrame, WireResponseFrame, decode_request_frame,
+    decode_response_frame, encode_request_frame, encode_response_frame, read_request_frame,
+    read_response_frame, write_request_frame, write_response_frame,
+};

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -11,12 +11,15 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use tokio::io::{AsyncBufRead, AsyncWrite};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, mpsc, watch};
 
 use crate::wire::{
-    read_request_frame, read_response_frame, write_request_frame, write_response_frame,
+    MAX_WIRE_FRAME_BYTES, read_request_frame, read_response_frame, write_request_frame,
+    write_response_frame,
 };
 use crate::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Request, Response, Stat, WireError};
+
+const MAX_WIRE_WRITE_CHUNK_BYTES: usize = MAX_WIRE_FRAME_BYTES / 8;
 
 /// A file server: the backing implementation of one mountable tree.
 ///
@@ -211,19 +214,59 @@ impl InProcessTransport {
 /// added above this without changing the [`FileServer`] contract.
 pub async fn export_file_server<R, W>(
     server: Arc<dyn FileServer>,
-    mut reader: R,
+    reader: R,
     mut writer: W,
 ) -> Result<(), WireError>
 where
-    R: AsyncBufRead + Unpin,
+    R: AsyncBufRead + Send + Unpin + 'static,
     W: AsyncWrite + Unpin,
 {
     let transport = InProcessTransport::new(server);
-    while let Some(request) = read_request_frame(&mut reader).await? {
-        let result = transport.call(request).await;
+    let (request_tx, mut request_rx) = mpsc::channel(1);
+    let (reader_closed_tx, mut reader_closed_rx) = watch::channel(false);
+    tokio::spawn(read_export_requests(reader, request_tx, reader_closed_tx));
+
+    while let Some(message) = request_rx.recv().await {
+        let ExportReaderMessage::Request(request) = message?;
+        let result = tokio::select! {
+            result = transport.call(request) => result,
+            _ = reader_closed_rx.changed() => return Ok(()),
+        };
         write_response_frame(&mut writer, &result).await?;
     }
     Ok(())
+}
+
+enum ExportReaderMessage {
+    Request(Request),
+}
+
+async fn read_export_requests<R>(
+    mut reader: R,
+    request_tx: mpsc::Sender<Result<ExportReaderMessage, WireError>>,
+    reader_closed_tx: watch::Sender<bool>,
+) where
+    R: AsyncBufRead + Unpin,
+{
+    loop {
+        match read_request_frame(&mut reader).await {
+            Ok(Some(request)) => {
+                if request_tx
+                    .send(Ok(ExportReaderMessage::Request(request)))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            Ok(None) => break,
+            Err(error) => {
+                let _ = request_tx.send(Err(error)).await;
+                break;
+            }
+        }
+    }
+    let _ = reader_closed_tx.send(true);
 }
 
 /// Client side of one aP wire connection.
@@ -343,17 +386,47 @@ where
     }
 
     async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
-        match self
-            .remote_call(Request::Write {
-                fid,
-                offset,
-                data: data.to_vec(),
-            })
-            .await?
-        {
-            Response::Write { count } => Ok(count),
-            _ => Err(ErrorCode::BadRequest),
+        if data.is_empty() {
+            return match self
+                .remote_call(Request::Write {
+                    fid,
+                    offset,
+                    data: Vec::new(),
+                })
+                .await?
+            {
+                Response::Write { count } => Ok(count),
+                _ => Err(ErrorCode::BadRequest),
+            };
         }
+
+        let mut accepted_total = 0usize;
+        for chunk in data.chunks(MAX_WIRE_WRITE_CHUNK_BYTES) {
+            let chunk_offset = offset
+                .checked_add(accepted_total as u64)
+                .ok_or(ErrorCode::BadRequest)?;
+            let accepted = match self
+                .remote_call(Request::Write {
+                    fid,
+                    offset: chunk_offset,
+                    data: chunk.to_vec(),
+                })
+                .await?
+            {
+                Response::Write { count } => count as usize,
+                _ => return Err(ErrorCode::BadRequest),
+            };
+            if accepted > chunk.len() {
+                return Err(ErrorCode::BadRequest);
+            }
+            accepted_total = accepted_total
+                .checked_add(accepted)
+                .ok_or(ErrorCode::BadRequest)?;
+            if accepted < chunk.len() {
+                break;
+            }
+        }
+        u32::try_from(accepted_total).map_err(|_| ErrorCode::BadRequest)
     }
 
     async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -230,6 +230,7 @@ where
 pub struct WireTransportClient<R, W> {
     reader: R,
     writer: W,
+    in_flight: bool,
 }
 
 impl<R, W> WireTransportClient<R, W>
@@ -238,11 +239,30 @@ where
     W: AsyncWrite + Unpin,
 {
     pub fn new(reader: R, writer: W) -> Self {
-        Self { reader, writer }
+        Self {
+            reader,
+            writer,
+            in_flight: false,
+        }
     }
 
     /// Send one request and return the exact remote operation result.
     pub async fn call_result(
+        &mut self,
+        request: Request,
+    ) -> Result<Result<Response, ErrorCode>, WireError> {
+        if self.in_flight {
+            return Err(WireError::Unsynchronized);
+        }
+        self.in_flight = true;
+        let result = self.call_result_in_flight(request).await;
+        if result.is_ok() {
+            self.in_flight = false;
+        }
+        result
+    }
+
+    async fn call_result_in_flight(
         &mut self,
         request: Request,
     ) -> Result<Result<Response, ErrorCode>, WireError> {

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -430,23 +430,36 @@ where
         }
 
         let mut accepted_total = 0usize;
+        let accepted_count = |accepted_total: usize| {
+            u32::try_from(accepted_total).map_err(|_| ErrorCode::BadRequest)
+        };
         for chunk in data.chunks(MAX_WIRE_PAYLOAD_CHUNK_BYTES) {
             let chunk_offset = offset
                 .checked_add(accepted_total as u64)
                 .ok_or(ErrorCode::BadRequest)?;
-            let accepted = match self
+            let response = match self
                 .remote_call(Request::Write {
                     fid,
                     offset: chunk_offset,
                     data: chunk.to_vec(),
                 })
-                .await?
+                .await
             {
+                Ok(response) => response,
+                Err(_) if accepted_total > 0 => return accepted_count(accepted_total),
+                Err(error) => return Err(error),
+            };
+            let accepted = match response {
                 Response::Write { count } => count as usize,
+                _ if accepted_total > 0 => return accepted_count(accepted_total),
                 _ => return Err(ErrorCode::BadRequest),
             };
             if accepted > chunk.len() {
-                return Err(ErrorCode::BadRequest);
+                return if accepted_total > 0 {
+                    accepted_count(accepted_total)
+                } else {
+                    Err(ErrorCode::BadRequest)
+                };
             }
             accepted_total = accepted_total
                 .checked_add(accepted)
@@ -455,7 +468,7 @@ where
                 break;
             }
         }
-        u32::try_from(accepted_total).map_err(|_| ErrorCode::BadRequest)
+        accepted_count(accepted_total)
     }
 
     async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tokio::io::{AsyncBufRead, AsyncWrite};
 use tokio::sync::{Mutex, mpsc, watch};
+use tokio::task::JoinHandle;
 
 use crate::wire::{
     MAX_WIRE_FRAME_BYTES, read_request_frame, read_response_frame, write_request_frame,
@@ -224,17 +225,54 @@ where
     let transport = InProcessTransport::new(server);
     let (request_tx, mut request_rx) = mpsc::channel(1);
     let (reader_closed_tx, mut reader_closed_rx) = watch::channel(false);
-    tokio::spawn(read_export_requests(reader, request_tx, reader_closed_tx));
+    let reader_task = AbortOnDrop::new(tokio::spawn(read_export_requests(
+        reader,
+        request_tx,
+        reader_closed_tx,
+    )));
 
-    while let Some(message) = request_rx.recv().await {
-        let ExportReaderMessage::Request(request) = message?;
-        let result = tokio::select! {
-            result = transport.call(request) => result,
-            _ = reader_closed_rx.changed() => return Ok(()),
-        };
-        write_response_frame(&mut writer, &result).await?;
+    let result = async {
+        while let Some(message) = request_rx.recv().await {
+            let ExportReaderMessage::Request(request) = message?;
+            let result = tokio::select! {
+                result = transport.call(request) => result,
+                _ = reader_closed_rx.changed() => return Ok(()),
+            };
+            write_response_frame(&mut writer, &result).await?;
+        }
+        Ok(())
     }
-    Ok(())
+    .await;
+
+    reader_task.abort_and_join().await;
+    result
+}
+
+struct AbortOnDrop {
+    handle: Option<JoinHandle<()>>,
+}
+
+impl AbortOnDrop {
+    fn new(handle: JoinHandle<()>) -> Self {
+        Self {
+            handle: Some(handle),
+        }
+    }
+
+    async fn abort_and_join(mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+            let _ = handle.await;
+        }
+    }
+}
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        if let Some(handle) = &self.handle {
+            handle.abort();
+        }
+    }
 }
 
 enum ExportReaderMessage {

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -10,8 +10,13 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use tokio::io::{AsyncBufRead, AsyncWrite};
+use tokio::sync::Mutex;
 
-use crate::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Request, Response, Stat};
+use crate::wire::{
+    read_request_frame, read_response_frame, write_request_frame, write_response_frame,
+};
+use crate::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Request, Response, Stat, WireError};
 
 /// A file server: the backing implementation of one mountable tree.
 ///
@@ -195,6 +200,181 @@ impl InProcessTransport {
                 .map(|qid| Response::Create { qid }),
             Request::Remove { fid } => s.remove(fid).await.map(|()| Response::Remove),
             Request::Clunk { fid } => s.clunk(fid).await.map(|()| Response::Clunk),
+        }
+    }
+}
+
+/// Export a [`FileServer`] over the aP byte transport.
+///
+/// The loop is intentionally simple in v1: one connection carries a serialized
+/// sequence of request frames and response-result frames. Multiplexing can be
+/// added above this without changing the [`FileServer`] contract.
+pub async fn export_file_server<R, W>(
+    server: Arc<dyn FileServer>,
+    mut reader: R,
+    mut writer: W,
+) -> Result<(), WireError>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let transport = InProcessTransport::new(server);
+    while let Some(request) = read_request_frame(&mut reader).await? {
+        let result = transport.call(request).await;
+        write_response_frame(&mut writer, &result).await?;
+    }
+    Ok(())
+}
+
+/// Client side of one aP wire connection.
+pub struct WireTransportClient<R, W> {
+    reader: R,
+    writer: W,
+}
+
+impl<R, W> WireTransportClient<R, W>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    pub fn new(reader: R, writer: W) -> Self {
+        Self { reader, writer }
+    }
+
+    /// Send one request and return the exact remote operation result.
+    pub async fn call_result(
+        &mut self,
+        request: Request,
+    ) -> Result<Result<Response, ErrorCode>, WireError> {
+        write_request_frame(&mut self.writer, &request).await?;
+        read_response_frame(&mut self.reader)
+            .await?
+            .ok_or(WireError::Closed)
+    }
+
+    /// Send one request and map transport failures back into aP error space.
+    pub async fn call(&mut self, request: Request) -> Result<Response, ErrorCode> {
+        self.call_result(request)
+            .await
+            .map_err(|error| error.to_error_code())?
+    }
+}
+
+/// A remote aP tree imported as a normal [`FileServer`].
+///
+/// V1 serializes requests through one connection. This preserves aP semantics and
+/// keeps request IDs out of the first wire slice; a later transport can add
+/// multiplexing without changing clients.
+pub struct ImportedFileServer<R, W> {
+    client: Mutex<WireTransportClient<R, W>>,
+}
+
+impl<R, W> ImportedFileServer<R, W>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    pub fn new(reader: R, writer: W) -> Self {
+        Self {
+            client: Mutex::new(WireTransportClient::new(reader, writer)),
+        }
+    }
+
+    async fn remote_call(&self, request: Request) -> Result<Response, ErrorCode> {
+        self.client.lock().await.call(request).await
+    }
+}
+
+#[async_trait]
+impl<R, W> FileServer for ImportedFileServer<R, W>
+where
+    R: AsyncBufRead + Send + Unpin + 'static,
+    W: AsyncWrite + Send + Unpin + 'static,
+{
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        match self
+            .remote_call(Request::Walk {
+                fid,
+                newfid,
+                names: names.to_vec(),
+            })
+            .await?
+        {
+            Response::Walk { qid } => Ok(qid),
+            _ => Err(ErrorCode::BadRequest),
+        }
+    }
+
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
+        match self.remote_call(Request::Open { fid, mode }).await? {
+            Response::Open { qid } => Ok(qid),
+            _ => Err(ErrorCode::BadRequest),
+        }
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        match self
+            .remote_call(Request::Read { fid, offset, count })
+            .await?
+        {
+            Response::Read { data } => Ok(data),
+            _ => Err(ErrorCode::BadRequest),
+        }
+    }
+
+    async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        match self
+            .remote_call(Request::Write {
+                fid,
+                offset,
+                data: data.to_vec(),
+            })
+            .await?
+        {
+            Response::Write { count } => Ok(count),
+            _ => Err(ErrorCode::BadRequest),
+        }
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        match self.remote_call(Request::Stat { fid }).await? {
+            Response::Stat { stat } => Ok(stat),
+            _ => Err(ErrorCode::BadRequest),
+        }
+    }
+
+    async fn create(
+        &self,
+        fid: Fid,
+        newfid: Fid,
+        name: &str,
+        kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        match self
+            .remote_call(Request::Create {
+                fid,
+                newfid,
+                name: name.to_string(),
+                kind,
+            })
+            .await?
+        {
+            Response::Create { qid } => Ok(qid),
+            _ => Err(ErrorCode::BadRequest),
+        }
+    }
+
+    async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
+        match self.remote_call(Request::Remove { fid }).await? {
+            Response::Remove => Ok(()),
+            _ => Err(ErrorCode::BadRequest),
+        }
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        match self.remote_call(Request::Clunk { fid }).await? {
+            Response::Clunk => Ok(()),
+            _ => Err(ErrorCode::BadRequest),
         }
     }
 }

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -19,7 +19,7 @@ use crate::wire::{
 };
 use crate::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Request, Response, Stat, WireError};
 
-const MAX_WIRE_WRITE_CHUNK_BYTES: usize = MAX_WIRE_FRAME_BYTES / 8;
+const MAX_WIRE_PAYLOAD_CHUNK_BYTES: usize = MAX_WIRE_FRAME_BYTES / 8;
 
 /// A file server: the backing implementation of one mountable tree.
 ///
@@ -376,6 +376,7 @@ where
     }
 
     async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let count = count.min(MAX_WIRE_PAYLOAD_CHUNK_BYTES as u32);
         match self
             .remote_call(Request::Read { fid, offset, count })
             .await?
@@ -401,7 +402,7 @@ where
         }
 
         let mut accepted_total = 0usize;
-        for chunk in data.chunks(MAX_WIRE_WRITE_CHUNK_BYTES) {
+        for chunk in data.chunks(MAX_WIRE_PAYLOAD_CHUNK_BYTES) {
             let chunk_offset = offset
                 .checked_add(accepted_total as u64)
                 .ok_or(ErrorCode::BadRequest)?;

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use tokio::io::{AsyncBufRead, AsyncWrite};
-use tokio::sync::{Mutex, mpsc, watch};
+use tokio::sync::{Mutex, mpsc};
 use tokio::task::JoinHandle;
 
 use crate::wire::{
@@ -224,20 +224,12 @@ where
 {
     let transport = InProcessTransport::new(server);
     let (request_tx, mut request_rx) = mpsc::channel(1);
-    let (reader_closed_tx, mut reader_closed_rx) = watch::channel(false);
-    let reader_task = AbortOnDrop::new(tokio::spawn(read_export_requests(
-        reader,
-        request_tx,
-        reader_closed_tx,
-    )));
+    let reader_task = AbortOnDrop::new(tokio::spawn(read_export_requests(reader, request_tx)));
 
     let result = async {
         while let Some(message) = request_rx.recv().await {
             let ExportReaderMessage::Request(request) = message?;
-            let result = tokio::select! {
-                result = transport.call(request) => result,
-                _ = reader_closed_rx.changed() => return Ok(()),
-            };
+            let result = transport.call(request).await;
             write_response_frame(&mut writer, &result).await?;
         }
         Ok(())
@@ -282,7 +274,6 @@ enum ExportReaderMessage {
 async fn read_export_requests<R>(
     mut reader: R,
     request_tx: mpsc::Sender<Result<ExportReaderMessage, WireError>>,
-    reader_closed_tx: watch::Sender<bool>,
 ) where
     R: AsyncBufRead + Unpin,
 {
@@ -304,7 +295,6 @@ async fn read_export_requests<R>(
             }
         }
     }
-    let _ = reader_closed_tx.send(true);
 }
 
 /// Client side of one aP wire connection.

--- a/crates/ap/src/wire.rs
+++ b/crates/ap/src/wire.rs
@@ -127,6 +127,8 @@ pub enum WireError {
     Unsynchronized,
     #[error("aP wire frame exceeds {max} bytes")]
     FrameTooLarge { max: usize },
+    #[error("aP wire frame ended before newline delimiter")]
+    TruncatedFrame,
 }
 
 impl WireError {
@@ -134,7 +136,9 @@ impl WireError {
     /// imported file-server adapters.
     pub fn to_error_code(&self) -> ErrorCode {
         match self {
-            Self::Codec(_) | Self::FrameTooLarge { .. } => ErrorCode::BadRequest,
+            Self::Codec(_) | Self::FrameTooLarge { .. } | Self::TruncatedFrame => {
+                ErrorCode::BadRequest
+            }
             Self::Io(_) | Self::Closed | Self::Unsynchronized => ErrorCode::Io,
         }
     }
@@ -225,7 +229,7 @@ where
             return if frame.is_empty() {
                 Ok(None)
             } else {
-                Ok(Some(frame))
+                Err(WireError::TruncatedFrame)
             };
         }
 

--- a/crates/ap/src/wire.rs
+++ b/crates/ap/src/wire.rs
@@ -120,6 +120,8 @@ pub enum WireError {
     Codec(#[from] serde_json::Error),
     #[error("aP wire peer closed before a response frame")]
     Closed,
+    #[error("aP wire connection has an abandoned in-flight request")]
+    Unsynchronized,
 }
 
 impl WireError {
@@ -128,7 +130,7 @@ impl WireError {
     pub fn to_error_code(&self) -> ErrorCode {
         match self {
             Self::Codec(_) => ErrorCode::BadRequest,
-            Self::Io(_) | Self::Closed => ErrorCode::Io,
+            Self::Io(_) | Self::Closed | Self::Unsynchronized => ErrorCode::Io,
         }
     }
 }

--- a/crates/ap/src/wire.rs
+++ b/crates/ap/src/wire.rs
@@ -13,8 +13,9 @@
 //! to learn the allocated resource's name, then `walk`s to that name.
 
 use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt};
 
-use crate::{Fid, FileKind, Offset, OpenMode, Qid, Stat};
+use crate::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Stat};
 
 /// One aP operation request. Inputs are fids, paths (name components), byte
 /// buffers, offsets, and counts — nothing in-process-only.
@@ -72,4 +73,148 @@ pub enum Response {
     Create { qid: Qid },
     Remove,
     Clunk,
+}
+
+/// A newline-delimited request frame carried by the aP byte transport.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WireRequestFrame {
+    pub request: Request,
+}
+
+/// A newline-delimited response frame carried by the aP byte transport.
+///
+/// Successful aP operation results and typed [`ErrorCode`] failures are both
+/// first-class protocol results. Transport IO/codec failures stay outside this
+/// envelope and map to [`WireError`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "status")]
+pub enum WireResponseFrame {
+    Ok { response: Response },
+    Error { code: ErrorCode },
+}
+
+impl WireResponseFrame {
+    pub fn from_result(result: &Result<Response, ErrorCode>) -> Self {
+        match result {
+            Ok(response) => Self::Ok {
+                response: response.clone(),
+            },
+            Err(code) => Self::Error { code: *code },
+        }
+    }
+
+    pub fn into_result(self) -> Result<Response, ErrorCode> {
+        match self {
+            Self::Ok { response } => Ok(response),
+            Self::Error { code } => Err(code),
+        }
+    }
+}
+
+/// Errors in the byte transport itself, separate from aP operation failures.
+#[derive(Debug, thiserror::Error)]
+pub enum WireError {
+    #[error("aP wire io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("aP wire codec error: {0}")]
+    Codec(#[from] serde_json::Error),
+    #[error("aP wire peer closed before a response frame")]
+    Closed,
+}
+
+impl WireError {
+    /// Map transport-level failures back into typed aP operation errors for
+    /// imported file-server adapters.
+    pub fn to_error_code(&self) -> ErrorCode {
+        match self {
+            Self::Codec(_) => ErrorCode::BadRequest,
+            Self::Io(_) | Self::Closed => ErrorCode::Io,
+        }
+    }
+}
+
+pub fn encode_request_frame(request: &Request) -> Result<Vec<u8>, WireError> {
+    encode_json_line(&WireRequestFrame {
+        request: request.clone(),
+    })
+}
+
+pub fn decode_request_frame(frame: &[u8]) -> Result<Request, WireError> {
+    let frame: WireRequestFrame = serde_json::from_slice(frame)?;
+    Ok(frame.request)
+}
+
+pub fn encode_response_frame(result: &Result<Response, ErrorCode>) -> Result<Vec<u8>, WireError> {
+    encode_json_line(&WireResponseFrame::from_result(result))
+}
+
+pub fn decode_response_frame(frame: &[u8]) -> Result<Result<Response, ErrorCode>, WireError> {
+    let frame: WireResponseFrame = serde_json::from_slice(frame)?;
+    Ok(frame.into_result())
+}
+
+pub async fn write_request_frame<W>(writer: &mut W, request: &Request) -> Result<(), WireError>
+where
+    W: AsyncWrite + Unpin,
+{
+    let frame = encode_request_frame(request)?;
+    writer.write_all(&frame).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+pub async fn read_request_frame<R>(reader: &mut R) -> Result<Option<Request>, WireError>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let Some(frame) = read_json_line(reader).await? else {
+        return Ok(None);
+    };
+    decode_request_frame(&frame).map(Some)
+}
+
+pub async fn write_response_frame<W>(
+    writer: &mut W,
+    result: &Result<Response, ErrorCode>,
+) -> Result<(), WireError>
+where
+    W: AsyncWrite + Unpin,
+{
+    let frame = encode_response_frame(result)?;
+    writer.write_all(&frame).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+pub async fn read_response_frame<R>(
+    reader: &mut R,
+) -> Result<Option<Result<Response, ErrorCode>>, WireError>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let Some(frame) = read_json_line(reader).await? else {
+        return Ok(None);
+    };
+    decode_response_frame(&frame).map(Some)
+}
+
+fn encode_json_line<T>(value: &T) -> Result<Vec<u8>, WireError>
+where
+    T: Serialize,
+{
+    let mut frame = serde_json::to_vec(value)?;
+    frame.push(b'\n');
+    Ok(frame)
+}
+
+async fn read_json_line<R>(reader: &mut R) -> Result<Option<Vec<u8>>, WireError>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut frame = Vec::new();
+    let read = reader.read_until(b'\n', &mut frame).await?;
+    if read == 0 {
+        return Ok(None);
+    }
+    Ok(Some(frame))
 }

--- a/crates/ap/src/wire.rs
+++ b/crates/ap/src/wire.rs
@@ -17,6 +17,9 @@ use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Stat};
 
+/// Maximum newline-delimited aP wire frame accepted by the v1 byte transport.
+pub const MAX_WIRE_FRAME_BYTES: usize = 1 << 20; // 1 MiB
+
 /// One aP operation request. Inputs are fids, paths (name components), byte
 /// buffers, offsets, and counts — nothing in-process-only.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -122,6 +125,8 @@ pub enum WireError {
     Closed,
     #[error("aP wire connection has an abandoned in-flight request")]
     Unsynchronized,
+    #[error("aP wire frame exceeds {max} bytes")]
+    FrameTooLarge { max: usize },
 }
 
 impl WireError {
@@ -129,7 +134,7 @@ impl WireError {
     /// imported file-server adapters.
     pub fn to_error_code(&self) -> ErrorCode {
         match self {
-            Self::Codec(_) => ErrorCode::BadRequest,
+            Self::Codec(_) | Self::FrameTooLarge { .. } => ErrorCode::BadRequest,
             Self::Io(_) | Self::Closed | Self::Unsynchronized => ErrorCode::Io,
         }
     }
@@ -214,9 +219,31 @@ where
     R: AsyncBufRead + Unpin,
 {
     let mut frame = Vec::new();
-    let read = reader.read_until(b'\n', &mut frame).await?;
-    if read == 0 {
-        return Ok(None);
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            return if frame.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(frame))
+            };
+        }
+
+        let consumed = if let Some(newline) = available.iter().position(|byte| *byte == b'\n') {
+            newline + 1
+        } else {
+            available.len()
+        };
+        if frame.len().saturating_add(consumed) > MAX_WIRE_FRAME_BYTES {
+            return Err(WireError::FrameTooLarge {
+                max: MAX_WIRE_FRAME_BYTES,
+            });
+        }
+        frame.extend_from_slice(&available[..consumed]);
+        reader.consume(consumed);
+
+        if frame.last() == Some(&b'\n') {
+            return Ok(Some(frame));
+        }
     }
-    Ok(Some(frame))
 }

--- a/crates/ap/tests/wire.rs
+++ b/crates/ap/tests/wire.rs
@@ -5,7 +5,13 @@
 //! trip. If any aP type stops being wire-shaped (borrows, non-serializable
 //! fields), these tests fail before any wire transport exists.
 
-use alan_ap::{ErrorCode, Fid, FileKind, OpenMode, Qid, Request, Response, Stat};
+use std::io::Cursor;
+
+use alan_ap::{
+    ErrorCode, Fid, FileKind, MAX_WIRE_FRAME_BYTES, OpenMode, Qid, Request, Response, Stat,
+    WireError, read_request_frame,
+};
+use tokio::io::BufReader;
 
 fn roundtrip<T>(value: &T) -> T
 where
@@ -141,4 +147,30 @@ fn every_response_operation_survives_roundtrip() {
     for resp in responses {
         assert_eq!(roundtrip(&resp), resp);
     }
+}
+
+#[tokio::test]
+async fn oversized_request_frame_without_newline_is_rejected() {
+    let mut reader = BufReader::new(Cursor::new(vec![b'x'; MAX_WIRE_FRAME_BYTES + 1]));
+
+    assert!(matches!(
+        read_request_frame(&mut reader).await,
+        Err(WireError::FrameTooLarge {
+            max: MAX_WIRE_FRAME_BYTES
+        })
+    ));
+}
+
+#[tokio::test]
+async fn oversized_request_frame_with_newline_is_rejected() {
+    let mut frame = vec![b'x'; MAX_WIRE_FRAME_BYTES + 1];
+    frame.push(b'\n');
+    let mut reader = BufReader::new(Cursor::new(frame));
+
+    assert!(matches!(
+        read_request_frame(&mut reader).await,
+        Err(WireError::FrameTooLarge {
+            max: MAX_WIRE_FRAME_BYTES
+        })
+    ));
 }

--- a/crates/ap/tests/wire.rs
+++ b/crates/ap/tests/wire.rs
@@ -9,7 +9,7 @@ use std::io::Cursor;
 
 use alan_ap::{
     ErrorCode, Fid, FileKind, MAX_WIRE_FRAME_BYTES, OpenMode, Qid, Request, Response, Stat,
-    WireError, read_request_frame,
+    WireError, encode_request_frame, read_request_frame,
 };
 use tokio::io::BufReader;
 
@@ -172,5 +172,17 @@ async fn oversized_request_frame_with_newline_is_rejected() {
         Err(WireError::FrameTooLarge {
             max: MAX_WIRE_FRAME_BYTES
         })
+    ));
+}
+
+#[tokio::test]
+async fn request_frame_without_newline_is_rejected() {
+    let mut frame = encode_request_frame(&Request::Stat { fid: Fid(1) }).unwrap();
+    assert_eq!(frame.pop(), Some(b'\n'));
+    let mut reader = BufReader::new(Cursor::new(frame));
+
+    assert!(matches!(
+        read_request_frame(&mut reader).await,
+        Err(WireError::TruncatedFrame)
     ));
 }

--- a/crates/ap/tests/wire_transport.rs
+++ b/crates/ap/tests/wire_transport.rs
@@ -9,6 +9,7 @@ use alan_ap::{
     encode_response_frame, export_file_server,
 };
 use tokio::io::{BufReader, duplex};
+use tokio::sync::Notify;
 
 fn qid(kind: FileKind, path: u64) -> Qid {
     Qid {
@@ -198,6 +199,7 @@ async fn imported_tree_dispatches_to_exported_server() {
 
 struct StreamFile {
     stream: Stream,
+    read_started: Option<Arc<Notify>>,
 }
 
 #[async_trait::async_trait]
@@ -216,6 +218,9 @@ impl FileServer for StreamFile {
 
     async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
         if fid == Fid(1) {
+            if let Some(read_started) = &self.read_started {
+                read_started.notify_one();
+            }
             Ok(self.stream.read(offset, count).await)
         } else {
             Err(ErrorCode::NotFound)
@@ -267,6 +272,7 @@ async fn imported_stream_read_blocks_until_remote_stream_has_data() {
     let stream = Stream::new();
     let server: Arc<dyn FileServer> = Arc::new(StreamFile {
         stream: stream.clone(),
+        read_started: None,
     });
     let server_task = tokio::spawn(export_file_server(
         server,
@@ -295,6 +301,51 @@ async fn imported_stream_read_blocks_until_remote_stream_has_data() {
         .expect("imported stream read did not wake")
         .expect("reader task panicked");
     assert_eq!(got, Ok(b"late bytes".to_vec()));
+
+    drop(imported);
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn cancelled_in_flight_call_does_not_desynchronize_next_request() {
+    let (client_stream, server_stream) = duplex(4096);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+
+    let stream = Stream::new();
+    let read_started = Arc::new(Notify::new());
+    let server: Arc<dyn FileServer> = Arc::new(StreamFile {
+        stream: stream.clone(),
+        read_started: Some(Arc::clone(&read_started)),
+    });
+    let server_task = tokio::spawn(export_file_server(
+        server,
+        BufReader::new(server_read),
+        server_write,
+    ));
+    let imported = Arc::new(ImportedFileServer::new(
+        BufReader::new(client_read),
+        client_write,
+    ));
+
+    imported.open(Fid(1), OpenMode::Read).await.unwrap();
+    let reader = Arc::clone(&imported);
+    let handle = tokio::spawn(async move { reader.read(Fid(1), 0, 64).await });
+    tokio::time::timeout(Duration::from_millis(500), read_started.notified())
+        .await
+        .expect("remote read request did not reach exported server");
+
+    handle.abort();
+    assert!(
+        handle
+            .await
+            .expect_err("reader task should have been cancelled")
+            .is_cancelled()
+    );
+
+    stream.append(b"abandoned response").await;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(imported.stat(Fid(1)).await, Err(ErrorCode::Io));
 
     drop(imported);
     server_task.abort();

--- a/crates/ap/tests/wire_transport.rs
+++ b/crates/ap/tests/wire_transport.rs
@@ -2,13 +2,17 @@
 
 use std::sync::Arc;
 use std::time::Duration;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use alan_ap::{
     ErrorCode, Fid, FileKind, FileServer, ImportedFileServer, MAX_WIRE_FRAME_BYTES, Offset,
     OpenMode, Qid, Request, Response, Stat, Stream, decode_request_frame, decode_response_frame,
     encode_request_frame, encode_response_frame, export_file_server,
 };
-use tokio::io::{BufReader, duplex};
+use tokio::io::{AsyncBufRead, AsyncRead, BufReader, ReadBuf, duplex};
 use tokio::sync::{Mutex, Notify};
 
 fn qid(kind: FileKind, path: u64) -> Qid {
@@ -16,6 +20,51 @@ fn qid(kind: FileKind, path: u64) -> Qid {
         kind,
         version: 0,
         path,
+    }
+}
+
+struct DropNotifyReader<R> {
+    inner: R,
+    dropped: Arc<Notify>,
+}
+
+impl<R> DropNotifyReader<R> {
+    fn new(inner: R, dropped: Arc<Notify>) -> Self {
+        Self { inner, dropped }
+    }
+}
+
+impl<R> Drop for DropNotifyReader<R> {
+    fn drop(&mut self) {
+        self.dropped.notify_one();
+    }
+}
+
+impl<R> AsyncRead for DropNotifyReader<R>
+where
+    R: AsyncRead + Unpin,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl<R> AsyncBufRead for DropNotifyReader<R>
+where
+    R: AsyncBufRead + Unpin,
+{
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<&[u8]>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.inner).poll_fill_buf(cx)
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        let this = self.get_mut();
+        Pin::new(&mut this.inner).consume(amt);
     }
 }
 
@@ -195,6 +244,27 @@ async fn imported_tree_dispatches_to_exported_server() {
 
     drop(imported);
     server_task.abort();
+}
+
+#[tokio::test]
+async fn aborting_export_drops_the_background_reader() {
+    let (client_stream, server_stream) = duplex(4096);
+    let (_client_read, client_write) = tokio::io::split(client_stream);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+
+    let reader_dropped = Arc::new(Notify::new());
+    let reader = DropNotifyReader::new(BufReader::new(server_read), Arc::clone(&reader_dropped));
+    let server: Arc<dyn FileServer> = Arc::new(OneFile);
+    let server_task = tokio::spawn(export_file_server(server, reader, server_write));
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    server_task.abort();
+    let _ = server_task.await;
+
+    tokio::time::timeout(Duration::from_millis(500), reader_dropped.notified())
+        .await
+        .expect("export abort left the background reader task alive");
+    drop(client_write);
 }
 
 struct StreamFile {

--- a/crates/ap/tests/wire_transport.rs
+++ b/crates/ap/tests/wire_transport.rs
@@ -534,3 +534,85 @@ async fn imported_large_write_is_split_into_bounded_remote_frames() {
     drop(imported);
     server_task.abort();
 }
+
+struct LargeReadFile {
+    requested_counts: Mutex<Vec<u32>>,
+}
+
+#[async_trait::async_trait]
+impl FileServer for LargeReadFile {
+    async fn walk(&self, _fid: Fid, _newfid: Fid, _names: &[String]) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn read(&self, _fid: Fid, _offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        self.requested_counts.lock().await.push(count);
+        Ok(vec![255; count as usize])
+    }
+
+    async fn write(&self, _fid: Fid, _offset: Offset, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::NoAccess)
+    }
+
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Ok(Stat {
+            name: "large".into(),
+            qid: qid(FileKind::File, 1),
+            length: MAX_WIRE_FRAME_BYTES as u64,
+            writable: false,
+        })
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn imported_large_read_caps_remote_count_to_bounded_frame() {
+    let (client_stream, server_stream) = duplex(1024 * 1024);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+
+    let server = Arc::new(LargeReadFile {
+        requested_counts: Mutex::new(Vec::new()),
+    });
+    let server_task = tokio::spawn(export_file_server(
+        server.clone(),
+        BufReader::new(server_read),
+        server_write,
+    ));
+    let imported = ImportedFileServer::new(BufReader::new(client_read), client_write);
+
+    let data = imported
+        .read(Fid(1), 0, MAX_WIRE_FRAME_BYTES as u32)
+        .await
+        .unwrap();
+    assert!(data.len() < MAX_WIRE_FRAME_BYTES);
+    assert_eq!(
+        server.requested_counts.lock().await.as_slice(),
+        &[data.len() as u32]
+    );
+    assert_eq!(imported.stat(Fid(1)).await.unwrap().name, "large");
+
+    drop(imported);
+    server_task.abort();
+}

--- a/crates/ap/tests/wire_transport.rs
+++ b/crates/ap/tests/wire_transport.rs
@@ -4,12 +4,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use alan_ap::{
-    ErrorCode, Fid, FileKind, FileServer, ImportedFileServer, Offset, OpenMode, Qid, Request,
-    Response, Stat, Stream, decode_request_frame, decode_response_frame, encode_request_frame,
-    encode_response_frame, export_file_server,
+    ErrorCode, Fid, FileKind, FileServer, ImportedFileServer, MAX_WIRE_FRAME_BYTES, Offset,
+    OpenMode, Qid, Request, Response, Stat, Stream, decode_request_frame, decode_response_frame,
+    encode_request_frame, encode_response_frame, export_file_server,
 };
 use tokio::io::{BufReader, duplex};
-use tokio::sync::Notify;
+use tokio::sync::{Mutex, Notify};
 
 fn qid(kind: FileKind, path: u64) -> Qid {
     Qid {
@@ -346,6 +346,190 @@ async fn cancelled_in_flight_call_does_not_desynchronize_next_request() {
     stream.append(b"abandoned response").await;
     tokio::time::sleep(Duration::from_millis(20)).await;
     assert_eq!(imported.stat(Fid(1)).await, Err(ErrorCode::Io));
+
+    drop(imported);
+    server_task.abort();
+}
+
+struct BlockingReadFile {
+    read_started: Arc<Notify>,
+    read_dropped: Arc<Notify>,
+}
+
+#[async_trait::async_trait]
+impl FileServer for BlockingReadFile {
+    async fn walk(&self, _fid: Fid, _newfid: Fid, _names: &[String]) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn read(&self, _fid: Fid, _offset: Offset, _count: u32) -> Result<Vec<u8>, ErrorCode> {
+        struct DropNotify(Arc<Notify>);
+
+        impl Drop for DropNotify {
+            fn drop(&mut self) {
+                self.0.notify_one();
+            }
+        }
+
+        self.read_started.notify_one();
+        let _drop_notify = DropNotify(Arc::clone(&self.read_dropped));
+        std::future::pending().await
+    }
+
+    async fn write(&self, _fid: Fid, _offset: Offset, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::NoAccess)
+    }
+
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn export_cancels_blocking_call_when_peer_disconnects() {
+    let (client_stream, server_stream) = duplex(4096);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+
+    let read_started = Arc::new(Notify::new());
+    let read_dropped = Arc::new(Notify::new());
+    let server: Arc<dyn FileServer> = Arc::new(BlockingReadFile {
+        read_started: Arc::clone(&read_started),
+        read_dropped: Arc::clone(&read_dropped),
+    });
+    let server_task = tokio::spawn(export_file_server(
+        server,
+        BufReader::new(server_read),
+        server_write,
+    ));
+    let imported = Arc::new(ImportedFileServer::new(
+        BufReader::new(client_read),
+        client_write,
+    ));
+
+    let reader = Arc::clone(&imported);
+    let read_task = tokio::spawn(async move { reader.read(Fid(1), 0, 64).await });
+    tokio::time::timeout(Duration::from_millis(500), read_started.notified())
+        .await
+        .expect("remote read request did not reach exported server");
+
+    drop(imported);
+    read_task.abort();
+    let _ = read_task.await;
+
+    tokio::time::timeout(Duration::from_millis(500), read_dropped.notified())
+        .await
+        .expect("exported blocking read was not cancelled after peer disconnect");
+    let result = tokio::time::timeout(Duration::from_millis(500), server_task)
+        .await
+        .expect("export task did not exit after peer disconnect")
+        .expect("export task panicked");
+    assert!(result.is_ok(), "{result:?}");
+}
+
+struct RecordingWriteFile {
+    writes: Mutex<Vec<(Offset, Vec<u8>)>>,
+}
+
+#[async_trait::async_trait]
+impl FileServer for RecordingWriteFile {
+    async fn walk(&self, _fid: Fid, _newfid: Fid, _names: &[String]) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn read(&self, _fid: Fid, _offset: Offset, _count: u32) -> Result<Vec<u8>, ErrorCode> {
+        Err(ErrorCode::NoAccess)
+    }
+
+    async fn write(&self, _fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        self.writes.lock().await.push((offset, data.to_vec()));
+        Ok(data.len() as u32)
+    }
+
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn imported_large_write_is_split_into_bounded_remote_frames() {
+    let (client_stream, server_stream) = duplex(1024 * 1024);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+
+    let server = Arc::new(RecordingWriteFile {
+        writes: Mutex::new(Vec::new()),
+    });
+    let server_task = tokio::spawn(export_file_server(
+        server.clone(),
+        BufReader::new(server_read),
+        server_write,
+    ));
+    let imported = ImportedFileServer::new(BufReader::new(client_read), client_write);
+    let data = vec![255; MAX_WIRE_FRAME_BYTES];
+
+    assert_eq!(
+        imported.write(Fid(1), 7, &data).await,
+        Ok(data.len() as u32)
+    );
+
+    let writes = server.writes.lock().await;
+    assert!(
+        writes.len() > 1,
+        "large imported write should be split into multiple bounded frames"
+    );
+    let mut next_offset = 7;
+    let mut reconstructed = Vec::new();
+    for (offset, chunk) in writes.iter() {
+        assert_eq!(*offset, next_offset);
+        next_offset += chunk.len() as u64;
+        reconstructed.extend_from_slice(chunk);
+    }
+    assert_eq!(reconstructed, data);
 
     drop(imported);
     server_task.abort();

--- a/crates/ap/tests/wire_transport.rs
+++ b/crates/ap/tests/wire_transport.rs
@@ -10,9 +10,10 @@ use std::{
 use alan_ap::{
     ErrorCode, Fid, FileKind, FileServer, ImportedFileServer, MAX_WIRE_FRAME_BYTES, Offset,
     OpenMode, Qid, Request, Response, Stat, Stream, decode_request_frame, decode_response_frame,
-    encode_request_frame, encode_response_frame, export_file_server,
+    encode_request_frame, encode_response_frame, export_file_server, read_response_frame,
+    write_request_frame,
 };
-use tokio::io::{AsyncBufRead, AsyncRead, BufReader, ReadBuf, duplex};
+use tokio::io::{AsyncBufRead, AsyncRead, AsyncWriteExt, BufReader, ReadBuf, duplex};
 use tokio::sync::{Mutex, Notify};
 
 fn qid(kind: FileKind, path: u64) -> Qid {
@@ -421,100 +422,55 @@ async fn cancelled_in_flight_call_does_not_desynchronize_next_request() {
     server_task.abort();
 }
 
-struct BlockingReadFile {
-    read_started: Arc<Notify>,
-    read_dropped: Arc<Notify>,
-}
-
-#[async_trait::async_trait]
-impl FileServer for BlockingReadFile {
-    async fn walk(&self, _fid: Fid, _newfid: Fid, _names: &[String]) -> Result<Qid, ErrorCode> {
-        Err(ErrorCode::NotFound)
-    }
-
-    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
-        Err(ErrorCode::Unsupported)
-    }
-
-    async fn read(&self, _fid: Fid, _offset: Offset, _count: u32) -> Result<Vec<u8>, ErrorCode> {
-        struct DropNotify(Arc<Notify>);
-
-        impl Drop for DropNotify {
-            fn drop(&mut self) {
-                self.0.notify_one();
-            }
-        }
-
-        self.read_started.notify_one();
-        let _drop_notify = DropNotify(Arc::clone(&self.read_dropped));
-        std::future::pending().await
-    }
-
-    async fn write(&self, _fid: Fid, _offset: Offset, _data: &[u8]) -> Result<u32, ErrorCode> {
-        Err(ErrorCode::NoAccess)
-    }
-
-    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
-        Err(ErrorCode::NotFound)
-    }
-
-    async fn create(
-        &self,
-        _fid: Fid,
-        _newfid: Fid,
-        _name: &str,
-        _kind: FileKind,
-    ) -> Result<Qid, ErrorCode> {
-        Err(ErrorCode::Unsupported)
-    }
-
-    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
-        Err(ErrorCode::Unsupported)
-    }
-
-    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
-        Ok(())
-    }
-}
-
 #[tokio::test]
-async fn export_cancels_blocking_call_when_peer_disconnects() {
+async fn export_finishes_in_flight_request_after_request_eof() {
     let (client_stream, server_stream) = duplex(4096);
-    let (client_read, client_write) = tokio::io::split(client_stream);
+    let (client_read, mut client_write) = tokio::io::split(client_stream);
     let (server_read, server_write) = tokio::io::split(server_stream);
 
-    let read_started = Arc::new(Notify::new());
-    let read_dropped = Arc::new(Notify::new());
-    let server: Arc<dyn FileServer> = Arc::new(BlockingReadFile {
-        read_started: Arc::clone(&read_started),
-        read_dropped: Arc::clone(&read_dropped),
+    let stream = Stream::new();
+    let server: Arc<dyn FileServer> = Arc::new(StreamFile {
+        stream: stream.clone(),
+        read_started: None,
     });
     let server_task = tokio::spawn(export_file_server(
         server,
         BufReader::new(server_read),
         server_write,
     ));
-    let imported = Arc::new(ImportedFileServer::new(
-        BufReader::new(client_read),
-        client_write,
-    ));
+    let mut client_reader = BufReader::new(client_read);
 
-    let reader = Arc::clone(&imported);
-    let read_task = tokio::spawn(async move { reader.read(Fid(1), 0, 64).await });
-    tokio::time::timeout(Duration::from_millis(500), read_started.notified())
-        .await
-        .expect("remote read request did not reach exported server");
+    write_request_frame(
+        &mut client_write,
+        &Request::Read {
+            fid: Fid(1),
+            offset: 0,
+            count: 64,
+        },
+    )
+    .await
+    .unwrap();
+    client_write.shutdown().await.unwrap();
+    drop(client_write);
 
-    drop(imported);
-    read_task.abort();
-    let _ = read_task.await;
+    stream.append(b"half-close response").await;
+    let response = tokio::time::timeout(
+        Duration::from_millis(500),
+        read_response_frame(&mut client_reader),
+    )
+    .await
+    .expect("half-closed client did not receive response")
+    .unwrap();
+    assert_eq!(
+        response,
+        Some(Ok(Response::Read {
+            data: b"half-close response".to_vec()
+        }))
+    );
 
-    tokio::time::timeout(Duration::from_millis(500), read_dropped.notified())
-        .await
-        .expect("exported blocking read was not cancelled after peer disconnect");
     let result = tokio::time::timeout(Duration::from_millis(500), server_task)
         .await
-        .expect("export task did not exit after peer disconnect")
+        .expect("export task did not exit after request EOF")
         .expect("export task panicked");
     assert!(result.is_ok(), "{result:?}");
 }

--- a/crates/ap/tests/wire_transport.rs
+++ b/crates/ap/tests/wire_transport.rs
@@ -521,6 +521,57 @@ impl FileServer for RecordingWriteFile {
     }
 }
 
+struct FailSecondWriteFile {
+    writes: Mutex<Vec<(Offset, Vec<u8>)>>,
+}
+
+#[async_trait::async_trait]
+impl FileServer for FailSecondWriteFile {
+    async fn walk(&self, _fid: Fid, _newfid: Fid, _names: &[String]) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn read(&self, _fid: Fid, _offset: Offset, _count: u32) -> Result<Vec<u8>, ErrorCode> {
+        Err(ErrorCode::NoAccess)
+    }
+
+    async fn write(&self, _fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        let mut writes = self.writes.lock().await;
+        if writes.is_empty() {
+            writes.push((offset, data.to_vec()));
+            Ok(data.len() as u32)
+        } else {
+            Err(ErrorCode::NoAccess)
+        }
+    }
+
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
 #[tokio::test]
 async fn imported_large_write_is_split_into_bounded_remote_frames() {
     let (client_stream, server_stream) = duplex(1024 * 1024);
@@ -556,6 +607,35 @@ async fn imported_large_write_is_split_into_bounded_remote_frames() {
         reconstructed.extend_from_slice(chunk);
     }
     assert_eq!(reconstructed, data);
+
+    drop(imported);
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn imported_large_write_reports_partial_count_after_later_chunk_failure() {
+    let (client_stream, server_stream) = duplex(1024 * 1024);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+
+    let server = Arc::new(FailSecondWriteFile {
+        writes: Mutex::new(Vec::new()),
+    });
+    let server_task = tokio::spawn(export_file_server(
+        server.clone(),
+        BufReader::new(server_read),
+        server_write,
+    ));
+    let imported = ImportedFileServer::new(BufReader::new(client_read), client_write);
+    let data = vec![255; MAX_WIRE_FRAME_BYTES];
+
+    let accepted = imported.write(Fid(1), 11, &data).await.unwrap();
+
+    let writes = server.writes.lock().await;
+    assert_eq!(writes.len(), 1);
+    assert_eq!(writes[0].0, 11);
+    assert_eq!(accepted as usize, writes[0].1.len());
+    assert!((accepted as usize) < data.len());
 
     drop(imported);
     server_task.abort();

--- a/crates/ap/tests/wire_transport.rs
+++ b/crates/ap/tests/wire_transport.rs
@@ -1,0 +1,301 @@
+//! aP byte transport: framed requests/results, export loop, and imported trees.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use alan_ap::{
+    ErrorCode, Fid, FileKind, FileServer, ImportedFileServer, Offset, OpenMode, Qid, Request,
+    Response, Stat, Stream, decode_request_frame, decode_response_frame, encode_request_frame,
+    encode_response_frame, export_file_server,
+};
+use tokio::io::{BufReader, duplex};
+
+fn qid(kind: FileKind, path: u64) -> Qid {
+    Qid {
+        kind,
+        version: 0,
+        path,
+    }
+}
+
+#[test]
+fn every_request_and_response_result_survives_byte_framing() {
+    let requests = [
+        Request::Walk {
+            fid: Fid::ROOT,
+            newfid: Fid(1),
+            names: vec!["agent".into(), "root".into()],
+        },
+        Request::Open {
+            fid: Fid(1),
+            mode: OpenMode::Read,
+        },
+        Request::Read {
+            fid: Fid(1),
+            offset: 7,
+            count: 128,
+        },
+        Request::Write {
+            fid: Fid(1),
+            offset: 0,
+            data: b"payload".to_vec(),
+        },
+        Request::Stat { fid: Fid(1) },
+        Request::Create {
+            fid: Fid::ROOT,
+            newfid: Fid(2),
+            name: "child".into(),
+            kind: FileKind::File,
+        },
+        Request::Remove { fid: Fid(2) },
+        Request::Clunk { fid: Fid(1) },
+    ];
+
+    for request in requests {
+        let frame = encode_request_frame(&request).expect("encode request frame");
+        assert_eq!(frame.last(), Some(&b'\n'));
+        assert_eq!(
+            decode_request_frame(&frame).expect("decode request frame"),
+            request
+        );
+    }
+
+    let stat = Stat {
+        name: "file".into(),
+        qid: qid(FileKind::File, 1),
+        length: 7,
+        writable: true,
+    };
+    let responses = [
+        Ok(Response::Walk {
+            qid: qid(FileKind::Dir, 10),
+        }),
+        Ok(Response::Open {
+            qid: qid(FileKind::File, 1),
+        }),
+        Ok(Response::Read {
+            data: b"payload".to_vec(),
+        }),
+        Ok(Response::Write { count: 7 }),
+        Ok(Response::Stat { stat }),
+        Ok(Response::Create {
+            qid: qid(FileKind::File, 2),
+        }),
+        Ok(Response::Remove),
+        Ok(Response::Clunk),
+        Err(ErrorCode::NoAccess),
+        Err(ErrorCode::BadRequest),
+        Err(ErrorCode::Io),
+    ];
+
+    for response in responses {
+        let frame = encode_response_frame(&response).expect("encode response frame");
+        assert_eq!(frame.last(), Some(&b'\n'));
+        assert_eq!(
+            decode_response_frame(&frame).expect("decode response frame"),
+            response
+        );
+    }
+}
+
+struct OneFile;
+
+#[async_trait::async_trait]
+impl FileServer for OneFile {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        if fid == Fid::ROOT && newfid == Fid(1) && names == ["file"] {
+            Ok(qid(FileKind::File, 1))
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        if fid == Fid(1) {
+            Ok(qid(FileKind::File, 1))
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        if fid != Fid(1) {
+            return Err(ErrorCode::NotFound);
+        }
+        let bytes = b"hello over aP";
+        let start = (offset as usize).min(bytes.len());
+        let end = bytes.len().min(start + count as usize);
+        Ok(bytes[start..end].to_vec())
+    }
+
+    async fn write(&self, _fid: Fid, _offset: Offset, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::NoAccess)
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        if fid == Fid(1) {
+            Ok(Stat {
+                name: "file".into(),
+                qid: qid(FileKind::File, 1),
+                length: b"hello over aP".len() as u64,
+                writable: false,
+            })
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn imported_tree_dispatches_to_exported_server() {
+    let (client_stream, server_stream) = duplex(4096);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+
+    let server: Arc<dyn FileServer> = Arc::new(OneFile);
+    let server_task = tokio::spawn(export_file_server(
+        server,
+        BufReader::new(server_read),
+        server_write,
+    ));
+    let imported = ImportedFileServer::new(BufReader::new(client_read), client_write);
+
+    let walked = imported
+        .walk(Fid::ROOT, Fid(1), &["file".to_string()])
+        .await;
+    assert_eq!(walked, Ok(qid(FileKind::File, 1)));
+
+    let opened = imported.open(Fid(1), OpenMode::Read).await;
+    assert_eq!(opened, Ok(qid(FileKind::File, 1)));
+
+    let read = imported.read(Fid(1), 6, 128).await;
+    assert_eq!(read, Ok(b"over aP".to_vec()));
+
+    let denied = imported.write(Fid(1), 0, b"x").await;
+    assert_eq!(denied, Err(ErrorCode::NoAccess));
+
+    drop(imported);
+    server_task.abort();
+}
+
+struct StreamFile {
+    stream: Stream,
+}
+
+#[async_trait::async_trait]
+impl FileServer for StreamFile {
+    async fn walk(&self, _fid: Fid, _newfid: Fid, _names: &[String]) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+
+    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        if fid == Fid(1) {
+            Ok(qid(FileKind::Stream, 1))
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        if fid == Fid(1) {
+            Ok(self.stream.read(offset, count).await)
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn write(&self, _fid: Fid, _offset: Offset, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::NoAccess)
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        if fid == Fid(1) {
+            Ok(Stat {
+                name: "stream".into(),
+                qid: qid(FileKind::Stream, 1),
+                length: self.stream.len().await,
+                writable: false,
+            })
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn imported_stream_read_blocks_until_remote_stream_has_data() {
+    let (client_stream, server_stream) = duplex(4096);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+
+    let stream = Stream::new();
+    let server: Arc<dyn FileServer> = Arc::new(StreamFile {
+        stream: stream.clone(),
+    });
+    let server_task = tokio::spawn(export_file_server(
+        server,
+        BufReader::new(server_read),
+        server_write,
+    ));
+    let imported = Arc::new(ImportedFileServer::new(
+        BufReader::new(client_read),
+        client_write,
+    ));
+
+    imported.open(Fid(1), OpenMode::Read).await.unwrap();
+
+    let reader = Arc::clone(&imported);
+    let handle = tokio::spawn(async move { reader.read(Fid(1), 0, 64).await });
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(
+        !handle.is_finished(),
+        "imported stream read returned before remote stream had data"
+    );
+
+    stream.append(b"late bytes").await;
+    let got = tokio::time::timeout(Duration::from_millis(500), handle)
+        .await
+        .expect("imported stream read did not wake")
+        .expect("reader task panicked");
+    assert_eq!(got, Ok(b"late bytes".to_vec()));
+
+    drop(imported);
+    server_task.abort();
+}

--- a/openspec/changes/add-ap-wire-transport/.openspec.yaml
+++ b/openspec/changes/add-ap-wire-transport/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/add-ap-wire-transport/design.md
+++ b/openspec/changes/add-ap-wire-transport/design.md
@@ -1,0 +1,81 @@
+## Context
+
+ADR-0025 makes `alan-ap` the owner of Alan's file-service protocol and its
+transport shape. The crate already has serializable `Request`/`Response` values,
+an in-process fast path, and tests proving each operation is wire-shaped. ADR-0026
+D1 records the missing Ring 3 capability: importing/exporting aP file trees across
+machines so distributed agents mount remote resources instead of calling a new
+RPC mesh.
+
+This slice turns the existing wire-shaped contract into a real byte transport
+without changing any `FileServer` implementation or kernel API.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Carry every existing aP `Request`/`Response` across an async byte stream.
+- Export any `FileServer` through a server loop that receives requests and sends
+  responses.
+- Import a remote tree as a `FileServer` adapter so local clients keep using the
+  same walk/open/read/write/stat/create/remove/clunk semantics.
+- Preserve typed `ErrorCode` failures across the transport.
+- Keep the kernel unaware of the transport.
+
+**Non-Goals:**
+
+- Network discovery, peer identity, auth, encryption, reconnect, or multiplexing.
+- Public CLI/daemon commands for remote hosts.
+- Cross-host Service Manager policy or distributed-agent product UX.
+- Literal 9P compatibility.
+
+## Decisions
+
+1. **Implement the first wire transport inside `alan-ap`.**
+
+   `alan-ap` already owns protocol messages and `InProcessTransport`; putting the
+   byte transport beside them keeps protocol ownership coherent and avoids a
+   second crate that must mirror every future operation.
+
+   Alternative considered: add `alan-ap-wire` as a separate crate. That keeps
+   optional transport dependencies out of `alan-ap`, but the current dependencies
+   already include Tokio and Serde, and ADR-0025 names the in-process and future
+   wire transports as part of aP.
+
+2. **Use newline-delimited JSON frames for v1.**
+
+   A frame is one JSON object plus `\n`. The format is debuggable, works with
+   existing Serde types, and is enough to prove import/export semantics.
+
+   Alternative considered: length-prefixed binary frames. That is more compact
+   and handles arbitrary payload bytes without escaping overhead, but it makes
+   the first slice less inspectable. We can add a binary codec later without
+   changing `Request`/`Response`.
+
+3. **Wrap responses in an envelope that can carry typed errors.**
+
+   `Response` only represents successful operation results. The transport must
+   preserve `Result<Response, ErrorCode>`, so the wire response is an explicit
+   success/error envelope.
+
+4. **Keep v1 strictly one request in flight per connection.**
+
+   The imported adapter serializes calls with a mutex around the stream. That
+   avoids request IDs and response reordering while still proving that a remote
+   tree can be used like a local one. Multiplexing can be added later as a
+   compatible transport upgrade.
+
+## Risks / Trade-offs
+
+- [Risk] JSON framing is inefficient for high-rate streams. -> Mitigation: this
+  is a correctness slice; the protocol messages stay codec-independent.
+- [Risk] A single in-flight request can head-of-line block on a blocking stream
+  read. -> Mitigation: v1 makes that limitation explicit; later multiplexing can
+  add request IDs without changing `FileServer`.
+- [Risk] Transport IO failures do not map perfectly onto file-server errors. ->
+  Mitigation: v1 maps malformed frames and IO shutdown to `ErrorCode::Io` or
+  `ErrorCode::BadRequest` at the adapter boundary, keeping clients in typed aP
+  error space.
+- [Risk] Adding transport code to `alan-ap` could tempt kernel coupling. ->
+  Mitigation: dependency-boundary tests continue to require `alan-kernel` to
+  depend only on `alan-ap`, and the kernel does not call transport constructors.

--- a/openspec/changes/add-ap-wire-transport/proposal.md
+++ b/openspec/changes/add-ap-wire-transport/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+ADR-0026 D1 records aP network transparency as the next Ring 3 North Star slice
+after content-addressed knowledge and routefs. The in-process aP contract is now
+usable enough that we can add the first import/export transport without changing
+clients or turning distributed agents into an RPC mesh.
+
+## What Changes
+
+- Add a small aP wire transport that serializes aP operations and responses over
+  an async byte stream.
+- Provide an exported-server loop that serves any `alan_ap::FileServer` through
+  the wire protocol.
+- Provide an imported-client adapter that implements `alan_ap::FileServer` while
+  forwarding operations to the exported remote tree.
+- Preserve local semantics: clients use the same walk/open/read/write/clunk API
+  whether the tree is local or imported.
+- Keep this slice transport-focused; discovery, auth, encryption, multi-host
+  topology, and distributed-agent product UX remain later work.
+
+## Capabilities
+
+### New Capabilities
+
+- `ap-wire-transport`: Defines import/export of aP file trees over a byte
+  transport while preserving normal aP operation semantics for clients.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Extends the `alan-ap` transport layer; `alan-kernel` remains
+  dependency-isolated and transport-agnostic.
+- Adds focused integration tests using in-memory async streams and existing aP
+  file servers.
+- Updates workspace wiring and OpenSpec coverage for the network-transparency
+  slice referenced by ADR-0026 and ADR-0027.

--- a/openspec/changes/add-ap-wire-transport/specs/ap-wire-transport/spec.md
+++ b/openspec/changes/add-ap-wire-transport/specs/ap-wire-transport/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: aP operations are framed over bytes
+
+Alan SHALL provide a byte transport representation for every existing aP
+`Request` and for every successful or failed aP response.
+
+#### Scenario: Request survives byte framing
+
+- **WHEN** a client encodes any supported aP request as a wire frame
+- **THEN** the receiver decodes the same request value without in-process state
+  or borrowed data
+
+#### Scenario: Response result survives byte framing
+
+- **WHEN** a server encodes either a successful aP response or a typed
+  `ErrorCode` as a wire frame
+- **THEN** the receiver decodes the same `Result<Response, ErrorCode>` value
+
+### Requirement: Any file server can be exported
+
+Alan SHALL provide a server-side transport loop that accepts framed aP requests,
+dispatches them to an `alan_ap::FileServer`, and writes framed response results.
+
+#### Scenario: Exported server dispatches normal operations
+
+- **WHEN** a remote client sends framed walk/open/read/write/stat/create/remove
+  or clunk requests
+- **THEN** the export loop invokes the same `FileServer` methods as the
+  in-process transport
+
+#### Scenario: Exported server preserves typed failures
+
+- **WHEN** the exported file server returns an aP `ErrorCode`
+- **THEN** the transport sends that typed failure instead of collapsing it into
+  an unstructured IO failure
+
+### Requirement: Remote trees import as file servers
+
+Alan SHALL provide a client-side adapter that implements `alan_ap::FileServer`
+while forwarding operations over the wire transport to an exported remote tree.
+
+#### Scenario: Imported tree is used like a local tree
+
+- **WHEN** a local client uses the imported adapter through walk/open/read/write,
+  stat, create, remove, or clunk
+- **THEN** the client observes normal aP results and does not distinguish the
+  imported tree from an in-process file server
+
+#### Scenario: Blocking stream reads preserve aP semantics
+
+- **WHEN** a local client reads from an imported stream before the remote stream
+  has data at the requested offset
+- **THEN** the read remains pending until the remote file server produces data
+
+### Requirement: Kernel remains transport agnostic
+
+Alan SHALL keep aP wire import/export above the kernel boundary; `alan-kernel`
+SHALL NOT depend on transport-specific crates or call transport-specific APIs.
+
+#### Scenario: Kernel dependency boundary is preserved
+
+- **WHEN** the aP wire transport is added
+- **THEN** `alan-kernel` still depends only on `alan-ap` among Alan crates
+- **AND** remote import/export is represented to the kernel as ordinary mounted
+  file-server handles

--- a/openspec/changes/add-ap-wire-transport/tasks.md
+++ b/openspec/changes/add-ap-wire-transport/tasks.md
@@ -1,0 +1,64 @@
+## 1. Wire Frames
+
+- [x] 1.1 Add public aP wire frame types for request frames and
+  `Result<Response, ErrorCode>` response frames.
+  Done 2026-07-02: added `WireRequestFrame`, `WireResponseFrame`, and
+  `WireError` to `alan-ap`.
+- [x] 1.2 Implement newline-delimited JSON encode/decode helpers over async byte
+  streams.
+  Done 2026-07-02: added request/response encode, decode, read, and write
+  helpers for newline-delimited JSON frames.
+- [x] 1.3 Add focused tests proving every request and response result survives
+  byte framing.
+  Done 2026-07-02: `crates/ap/tests/wire_transport.rs` covers every aP request
+  and both successful/error response results.
+
+## 2. Export Loop
+
+- [x] 2.1 Add an export loop that reads framed requests, dispatches them through
+  the same `FileServer` methods as `InProcessTransport`, and writes framed
+  response results.
+  Done 2026-07-02: added `export_file_server`, which dispatches through
+  `InProcessTransport` and writes a framed operation result.
+- [x] 2.2 Preserve typed `ErrorCode` values returned by the exported server.
+  Done 2026-07-02: response frames carry typed `ErrorCode` values; tests verify
+  `NoAccess` survives an exported/imported write failure.
+
+## 3. Import Adapter
+
+- [x] 3.1 Add an imported-tree adapter that implements `FileServer` and forwards
+  each method over the wire transport.
+  Done 2026-07-02: added `WireTransportClient` and `ImportedFileServer` with
+  method-by-method forwarding to the exported remote tree.
+- [x] 3.2 Serialize v1 calls to one in-flight request per connection and document
+  that multiplexing is a later transport upgrade.
+  Done 2026-07-02: `ImportedFileServer` guards one connection with a mutex, and
+  the API docs/design document call out multiplexing as later work.
+- [x] 3.3 Preserve blocking stream-read semantics through the imported adapter.
+  Done 2026-07-02: added a remote `Stream` test proving imported reads stay
+  pending until the exported server's stream produces data.
+
+## 4. Boundaries And Verification
+
+- [x] 4.1 Verify `alan-kernel` stays transport-agnostic and depends only on
+  `alan-ap` among Alan crates.
+  Done 2026-07-02: `cargo test -p alan-kernel --test dependency_boundary --
+  --nocapture` passed.
+- [x] 4.2 Run focused aP transport tests.
+  Done 2026-07-02: `cargo test -p alan-ap -- --nocapture` and
+  `cargo clippy -p alan-ap --all-targets --all-features -- -D warnings` passed.
+- [x] 4.3 Run `just verify`.
+  Done 2026-07-02: `just verify` passed, including workspace fmt, clippy,
+  tests, doctests, and the `alan` smoke suite.
+- [x] 4.4 Run `openspec validate add-ap-wire-transport --strict`.
+  Done 2026-07-02: strict OpenSpec validation passed for
+  `add-ap-wire-transport`.
+
+## 5. PR Hygiene
+
+- [x] 5.1 Commit this slice separately from routefs.
+  Done 2026-07-03: committed as
+  `feat(ap): add wire import export transport` on `feat/northstar-ap-wire`.
+- [x] 5.2 Open a stacked draft PR on top of `feat/northstar-routefs`.
+  Done 2026-07-03: opened #591 on top of `feat/northstar-routefs`, then marked
+  it ready for review to match the current PR workflow.


### PR DESCRIPTION
Stack: 6/6, stacked on #590 / feat/northstar-routefs.

This implements the add-ap-wire-transport Ring 3 network-transparency slice from ADR-0026 D1 / ADR-0027: aP request/result framing over async byte streams, an export loop for any alan_ap::FileServer, and an imported FileServer adapter that preserves normal aP semantics for clients.

Scope kept intentionally transport-focused: no discovery, auth, encryption, reconnect, multiplexing, CLI UX, or distributed-agent product flow yet.

Verification:
- just verify
- cargo test -p alan-ap -- --nocapture
- cargo clippy -p alan-ap --all-targets --all-features -- -D warnings
- cargo test -p alan-kernel --test dependency_boundary -- --nocapture
- openspec validate add-ap-wire-transport --strict
- git diff --check