### PR TITLE
North Star 8/8: add headless editable buffer file server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "alan-editfs"
+version = "0.1.0"
+dependencies = [
+ "alan-ap",
+ "async-trait",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "alan-kernel"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/knowledge",
     "crates/memfs",
     "crates/routefs",
+    "crates/editfs",
     "crates/agent-protocol",
     "crates/llm",
     "crates/llmfs",
@@ -122,6 +123,7 @@ alan-agent-engine = { path = "crates/agent-engine" }
 alan-knowledge = { path = "crates/knowledge" }
 alan-memfs = { path = "crates/memfs" }
 alan-routefs = { path = "crates/routefs" }
+alan-editfs = { path = "crates/editfs" }
 alan-swebench-tooling = { path = "crates/agent-engine/skills/swebench/tooling" }
 alan-shell-core = { path = "crates/shell-core" }
 alan-shell-core-ffi = { path = "crates/shell-core-ffi" }

--- a/crates/ap/src/lib.rs
+++ b/crates/ap/src/lib.rs
@@ -28,7 +28,7 @@ pub use stream::Stream;
 pub use types::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Stat};
 pub use version::VersionTable;
 pub use wire::{
-    Request, Response, WireError, WireRequestFrame, WireResponseFrame, decode_request_frame,
-    decode_response_frame, encode_request_frame, encode_response_frame, read_request_frame,
-    read_response_frame, write_request_frame, write_response_frame,
+    MAX_WIRE_FRAME_BYTES, Request, Response, WireError, WireRequestFrame, WireResponseFrame,
+    decode_request_frame, decode_response_frame, encode_request_frame, encode_response_frame,
+    read_request_frame, read_response_frame, write_request_frame, write_response_frame,
 };

--- a/crates/ap/src/lib.rs
+++ b/crates/ap/src/lib.rs
@@ -19,11 +19,16 @@ mod version;
 mod wire;
 
 pub use server::{
-    FileServer, InProcessTransport, ProcessEvent, ProcessEventSink, ProcessEventSource,
-    ProcessInputEventSink, ProcessInputEventSource, ProcessIoEventKind, ProcessIoEventSink,
-    ProcessIoEventSource, ProcessOutputEventSink, ProcessOutputEventSource,
+    FileServer, ImportedFileServer, InProcessTransport, ProcessEvent, ProcessEventSink,
+    ProcessEventSource, ProcessInputEventSink, ProcessInputEventSource, ProcessIoEventKind,
+    ProcessIoEventSink, ProcessIoEventSource, ProcessOutputEventSink, ProcessOutputEventSource,
+    WireTransportClient, export_file_server,
 };
 pub use stream::Stream;
 pub use types::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Stat};
 pub use version::VersionTable;
-pub use wire::{Request, Response};
+pub use wire::{
+    Request, Response, WireError, WireRequestFrame, WireResponseFrame, decode_request_frame,
+    decode_response_frame, encode_request_frame, encode_response_frame, read_request_frame,
+    read_response_frame, write_request_frame, write_response_frame,
+};

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -11,12 +11,15 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use tokio::io::{AsyncBufRead, AsyncWrite};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, mpsc, watch};
 
 use crate::wire::{
-    read_request_frame, read_response_frame, write_request_frame, write_response_frame,
+    MAX_WIRE_FRAME_BYTES, read_request_frame, read_response_frame, write_request_frame,
+    write_response_frame,
 };
 use crate::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Request, Response, Stat, WireError};
+
+const MAX_WIRE_WRITE_CHUNK_BYTES: usize = MAX_WIRE_FRAME_BYTES / 8;
 
 /// A file server: the backing implementation of one mountable tree.
 ///
@@ -211,19 +214,59 @@ impl InProcessTransport {
 /// added above this without changing the [`FileServer`] contract.
 pub async fn export_file_server<R, W>(
     server: Arc<dyn FileServer>,
-    mut reader: R,
+    reader: R,
     mut writer: W,
 ) -> Result<(), WireError>
 where
-    R: AsyncBufRead + Unpin,
+    R: AsyncBufRead + Send + Unpin + 'static,
     W: AsyncWrite + Unpin,
 {
     let transport = InProcessTransport::new(server);
-    while let Some(request) = read_request_frame(&mut reader).await? {
-        let result = transport.call(request).await;
+    let (request_tx, mut request_rx) = mpsc::channel(1);
+    let (reader_closed_tx, mut reader_closed_rx) = watch::channel(false);
+    tokio::spawn(read_export_requests(reader, request_tx, reader_closed_tx));
+
+    while let Some(message) = request_rx.recv().await {
+        let ExportReaderMessage::Request(request) = message?;
+        let result = tokio::select! {
+            result = transport.call(request) => result,
+            _ = reader_closed_rx.changed() => return Ok(()),
+        };
         write_response_frame(&mut writer, &result).await?;
     }
     Ok(())
+}
+
+enum ExportReaderMessage {
+    Request(Request),
+}
+
+async fn read_export_requests<R>(
+    mut reader: R,
+    request_tx: mpsc::Sender<Result<ExportReaderMessage, WireError>>,
+    reader_closed_tx: watch::Sender<bool>,
+) where
+    R: AsyncBufRead + Unpin,
+{
+    loop {
+        match read_request_frame(&mut reader).await {
+            Ok(Some(request)) => {
+                if request_tx
+                    .send(Ok(ExportReaderMessage::Request(request)))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            Ok(None) => break,
+            Err(error) => {
+                let _ = request_tx.send(Err(error)).await;
+                break;
+            }
+        }
+    }
+    let _ = reader_closed_tx.send(true);
 }
 
 /// Client side of one aP wire connection.
@@ -343,17 +386,47 @@ where
     }
 
     async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
-        match self
-            .remote_call(Request::Write {
-                fid,
-                offset,
-                data: data.to_vec(),
-            })
-            .await?
-        {
-            Response::Write { count } => Ok(count),
-            _ => Err(ErrorCode::BadRequest),
+        if data.is_empty() {
+            return match self
+                .remote_call(Request::Write {
+                    fid,
+                    offset,
+                    data: Vec::new(),
+                })
+                .await?
+            {
+                Response::Write { count } => Ok(count),
+                _ => Err(ErrorCode::BadRequest),
+            };
         }
+
+        let mut accepted_total = 0usize;
+        for chunk in data.chunks(MAX_WIRE_WRITE_CHUNK_BYTES) {
+            let chunk_offset = offset
+                .checked_add(accepted_total as u64)
+                .ok_or(ErrorCode::BadRequest)?;
+            let accepted = match self
+                .remote_call(Request::Write {
+                    fid,
+                    offset: chunk_offset,
+                    data: chunk.to_vec(),
+                })
+                .await?
+            {
+                Response::Write { count } => count as usize,
+                _ => return Err(ErrorCode::BadRequest),
+            };
+            if accepted > chunk.len() {
+                return Err(ErrorCode::BadRequest);
+            }
+            accepted_total = accepted_total
+                .checked_add(accepted)
+                .ok_or(ErrorCode::BadRequest)?;
+            if accepted < chunk.len() {
+                break;
+            }
+        }
+        u32::try_from(accepted_total).map_err(|_| ErrorCode::BadRequest)
     }
 
     async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -230,6 +230,7 @@ where
 pub struct WireTransportClient<R, W> {
     reader: R,
     writer: W,
+    in_flight: bool,
 }
 
 impl<R, W> WireTransportClient<R, W>
@@ -238,11 +239,30 @@ where
     W: AsyncWrite + Unpin,
 {
     pub fn new(reader: R, writer: W) -> Self {
-        Self { reader, writer }
+        Self {
+            reader,
+            writer,
+            in_flight: false,
+        }
     }
 
     /// Send one request and return the exact remote operation result.
     pub async fn call_result(
+        &mut self,
+        request: Request,
+    ) -> Result<Result<Response, ErrorCode>, WireError> {
+        if self.in_flight {
+            return Err(WireError::Unsynchronized);
+        }
+        self.in_flight = true;
+        let result = self.call_result_in_flight(request).await;
+        if result.is_ok() {
+            self.in_flight = false;
+        }
+        result
+    }
+
+    async fn call_result_in_flight(
         &mut self,
         request: Request,
     ) -> Result<Result<Response, ErrorCode>, WireError> {

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -430,23 +430,36 @@ where
         }
 
         let mut accepted_total = 0usize;
+        let accepted_count = |accepted_total: usize| {
+            u32::try_from(accepted_total).map_err(|_| ErrorCode::BadRequest)
+        };
         for chunk in data.chunks(MAX_WIRE_PAYLOAD_CHUNK_BYTES) {
             let chunk_offset = offset
                 .checked_add(accepted_total as u64)
                 .ok_or(ErrorCode::BadRequest)?;
-            let accepted = match self
+            let response = match self
                 .remote_call(Request::Write {
                     fid,
                     offset: chunk_offset,
                     data: chunk.to_vec(),
                 })
-                .await?
+                .await
             {
+                Ok(response) => response,
+                Err(_) if accepted_total > 0 => return accepted_count(accepted_total),
+                Err(error) => return Err(error),
+            };
+            let accepted = match response {
                 Response::Write { count } => count as usize,
+                _ if accepted_total > 0 => return accepted_count(accepted_total),
                 _ => return Err(ErrorCode::BadRequest),
             };
             if accepted > chunk.len() {
-                return Err(ErrorCode::BadRequest);
+                return if accepted_total > 0 {
+                    accepted_count(accepted_total)
+                } else {
+                    Err(ErrorCode::BadRequest)
+                };
             }
             accepted_total = accepted_total
                 .checked_add(accepted)
@@ -455,7 +468,7 @@ where
                 break;
             }
         }
-        u32::try_from(accepted_total).map_err(|_| ErrorCode::BadRequest)
+        accepted_count(accepted_total)
     }
 
     async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tokio::io::{AsyncBufRead, AsyncWrite};
 use tokio::sync::{Mutex, mpsc, watch};
+use tokio::task::JoinHandle;
 
 use crate::wire::{
     MAX_WIRE_FRAME_BYTES, read_request_frame, read_response_frame, write_request_frame,
@@ -224,17 +225,54 @@ where
     let transport = InProcessTransport::new(server);
     let (request_tx, mut request_rx) = mpsc::channel(1);
     let (reader_closed_tx, mut reader_closed_rx) = watch::channel(false);
-    tokio::spawn(read_export_requests(reader, request_tx, reader_closed_tx));
+    let reader_task = AbortOnDrop::new(tokio::spawn(read_export_requests(
+        reader,
+        request_tx,
+        reader_closed_tx,
+    )));
 
-    while let Some(message) = request_rx.recv().await {
-        let ExportReaderMessage::Request(request) = message?;
-        let result = tokio::select! {
-            result = transport.call(request) => result,
-            _ = reader_closed_rx.changed() => return Ok(()),
-        };
-        write_response_frame(&mut writer, &result).await?;
+    let result = async {
+        while let Some(message) = request_rx.recv().await {
+            let ExportReaderMessage::Request(request) = message?;
+            let result = tokio::select! {
+                result = transport.call(request) => result,
+                _ = reader_closed_rx.changed() => return Ok(()),
+            };
+            write_response_frame(&mut writer, &result).await?;
+        }
+        Ok(())
     }
-    Ok(())
+    .await;
+
+    reader_task.abort_and_join().await;
+    result
+}
+
+struct AbortOnDrop {
+    handle: Option<JoinHandle<()>>,
+}
+
+impl AbortOnDrop {
+    fn new(handle: JoinHandle<()>) -> Self {
+        Self {
+            handle: Some(handle),
+        }
+    }
+
+    async fn abort_and_join(mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+            let _ = handle.await;
+        }
+    }
+}
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        if let Some(handle) = &self.handle {
+            handle.abort();
+        }
+    }
 }
 
 enum ExportReaderMessage {

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -10,8 +10,13 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use tokio::io::{AsyncBufRead, AsyncWrite};
+use tokio::sync::Mutex;
 
-use crate::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Request, Response, Stat};
+use crate::wire::{
+    read_request_frame, read_response_frame, write_request_frame, write_response_frame,
+};
+use crate::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Request, Response, Stat, WireError};
 
 /// A file server: the backing implementation of one mountable tree.
 ///
@@ -195,6 +200,181 @@ impl InProcessTransport {
                 .map(|qid| Response::Create { qid }),
             Request::Remove { fid } => s.remove(fid).await.map(|()| Response::Remove),
             Request::Clunk { fid } => s.clunk(fid).await.map(|()| Response::Clunk),
+        }
+    }
+}
+
+/// Export a [`FileServer`] over the aP byte transport.
+///
+/// The loop is intentionally simple in v1: one connection carries a serialized
+/// sequence of request frames and response-result frames. Multiplexing can be
+/// added above this without changing the [`FileServer`] contract.
+pub async fn export_file_server<R, W>(
+    server: Arc<dyn FileServer>,
+    mut reader: R,
+    mut writer: W,
+) -> Result<(), WireError>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let transport = InProcessTransport::new(server);
+    while let Some(request) = read_request_frame(&mut reader).await? {
+        let result = transport.call(request).await;
+        write_response_frame(&mut writer, &result).await?;
+    }
+    Ok(())
+}
+
+/// Client side of one aP wire connection.
+pub struct WireTransportClient<R, W> {
+    reader: R,
+    writer: W,
+}
+
+impl<R, W> WireTransportClient<R, W>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    pub fn new(reader: R, writer: W) -> Self {
+        Self { reader, writer }
+    }
+
+    /// Send one request and return the exact remote operation result.
+    pub async fn call_result(
+        &mut self,
+        request: Request,
+    ) -> Result<Result<Response, ErrorCode>, WireError> {
+        write_request_frame(&mut self.writer, &request).await?;
+        read_response_frame(&mut self.reader)
+            .await?
+            .ok_or(WireError::Closed)
+    }
+
+    /// Send one request and map transport failures back into aP error space.
+    pub async fn call(&mut self, request: Request) -> Result<Response, ErrorCode> {
+        self.call_result(request)
+            .await
+            .map_err(|error| error.to_error_code())?
+    }
+}
+
+/// A remote aP tree imported as a normal [`FileServer`].
+///
+/// V1 serializes requests through one connection. This preserves aP semantics and
+/// keeps request IDs out of the first wire slice; a later transport can add
+/// multiplexing without changing clients.
+pub struct ImportedFileServer<R, W> {
+    client: Mutex<WireTransportClient<R, W>>,
+}
+
+impl<R, W> ImportedFileServer<R, W>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    pub fn new(reader: R, writer: W) -> Self {
+        Self {
+            client: Mutex::new(WireTransportClient::new(reader, writer)),
+        }
+    }
+
+    async fn remote_call(&self, request: Request) -> Result<Response, ErrorCode> {
+        self.client.lock().await.call(request).await
+    }
+}
+
+#[async_trait]
+impl<R, W> FileServer for ImportedFileServer<R, W>
+where
+    R: AsyncBufRead + Send + Unpin + 'static,
+    W: AsyncWrite + Send + Unpin + 'static,
+{
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        match self
+            .remote_call(Request::Walk {
+                fid,
+                newfid,
+                names: names.to_vec(),
+            })
+            .await?
+        {
+            Response::Walk { qid } => Ok(qid),
+            _ => Err(ErrorCode::BadRequest),
+        }
+    }
+
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
+        match self.remote_call(Request::Open { fid, mode }).await? {
+            Response::Open { qid } => Ok(qid),
+            _ => Err(ErrorCode::BadRequest),
+        }
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        match self
+            .remote_call(Request::Read { fid, offset, count })
+            .await?
+        {
+            Response::Read { data } => Ok(data),
+            _ => Err(ErrorCode::BadRequest),
+        }
+    }
+
+    async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        match self
+            .remote_call(Request::Write {
+                fid,
+                offset,
+                data: data.to_vec(),
+            })
+            .await?
+        {
+            Response::Write { count } => Ok(count),
+            _ => Err(ErrorCode::BadRequest),
+        }
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        match self.remote_call(Request::Stat { fid }).await? {
+            Response::Stat { stat } => Ok(stat),
+            _ => Err(ErrorCode::BadRequest),
+        }
+    }
+
+    async fn create(
+        &self,
+        fid: Fid,
+        newfid: Fid,
+        name: &str,
+        kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        match self
+            .remote_call(Request::Create {
+                fid,
+                newfid,
+                name: name.to_string(),
+                kind,
+            })
+            .await?
+        {
+            Response::Create { qid } => Ok(qid),
+            _ => Err(ErrorCode::BadRequest),
+        }
+    }
+
+    async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
+        match self.remote_call(Request::Remove { fid }).await? {
+            Response::Remove => Ok(()),
+            _ => Err(ErrorCode::BadRequest),
+        }
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        match self.remote_call(Request::Clunk { fid }).await? {
+            Response::Clunk => Ok(()),
+            _ => Err(ErrorCode::BadRequest),
         }
     }
 }

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -19,7 +19,7 @@ use crate::wire::{
 };
 use crate::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Request, Response, Stat, WireError};
 
-const MAX_WIRE_WRITE_CHUNK_BYTES: usize = MAX_WIRE_FRAME_BYTES / 8;
+const MAX_WIRE_PAYLOAD_CHUNK_BYTES: usize = MAX_WIRE_FRAME_BYTES / 8;
 
 /// A file server: the backing implementation of one mountable tree.
 ///
@@ -376,6 +376,7 @@ where
     }
 
     async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let count = count.min(MAX_WIRE_PAYLOAD_CHUNK_BYTES as u32);
         match self
             .remote_call(Request::Read { fid, offset, count })
             .await?
@@ -401,7 +402,7 @@ where
         }
 
         let mut accepted_total = 0usize;
-        for chunk in data.chunks(MAX_WIRE_WRITE_CHUNK_BYTES) {
+        for chunk in data.chunks(MAX_WIRE_PAYLOAD_CHUNK_BYTES) {
             let chunk_offset = offset
                 .checked_add(accepted_total as u64)
                 .ok_or(ErrorCode::BadRequest)?;

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use tokio::io::{AsyncBufRead, AsyncWrite};
-use tokio::sync::{Mutex, mpsc, watch};
+use tokio::sync::{Mutex, mpsc};
 use tokio::task::JoinHandle;
 
 use crate::wire::{
@@ -224,20 +224,12 @@ where
 {
     let transport = InProcessTransport::new(server);
     let (request_tx, mut request_rx) = mpsc::channel(1);
-    let (reader_closed_tx, mut reader_closed_rx) = watch::channel(false);
-    let reader_task = AbortOnDrop::new(tokio::spawn(read_export_requests(
-        reader,
-        request_tx,
-        reader_closed_tx,
-    )));
+    let reader_task = AbortOnDrop::new(tokio::spawn(read_export_requests(reader, request_tx)));
 
     let result = async {
         while let Some(message) = request_rx.recv().await {
             let ExportReaderMessage::Request(request) = message?;
-            let result = tokio::select! {
-                result = transport.call(request) => result,
-                _ = reader_closed_rx.changed() => return Ok(()),
-            };
+            let result = transport.call(request).await;
             write_response_frame(&mut writer, &result).await?;
         }
         Ok(())
@@ -282,7 +274,6 @@ enum ExportReaderMessage {
 async fn read_export_requests<R>(
     mut reader: R,
     request_tx: mpsc::Sender<Result<ExportReaderMessage, WireError>>,
-    reader_closed_tx: watch::Sender<bool>,
 ) where
     R: AsyncBufRead + Unpin,
 {
@@ -304,7 +295,6 @@ async fn read_export_requests<R>(
             }
         }
     }
-    let _ = reader_closed_tx.send(true);
 }
 
 /// Client side of one aP wire connection.

--- a/crates/ap/src/wire.rs
+++ b/crates/ap/src/wire.rs
@@ -127,6 +127,8 @@ pub enum WireError {
     Unsynchronized,
     #[error("aP wire frame exceeds {max} bytes")]
     FrameTooLarge { max: usize },
+    #[error("aP wire frame ended before newline delimiter")]
+    TruncatedFrame,
 }
 
 impl WireError {
@@ -134,7 +136,9 @@ impl WireError {
     /// imported file-server adapters.
     pub fn to_error_code(&self) -> ErrorCode {
         match self {
-            Self::Codec(_) | Self::FrameTooLarge { .. } => ErrorCode::BadRequest,
+            Self::Codec(_) | Self::FrameTooLarge { .. } | Self::TruncatedFrame => {
+                ErrorCode::BadRequest
+            }
             Self::Io(_) | Self::Closed | Self::Unsynchronized => ErrorCode::Io,
         }
     }
@@ -225,7 +229,7 @@ where
             return if frame.is_empty() {
                 Ok(None)
             } else {
-                Ok(Some(frame))
+                Err(WireError::TruncatedFrame)
             };
         }
 

--- a/crates/ap/src/wire.rs
+++ b/crates/ap/src/wire.rs
@@ -120,6 +120,8 @@ pub enum WireError {
     Codec(#[from] serde_json::Error),
     #[error("aP wire peer closed before a response frame")]
     Closed,
+    #[error("aP wire connection has an abandoned in-flight request")]
+    Unsynchronized,
 }
 
 impl WireError {
@@ -128,7 +130,7 @@ impl WireError {
     pub fn to_error_code(&self) -> ErrorCode {
         match self {
             Self::Codec(_) => ErrorCode::BadRequest,
-            Self::Io(_) | Self::Closed => ErrorCode::Io,
+            Self::Io(_) | Self::Closed | Self::Unsynchronized => ErrorCode::Io,
         }
     }
 }

--- a/crates/ap/src/wire.rs
+++ b/crates/ap/src/wire.rs
@@ -13,8 +13,9 @@
 //! to learn the allocated resource's name, then `walk`s to that name.
 
 use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt};
 
-use crate::{Fid, FileKind, Offset, OpenMode, Qid, Stat};
+use crate::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Stat};
 
 /// One aP operation request. Inputs are fids, paths (name components), byte
 /// buffers, offsets, and counts — nothing in-process-only.
@@ -72,4 +73,148 @@ pub enum Response {
     Create { qid: Qid },
     Remove,
     Clunk,
+}
+
+/// A newline-delimited request frame carried by the aP byte transport.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WireRequestFrame {
+    pub request: Request,
+}
+
+/// A newline-delimited response frame carried by the aP byte transport.
+///
+/// Successful aP operation results and typed [`ErrorCode`] failures are both
+/// first-class protocol results. Transport IO/codec failures stay outside this
+/// envelope and map to [`WireError`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "status")]
+pub enum WireResponseFrame {
+    Ok { response: Response },
+    Error { code: ErrorCode },
+}
+
+impl WireResponseFrame {
+    pub fn from_result(result: &Result<Response, ErrorCode>) -> Self {
+        match result {
+            Ok(response) => Self::Ok {
+                response: response.clone(),
+            },
+            Err(code) => Self::Error { code: *code },
+        }
+    }
+
+    pub fn into_result(self) -> Result<Response, ErrorCode> {
+        match self {
+            Self::Ok { response } => Ok(response),
+            Self::Error { code } => Err(code),
+        }
+    }
+}
+
+/// Errors in the byte transport itself, separate from aP operation failures.
+#[derive(Debug, thiserror::Error)]
+pub enum WireError {
+    #[error("aP wire io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("aP wire codec error: {0}")]
+    Codec(#[from] serde_json::Error),
+    #[error("aP wire peer closed before a response frame")]
+    Closed,
+}
+
+impl WireError {
+    /// Map transport-level failures back into typed aP operation errors for
+    /// imported file-server adapters.
+    pub fn to_error_code(&self) -> ErrorCode {
+        match self {
+            Self::Codec(_) => ErrorCode::BadRequest,
+            Self::Io(_) | Self::Closed => ErrorCode::Io,
+        }
+    }
+}
+
+pub fn encode_request_frame(request: &Request) -> Result<Vec<u8>, WireError> {
+    encode_json_line(&WireRequestFrame {
+        request: request.clone(),
+    })
+}
+
+pub fn decode_request_frame(frame: &[u8]) -> Result<Request, WireError> {
+    let frame: WireRequestFrame = serde_json::from_slice(frame)?;
+    Ok(frame.request)
+}
+
+pub fn encode_response_frame(result: &Result<Response, ErrorCode>) -> Result<Vec<u8>, WireError> {
+    encode_json_line(&WireResponseFrame::from_result(result))
+}
+
+pub fn decode_response_frame(frame: &[u8]) -> Result<Result<Response, ErrorCode>, WireError> {
+    let frame: WireResponseFrame = serde_json::from_slice(frame)?;
+    Ok(frame.into_result())
+}
+
+pub async fn write_request_frame<W>(writer: &mut W, request: &Request) -> Result<(), WireError>
+where
+    W: AsyncWrite + Unpin,
+{
+    let frame = encode_request_frame(request)?;
+    writer.write_all(&frame).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+pub async fn read_request_frame<R>(reader: &mut R) -> Result<Option<Request>, WireError>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let Some(frame) = read_json_line(reader).await? else {
+        return Ok(None);
+    };
+    decode_request_frame(&frame).map(Some)
+}
+
+pub async fn write_response_frame<W>(
+    writer: &mut W,
+    result: &Result<Response, ErrorCode>,
+) -> Result<(), WireError>
+where
+    W: AsyncWrite + Unpin,
+{
+    let frame = encode_response_frame(result)?;
+    writer.write_all(&frame).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+pub async fn read_response_frame<R>(
+    reader: &mut R,
+) -> Result<Option<Result<Response, ErrorCode>>, WireError>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let Some(frame) = read_json_line(reader).await? else {
+        return Ok(None);
+    };
+    decode_response_frame(&frame).map(Some)
+}
+
+fn encode_json_line<T>(value: &T) -> Result<Vec<u8>, WireError>
+where
+    T: Serialize,
+{
+    let mut frame = serde_json::to_vec(value)?;
+    frame.push(b'\n');
+    Ok(frame)
+}
+
+async fn read_json_line<R>(reader: &mut R) -> Result<Option<Vec<u8>>, WireError>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut frame = Vec::new();
+    let read = reader.read_until(b'\n', &mut frame).await?;
+    if read == 0 {
+        return Ok(None);
+    }
+    Ok(Some(frame))
 }

--- a/crates/ap/src/wire.rs
+++ b/crates/ap/src/wire.rs
@@ -17,6 +17,9 @@ use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Stat};
 
+/// Maximum newline-delimited aP wire frame accepted by the v1 byte transport.
+pub const MAX_WIRE_FRAME_BYTES: usize = 1 << 20; // 1 MiB
+
 /// One aP operation request. Inputs are fids, paths (name components), byte
 /// buffers, offsets, and counts — nothing in-process-only.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -122,6 +125,8 @@ pub enum WireError {
     Closed,
     #[error("aP wire connection has an abandoned in-flight request")]
     Unsynchronized,
+    #[error("aP wire frame exceeds {max} bytes")]
+    FrameTooLarge { max: usize },
 }
 
 impl WireError {
@@ -129,7 +134,7 @@ impl WireError {
     /// imported file-server adapters.
     pub fn to_error_code(&self) -> ErrorCode {
         match self {
-            Self::Codec(_) => ErrorCode::BadRequest,
+            Self::Codec(_) | Self::FrameTooLarge { .. } => ErrorCode::BadRequest,
             Self::Io(_) | Self::Closed | Self::Unsynchronized => ErrorCode::Io,
         }
     }
@@ -214,9 +219,31 @@ where
     R: AsyncBufRead + Unpin,
 {
     let mut frame = Vec::new();
-    let read = reader.read_until(b'\n', &mut frame).await?;
-    if read == 0 {
-        return Ok(None);
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            return if frame.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(frame))
+            };
+        }
+
+        let consumed = if let Some(newline) = available.iter().position(|byte| *byte == b'\n') {
+            newline + 1
+        } else {
+            available.len()
+        };
+        if frame.len().saturating_add(consumed) > MAX_WIRE_FRAME_BYTES {
+            return Err(WireError::FrameTooLarge {
+                max: MAX_WIRE_FRAME_BYTES,
+            });
+        }
+        frame.extend_from_slice(&available[..consumed]);
+        reader.consume(consumed);
+
+        if frame.last() == Some(&b'\n') {
+            return Ok(Some(frame));
+        }
     }
-    Ok(Some(frame))
 }

--- a/crates/ap/tests/wire.rs
+++ b/crates/ap/tests/wire.rs
@@ -5,7 +5,13 @@
 //! trip. If any aP type stops being wire-shaped (borrows, non-serializable
 //! fields), these tests fail before any wire transport exists.
 
-use alan_ap::{ErrorCode, Fid, FileKind, OpenMode, Qid, Request, Response, Stat};
+use std::io::Cursor;
+
+use alan_ap::{
+    ErrorCode, Fid, FileKind, MAX_WIRE_FRAME_BYTES, OpenMode, Qid, Request, Response, Stat,
+    WireError, read_request_frame,
+};
+use tokio::io::BufReader;
 
 fn roundtrip<T>(value: &T) -> T
 where
@@ -141,4 +147,30 @@ fn every_response_operation_survives_roundtrip() {
     for resp in responses {
         assert_eq!(roundtrip(&resp), resp);
     }
+}
+
+#[tokio::test]
+async fn oversized_request_frame_without_newline_is_rejected() {
+    let mut reader = BufReader::new(Cursor::new(vec![b'x'; MAX_WIRE_FRAME_BYTES + 1]));
+
+    assert!(matches!(
+        read_request_frame(&mut reader).await,
+        Err(WireError::FrameTooLarge {
+            max: MAX_WIRE_FRAME_BYTES
+        })
+    ));
+}
+
+#[tokio::test]
+async fn oversized_request_frame_with_newline_is_rejected() {
+    let mut frame = vec![b'x'; MAX_WIRE_FRAME_BYTES + 1];
+    frame.push(b'\n');
+    let mut reader = BufReader::new(Cursor::new(frame));
+
+    assert!(matches!(
+        read_request_frame(&mut reader).await,
+        Err(WireError::FrameTooLarge {
+            max: MAX_WIRE_FRAME_BYTES
+        })
+    ));
 }

--- a/crates/ap/tests/wire.rs
+++ b/crates/ap/tests/wire.rs
@@ -9,7 +9,7 @@ use std::io::Cursor;
 
 use alan_ap::{
     ErrorCode, Fid, FileKind, MAX_WIRE_FRAME_BYTES, OpenMode, Qid, Request, Response, Stat,
-    WireError, read_request_frame,
+    WireError, encode_request_frame, read_request_frame,
 };
 use tokio::io::BufReader;
 
@@ -172,5 +172,17 @@ async fn oversized_request_frame_with_newline_is_rejected() {
         Err(WireError::FrameTooLarge {
             max: MAX_WIRE_FRAME_BYTES
         })
+    ));
+}
+
+#[tokio::test]
+async fn request_frame_without_newline_is_rejected() {
+    let mut frame = encode_request_frame(&Request::Stat { fid: Fid(1) }).unwrap();
+    assert_eq!(frame.pop(), Some(b'\n'));
+    let mut reader = BufReader::new(Cursor::new(frame));
+
+    assert!(matches!(
+        read_request_frame(&mut reader).await,
+        Err(WireError::TruncatedFrame)
     ));
 }

--- a/crates/ap/tests/wire_transport.rs
+++ b/crates/ap/tests/wire_transport.rs
@@ -9,6 +9,7 @@ use alan_ap::{
     encode_response_frame, export_file_server,
 };
 use tokio::io::{BufReader, duplex};
+use tokio::sync::Notify;
 
 fn qid(kind: FileKind, path: u64) -> Qid {
     Qid {
@@ -198,6 +199,7 @@ async fn imported_tree_dispatches_to_exported_server() {
 
 struct StreamFile {
     stream: Stream,
+    read_started: Option<Arc<Notify>>,
 }
 
 #[async_trait::async_trait]
@@ -216,6 +218,9 @@ impl FileServer for StreamFile {
 
     async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
         if fid == Fid(1) {
+            if let Some(read_started) = &self.read_started {
+                read_started.notify_one();
+            }
             Ok(self.stream.read(offset, count).await)
         } else {
             Err(ErrorCode::NotFound)
@@ -267,6 +272,7 @@ async fn imported_stream_read_blocks_until_remote_stream_has_data() {
     let stream = Stream::new();
     let server: Arc<dyn FileServer> = Arc::new(StreamFile {
         stream: stream.clone(),
+        read_started: None,
     });
     let server_task = tokio::spawn(export_file_server(
         server,
@@ -295,6 +301,51 @@ async fn imported_stream_read_blocks_until_remote_stream_has_data() {
         .expect("imported stream read did not wake")
         .expect("reader task panicked");
     assert_eq!(got, Ok(b"late bytes".to_vec()));
+
+    drop(imported);
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn cancelled_in_flight_call_does_not_desynchronize_next_request() {
+    let (client_stream, server_stream) = duplex(4096);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+
+    let stream = Stream::new();
+    let read_started = Arc::new(Notify::new());
+    let server: Arc<dyn FileServer> = Arc::new(StreamFile {
+        stream: stream.clone(),
+        read_started: Some(Arc::clone(&read_started)),
+    });
+    let server_task = tokio::spawn(export_file_server(
+        server,
+        BufReader::new(server_read),
+        server_write,
+    ));
+    let imported = Arc::new(ImportedFileServer::new(
+        BufReader::new(client_read),
+        client_write,
+    ));
+
+    imported.open(Fid(1), OpenMode::Read).await.unwrap();
+    let reader = Arc::clone(&imported);
+    let handle = tokio::spawn(async move { reader.read(Fid(1), 0, 64).await });
+    tokio::time::timeout(Duration::from_millis(500), read_started.notified())
+        .await
+        .expect("remote read request did not reach exported server");
+
+    handle.abort();
+    assert!(
+        handle
+            .await
+            .expect_err("reader task should have been cancelled")
+            .is_cancelled()
+    );
+
+    stream.append(b"abandoned response").await;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(imported.stat(Fid(1)).await, Err(ErrorCode::Io));
 
     drop(imported);
     server_task.abort();

--- a/crates/ap/tests/wire_transport.rs
+++ b/crates/ap/tests/wire_transport.rs
@@ -2,13 +2,17 @@
 
 use std::sync::Arc;
 use std::time::Duration;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use alan_ap::{
     ErrorCode, Fid, FileKind, FileServer, ImportedFileServer, MAX_WIRE_FRAME_BYTES, Offset,
     OpenMode, Qid, Request, Response, Stat, Stream, decode_request_frame, decode_response_frame,
     encode_request_frame, encode_response_frame, export_file_server,
 };
-use tokio::io::{BufReader, duplex};
+use tokio::io::{AsyncBufRead, AsyncRead, BufReader, ReadBuf, duplex};
 use tokio::sync::{Mutex, Notify};
 
 fn qid(kind: FileKind, path: u64) -> Qid {
@@ -16,6 +20,51 @@ fn qid(kind: FileKind, path: u64) -> Qid {
         kind,
         version: 0,
         path,
+    }
+}
+
+struct DropNotifyReader<R> {
+    inner: R,
+    dropped: Arc<Notify>,
+}
+
+impl<R> DropNotifyReader<R> {
+    fn new(inner: R, dropped: Arc<Notify>) -> Self {
+        Self { inner, dropped }
+    }
+}
+
+impl<R> Drop for DropNotifyReader<R> {
+    fn drop(&mut self) {
+        self.dropped.notify_one();
+    }
+}
+
+impl<R> AsyncRead for DropNotifyReader<R>
+where
+    R: AsyncRead + Unpin,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl<R> AsyncBufRead for DropNotifyReader<R>
+where
+    R: AsyncBufRead + Unpin,
+{
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<&[u8]>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.inner).poll_fill_buf(cx)
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        let this = self.get_mut();
+        Pin::new(&mut this.inner).consume(amt);
     }
 }
 
@@ -195,6 +244,27 @@ async fn imported_tree_dispatches_to_exported_server() {
 
     drop(imported);
     server_task.abort();
+}
+
+#[tokio::test]
+async fn aborting_export_drops_the_background_reader() {
+    let (client_stream, server_stream) = duplex(4096);
+    let (_client_read, client_write) = tokio::io::split(client_stream);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+
+    let reader_dropped = Arc::new(Notify::new());
+    let reader = DropNotifyReader::new(BufReader::new(server_read), Arc::clone(&reader_dropped));
+    let server: Arc<dyn FileServer> = Arc::new(OneFile);
+    let server_task = tokio::spawn(export_file_server(server, reader, server_write));
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    server_task.abort();
+    let _ = server_task.await;
+
+    tokio::time::timeout(Duration::from_millis(500), reader_dropped.notified())
+        .await
+        .expect("export abort left the background reader task alive");
+    drop(client_write);
 }
 
 struct StreamFile {

--- a/crates/ap/tests/wire_transport.rs
+++ b/crates/ap/tests/wire_transport.rs
@@ -534,3 +534,85 @@ async fn imported_large_write_is_split_into_bounded_remote_frames() {
     drop(imported);
     server_task.abort();
 }
+
+struct LargeReadFile {
+    requested_counts: Mutex<Vec<u32>>,
+}
+
+#[async_trait::async_trait]
+impl FileServer for LargeReadFile {
+    async fn walk(&self, _fid: Fid, _newfid: Fid, _names: &[String]) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn read(&self, _fid: Fid, _offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        self.requested_counts.lock().await.push(count);
+        Ok(vec![255; count as usize])
+    }
+
+    async fn write(&self, _fid: Fid, _offset: Offset, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::NoAccess)
+    }
+
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Ok(Stat {
+            name: "large".into(),
+            qid: qid(FileKind::File, 1),
+            length: MAX_WIRE_FRAME_BYTES as u64,
+            writable: false,
+        })
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn imported_large_read_caps_remote_count_to_bounded_frame() {
+    let (client_stream, server_stream) = duplex(1024 * 1024);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+
+    let server = Arc::new(LargeReadFile {
+        requested_counts: Mutex::new(Vec::new()),
+    });
+    let server_task = tokio::spawn(export_file_server(
+        server.clone(),
+        BufReader::new(server_read),
+        server_write,
+    ));
+    let imported = ImportedFileServer::new(BufReader::new(client_read), client_write);
+
+    let data = imported
+        .read(Fid(1), 0, MAX_WIRE_FRAME_BYTES as u32)
+        .await
+        .unwrap();
+    assert!(data.len() < MAX_WIRE_FRAME_BYTES);
+    assert_eq!(
+        server.requested_counts.lock().await.as_slice(),
+        &[data.len() as u32]
+    );
+    assert_eq!(imported.stat(Fid(1)).await.unwrap().name, "large");
+
+    drop(imported);
+    server_task.abort();
+}

--- a/crates/ap/tests/wire_transport.rs
+++ b/crates/ap/tests/wire_transport.rs
@@ -4,12 +4,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use alan_ap::{
-    ErrorCode, Fid, FileKind, FileServer, ImportedFileServer, Offset, OpenMode, Qid, Request,
-    Response, Stat, Stream, decode_request_frame, decode_response_frame, encode_request_frame,
-    encode_response_frame, export_file_server,
+    ErrorCode, Fid, FileKind, FileServer, ImportedFileServer, MAX_WIRE_FRAME_BYTES, Offset,
+    OpenMode, Qid, Request, Response, Stat, Stream, decode_request_frame, decode_response_frame,
+    encode_request_frame, encode_response_frame, export_file_server,
 };
 use tokio::io::{BufReader, duplex};
-use tokio::sync::Notify;
+use tokio::sync::{Mutex, Notify};
 
 fn qid(kind: FileKind, path: u64) -> Qid {
     Qid {
@@ -346,6 +346,190 @@ async fn cancelled_in_flight_call_does_not_desynchronize_next_request() {
     stream.append(b"abandoned response").await;
     tokio::time::sleep(Duration::from_millis(20)).await;
     assert_eq!(imported.stat(Fid(1)).await, Err(ErrorCode::Io));
+
+    drop(imported);
+    server_task.abort();
+}
+
+struct BlockingReadFile {
+    read_started: Arc<Notify>,
+    read_dropped: Arc<Notify>,
+}
+
+#[async_trait::async_trait]
+impl FileServer for BlockingReadFile {
+    async fn walk(&self, _fid: Fid, _newfid: Fid, _names: &[String]) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn read(&self, _fid: Fid, _offset: Offset, _count: u32) -> Result<Vec<u8>, ErrorCode> {
+        struct DropNotify(Arc<Notify>);
+
+        impl Drop for DropNotify {
+            fn drop(&mut self) {
+                self.0.notify_one();
+            }
+        }
+
+        self.read_started.notify_one();
+        let _drop_notify = DropNotify(Arc::clone(&self.read_dropped));
+        std::future::pending().await
+    }
+
+    async fn write(&self, _fid: Fid, _offset: Offset, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::NoAccess)
+    }
+
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn export_cancels_blocking_call_when_peer_disconnects() {
+    let (client_stream, server_stream) = duplex(4096);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+
+    let read_started = Arc::new(Notify::new());
+    let read_dropped = Arc::new(Notify::new());
+    let server: Arc<dyn FileServer> = Arc::new(BlockingReadFile {
+        read_started: Arc::clone(&read_started),
+        read_dropped: Arc::clone(&read_dropped),
+    });
+    let server_task = tokio::spawn(export_file_server(
+        server,
+        BufReader::new(server_read),
+        server_write,
+    ));
+    let imported = Arc::new(ImportedFileServer::new(
+        BufReader::new(client_read),
+        client_write,
+    ));
+
+    let reader = Arc::clone(&imported);
+    let read_task = tokio::spawn(async move { reader.read(Fid(1), 0, 64).await });
+    tokio::time::timeout(Duration::from_millis(500), read_started.notified())
+        .await
+        .expect("remote read request did not reach exported server");
+
+    drop(imported);
+    read_task.abort();
+    let _ = read_task.await;
+
+    tokio::time::timeout(Duration::from_millis(500), read_dropped.notified())
+        .await
+        .expect("exported blocking read was not cancelled after peer disconnect");
+    let result = tokio::time::timeout(Duration::from_millis(500), server_task)
+        .await
+        .expect("export task did not exit after peer disconnect")
+        .expect("export task panicked");
+    assert!(result.is_ok(), "{result:?}");
+}
+
+struct RecordingWriteFile {
+    writes: Mutex<Vec<(Offset, Vec<u8>)>>,
+}
+
+#[async_trait::async_trait]
+impl FileServer for RecordingWriteFile {
+    async fn walk(&self, _fid: Fid, _newfid: Fid, _names: &[String]) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn read(&self, _fid: Fid, _offset: Offset, _count: u32) -> Result<Vec<u8>, ErrorCode> {
+        Err(ErrorCode::NoAccess)
+    }
+
+    async fn write(&self, _fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        self.writes.lock().await.push((offset, data.to_vec()));
+        Ok(data.len() as u32)
+    }
+
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn imported_large_write_is_split_into_bounded_remote_frames() {
+    let (client_stream, server_stream) = duplex(1024 * 1024);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+
+    let server = Arc::new(RecordingWriteFile {
+        writes: Mutex::new(Vec::new()),
+    });
+    let server_task = tokio::spawn(export_file_server(
+        server.clone(),
+        BufReader::new(server_read),
+        server_write,
+    ));
+    let imported = ImportedFileServer::new(BufReader::new(client_read), client_write);
+    let data = vec![255; MAX_WIRE_FRAME_BYTES];
+
+    assert_eq!(
+        imported.write(Fid(1), 7, &data).await,
+        Ok(data.len() as u32)
+    );
+
+    let writes = server.writes.lock().await;
+    assert!(
+        writes.len() > 1,
+        "large imported write should be split into multiple bounded frames"
+    );
+    let mut next_offset = 7;
+    let mut reconstructed = Vec::new();
+    for (offset, chunk) in writes.iter() {
+        assert_eq!(*offset, next_offset);
+        next_offset += chunk.len() as u64;
+        reconstructed.extend_from_slice(chunk);
+    }
+    assert_eq!(reconstructed, data);
 
     drop(imported);
     server_task.abort();

--- a/crates/ap/tests/wire_transport.rs
+++ b/crates/ap/tests/wire_transport.rs
@@ -10,9 +10,10 @@ use std::{
 use alan_ap::{
     ErrorCode, Fid, FileKind, FileServer, ImportedFileServer, MAX_WIRE_FRAME_BYTES, Offset,
     OpenMode, Qid, Request, Response, Stat, Stream, decode_request_frame, decode_response_frame,
-    encode_request_frame, encode_response_frame, export_file_server,
+    encode_request_frame, encode_response_frame, export_file_server, read_response_frame,
+    write_request_frame,
 };
-use tokio::io::{AsyncBufRead, AsyncRead, BufReader, ReadBuf, duplex};
+use tokio::io::{AsyncBufRead, AsyncRead, AsyncWriteExt, BufReader, ReadBuf, duplex};
 use tokio::sync::{Mutex, Notify};
 
 fn qid(kind: FileKind, path: u64) -> Qid {
@@ -421,100 +422,55 @@ async fn cancelled_in_flight_call_does_not_desynchronize_next_request() {
     server_task.abort();
 }
 
-struct BlockingReadFile {
-    read_started: Arc<Notify>,
-    read_dropped: Arc<Notify>,
-}
-
-#[async_trait::async_trait]
-impl FileServer for BlockingReadFile {
-    async fn walk(&self, _fid: Fid, _newfid: Fid, _names: &[String]) -> Result<Qid, ErrorCode> {
-        Err(ErrorCode::NotFound)
-    }
-
-    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
-        Err(ErrorCode::Unsupported)
-    }
-
-    async fn read(&self, _fid: Fid, _offset: Offset, _count: u32) -> Result<Vec<u8>, ErrorCode> {
-        struct DropNotify(Arc<Notify>);
-
-        impl Drop for DropNotify {
-            fn drop(&mut self) {
-                self.0.notify_one();
-            }
-        }
-
-        self.read_started.notify_one();
-        let _drop_notify = DropNotify(Arc::clone(&self.read_dropped));
-        std::future::pending().await
-    }
-
-    async fn write(&self, _fid: Fid, _offset: Offset, _data: &[u8]) -> Result<u32, ErrorCode> {
-        Err(ErrorCode::NoAccess)
-    }
-
-    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
-        Err(ErrorCode::NotFound)
-    }
-
-    async fn create(
-        &self,
-        _fid: Fid,
-        _newfid: Fid,
-        _name: &str,
-        _kind: FileKind,
-    ) -> Result<Qid, ErrorCode> {
-        Err(ErrorCode::Unsupported)
-    }
-
-    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
-        Err(ErrorCode::Unsupported)
-    }
-
-    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
-        Ok(())
-    }
-}
-
 #[tokio::test]
-async fn export_cancels_blocking_call_when_peer_disconnects() {
+async fn export_finishes_in_flight_request_after_request_eof() {
     let (client_stream, server_stream) = duplex(4096);
-    let (client_read, client_write) = tokio::io::split(client_stream);
+    let (client_read, mut client_write) = tokio::io::split(client_stream);
     let (server_read, server_write) = tokio::io::split(server_stream);
 
-    let read_started = Arc::new(Notify::new());
-    let read_dropped = Arc::new(Notify::new());
-    let server: Arc<dyn FileServer> = Arc::new(BlockingReadFile {
-        read_started: Arc::clone(&read_started),
-        read_dropped: Arc::clone(&read_dropped),
+    let stream = Stream::new();
+    let server: Arc<dyn FileServer> = Arc::new(StreamFile {
+        stream: stream.clone(),
+        read_started: None,
     });
     let server_task = tokio::spawn(export_file_server(
         server,
         BufReader::new(server_read),
         server_write,
     ));
-    let imported = Arc::new(ImportedFileServer::new(
-        BufReader::new(client_read),
-        client_write,
-    ));
+    let mut client_reader = BufReader::new(client_read);
 
-    let reader = Arc::clone(&imported);
-    let read_task = tokio::spawn(async move { reader.read(Fid(1), 0, 64).await });
-    tokio::time::timeout(Duration::from_millis(500), read_started.notified())
-        .await
-        .expect("remote read request did not reach exported server");
+    write_request_frame(
+        &mut client_write,
+        &Request::Read {
+            fid: Fid(1),
+            offset: 0,
+            count: 64,
+        },
+    )
+    .await
+    .unwrap();
+    client_write.shutdown().await.unwrap();
+    drop(client_write);
 
-    drop(imported);
-    read_task.abort();
-    let _ = read_task.await;
+    stream.append(b"half-close response").await;
+    let response = tokio::time::timeout(
+        Duration::from_millis(500),
+        read_response_frame(&mut client_reader),
+    )
+    .await
+    .expect("half-closed client did not receive response")
+    .unwrap();
+    assert_eq!(
+        response,
+        Some(Ok(Response::Read {
+            data: b"half-close response".to_vec()
+        }))
+    );
 
-    tokio::time::timeout(Duration::from_millis(500), read_dropped.notified())
-        .await
-        .expect("exported blocking read was not cancelled after peer disconnect");
     let result = tokio::time::timeout(Duration::from_millis(500), server_task)
         .await
-        .expect("export task did not exit after peer disconnect")
+        .expect("export task did not exit after request EOF")
         .expect("export task panicked");
     assert!(result.is_ok(), "{result:?}");
 }

--- a/crates/ap/tests/wire_transport.rs
+++ b/crates/ap/tests/wire_transport.rs
@@ -521,6 +521,57 @@ impl FileServer for RecordingWriteFile {
     }
 }
 
+struct FailSecondWriteFile {
+    writes: Mutex<Vec<(Offset, Vec<u8>)>>,
+}
+
+#[async_trait::async_trait]
+impl FileServer for FailSecondWriteFile {
+    async fn walk(&self, _fid: Fid, _newfid: Fid, _names: &[String]) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn read(&self, _fid: Fid, _offset: Offset, _count: u32) -> Result<Vec<u8>, ErrorCode> {
+        Err(ErrorCode::NoAccess)
+    }
+
+    async fn write(&self, _fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        let mut writes = self.writes.lock().await;
+        if writes.is_empty() {
+            writes.push((offset, data.to_vec()));
+            Ok(data.len() as u32)
+        } else {
+            Err(ErrorCode::NoAccess)
+        }
+    }
+
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
 #[tokio::test]
 async fn imported_large_write_is_split_into_bounded_remote_frames() {
     let (client_stream, server_stream) = duplex(1024 * 1024);
@@ -556,6 +607,35 @@ async fn imported_large_write_is_split_into_bounded_remote_frames() {
         reconstructed.extend_from_slice(chunk);
     }
     assert_eq!(reconstructed, data);
+
+    drop(imported);
+    server_task.abort();
+}
+
+#[tokio::test]
+async fn imported_large_write_reports_partial_count_after_later_chunk_failure() {
+    let (client_stream, server_stream) = duplex(1024 * 1024);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+
+    let server = Arc::new(FailSecondWriteFile {
+        writes: Mutex::new(Vec::new()),
+    });
+    let server_task = tokio::spawn(export_file_server(
+        server.clone(),
+        BufReader::new(server_read),
+        server_write,
+    ));
+    let imported = ImportedFileServer::new(BufReader::new(client_read), client_write);
+    let data = vec![255; MAX_WIRE_FRAME_BYTES];
+
+    let accepted = imported.write(Fid(1), 11, &data).await.unwrap();
+
+    let writes = server.writes.lock().await;
+    assert_eq!(writes.len(), 1);
+    assert_eq!(writes[0].0, 11);
+    assert_eq!(accepted as usize, writes[0].1.len());
+    assert!((accepted as usize) < data.len());
 
     drop(imported);
     server_task.abort();

--- a/crates/ap/tests/wire_transport.rs
+++ b/crates/ap/tests/wire_transport.rs
@@ -1,0 +1,301 @@
+//! aP byte transport: framed requests/results, export loop, and imported trees.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use alan_ap::{
+    ErrorCode, Fid, FileKind, FileServer, ImportedFileServer, Offset, OpenMode, Qid, Request,
+    Response, Stat, Stream, decode_request_frame, decode_response_frame, encode_request_frame,
+    encode_response_frame, export_file_server,
+};
+use tokio::io::{BufReader, duplex};
+
+fn qid(kind: FileKind, path: u64) -> Qid {
+    Qid {
+        kind,
+        version: 0,
+        path,
+    }
+}
+
+#[test]
+fn every_request_and_response_result_survives_byte_framing() {
+    let requests = [
+        Request::Walk {
+            fid: Fid::ROOT,
+            newfid: Fid(1),
+            names: vec!["agent".into(), "root".into()],
+        },
+        Request::Open {
+            fid: Fid(1),
+            mode: OpenMode::Read,
+        },
+        Request::Read {
+            fid: Fid(1),
+            offset: 7,
+            count: 128,
+        },
+        Request::Write {
+            fid: Fid(1),
+            offset: 0,
+            data: b"payload".to_vec(),
+        },
+        Request::Stat { fid: Fid(1) },
+        Request::Create {
+            fid: Fid::ROOT,
+            newfid: Fid(2),
+            name: "child".into(),
+            kind: FileKind::File,
+        },
+        Request::Remove { fid: Fid(2) },
+        Request::Clunk { fid: Fid(1) },
+    ];
+
+    for request in requests {
+        let frame = encode_request_frame(&request).expect("encode request frame");
+        assert_eq!(frame.last(), Some(&b'\n'));
+        assert_eq!(
+            decode_request_frame(&frame).expect("decode request frame"),
+            request
+        );
+    }
+
+    let stat = Stat {
+        name: "file".into(),
+        qid: qid(FileKind::File, 1),
+        length: 7,
+        writable: true,
+    };
+    let responses = [
+        Ok(Response::Walk {
+            qid: qid(FileKind::Dir, 10),
+        }),
+        Ok(Response::Open {
+            qid: qid(FileKind::File, 1),
+        }),
+        Ok(Response::Read {
+            data: b"payload".to_vec(),
+        }),
+        Ok(Response::Write { count: 7 }),
+        Ok(Response::Stat { stat }),
+        Ok(Response::Create {
+            qid: qid(FileKind::File, 2),
+        }),
+        Ok(Response::Remove),
+        Ok(Response::Clunk),
+        Err(ErrorCode::NoAccess),
+        Err(ErrorCode::BadRequest),
+        Err(ErrorCode::Io),
+    ];
+
+    for response in responses {
+        let frame = encode_response_frame(&response).expect("encode response frame");
+        assert_eq!(frame.last(), Some(&b'\n'));
+        assert_eq!(
+            decode_response_frame(&frame).expect("decode response frame"),
+            response
+        );
+    }
+}
+
+struct OneFile;
+
+#[async_trait::async_trait]
+impl FileServer for OneFile {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        if fid == Fid::ROOT && newfid == Fid(1) && names == ["file"] {
+            Ok(qid(FileKind::File, 1))
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        if fid == Fid(1) {
+            Ok(qid(FileKind::File, 1))
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        if fid != Fid(1) {
+            return Err(ErrorCode::NotFound);
+        }
+        let bytes = b"hello over aP";
+        let start = (offset as usize).min(bytes.len());
+        let end = bytes.len().min(start + count as usize);
+        Ok(bytes[start..end].to_vec())
+    }
+
+    async fn write(&self, _fid: Fid, _offset: Offset, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::NoAccess)
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        if fid == Fid(1) {
+            Ok(Stat {
+                name: "file".into(),
+                qid: qid(FileKind::File, 1),
+                length: b"hello over aP".len() as u64,
+                writable: false,
+            })
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn imported_tree_dispatches_to_exported_server() {
+    let (client_stream, server_stream) = duplex(4096);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+
+    let server: Arc<dyn FileServer> = Arc::new(OneFile);
+    let server_task = tokio::spawn(export_file_server(
+        server,
+        BufReader::new(server_read),
+        server_write,
+    ));
+    let imported = ImportedFileServer::new(BufReader::new(client_read), client_write);
+
+    let walked = imported
+        .walk(Fid::ROOT, Fid(1), &["file".to_string()])
+        .await;
+    assert_eq!(walked, Ok(qid(FileKind::File, 1)));
+
+    let opened = imported.open(Fid(1), OpenMode::Read).await;
+    assert_eq!(opened, Ok(qid(FileKind::File, 1)));
+
+    let read = imported.read(Fid(1), 6, 128).await;
+    assert_eq!(read, Ok(b"over aP".to_vec()));
+
+    let denied = imported.write(Fid(1), 0, b"x").await;
+    assert_eq!(denied, Err(ErrorCode::NoAccess));
+
+    drop(imported);
+    server_task.abort();
+}
+
+struct StreamFile {
+    stream: Stream,
+}
+
+#[async_trait::async_trait]
+impl FileServer for StreamFile {
+    async fn walk(&self, _fid: Fid, _newfid: Fid, _names: &[String]) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+
+    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        if fid == Fid(1) {
+            Ok(qid(FileKind::Stream, 1))
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        if fid == Fid(1) {
+            Ok(self.stream.read(offset, count).await)
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn write(&self, _fid: Fid, _offset: Offset, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::NoAccess)
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        if fid == Fid(1) {
+            Ok(Stat {
+                name: "stream".into(),
+                qid: qid(FileKind::Stream, 1),
+                length: self.stream.len().await,
+                writable: false,
+            })
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn imported_stream_read_blocks_until_remote_stream_has_data() {
+    let (client_stream, server_stream) = duplex(4096);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+
+    let stream = Stream::new();
+    let server: Arc<dyn FileServer> = Arc::new(StreamFile {
+        stream: stream.clone(),
+    });
+    let server_task = tokio::spawn(export_file_server(
+        server,
+        BufReader::new(server_read),
+        server_write,
+    ));
+    let imported = Arc::new(ImportedFileServer::new(
+        BufReader::new(client_read),
+        client_write,
+    ));
+
+    imported.open(Fid(1), OpenMode::Read).await.unwrap();
+
+    let reader = Arc::clone(&imported);
+    let handle = tokio::spawn(async move { reader.read(Fid(1), 0, 64).await });
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(
+        !handle.is_finished(),
+        "imported stream read returned before remote stream had data"
+    );
+
+    stream.append(b"late bytes").await;
+    let got = tokio::time::timeout(Duration::from_millis(500), handle)
+        .await
+        .expect("imported stream read did not wake")
+        .expect("reader task panicked");
+    assert_eq!(got, Ok(b"late bytes".to_vec()));
+
+    drop(imported);
+    server_task.abort();
+}

--- a/crates/editfs/Cargo.toml
+++ b/crates/editfs/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "alan-editfs"
+description = "Editable buffer interaction file server for Alan OS."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+alan-ap = { path = "../ap" }
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true }

--- a/crates/editfs/src/lib.rs
+++ b/crates/editfs/src/lib.rs
@@ -256,6 +256,19 @@ impl State {
         Ok(bytes)
     }
 
+    fn write_seed_bytes(&self, node: &Node) -> Result<Vec<u8>, ErrorCode> {
+        let bytes = match node {
+            Node::Body | Node::Tag => self.computed_bytes(node)?,
+            Node::Addr => format!(
+                "rev:{} {}..{}",
+                self.addr.body_revision, self.addr.start, self.addr.end
+            )
+            .into_bytes(),
+            _ => return Err(ErrorCode::Unsupported),
+        };
+        Ok(bytes)
+    }
+
     fn stream_for(&self, node: &Node) -> Option<Stream> {
         match node {
             Node::Event => Some(self.event.clone()),
@@ -381,7 +394,7 @@ impl FileServer for EditFs {
         let read_write_seed = if matches!(mode, OpenMode::ReadWrite)
             && matches!(node, Node::Body | Node::Tag | Node::Addr)
         {
-            Some(state.computed_bytes(&node)?)
+            Some(state.write_seed_bytes(&node)?)
         } else {
             None
         };

--- a/crates/editfs/src/lib.rs
+++ b/crates/editfs/src/lib.rs
@@ -333,9 +333,19 @@ impl FileServer for EditFs {
         if matches!(mode, OpenMode::Write | OpenMode::ReadWrite) && !is_writable(&node) {
             return Err(ErrorCode::NoAccess);
         }
+        let read_write_seed = if matches!(mode, OpenMode::ReadWrite)
+            && matches!(node, Node::Body | Node::Tag | Node::Addr)
+        {
+            Some(state.computed_bytes(&node)?)
+        } else {
+            None
+        };
         if fid != Fid::ROOT {
             let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
             f.mode = Some(mode);
+            if let Some(seed) = read_write_seed {
+                f.write_buf = seed;
+            }
         }
         Ok(state.qid(&node))
     }

--- a/crates/editfs/src/lib.rs
+++ b/crates/editfs/src/lib.rs
@@ -3,7 +3,7 @@
 //! The server exposes one editable buffer with `body`, `tag`, `addr`, `ctl`, and
 //! `event` files. It proves the Ring 4 editable-buffer contract without native UI
 //! or real shell execution: text edits are committed on clunk, address ranges are
-//! revision-bound, explicit `ctl exec` is policy-gated, and all activity is
+//! revision-bound, snapshot-bearing `ctl exec` is policy-gated, and all activity is
 //! observable through a retained blocking-read event stream.
 
 use std::collections::HashMap;
@@ -25,8 +25,8 @@ pub const MOUNT_PATH: &str = "/mnt/edit";
 
 /// Minimal execution policy for the headless v1 server.
 ///
-/// This does not execute shell commands. It records whether an explicit `ctl
-/// exec` would be accepted by the mounted policy boundary, keeping the file
+/// This does not execute shell commands. It records whether a snapshot-bearing
+/// `ctl exec` would be accepted by the mounted policy boundary, keeping the file
 /// contract testable without granting hidden authority.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecutionPolicy {

--- a/crates/editfs/src/lib.rs
+++ b/crates/editfs/src/lib.rs
@@ -1,0 +1,488 @@
+//! alan-editfs — headless editable-buffer interaction as an aP file server.
+//!
+//! The server exposes one editable buffer with `body`, `tag`, `addr`, `ctl`, and
+//! `event` files. It proves the Ring 4 editable-buffer contract without native UI
+//! or real shell execution: text edits are committed on clunk, address ranges are
+//! revision-bound, explicit `ctl exec` is policy-gated, and all activity is
+//! observable through a retained blocking-read event stream.
+
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+
+use alan_ap::{
+    ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat, Stream, VersionTable,
+};
+use async_trait::async_trait;
+use serde::Serialize;
+use tokio::sync::Mutex;
+
+const MAX_DOC_BYTES: usize = 1 << 20; // 1 MiB
+
+/// Canonical `/srv` handle name for the editable-buffer file server.
+pub const SRV_HANDLE: &str = "edit";
+/// Conventional mount path for the first editable-buffer surface.
+pub const MOUNT_PATH: &str = "/mnt/edit";
+
+/// Minimal execution policy for the headless v1 server.
+///
+/// This does not execute shell commands. It records whether an explicit `ctl
+/// exec` would be accepted by the mounted policy boundary, keeping the file
+/// contract testable without granting hidden authority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionPolicy {
+    /// Reject all explicit executions.
+    DenyAll,
+    /// Accept explicit executions for harness/testing.
+    AcceptAll,
+}
+
+impl ExecutionPolicy {
+    fn decide(self, _command: &str) -> ExecutionStatus {
+        match self {
+            Self::DenyAll => ExecutionStatus::Denied,
+            Self::AcceptAll => ExecutionStatus::Accepted,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ExecutionStatus {
+    Accepted,
+    Denied,
+}
+
+/// A revision-bound byte range in `body`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AddressRange {
+    pub revision: u64,
+    pub start: usize,
+    pub end: usize,
+}
+
+impl AddressRange {
+    fn collapsed(revision: u64) -> Self {
+        Self {
+            revision,
+            start: 0,
+            end: 0,
+        }
+    }
+
+    fn parse(source: &str) -> Result<Self, ErrorCode> {
+        let trimmed = source.trim();
+        let (revision, range) = trimmed
+            .strip_prefix("rev:")
+            .and_then(|rest| rest.split_once(' '))
+            .ok_or(ErrorCode::BadRequest)?;
+        let revision = revision.parse::<u64>().map_err(|_| ErrorCode::BadRequest)?;
+        let (start, end) = range.split_once("..").ok_or(ErrorCode::BadRequest)?;
+        let start = start.parse::<usize>().map_err(|_| ErrorCode::BadRequest)?;
+        let end = end.parse::<usize>().map_err(|_| ErrorCode::BadRequest)?;
+        if start > end {
+            return Err(ErrorCode::BadRequest);
+        }
+        Ok(Self {
+            revision,
+            start,
+            end,
+        })
+    }
+}
+
+impl std::fmt::Display for AddressRange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "rev:{} {}..{}", self.revision, self.start, self.end)
+    }
+}
+
+struct State {
+    body: String,
+    tag: String,
+    body_revision: u64,
+    addr: AddressRange,
+    event: Stream,
+    versions: VersionTable,
+    fids: HashMap<Fid, EditFid>,
+    execution_policy: ExecutionPolicy,
+}
+
+struct EditFid {
+    node: Node,
+    mode: Option<OpenMode>,
+    write_buf: Vec<u8>,
+    wrote: bool,
+}
+
+#[derive(Debug, Clone)]
+enum Node {
+    Root,
+    Body,
+    Tag,
+    Addr,
+    Ctl,
+    Event,
+}
+
+/// Editable-buffer file server.
+pub struct EditFs {
+    state: Mutex<State>,
+}
+
+impl Default for EditFs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EditFs {
+    /// Create an editable buffer with default-denied execution.
+    pub fn new() -> Self {
+        Self::with_execution_policy(ExecutionPolicy::DenyAll)
+    }
+
+    /// Create an editable buffer with an explicit execution policy.
+    pub fn with_execution_policy(execution_policy: ExecutionPolicy) -> Self {
+        Self {
+            state: Mutex::new(State {
+                body: String::new(),
+                tag: String::new(),
+                body_revision: 0,
+                addr: AddressRange::collapsed(0),
+                event: Stream::new(),
+                versions: VersionTable::new(),
+                fids: HashMap::new(),
+                execution_policy,
+            }),
+        }
+    }
+
+    /// Return the current body revision for tests and bootstrap code.
+    pub async fn body_revision(&self) -> u64 {
+        self.state.lock().await.body_revision
+    }
+}
+
+impl State {
+    fn node_of(&self, fid: Fid) -> Result<Node, ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(Node::Root);
+        }
+        self.fids
+            .get(&fid)
+            .map(|f| f.node.clone())
+            .ok_or(ErrorCode::NotFound)
+    }
+
+    fn qid(&self, node: &Node) -> Qid {
+        let (kind, path) = node_identity(node);
+        Qid {
+            kind,
+            version: self.versions.get(path),
+            path,
+        }
+    }
+
+    fn child(&self, node: &Node, name: &str) -> Result<Node, ErrorCode> {
+        match node {
+            Node::Root => match name {
+                "body" => Ok(Node::Body),
+                "tag" => Ok(Node::Tag),
+                "addr" => Ok(Node::Addr),
+                "ctl" => Ok(Node::Ctl),
+                "event" => Ok(Node::Event),
+                _ => Err(ErrorCode::NotFound),
+            },
+            _ => Err(ErrorCode::NotDirectory),
+        }
+    }
+
+    fn computed_bytes(&self, node: &Node) -> Result<Vec<u8>, ErrorCode> {
+        let bytes = match node {
+            Node::Root => b"body\ntag\naddr\nctl\nevent".to_vec(),
+            Node::Body => self.body.as_bytes().to_vec(),
+            Node::Tag => self.tag.as_bytes().to_vec(),
+            Node::Addr => self.addr.to_string().into_bytes(),
+            Node::Ctl => b"# editfs ctl: write 'exec' and clunk to execute addr\n".to_vec(),
+            Node::Event => return Err(ErrorCode::Unsupported),
+        };
+        Ok(bytes)
+    }
+
+    fn stream_for(&self, node: &Node) -> Option<Stream> {
+        match node {
+            Node::Event => Some(self.event.clone()),
+            _ => None,
+        }
+    }
+
+    async fn commit_document(&mut self, node: Node, bytes: Vec<u8>) -> Result<(), ErrorCode> {
+        let text = String::from_utf8(bytes).map_err(|_| ErrorCode::BadRequest)?;
+        match node {
+            Node::Body => {
+                self.body = text;
+                self.body_revision += 1;
+                self.versions.bump(node_identity(&Node::Body).1);
+                self.versions.bump(node_identity(&Node::Addr).1);
+                self.append_event(EventRecord::Edit {
+                    file: "body",
+                    revision: Some(self.body_revision),
+                    length: self.body.len(),
+                })
+                .await
+            }
+            Node::Tag => {
+                self.tag = text;
+                self.versions.bump(node_identity(&Node::Tag).1);
+                self.append_event(EventRecord::Edit {
+                    file: "tag",
+                    revision: None,
+                    length: self.tag.len(),
+                })
+                .await
+            }
+            _ => Err(ErrorCode::Unsupported),
+        }
+    }
+
+    async fn commit_addr(&mut self, bytes: Vec<u8>) -> Result<(), ErrorCode> {
+        let text = String::from_utf8(bytes).map_err(|_| ErrorCode::BadRequest)?;
+        let addr = AddressRange::parse(&text)?;
+        self.validate_range_shape(&addr)?;
+        self.addr = addr.clone();
+        self.versions.bump(node_identity(&Node::Addr).1);
+        self.append_event(EventRecord::Address { range: addr })
+            .await
+    }
+
+    async fn commit_ctl(&mut self, bytes: Vec<u8>) -> Result<(), ErrorCode> {
+        let text = String::from_utf8(bytes).map_err(|_| ErrorCode::BadRequest)?;
+        match text.trim() {
+            "exec" => self.exec_addr().await,
+            _ => Err(ErrorCode::BadRequest),
+        }
+    }
+
+    fn validate_range_shape(&self, addr: &AddressRange) -> Result<(), ErrorCode> {
+        if addr.end > self.body.len()
+            || !self.body.is_char_boundary(addr.start)
+            || !self.body.is_char_boundary(addr.end)
+        {
+            return Err(ErrorCode::BadRequest);
+        }
+        Ok(())
+    }
+
+    async fn exec_addr(&mut self) -> Result<(), ErrorCode> {
+        let addr = self.addr.clone();
+        if addr.revision != self.body_revision {
+            return Err(ErrorCode::BadRequest);
+        }
+        self.validate_range_shape(&addr)?;
+        let command = self
+            .body
+            .get(addr.start..addr.end)
+            .ok_or(ErrorCode::BadRequest)?
+            .to_string();
+        let status = self.execution_policy.decide(&command);
+        self.append_event(EventRecord::Exec {
+            range: addr,
+            command,
+            status,
+        })
+        .await?;
+        match status {
+            ExecutionStatus::Accepted => Ok(()),
+            ExecutionStatus::Denied => Err(ErrorCode::NoAccess),
+        }
+    }
+
+    async fn append_event(&self, event: EventRecord<'_>) -> Result<(), ErrorCode> {
+        let mut bytes = serde_json::to_vec(&event).map_err(|_| ErrorCode::BadRequest)?;
+        bytes.push(b'\n');
+        self.event.append(&bytes).await;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl FileServer for EditFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        let mut state = self.state.lock().await;
+        if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
+            return Err(ErrorCode::BadRequest);
+        }
+        let mut node = state.node_of(fid)?;
+        for name in names {
+            node = state.child(&node, name)?;
+        }
+        let qid = state.qid(&node);
+        state.fids.insert(newfid, EditFid::at(node));
+        Ok(qid)
+    }
+
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
+        let mut state = self.state.lock().await;
+        let node = state.node_of(fid)?;
+        if fid != Fid::ROOT && state.fids.get(&fid).is_some_and(|f| f.mode.is_some()) {
+            return Err(ErrorCode::BadRequest);
+        }
+        if matches!(mode, OpenMode::Write | OpenMode::ReadWrite) && !is_writable(&node) {
+            return Err(ErrorCode::NoAccess);
+        }
+        if fid != Fid::ROOT {
+            let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
+            f.mode = Some(mode);
+        }
+        Ok(state.qid(&node))
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let (node, stream) = {
+            let state = self.state.lock().await;
+            if fid != Fid::ROOT {
+                let f = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+                if !matches!(f.mode, Some(OpenMode::Read | OpenMode::ReadWrite)) {
+                    return Err(ErrorCode::NoAccess);
+                }
+            }
+            let node = state.node_of(fid)?;
+            let stream = state.stream_for(&node);
+            (node, stream)
+        };
+        if let Some(stream) = stream {
+            return Ok(stream.read(offset, count).await);
+        }
+        let state = self.state.lock().await;
+        Ok(slice(state.computed_bytes(&node)?, offset, count))
+    }
+
+    async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        let mut state = self.state.lock().await;
+        let node = state.node_of(fid)?;
+        let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
+        if !matches!(f.mode, Some(OpenMode::Write | OpenMode::ReadWrite)) {
+            return Err(ErrorCode::NoAccess);
+        }
+        if !is_writable(&node) {
+            return Err(ErrorCode::Unsupported);
+        }
+        let start = usize::try_from(offset).map_err(|_| ErrorCode::BadRequest)?;
+        let end = start.checked_add(data.len()).ok_or(ErrorCode::BadRequest)?;
+        if end > MAX_DOC_BYTES {
+            return Err(ErrorCode::BadRequest);
+        }
+        if f.write_buf.len() < end {
+            f.write_buf.resize(end, 0);
+        }
+        f.write_buf[start..end].copy_from_slice(data);
+        f.wrote = true;
+        Ok(data.len() as u32)
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        let state = self.state.lock().await;
+        let node = state.node_of(fid)?;
+        let length = match &node {
+            Node::Event => {
+                state
+                    .stream_for(&node)
+                    .ok_or(ErrorCode::NotFound)?
+                    .len()
+                    .await
+            }
+            other => state.computed_bytes(other)?.len() as u64,
+        };
+        Ok(Stat {
+            name: String::new(),
+            qid: state.qid(&node),
+            length,
+            writable: is_writable(&node),
+        })
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(());
+        }
+        let mut state = self.state.lock().await;
+        let f = state.fids.remove(&fid).ok_or(ErrorCode::NotFound)?;
+        if !f.wrote {
+            return Ok(());
+        }
+        match f.node {
+            Node::Body | Node::Tag => state.commit_document(f.node, f.write_buf).await,
+            Node::Addr => state.commit_addr(f.write_buf).await,
+            Node::Ctl => state.commit_ctl(f.write_buf).await,
+            _ => Ok(()),
+        }
+    }
+}
+
+impl EditFid {
+    fn at(node: Node) -> Self {
+        Self {
+            node,
+            mode: None,
+            write_buf: Vec::new(),
+            wrote: false,
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+enum EventRecord<'a> {
+    Edit {
+        file: &'a str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        revision: Option<u64>,
+        length: usize,
+    },
+    Address {
+        range: AddressRange,
+    },
+    Exec {
+        range: AddressRange,
+        command: String,
+        status: ExecutionStatus,
+    },
+}
+
+fn is_writable(node: &Node) -> bool {
+    matches!(node, Node::Body | Node::Tag | Node::Addr | Node::Ctl)
+}
+
+fn node_identity(node: &Node) -> (FileKind, u64) {
+    let (kind, key) = match node {
+        Node::Root => (FileKind::Dir, "/"),
+        Node::Body => (FileKind::File, "body"),
+        Node::Tag => (FileKind::File, "tag"),
+        Node::Addr => (FileKind::File, "addr"),
+        Node::Ctl => (FileKind::File, "ctl"),
+        Node::Event => (FileKind::Stream, "event"),
+    };
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut h);
+    (kind, h.finish())
+}
+
+fn slice(bytes: Vec<u8>, offset: Offset, count: u32) -> Vec<u8> {
+    let start = (offset as usize).min(bytes.len());
+    let end = bytes.len().min(start + count as usize);
+    bytes[start..end].to_vec()
+}

--- a/crates/editfs/src/lib.rs
+++ b/crates/editfs/src/lib.rs
@@ -248,6 +248,9 @@ impl State {
     async fn commit_addr(&mut self, bytes: Vec<u8>) -> Result<(), ErrorCode> {
         let text = String::from_utf8(bytes).map_err(|_| ErrorCode::BadRequest)?;
         let addr = AddressRange::parse(&text)?;
+        if addr.revision != self.body_revision {
+            return Err(ErrorCode::BadRequest);
+        }
         self.validate_range_shape(&addr)?;
         self.addr = addr.clone();
         self.versions.bump(node_identity(&Node::Addr).1);

--- a/crates/editfs/src/lib.rs
+++ b/crates/editfs/src/lib.rs
@@ -55,44 +55,88 @@ enum ExecutionStatus {
 /// A revision-bound byte range in `body`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct AddressRange {
-    pub revision: u64,
+    pub body_revision: u64,
+    pub addr_revision: u64,
     pub start: usize,
     pub end: usize,
 }
 
 impl AddressRange {
-    fn collapsed(revision: u64) -> Self {
+    fn collapsed(body_revision: u64) -> Self {
         Self {
-            revision,
+            body_revision,
+            addr_revision: 0,
             start: 0,
             end: 0,
         }
     }
 
-    fn parse(source: &str) -> Result<Self, ErrorCode> {
-        let trimmed = source.trim();
-        let (revision, range) = trimmed
+    fn parse_addr_write(source: &str) -> Result<Self, ErrorCode> {
+        let (body_revision, start, end) = parse_body_revision_range(source.trim())?;
+        Ok(Self {
+            body_revision,
+            addr_revision: 0,
+            start,
+            end,
+        })
+    }
+
+    fn parse_exec(source: &str) -> Result<Self, ErrorCode> {
+        let trimmed = source
+            .trim()
+            .strip_prefix("exec ")
+            .ok_or(ErrorCode::BadRequest)?;
+        let (body_revision, rest) = trimmed
             .strip_prefix("rev:")
             .and_then(|rest| rest.split_once(' '))
             .ok_or(ErrorCode::BadRequest)?;
-        let revision = revision.parse::<u64>().map_err(|_| ErrorCode::BadRequest)?;
-        let (start, end) = range.split_once("..").ok_or(ErrorCode::BadRequest)?;
-        let start = start.parse::<usize>().map_err(|_| ErrorCode::BadRequest)?;
-        let end = end.parse::<usize>().map_err(|_| ErrorCode::BadRequest)?;
-        if start > end {
-            return Err(ErrorCode::BadRequest);
-        }
+        let body_revision = body_revision
+            .parse::<u64>()
+            .map_err(|_| ErrorCode::BadRequest)?;
+        let (addr_revision, range) = rest
+            .strip_prefix("addr:")
+            .and_then(|rest| rest.split_once(' '))
+            .ok_or(ErrorCode::BadRequest)?;
+        let addr_revision = addr_revision
+            .parse::<u64>()
+            .map_err(|_| ErrorCode::BadRequest)?;
+        let (start, end) = parse_range(range)?;
         Ok(Self {
-            revision,
+            body_revision,
+            addr_revision,
             start,
             end,
         })
     }
 }
 
+fn parse_body_revision_range(source: &str) -> Result<(u64, usize, usize), ErrorCode> {
+    let (revision, range) = source
+        .strip_prefix("rev:")
+        .and_then(|rest| rest.split_once(' '))
+        .ok_or(ErrorCode::BadRequest)?;
+    let revision = revision.parse::<u64>().map_err(|_| ErrorCode::BadRequest)?;
+    let (start, end) = parse_range(range)?;
+    Ok((revision, start, end))
+}
+
+fn parse_range(source: &str) -> Result<(usize, usize), ErrorCode> {
+    let (start, end) = source.split_once("..").ok_or(ErrorCode::BadRequest)?;
+    let start = start.parse::<usize>().map_err(|_| ErrorCode::BadRequest)?;
+    let end = end.parse::<usize>().map_err(|_| ErrorCode::BadRequest)?;
+    if start > end {
+        return Err(ErrorCode::BadRequest);
+    }
+    Ok((start, end))
+}
+
 impl std::fmt::Display for AddressRange {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "rev:{} {}..{}", self.revision, self.start, self.end)
+        write!(
+            f,
+            "rev:{} addr:{} {}..{}",
+            self.body_revision, self.addr_revision, self.start, self.end
+        )
     }
 }
 
@@ -203,7 +247,10 @@ impl State {
             Node::Body => self.body.as_bytes().to_vec(),
             Node::Tag => self.tag.as_bytes().to_vec(),
             Node::Addr => self.addr.to_string().into_bytes(),
-            Node::Ctl => b"# editfs ctl: write 'exec' and clunk to execute addr\n".to_vec(),
+            Node::Ctl => {
+                b"# editfs ctl: write 'exec rev:<body> addr:<addr> <start>..<end>' and clunk\n"
+                    .to_vec()
+            }
             Node::Event => return Err(ErrorCode::Unsupported),
         };
         Ok(bytes)
@@ -247,11 +294,12 @@ impl State {
 
     async fn commit_addr(&mut self, bytes: Vec<u8>) -> Result<(), ErrorCode> {
         let text = String::from_utf8(bytes).map_err(|_| ErrorCode::BadRequest)?;
-        let addr = AddressRange::parse(&text)?;
-        if addr.revision != self.body_revision {
+        let mut addr = AddressRange::parse_addr_write(&text)?;
+        if addr.body_revision != self.body_revision {
             return Err(ErrorCode::BadRequest);
         }
         self.validate_range_shape(&addr)?;
+        addr.addr_revision = self.addr.addr_revision + 1;
         self.addr = addr.clone();
         self.versions.bump(node_identity(&Node::Addr).1);
         self.append_event(EventRecord::Address { range: addr })
@@ -260,10 +308,8 @@ impl State {
 
     async fn commit_ctl(&mut self, bytes: Vec<u8>) -> Result<(), ErrorCode> {
         let text = String::from_utf8(bytes).map_err(|_| ErrorCode::BadRequest)?;
-        match text.trim() {
-            "exec" => self.exec_addr().await,
-            _ => Err(ErrorCode::BadRequest),
-        }
+        let addr = AddressRange::parse_exec(&text)?;
+        self.exec_addr(addr).await
     }
 
     fn validate_range_shape(&self, addr: &AddressRange) -> Result<(), ErrorCode> {
@@ -276,9 +322,8 @@ impl State {
         Ok(())
     }
 
-    async fn exec_addr(&mut self) -> Result<(), ErrorCode> {
-        let addr = self.addr.clone();
-        if addr.revision != self.body_revision {
+    async fn exec_addr(&mut self, addr: AddressRange) -> Result<(), ErrorCode> {
+        if addr != self.addr || addr.body_revision != self.body_revision {
             return Err(ErrorCode::BadRequest);
         }
         self.validate_range_shape(&addr)?;

--- a/crates/editfs/tests/editfs.rs
+++ b/crates/editfs/tests/editfs.rs
@@ -1,0 +1,179 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use alan_ap::{ErrorCode, Fid, FileServer, OpenMode};
+use alan_editfs::{EditFs, ExecutionPolicy};
+
+async fn read_text(fs: &EditFs, path: &[&str], fid: Fid) -> String {
+    let names = path.iter().map(|name| name.to_string()).collect::<Vec<_>>();
+    fs.walk(Fid::ROOT, fid, &names).await.expect("walk");
+    fs.open(fid, OpenMode::Read).await.expect("open");
+    let bytes = fs.read(fid, 0, 4096).await.expect("read");
+    fs.clunk(fid).await.expect("clunk");
+    String::from_utf8(bytes).expect("utf8")
+}
+
+async fn write_doc(fs: &EditFs, path: &[&str], fid: Fid, bytes: &[u8]) -> Result<(), ErrorCode> {
+    let names = path.iter().map(|name| name.to_string()).collect::<Vec<_>>();
+    fs.walk(Fid::ROOT, fid, &names).await?;
+    fs.open(fid, OpenMode::Write).await?;
+    fs.write(fid, 0, bytes).await?;
+    fs.clunk(fid).await
+}
+
+async fn event_len(fs: &EditFs, fid: Fid) -> u64 {
+    fs.walk(Fid::ROOT, fid, &["event".into()])
+        .await
+        .expect("walk event");
+    let stat = fs.stat(fid).await.expect("stat event");
+    fs.clunk(fid).await.expect("clunk event");
+    stat.length
+}
+
+#[tokio::test]
+async fn root_lists_editable_buffer_files() {
+    let fs = EditFs::new();
+    let root = read_text(&fs, &[], Fid(1)).await;
+    for entry in ["body", "tag", "addr", "ctl", "event"] {
+        assert!(root.lines().any(|line| line == entry), "{root}");
+    }
+}
+
+#[tokio::test]
+async fn body_and_tag_commit_on_clunk_and_emit_events() {
+    let fs = EditFs::new();
+
+    write_doc(&fs, &["body"], Fid(1), b"run tests")
+        .await
+        .unwrap();
+    write_doc(&fs, &["tag"], Fid(2), b"Exec Save")
+        .await
+        .unwrap();
+
+    assert_eq!(read_text(&fs, &["body"], Fid(3)).await, "run tests");
+    assert_eq!(read_text(&fs, &["tag"], Fid(4)).await, "Exec Save");
+
+    let events = read_text(&fs, &["event"], Fid(5)).await;
+    assert!(events.contains(r#""type":"edit""#), "{events}");
+    assert!(events.contains(r#""file":"body""#), "{events}");
+    assert!(events.contains(r#""file":"tag""#), "{events}");
+}
+
+#[tokio::test]
+async fn invalid_utf8_is_rejected_without_changing_visible_content() {
+    let fs = EditFs::new();
+    write_doc(&fs, &["body"], Fid(1), b"stable").await.unwrap();
+
+    let err = write_doc(&fs, &["body"], Fid(2), &[0xff, 0xfe])
+        .await
+        .unwrap_err();
+    assert_eq!(err, ErrorCode::BadRequest);
+    assert_eq!(read_text(&fs, &["body"], Fid(3)).await, "stable");
+}
+
+#[tokio::test]
+async fn addr_selects_a_revision_bound_body_range() {
+    let fs = EditFs::new();
+    write_doc(&fs, &["body"], Fid(1), b"alpha beta")
+        .await
+        .unwrap();
+
+    write_doc(&fs, &["addr"], Fid(2), b"rev:1 6..10")
+        .await
+        .unwrap();
+
+    assert_eq!(read_text(&fs, &["addr"], Fid(3)).await, "rev:1 6..10");
+    let events = read_text(&fs, &["event"], Fid(4)).await;
+    assert!(events.contains(r#""type":"address""#), "{events}");
+    assert!(events.contains(r#""start":6"#), "{events}");
+}
+
+#[tokio::test]
+async fn stale_addr_is_rejected_when_exec_consumes_it() {
+    let fs = EditFs::with_execution_policy(ExecutionPolicy::AcceptAll);
+    write_doc(&fs, &["body"], Fid(1), b"first").await.unwrap();
+    write_doc(&fs, &["addr"], Fid(2), b"rev:1 0..5")
+        .await
+        .unwrap();
+    write_doc(&fs, &["body"], Fid(3), b"second").await.unwrap();
+
+    let err = write_doc(&fs, &["ctl"], Fid(4), b"exec").await.unwrap_err();
+    assert_eq!(err, ErrorCode::BadRequest);
+
+    let events = read_text(&fs, &["event"], Fid(5)).await;
+    assert!(!events.contains(r#""type":"exec""#), "{events}");
+}
+
+#[tokio::test]
+async fn exec_records_accepted_and_denied_policy_outcomes() {
+    let accepted = EditFs::with_execution_policy(ExecutionPolicy::AcceptAll);
+    write_doc(&accepted, &["body"], Fid(1), b"cargo test")
+        .await
+        .unwrap();
+    write_doc(&accepted, &["addr"], Fid(2), b"rev:1 0..10")
+        .await
+        .unwrap();
+    write_doc(&accepted, &["ctl"], Fid(3), b"exec")
+        .await
+        .unwrap();
+    let accepted_events = read_text(&accepted, &["event"], Fid(4)).await;
+    assert!(
+        accepted_events.contains(r#""type":"exec""#),
+        "{accepted_events}"
+    );
+    assert!(
+        accepted_events.contains(r#""status":"accepted""#),
+        "{accepted_events}"
+    );
+    assert!(
+        accepted_events.contains(r#""command":"cargo test""#),
+        "{accepted_events}"
+    );
+
+    let denied = EditFs::new();
+    write_doc(&denied, &["body"], Fid(11), b"rm -rf /")
+        .await
+        .unwrap();
+    write_doc(&denied, &["addr"], Fid(12), b"rev:1 0..8")
+        .await
+        .unwrap();
+    let err = write_doc(&denied, &["ctl"], Fid(13), b"exec")
+        .await
+        .unwrap_err();
+    assert_eq!(err, ErrorCode::NoAccess);
+    let denied_events = read_text(&denied, &["event"], Fid(14)).await;
+    assert!(
+        denied_events.contains(r#""type":"exec""#),
+        "{denied_events}"
+    );
+    assert!(
+        denied_events.contains(r#""status":"denied""#),
+        "{denied_events}"
+    );
+}
+
+#[tokio::test]
+async fn event_read_blocks_until_activity_is_appended() {
+    let fs = Arc::new(EditFs::new());
+    let start = event_len(&fs, Fid(1)).await;
+
+    fs.walk(Fid::ROOT, Fid(2), &["event".into()])
+        .await
+        .expect("walk event");
+    fs.open(Fid(2), OpenMode::Read).await.expect("open event");
+
+    let reader = {
+        let fs = fs.clone();
+        tokio::spawn(async move { fs.read(Fid(2), start, 4096).await })
+    };
+    assert!(
+        tokio::time::timeout(Duration::from_millis(30), reader)
+            .await
+            .is_err(),
+        "event read should block at the live edge"
+    );
+
+    write_doc(&fs, &["tag"], Fid(3), b"status").await.unwrap();
+    let event = read_text(&fs, &["event"], Fid(4)).await;
+    assert!(event.contains(r#""file":"tag""#), "{event}");
+}

--- a/crates/editfs/tests/editfs.rs
+++ b/crates/editfs/tests/editfs.rs
@@ -114,6 +114,27 @@ async fn addr_selects_a_revision_bound_body_range() {
 }
 
 #[tokio::test]
+async fn readwrite_addr_seeds_writable_range_syntax() {
+    let fs = EditFs::new();
+    write_doc(&fs, &["body"], Fid(1), b"alpha beta")
+        .await
+        .unwrap();
+    write_doc(&fs, &["addr"], Fid(2), b"rev:1 0..5")
+        .await
+        .unwrap();
+
+    fs.walk(Fid::ROOT, Fid(3), &["addr".into()]).await.unwrap();
+    fs.open(Fid(3), OpenMode::ReadWrite).await.unwrap();
+    fs.write(Fid(3), 6, b"6..10").await.unwrap();
+    fs.clunk(Fid(3)).await.unwrap();
+
+    assert_eq!(
+        read_text(&fs, &["addr"], Fid(4)).await,
+        "rev:1 addr:2 6..10"
+    );
+}
+
+#[tokio::test]
 async fn addr_write_rejects_non_current_body_revision() {
     let fs = EditFs::new();
     write_doc(&fs, &["body"], Fid(1), b"alpha").await.unwrap();

--- a/crates/editfs/tests/editfs.rs
+++ b/crates/editfs/tests/editfs.rs
@@ -89,6 +89,27 @@ async fn addr_selects_a_revision_bound_body_range() {
 }
 
 #[tokio::test]
+async fn addr_write_rejects_non_current_body_revision() {
+    let fs = EditFs::new();
+    write_doc(&fs, &["body"], Fid(1), b"alpha").await.unwrap();
+
+    let future = write_doc(&fs, &["addr"], Fid(2), b"rev:2 0..5")
+        .await
+        .unwrap_err();
+    assert_eq!(future, ErrorCode::BadRequest);
+    assert_eq!(read_text(&fs, &["addr"], Fid(3)).await, "rev:0 0..0");
+
+    write_doc(&fs, &["body"], Fid(4), b"alpha beta")
+        .await
+        .unwrap();
+    let stale = write_doc(&fs, &["addr"], Fid(5), b"rev:1 0..5")
+        .await
+        .unwrap_err();
+    assert_eq!(stale, ErrorCode::BadRequest);
+    assert_eq!(read_text(&fs, &["addr"], Fid(6)).await, "rev:0 0..0");
+}
+
+#[tokio::test]
 async fn stale_addr_is_rejected_when_exec_consumes_it() {
     let fs = EditFs::with_execution_policy(ExecutionPolicy::AcceptAll);
     write_doc(&fs, &["body"], Fid(1), b"first").await.unwrap();

--- a/crates/editfs/tests/editfs.rs
+++ b/crates/editfs/tests/editfs.rs
@@ -60,6 +60,28 @@ async fn body_and_tag_commit_on_clunk_and_emit_events() {
 }
 
 #[tokio::test]
+async fn readwrite_edits_preserve_existing_body_and_tag_bytes() {
+    let fs = EditFs::new();
+    write_doc(&fs, &["body"], Fid(1), b"abcdef").await.unwrap();
+    write_doc(&fs, &["tag"], Fid(2), b"status-line")
+        .await
+        .unwrap();
+
+    fs.walk(Fid::ROOT, Fid(3), &["body".into()]).await.unwrap();
+    fs.open(Fid(3), OpenMode::ReadWrite).await.unwrap();
+    fs.write(Fid(3), 2, b"XY").await.unwrap();
+    fs.clunk(Fid(3)).await.unwrap();
+
+    fs.walk(Fid::ROOT, Fid(4), &["tag".into()]).await.unwrap();
+    fs.open(Fid(4), OpenMode::ReadWrite).await.unwrap();
+    fs.write(Fid(4), 7, b"row").await.unwrap();
+    fs.clunk(Fid(4)).await.unwrap();
+
+    assert_eq!(read_text(&fs, &["body"], Fid(5)).await, "abXYef");
+    assert_eq!(read_text(&fs, &["tag"], Fid(6)).await, "status-rowe");
+}
+
+#[tokio::test]
 async fn invalid_utf8_is_rejected_without_changing_visible_content() {
     let fs = EditFs::new();
     write_doc(&fs, &["body"], Fid(1), b"stable").await.unwrap();

--- a/crates/editfs/tests/editfs.rs
+++ b/crates/editfs/tests/editfs.rs
@@ -104,7 +104,10 @@ async fn addr_selects_a_revision_bound_body_range() {
         .await
         .unwrap();
 
-    assert_eq!(read_text(&fs, &["addr"], Fid(3)).await, "rev:1 6..10");
+    assert_eq!(
+        read_text(&fs, &["addr"], Fid(3)).await,
+        "rev:1 addr:1 6..10"
+    );
     let events = read_text(&fs, &["event"], Fid(4)).await;
     assert!(events.contains(r#""type":"address""#), "{events}");
     assert!(events.contains(r#""start":6"#), "{events}");
@@ -119,7 +122,7 @@ async fn addr_write_rejects_non_current_body_revision() {
         .await
         .unwrap_err();
     assert_eq!(future, ErrorCode::BadRequest);
-    assert_eq!(read_text(&fs, &["addr"], Fid(3)).await, "rev:0 0..0");
+    assert_eq!(read_text(&fs, &["addr"], Fid(3)).await, "rev:0 addr:0 0..0");
 
     write_doc(&fs, &["body"], Fid(4), b"alpha beta")
         .await
@@ -128,7 +131,7 @@ async fn addr_write_rejects_non_current_body_revision() {
         .await
         .unwrap_err();
     assert_eq!(stale, ErrorCode::BadRequest);
-    assert_eq!(read_text(&fs, &["addr"], Fid(6)).await, "rev:0 0..0");
+    assert_eq!(read_text(&fs, &["addr"], Fid(6)).await, "rev:0 addr:0 0..0");
 }
 
 #[tokio::test]
@@ -140,10 +143,36 @@ async fn stale_addr_is_rejected_when_exec_consumes_it() {
         .unwrap();
     write_doc(&fs, &["body"], Fid(3), b"second").await.unwrap();
 
-    let err = write_doc(&fs, &["ctl"], Fid(4), b"exec").await.unwrap_err();
+    let err = write_doc(&fs, &["ctl"], Fid(4), b"exec rev:1 addr:1 0..5")
+        .await
+        .unwrap_err();
     assert_eq!(err, ErrorCode::BadRequest);
 
     let events = read_text(&fs, &["event"], Fid(5)).await;
+    assert!(!events.contains(r#""type":"exec""#), "{events}");
+}
+
+#[tokio::test]
+async fn exec_rejects_stale_address_revision_after_another_selection() {
+    let fs = EditFs::with_execution_policy(ExecutionPolicy::AcceptAll);
+    write_doc(&fs, &["body"], Fid(1), b"alpha beta")
+        .await
+        .unwrap();
+    write_doc(&fs, &["addr"], Fid(2), b"rev:1 0..5")
+        .await
+        .unwrap();
+    let first_snapshot = read_text(&fs, &["addr"], Fid(3)).await;
+    assert_eq!(first_snapshot, "rev:1 addr:1 0..5");
+
+    write_doc(&fs, &["addr"], Fid(4), b"rev:1 6..10")
+        .await
+        .unwrap();
+    let err = write_doc(&fs, &["ctl"], Fid(5), b"exec rev:1 addr:1 0..5")
+        .await
+        .unwrap_err();
+    assert_eq!(err, ErrorCode::BadRequest);
+
+    let events = read_text(&fs, &["event"], Fid(6)).await;
     assert!(!events.contains(r#""type":"exec""#), "{events}");
 }
 
@@ -156,7 +185,7 @@ async fn exec_records_accepted_and_denied_policy_outcomes() {
     write_doc(&accepted, &["addr"], Fid(2), b"rev:1 0..10")
         .await
         .unwrap();
-    write_doc(&accepted, &["ctl"], Fid(3), b"exec")
+    write_doc(&accepted, &["ctl"], Fid(3), b"exec rev:1 addr:1 0..10")
         .await
         .unwrap();
     let accepted_events = read_text(&accepted, &["event"], Fid(4)).await;
@@ -180,7 +209,7 @@ async fn exec_records_accepted_and_denied_policy_outcomes() {
     write_doc(&denied, &["addr"], Fid(12), b"rev:1 0..8")
         .await
         .unwrap();
-    let err = write_doc(&denied, &["ctl"], Fid(13), b"exec")
+    let err = write_doc(&denied, &["ctl"], Fid(13), b"exec rev:1 addr:1 0..8")
         .await
         .unwrap_err();
     assert_eq!(err, ErrorCode::NoAccess);

--- a/docs/adr/0027-north-star-capability-map.md
+++ b/docs/adr/0027-north-star-capability-map.md
@@ -74,9 +74,10 @@ thesis is leaking.
 - **Ring 3 — Composition.** Chartered but barely started:
   `add-content-addressed-knowledge` (Venti idea), `add-message-routing`
   (Plumber idea), aP wire transport (9P network transparency).
-- **Ring 4 — Interaction.** Recorded in ADR-0026 D4, no change created:
-  an editable-buffer layer above `io/` where any text can be executed and the
-  UI surface is itself a file server. Absorb the idea, not Acme's literal UI.
+- **Ring 4 — Interaction.** Owned by
+  `define-editable-buffer-interaction`: an editable-buffer layer above `io/`
+  where any text can be executed and the UI surface is itself a file server.
+  Absorb the idea, not Acme's literal UI.
 - **Ring 5 — Ecosystem.** Chartered in the product constitution: apps get AI
   by opening bounded descriptors and spawning agent processes.
 

--- a/openspec/changes/add-ap-wire-transport/.openspec.yaml
+++ b/openspec/changes/add-ap-wire-transport/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/add-ap-wire-transport/design.md
+++ b/openspec/changes/add-ap-wire-transport/design.md
@@ -1,0 +1,81 @@
+## Context
+
+ADR-0025 makes `alan-ap` the owner of Alan's file-service protocol and its
+transport shape. The crate already has serializable `Request`/`Response` values,
+an in-process fast path, and tests proving each operation is wire-shaped. ADR-0026
+D1 records the missing Ring 3 capability: importing/exporting aP file trees across
+machines so distributed agents mount remote resources instead of calling a new
+RPC mesh.
+
+This slice turns the existing wire-shaped contract into a real byte transport
+without changing any `FileServer` implementation or kernel API.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Carry every existing aP `Request`/`Response` across an async byte stream.
+- Export any `FileServer` through a server loop that receives requests and sends
+  responses.
+- Import a remote tree as a `FileServer` adapter so local clients keep using the
+  same walk/open/read/write/stat/create/remove/clunk semantics.
+- Preserve typed `ErrorCode` failures across the transport.
+- Keep the kernel unaware of the transport.
+
+**Non-Goals:**
+
+- Network discovery, peer identity, auth, encryption, reconnect, or multiplexing.
+- Public CLI/daemon commands for remote hosts.
+- Cross-host Service Manager policy or distributed-agent product UX.
+- Literal 9P compatibility.
+
+## Decisions
+
+1. **Implement the first wire transport inside `alan-ap`.**
+
+   `alan-ap` already owns protocol messages and `InProcessTransport`; putting the
+   byte transport beside them keeps protocol ownership coherent and avoids a
+   second crate that must mirror every future operation.
+
+   Alternative considered: add `alan-ap-wire` as a separate crate. That keeps
+   optional transport dependencies out of `alan-ap`, but the current dependencies
+   already include Tokio and Serde, and ADR-0025 names the in-process and future
+   wire transports as part of aP.
+
+2. **Use newline-delimited JSON frames for v1.**
+
+   A frame is one JSON object plus `\n`. The format is debuggable, works with
+   existing Serde types, and is enough to prove import/export semantics.
+
+   Alternative considered: length-prefixed binary frames. That is more compact
+   and handles arbitrary payload bytes without escaping overhead, but it makes
+   the first slice less inspectable. We can add a binary codec later without
+   changing `Request`/`Response`.
+
+3. **Wrap responses in an envelope that can carry typed errors.**
+
+   `Response` only represents successful operation results. The transport must
+   preserve `Result<Response, ErrorCode>`, so the wire response is an explicit
+   success/error envelope.
+
+4. **Keep v1 strictly one request in flight per connection.**
+
+   The imported adapter serializes calls with a mutex around the stream. That
+   avoids request IDs and response reordering while still proving that a remote
+   tree can be used like a local one. Multiplexing can be added later as a
+   compatible transport upgrade.
+
+## Risks / Trade-offs
+
+- [Risk] JSON framing is inefficient for high-rate streams. -> Mitigation: this
+  is a correctness slice; the protocol messages stay codec-independent.
+- [Risk] A single in-flight request can head-of-line block on a blocking stream
+  read. -> Mitigation: v1 makes that limitation explicit; later multiplexing can
+  add request IDs without changing `FileServer`.
+- [Risk] Transport IO failures do not map perfectly onto file-server errors. ->
+  Mitigation: v1 maps malformed frames and IO shutdown to `ErrorCode::Io` or
+  `ErrorCode::BadRequest` at the adapter boundary, keeping clients in typed aP
+  error space.
+- [Risk] Adding transport code to `alan-ap` could tempt kernel coupling. ->
+  Mitigation: dependency-boundary tests continue to require `alan-kernel` to
+  depend only on `alan-ap`, and the kernel does not call transport constructors.

--- a/openspec/changes/add-ap-wire-transport/proposal.md
+++ b/openspec/changes/add-ap-wire-transport/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+ADR-0026 D1 records aP network transparency as the next Ring 3 North Star slice
+after content-addressed knowledge and routefs. The in-process aP contract is now
+usable enough that we can add the first import/export transport without changing
+clients or turning distributed agents into an RPC mesh.
+
+## What Changes
+
+- Add a small aP wire transport that serializes aP operations and responses over
+  an async byte stream.
+- Provide an exported-server loop that serves any `alan_ap::FileServer` through
+  the wire protocol.
+- Provide an imported-client adapter that implements `alan_ap::FileServer` while
+  forwarding operations to the exported remote tree.
+- Preserve local semantics: clients use the same walk/open/read/write/clunk API
+  whether the tree is local or imported.
+- Keep this slice transport-focused; discovery, auth, encryption, multi-host
+  topology, and distributed-agent product UX remain later work.
+
+## Capabilities
+
+### New Capabilities
+
+- `ap-wire-transport`: Defines import/export of aP file trees over a byte
+  transport while preserving normal aP operation semantics for clients.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Extends the `alan-ap` transport layer; `alan-kernel` remains
+  dependency-isolated and transport-agnostic.
+- Adds focused integration tests using in-memory async streams and existing aP
+  file servers.
+- Updates workspace wiring and OpenSpec coverage for the network-transparency
+  slice referenced by ADR-0026 and ADR-0027.

--- a/openspec/changes/add-ap-wire-transport/specs/ap-wire-transport/spec.md
+++ b/openspec/changes/add-ap-wire-transport/specs/ap-wire-transport/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: aP operations are framed over bytes
+
+Alan SHALL provide a byte transport representation for every existing aP
+`Request` and for every successful or failed aP response.
+
+#### Scenario: Request survives byte framing
+
+- **WHEN** a client encodes any supported aP request as a wire frame
+- **THEN** the receiver decodes the same request value without in-process state
+  or borrowed data
+
+#### Scenario: Response result survives byte framing
+
+- **WHEN** a server encodes either a successful aP response or a typed
+  `ErrorCode` as a wire frame
+- **THEN** the receiver decodes the same `Result<Response, ErrorCode>` value
+
+### Requirement: Any file server can be exported
+
+Alan SHALL provide a server-side transport loop that accepts framed aP requests,
+dispatches them to an `alan_ap::FileServer`, and writes framed response results.
+
+#### Scenario: Exported server dispatches normal operations
+
+- **WHEN** a remote client sends framed walk/open/read/write/stat/create/remove
+  or clunk requests
+- **THEN** the export loop invokes the same `FileServer` methods as the
+  in-process transport
+
+#### Scenario: Exported server preserves typed failures
+
+- **WHEN** the exported file server returns an aP `ErrorCode`
+- **THEN** the transport sends that typed failure instead of collapsing it into
+  an unstructured IO failure
+
+### Requirement: Remote trees import as file servers
+
+Alan SHALL provide a client-side adapter that implements `alan_ap::FileServer`
+while forwarding operations over the wire transport to an exported remote tree.
+
+#### Scenario: Imported tree is used like a local tree
+
+- **WHEN** a local client uses the imported adapter through walk/open/read/write,
+  stat, create, remove, or clunk
+- **THEN** the client observes normal aP results and does not distinguish the
+  imported tree from an in-process file server
+
+#### Scenario: Blocking stream reads preserve aP semantics
+
+- **WHEN** a local client reads from an imported stream before the remote stream
+  has data at the requested offset
+- **THEN** the read remains pending until the remote file server produces data
+
+### Requirement: Kernel remains transport agnostic
+
+Alan SHALL keep aP wire import/export above the kernel boundary; `alan-kernel`
+SHALL NOT depend on transport-specific crates or call transport-specific APIs.
+
+#### Scenario: Kernel dependency boundary is preserved
+
+- **WHEN** the aP wire transport is added
+- **THEN** `alan-kernel` still depends only on `alan-ap` among Alan crates
+- **AND** remote import/export is represented to the kernel as ordinary mounted
+  file-server handles

--- a/openspec/changes/add-ap-wire-transport/tasks.md
+++ b/openspec/changes/add-ap-wire-transport/tasks.md
@@ -1,0 +1,64 @@
+## 1. Wire Frames
+
+- [x] 1.1 Add public aP wire frame types for request frames and
+  `Result<Response, ErrorCode>` response frames.
+  Done 2026-07-02: added `WireRequestFrame`, `WireResponseFrame`, and
+  `WireError` to `alan-ap`.
+- [x] 1.2 Implement newline-delimited JSON encode/decode helpers over async byte
+  streams.
+  Done 2026-07-02: added request/response encode, decode, read, and write
+  helpers for newline-delimited JSON frames.
+- [x] 1.3 Add focused tests proving every request and response result survives
+  byte framing.
+  Done 2026-07-02: `crates/ap/tests/wire_transport.rs` covers every aP request
+  and both successful/error response results.
+
+## 2. Export Loop
+
+- [x] 2.1 Add an export loop that reads framed requests, dispatches them through
+  the same `FileServer` methods as `InProcessTransport`, and writes framed
+  response results.
+  Done 2026-07-02: added `export_file_server`, which dispatches through
+  `InProcessTransport` and writes a framed operation result.
+- [x] 2.2 Preserve typed `ErrorCode` values returned by the exported server.
+  Done 2026-07-02: response frames carry typed `ErrorCode` values; tests verify
+  `NoAccess` survives an exported/imported write failure.
+
+## 3. Import Adapter
+
+- [x] 3.1 Add an imported-tree adapter that implements `FileServer` and forwards
+  each method over the wire transport.
+  Done 2026-07-02: added `WireTransportClient` and `ImportedFileServer` with
+  method-by-method forwarding to the exported remote tree.
+- [x] 3.2 Serialize v1 calls to one in-flight request per connection and document
+  that multiplexing is a later transport upgrade.
+  Done 2026-07-02: `ImportedFileServer` guards one connection with a mutex, and
+  the API docs/design document call out multiplexing as later work.
+- [x] 3.3 Preserve blocking stream-read semantics through the imported adapter.
+  Done 2026-07-02: added a remote `Stream` test proving imported reads stay
+  pending until the exported server's stream produces data.
+
+## 4. Boundaries And Verification
+
+- [x] 4.1 Verify `alan-kernel` stays transport-agnostic and depends only on
+  `alan-ap` among Alan crates.
+  Done 2026-07-02: `cargo test -p alan-kernel --test dependency_boundary --
+  --nocapture` passed.
+- [x] 4.2 Run focused aP transport tests.
+  Done 2026-07-02: `cargo test -p alan-ap -- --nocapture` and
+  `cargo clippy -p alan-ap --all-targets --all-features -- -D warnings` passed.
+- [x] 4.3 Run `just verify`.
+  Done 2026-07-02: `just verify` passed, including workspace fmt, clippy,
+  tests, doctests, and the `alan` smoke suite.
+- [x] 4.4 Run `openspec validate add-ap-wire-transport --strict`.
+  Done 2026-07-02: strict OpenSpec validation passed for
+  `add-ap-wire-transport`.
+
+## 5. PR Hygiene
+
+- [x] 5.1 Commit this slice separately from routefs.
+  Done 2026-07-03: committed as
+  `feat(ap): add wire import export transport` on `feat/northstar-ap-wire`.
+- [x] 5.2 Open a stacked draft PR on top of `feat/northstar-routefs`.
+  Done 2026-07-03: opened #591 on top of `feat/northstar-routefs`, then marked
+  it ready for review to match the current PR workflow.

--- a/openspec/changes/add-editable-buffer-file-server/.openspec.yaml
+++ b/openspec/changes/add-editable-buffer-file-server/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/add-editable-buffer-file-server/design.md
+++ b/openspec/changes/add-editable-buffer-file-server/design.md
@@ -14,8 +14,8 @@ files with commit-on-clunk, and blocking-read `Stream`s for observation.
 
 - Add `alan-editfs` as a user-space aP file-server crate.
 - Serve one buffer directory exposing `body`, `tag`, `addr`, `ctl`, and `event`.
-- Support body/tag edits, revision-bound address ranges, explicit `ctl exec`,
-  and observable JSON-line events.
+- Support body/tag edits, revision-bound address ranges, snapshot-bearing
+  `ctl exec`, and observable JSON-line events.
 - Keep execution policy injectable and default-denied so the buffer never becomes
   a privileged command runner.
 
@@ -44,16 +44,20 @@ files with commit-on-clunk, and blocking-read `Stream`s for observation.
 
 3. **`addr` uses revision-bound byte ranges.**
 
-   V1 format is `rev:<revision> <start>..<end>`. The revision must match the
-   current body revision when `ctl exec` consumes the range. This proves stale
-   range rejection without inventing a full editor address language.
+   V1 write format is `rev:<body-revision> <start>..<end>`. Reads include the
+   selected body revision, address revision, and range as
+   `rev:<body-revision> addr:<addr-revision> <start>..<end>`. A `ctl exec`
+   document carries that full snapshot so execution can reject stale body
+   revisions, stale address revisions, and retargeted ranges without inventing a
+   full editor address language.
 
-4. **`ctl exec` is explicit and policy-gated.**
+4. **`ctl exec` is explicit, snapshot-bearing, and policy-gated.**
 
-   Writing `exec` to `ctl` executes the active `addr` range through an injected
-   `ExecutionPolicy`. The default policy denies all execution. A test policy can
-   accept so we verify both accepted and denied event records without running a
-   real shell command.
+   Writing `exec rev:<body> addr:<addr> <start>..<end>` to `ctl` executes only
+   if the supplied snapshot exactly matches the current active `addr` range and
+   body revision, then records the injected `ExecutionPolicy` outcome. The
+   default policy denies all execution. A test policy can accept so we verify
+   both accepted and denied event records without running a real shell command.
 
 5. **Events are JSON lines on a blocking-read stream.**
 

--- a/openspec/changes/add-editable-buffer-file-server/design.md
+++ b/openspec/changes/add-editable-buffer-file-server/design.md
@@ -1,0 +1,75 @@
+## Context
+
+`define-editable-buffer-interaction` defines the Ring 4 editable-buffer contract.
+This change is the first executable slice: a headless file server that can be
+mounted and tested through aP. The goal is to prove the file semantics before
+native UI, shell integration, or policy-rich execution.
+
+Existing Alan OS primitives are enough: aP files/directories, writable document
+files with commit-on-clunk, and blocking-read `Stream`s for observation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add `alan-editfs` as a user-space aP file-server crate.
+- Serve one buffer directory exposing `body`, `tag`, `addr`, `ctl`, and `event`.
+- Support body/tag edits, revision-bound address ranges, explicit `ctl exec`,
+  and observable JSON-line events.
+- Keep execution policy injectable and default-denied so the buffer never becomes
+  a privileged command runner.
+
+**Non-Goals:**
+
+- Native UI or Alan for macOS integration.
+- Real shell/process execution.
+- Multi-buffer discovery, persistence, CRDT editing, syntax highlighting, or
+  rich editor commands.
+- Replacing agent `io/` + `ctl`.
+
+## Decisions
+
+1. **One crate, one headless buffer surface.**
+
+   `alan-editfs` implements a single editable buffer rooted at the server root.
+   The first slice avoids a `buffers/<id>` hierarchy so tests and future clients
+   can focus on the file contract. A later slice can add multi-buffer allocation
+   through a clone file without changing the per-buffer shape.
+
+2. **Body and tag are commit-on-clunk UTF-8 documents.**
+
+   Writes buffer by fid and commit at `clunk`, matching the existing document
+   pattern in `llmfs` and `routefs`. Invalid UTF-8 fails at commit time with
+   `ErrorCode::BadRequest`.
+
+3. **`addr` uses revision-bound byte ranges.**
+
+   V1 format is `rev:<revision> <start>..<end>`. The revision must match the
+   current body revision when `ctl exec` consumes the range. This proves stale
+   range rejection without inventing a full editor address language.
+
+4. **`ctl exec` is explicit and policy-gated.**
+
+   Writing `exec` to `ctl` executes the active `addr` range through an injected
+   `ExecutionPolicy`. The default policy denies all execution. A test policy can
+   accept so we verify both accepted and denied event records without running a
+   real shell command.
+
+5. **Events are JSON lines on a blocking-read stream.**
+
+   `event` records edits, address changes, and execution outcomes. Consumers can
+   `read` at the live edge and block until a record arrives, matching ADR-0024
+   observation semantics.
+
+## Risks / Trade-offs
+
+- [Risk] Byte-range addressing can split a UTF-8 scalar. -> Mitigation: body and
+  tag contents must be UTF-8, and execution range extraction validates selected
+  bytes as UTF-8 before policy handling.
+- [Risk] A record-only execution policy may look weaker than real execution. ->
+  Mitigation: this slice proves explicit control, range validation, permission
+  outcome, and event audit; real shell/process adapters remain a later bounded
+  change.
+- [Risk] A single-buffer root may be too small for product use. -> Mitigation:
+  it preserves the final per-buffer file shape; allocation/discovery can be
+  layered later.

--- a/openspec/changes/add-editable-buffer-file-server/proposal.md
+++ b/openspec/changes/add-editable-buffer-file-server/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+`define-editable-buffer-interaction` establishes the Ring 4 editable-buffer
+contract, but the contract is not yet executable. The next useful North Star
+step is a headless `editfs` file server that proves `body` / `tag` / `addr` /
+`ctl` / `event` semantics through aP before any native UI work.
+
+## What Changes
+
+- Add an `alan-editfs` user-space aP file-server crate.
+- Serve one editable buffer directory with `body`, `tag`, `addr`, `ctl`, and
+  `event` files.
+- Support editable UTF-8 `body` and `tag` files with revisioned body content.
+- Support an `addr` file for revision-bound byte ranges over `body`.
+- Support explicit `exec` through `ctl`, recording accepted or denied execution
+  events without granting authority or running privileged side effects.
+- Append edit, address, and execution records to an observable blocking-read
+  `event` stream.
+- Keep the slice headless: no macOS UI, mouse behavior, syntax styling, or shell
+  product workflow changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `editable-buffer-file-server`: Defines the first headless `editfs` file-server
+  implementation of the editable-buffer interaction contract.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Adds a new workspace crate, `alan-editfs`, depending on `alan-ap`.
+- Adds focused aP integration tests for the buffer file surface, revision-bound
+  range addressing, explicit execution, event observation, and M0-M2 independence.
+- Does not change `alan-kernel`, agent runtime startup, macOS UI, or the current
+  agent `io/` + `ctl` path.

--- a/openspec/changes/add-editable-buffer-file-server/proposal.md
+++ b/openspec/changes/add-editable-buffer-file-server/proposal.md
@@ -12,8 +12,9 @@ step is a headless `editfs` file server that proves `body` / `tag` / `addr` /
   `event` files.
 - Support editable UTF-8 `body` and `tag` files with revisioned body content.
 - Support an `addr` file for revision-bound byte ranges over `body`.
-- Support explicit `exec` through `ctl`, recording accepted or denied execution
-  events without granting authority or running privileged side effects.
+- Support snapshot-bearing explicit `exec` through `ctl`, recording accepted or
+  denied execution events without granting authority or running privileged side
+  effects.
 - Append edit, address, and execution records to an observable blocking-read
   `event` stream.
 - Keep the slice headless: no macOS UI, mouse behavior, syntax styling, or shell

--- a/openspec/changes/add-editable-buffer-file-server/specs/editable-buffer-file-server/spec.md
+++ b/openspec/changes/add-editable-buffer-file-server/specs/editable-buffer-file-server/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: editfs exposes the editable buffer files
+
+Alan SHALL provide a headless `editfs` aP file server whose root directory
+contains `body`, `tag`, `addr`, `ctl`, and `event`.
+
+#### Scenario: Root lists buffer files
+
+- **WHEN** a client reads the `editfs` root directory
+- **THEN** the listing includes `body`, `tag`, `addr`, `ctl`, and `event`
+
+### Requirement: Body and tag edits commit on clunk
+
+Alan SHALL treat `body` and `tag` writes as UTF-8 document edits that become
+visible only when the writing fid is clunked.
+
+#### Scenario: Body edit commits
+
+- **WHEN** a client writes UTF-8 bytes to `body` and clunks the fid
+- **THEN** subsequent reads of `body` return the committed text
+- **AND** an edit event is appended to `event`
+
+#### Scenario: Invalid UTF-8 is rejected at commit
+
+- **WHEN** a client writes invalid UTF-8 bytes to `body` or `tag` and clunks the
+  fid
+- **THEN** the clunk fails with `ErrorCode::BadRequest`
+- **AND** the previous text remains visible
+
+### Requirement: Address ranges are revision-bound
+
+Alan SHALL store the active body range in `addr` using `rev:<revision>
+<start>..<end>` syntax.
+
+#### Scenario: Address range is selected
+
+- **WHEN** a client writes a valid current-revision range to `addr` and clunks
+  the fid
+- **THEN** subsequent reads of `addr` return that range
+- **AND** an address event is appended to `event`
+
+#### Scenario: Stale address fails at execution
+
+- **WHEN** the body revision changes after an address range is selected
+- **AND** a client writes `exec` to `ctl` and clunks the fid
+- **THEN** the clunk fails with `ErrorCode::BadRequest`
+- **AND** no command text from the stale range is executed
+
+### Requirement: Explicit exec records accepted and denied outcomes
+
+Alan SHALL handle `ctl exec` as an explicit policy-gated operation over the
+active `addr` range and SHALL record the outcome in `event`.
+
+#### Scenario: Execution is accepted by policy
+
+- **WHEN** the editfs execution policy accepts the selected command text
+- **AND** a client writes `exec` to `ctl` and clunks the fid
+- **THEN** the `event` stream records an execution event with status `accepted`
+  and the selected command text
+
+#### Scenario: Execution is denied by policy
+
+- **WHEN** the editfs execution policy denies the selected command text
+- **AND** a client writes `exec` to `ctl` and clunks the fid
+- **THEN** the `event` stream records an execution event with status `denied`
+  and the selected command text
+
+### Requirement: Event observation uses blocking reads
+
+Alan SHALL expose `event` as a retained blocking-read stream.
+
+#### Scenario: Event read blocks until activity
+
+- **WHEN** a client reads `event` at the live edge before new activity exists
+- **THEN** the read remains pending until an edit, address change, or execution
+  record is appended

--- a/openspec/changes/add-editable-buffer-file-server/specs/editable-buffer-file-server/spec.md
+++ b/openspec/changes/add-editable-buffer-file-server/specs/editable-buffer-file-server/spec.md
@@ -30,8 +30,10 @@ visible only when the writing fid is clunked.
 
 ### Requirement: Address ranges are revision-bound
 
-Alan SHALL store the active body range in `addr` using `rev:<revision>
-<start>..<end>` syntax.
+Alan SHALL store the active body range in `addr` using `rev:<body-revision>
+<start>..<end>` write syntax. Reads SHALL return the selected body revision,
+address revision, and range as `rev:<body-revision> addr:<addr-revision>
+<start>..<end>`.
 
 #### Scenario: Address range is selected
 
@@ -43,26 +45,30 @@ Alan SHALL store the active body range in `addr` using `rev:<revision>
 #### Scenario: Stale address fails at execution
 
 - **WHEN** the body revision changes after an address range is selected
-- **AND** a client writes `exec` to `ctl` and clunks the fid
+- **AND** a client writes `exec rev:<body-revision> addr:<addr-revision>
+  <start>..<end>` to `ctl` and clunks the fid
 - **THEN** the clunk fails with `ErrorCode::BadRequest`
 - **AND** no command text from the stale range is executed
 
 ### Requirement: Explicit exec records accepted and denied outcomes
 
-Alan SHALL handle `ctl exec` as an explicit policy-gated operation over the
-active `addr` range and SHALL record the outcome in `event`.
+Alan SHALL handle `ctl exec` as an explicit policy-gated operation over a
+caller-supplied `addr` snapshot that must match the active `addr` range and
+body revision. Alan SHALL record the outcome in `event`.
 
 #### Scenario: Execution is accepted by policy
 
 - **WHEN** the editfs execution policy accepts the selected command text
-- **AND** a client writes `exec` to `ctl` and clunks the fid
+- **AND** a client writes `exec rev:<body-revision> addr:<addr-revision>
+  <start>..<end>` to `ctl` and clunks the fid
 - **THEN** the `event` stream records an execution event with status `accepted`
   and the selected command text
 
 #### Scenario: Execution is denied by policy
 
 - **WHEN** the editfs execution policy denies the selected command text
-- **AND** a client writes `exec` to `ctl` and clunks the fid
+- **AND** a client writes `exec rev:<body-revision> addr:<addr-revision>
+  <start>..<end>` to `ctl` and clunks the fid
 - **THEN** the `event` stream records an execution event with status `denied`
   and the selected command text
 

--- a/openspec/changes/add-editable-buffer-file-server/tasks.md
+++ b/openspec/changes/add-editable-buffer-file-server/tasks.md
@@ -1,0 +1,68 @@
+## 1. Crate Setup
+
+- [x] 1.1 Add `crates/editfs` as workspace crate `alan-editfs`.
+  Done 2026-07-03: added `crates/editfs` to the workspace and workspace
+  dependency table.
+- [x] 1.2 Export a public `EditFs` aP file-server type and execution policy
+  types.
+  Done 2026-07-03: `alan-editfs` exports `EditFs`, `ExecutionPolicy`,
+  `AddressRange`, and mount/handle constants.
+
+## 2. Buffer Files
+
+- [x] 2.1 Serve root directory entries `body`, `tag`, `addr`, `ctl`, and `event`.
+  Done 2026-07-03: root reads list the five buffer files.
+- [x] 2.2 Implement `body` and `tag` as UTF-8 document files with
+  commit-on-clunk writes.
+  Done 2026-07-03: writes buffer per fid and become visible only at clunk.
+- [x] 2.3 Reject invalid UTF-8 at commit time without changing visible content.
+  Done 2026-07-03: invalid UTF-8 clunk returns `BadRequest` and preserves prior
+  text.
+
+## 3. Address And Control
+
+- [x] 3.1 Implement `addr` reads/writes using `rev:<revision> <start>..<end>`.
+  Done 2026-07-03: `AddressRange` parses and displays the revision-bound range
+  syntax.
+- [x] 3.2 Reject stale or invalid address ranges when `ctl exec` consumes the
+  active range.
+  Done 2026-07-03: `ctl exec` requires current body revision and UTF-8-safe range
+  boundaries.
+- [x] 3.3 Implement explicit `ctl exec` with default-denied and test-accepted
+  execution policies.
+  Done 2026-07-03: `ExecutionPolicy::DenyAll` is default and `AcceptAll` is
+  available for harness verification.
+
+## 4. Event Stream
+
+- [x] 4.1 Append JSON-line events for body/tag edits, address changes, and exec
+  accepted/denied outcomes.
+  Done 2026-07-03: edit, address, and exec records are appended as JSON lines.
+- [x] 4.2 Expose `event` as a retained blocking-read stream.
+  Done 2026-07-03: `event` is backed by `alan_ap::Stream`.
+
+## 5. Verification
+
+- [x] 5.1 Add focused `alan-editfs` integration tests covering root listing,
+  body/tag commit, invalid UTF-8 rejection, addr selection, stale addr rejection,
+  accepted/denied exec events, and blocking event reads.
+  Done 2026-07-03: `crates/editfs/tests/editfs.rs` covers all listed cases.
+- [x] 5.2 Run `cargo test -p alan-editfs -- --nocapture`.
+  Done 2026-07-03: focused editfs tests passed.
+- [x] 5.3 Run `cargo clippy -p alan-editfs --all-targets --all-features -- -D
+  warnings`.
+  Done 2026-07-03: focused editfs clippy passed with warnings denied.
+- [x] 5.4 Run `openspec validate add-editable-buffer-file-server --strict`.
+  Done 2026-07-03: strict OpenSpec validation passed.
+- [x] 5.5 Run `git diff --check`.
+  Done 2026-07-03: diff whitespace check passed.
+- [x] 5.6 Run `just verify`.
+  Done 2026-07-03: full workspace verification passed.
+
+## 6. PR Hygiene
+
+- [x] 6.1 Commit this slice separately from the editable-buffer contract PR.
+  Done 2026-07-03: committed as `6533e527`.
+- [x] 6.2 Open a stacked PR on top of
+  `feat/northstar-editable-buffer-contract` and mark it ready for review.
+  Done 2026-07-03: opened ready PR #593.

--- a/openspec/changes/add-editable-buffer-file-server/tasks.md
+++ b/openspec/changes/add-editable-buffer-file-server/tasks.md
@@ -21,13 +21,14 @@
 
 ## 3. Address And Control
 
-- [x] 3.1 Implement `addr` reads/writes using `rev:<revision> <start>..<end>`.
-  Done 2026-07-03: `AddressRange` parses and displays the revision-bound range
-  syntax.
-- [x] 3.2 Reject stale or invalid address ranges when `ctl exec` consumes the
-  active range.
-  Done 2026-07-03: `ctl exec` requires current body revision and UTF-8-safe range
-  boundaries.
+- [x] 3.1 Implement `addr` writes using `rev:<revision> <start>..<end>` and
+  reads using `rev:<revision> addr:<addr-revision> <start>..<end>`.
+  Done 2026-07-03: `AddressRange` parses revision-bound range writes and
+  displays the selected range snapshot with an address revision.
+- [x] 3.2 Reject stale or invalid address snapshots when `ctl exec` consumes the
+  caller-supplied range.
+  Done 2026-07-03: `ctl exec` requires the current body revision, current
+  address revision, exact active range, and UTF-8-safe range boundaries.
 - [x] 3.3 Implement explicit `ctl exec` with default-denied and test-accepted
   execution policies.
   Done 2026-07-03: `ExecutionPolicy::DenyAll` is default and `AcceptAll` is

--- a/openspec/changes/define-editable-buffer-interaction/.openspec.yaml
+++ b/openspec/changes/define-editable-buffer-interaction/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/define-editable-buffer-interaction/design.md
+++ b/openspec/changes/define-editable-buffer-interaction/design.md
@@ -49,23 +49,24 @@ future macOS view can all operate the same buffer through files.
 
    A buffer directory exposes `body`, `tag`, `ctl`, `addr`, and `event`.
    `body` is editable text, `tag` is a small command/status text surface, `addr`
-   names the active range together with an address-selection revision, `ctl`
-   commits operations, and `event` records edits, range changes, and
-   executions. Successful `body`/`tag` writes and range replacements update the
-   text returned by later reads; accepting an edit event while keeping stale
-   text is not conforming behavior.
+   names the active range together with the source `body` revision and an
+   address-selection revision, `ctl` commits operations, and `event` records
+   edits, range changes, and executions. Successful `body`/`tag` writes and
+   range replacements update the text returned by later reads; accepting an
+   edit event while keeping stale text is not conforming behavior.
 
    Alternative considered: one monolithic JSON document. That is easy to parse
    but not file-native; it would make shell usage and agent inspection worse.
 
 3. **Represent selection as address state, not hidden UI state.**
 
-   `addr` contains a stable range expression over `body` content plus an
-   address revision. Reads reveal the current range snapshot; writes propose a
-   new range and advance the address revision; `ctl` operations that consume the
-   range carry the expected range and revision so execution binds atomically to
-   the selection the caller observed. A UI selection is only one client
-   projection of `addr`.
+   `addr` contains a stable range expression over `body` content plus the body
+   revision observed when that range was selected and an address revision. Reads
+   reveal the current range snapshot; writes propose a new range and advance the
+   address revision; `ctl` operations that consume the range carry the expected
+   range, body revision, and address revision so execution binds atomically to
+   the selection and bytes the caller observed. A UI selection is only one
+   client projection of `addr`.
 
    Alternative considered: let the native UI own selection and publish events
    after the fact. That breaks the symmetry goal because agents cannot drive the
@@ -75,20 +76,24 @@ future macOS view can all operate the same buffer through files.
 
    Writing `exec` to `ctl` executes the expected range or supplied text through
    normal Alan Shell / process / routefs mechanisms. For range execution, the
-   operation includes the range and address revision observed by the caller; if
-   either no longer matches, the server rejects the operation instead of
-   executing another client's selection. It must produce an event and any side
-   effect still depends on the process namespace, descriptors, and policy. The
-   buffer server does not become a privileged command runner.
+   operation includes the range, body revision, and address revision observed by
+   the caller; if any no longer matches, the server rejects the operation
+   instead of executing another client's selection or mutated bytes. It must
+   produce an event and any side effect still depends on the process namespace,
+   descriptors, policy, and the ADR-0027 D3 qualification: until ADR-0024 R1
+   lands, the mount set is an architectural discipline rather than a security
+   property, and native subprocesses still need OS sandbox projection because
+   they cannot see Alan namespaces directly. The buffer server does not become a
+   privileged command runner.
 
    Alternative considered: every click or newline on command-looking text
    executes implicitly. That is faster but unsafe and hard to audit.
 
 ## Risks / Trade-offs
 
-- [Risk] Text execution can hide side effects in prose. -> Mitigation: execution
-  is an explicit `ctl` operation, records an event, and uses normal capability
-  checks.
+- [Risk] Text execution can hide side effects in prose. -> Mitigation:
+  execution is an explicit `ctl` operation, records an event, uses normal
+  capability checks, and keeps the R1 / OS sandbox boundary explicit.
 - [Risk] A buffer file server could fork from terminal/shell conventions. ->
   Mitigation: first implementation is headless and uses Alan Shell/process
   adapters below it rather than owning a parallel command system.

--- a/openspec/changes/define-editable-buffer-interaction/design.md
+++ b/openspec/changes/define-editable-buffer-interaction/design.md
@@ -82,9 +82,10 @@ future macOS view can all operate the same buffer through files.
    produce an event and any side effect still depends on the process namespace,
    descriptors, policy, and the ADR-0027 D3 qualification: until ADR-0024 R1
    lands, the mount set is an architectural discipline rather than a security
-   property, and native subprocesses still need OS sandbox projection because
-   they cannot see Alan namespaces directly. The buffer server does not become a
-   privileged command runner.
+   property, and native subprocesses still need OS sandbox projection as a
+   permanent second enforcement mechanism because they cannot see Alan
+   namespaces directly. The buffer server does not become a privileged command
+   runner.
 
    Alternative considered: every click or newline on command-looking text
    executes implicitly. That is faster but unsafe and hard to audit.

--- a/openspec/changes/define-editable-buffer-interaction/design.md
+++ b/openspec/changes/define-editable-buffer-interaction/design.md
@@ -49,17 +49,23 @@ future macOS view can all operate the same buffer through files.
 
    A buffer directory exposes `body`, `tag`, `ctl`, `addr`, and `event`.
    `body` is editable text, `tag` is a small command/status text surface, `addr`
-   names the active range, `ctl` commits operations, and `event` records edits,
-   range changes, and executions.
+   names the active range together with an address-selection revision, `ctl`
+   commits operations, and `event` records edits, range changes, and
+   executions. Successful `body`/`tag` writes and range replacements update the
+   text returned by later reads; accepting an edit event while keeping stale
+   text is not conforming behavior.
 
    Alternative considered: one monolithic JSON document. That is easy to parse
    but not file-native; it would make shell usage and agent inspection worse.
 
 3. **Represent selection as address state, not hidden UI state.**
 
-   `addr` contains a stable range expression over `body` content. Reads reveal
-   the current range; writes propose a new range; `ctl` operations consume that
-   range. A UI selection is only one client projection of `addr`.
+   `addr` contains a stable range expression over `body` content plus an
+   address revision. Reads reveal the current range snapshot; writes propose a
+   new range and advance the address revision; `ctl` operations that consume the
+   range carry the expected range and revision so execution binds atomically to
+   the selection the caller observed. A UI selection is only one client
+   projection of `addr`.
 
    Alternative considered: let the native UI own selection and publish events
    after the fact. That breaks the symmetry goal because agents cannot drive the
@@ -67,10 +73,13 @@ future macOS view can all operate the same buffer through files.
 
 4. **Execution is explicit and capability-bounded.**
 
-   Writing `exec` to `ctl` executes the current range or supplied text through
-   normal Alan Shell / process / routefs mechanisms. It must produce an event and
-   any side effect still depends on the process namespace, descriptors, and
-   policy. The buffer server does not become a privileged command runner.
+   Writing `exec` to `ctl` executes the expected range or supplied text through
+   normal Alan Shell / process / routefs mechanisms. For range execution, the
+   operation includes the range and address revision observed by the caller; if
+   either no longer matches, the server rejects the operation instead of
+   executing another client's selection. It must produce an event and any side
+   effect still depends on the process namespace, descriptors, and policy. The
+   buffer server does not become a privileged command runner.
 
    Alternative considered: every click or newline on command-looking text
    executes implicitly. That is faster but unsafe and hard to audit.
@@ -84,7 +93,8 @@ future macOS view can all operate the same buffer through files.
   Mitigation: first implementation is headless and uses Alan Shell/process
   adapters below it rather than owning a parallel command system.
 - [Risk] Range addresses can become invalid after concurrent edits. ->
-  Mitigation: events include revision metadata; stale `addr` commits fail with a
-  typed error instead of executing a different range.
+  Mitigation: `addr` and `exec` carry revision metadata; stale body or address
+  commits fail with a typed error instead of editing or executing a different
+  range.
 - [Risk] UI work could dominate the contract. -> Mitigation: this change's first
   tasks stop at file contract and tests; native host work is a later change.

--- a/openspec/changes/define-editable-buffer-interaction/design.md
+++ b/openspec/changes/define-editable-buffer-interaction/design.md
@@ -1,0 +1,90 @@
+## Context
+
+ADR-0026 D4 adopts the Acme idea, not Acme's literal UI: text is the
+programmable interaction surface, and the surface itself is a file server. The
+current Alan OS path already has the substrate needed below it: aP file servers,
+blocking-read streams, `io/` + `ctl` agent files, routefs for composition, and
+content-addressed backing for durable knowledge. This change defines the M4+
+interaction layer so future work can build it deliberately instead of adding
+ad-hoc command palettes or UI-only text affordances.
+
+The first implementation should prove the file contract before native UI. A
+headless file-server harness is enough to show that humans, agents, tests, and a
+future macOS view can all operate the same buffer through files.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define an editable interaction buffer as an Alan OS file-server surface.
+- Make text ranges addressable and executable through explicit file operations.
+- Keep events observable through blocking reads, consistent with ADR-0024 D8.
+- Make human and agent control symmetric: both use files, not hidden UI-only
+  state.
+- Keep the M0-M2 agent path independent; `io/` + `ctl` remains enough for the
+  current North Star stack.
+
+**Non-Goals:**
+
+- Recreate Acme's mouse chords, visual style, or editing taste.
+- Replace terminal panes, Alan Shell, or macOS shell navigation.
+- Add a native macOS UI in the first contract slice.
+- Add new authority outside namespace mounts, descriptors, and normal policy.
+- Treat arbitrary text execution as implicit approval for side effects.
+
+## Decisions
+
+1. **Name the first server shape `editfs`, not Acme.**
+
+   The name describes Alan's own surface: editable interaction buffers. The
+   historical source remains in ADR-0026 only. A future crate can be
+   `alan-editfs`, but this change defines the contract before requiring that
+   crate to exist.
+
+   Alternative considered: call it `alan-acme`. That would make the inspiration
+   obvious but would invite copying UI details and user expectations that Alan
+   explicitly does not adopt.
+
+2. **Use one directory per buffer surface.**
+
+   A buffer directory exposes `body`, `tag`, `ctl`, `addr`, and `event`.
+   `body` is editable text, `tag` is a small command/status text surface, `addr`
+   names the active range, `ctl` commits operations, and `event` records edits,
+   range changes, and executions.
+
+   Alternative considered: one monolithic JSON document. That is easy to parse
+   but not file-native; it would make shell usage and agent inspection worse.
+
+3. **Represent selection as address state, not hidden UI state.**
+
+   `addr` contains a stable range expression over `body` content. Reads reveal
+   the current range; writes propose a new range; `ctl` operations consume that
+   range. A UI selection is only one client projection of `addr`.
+
+   Alternative considered: let the native UI own selection and publish events
+   after the fact. That breaks the symmetry goal because agents cannot drive the
+   same surface without a UI adapter.
+
+4. **Execution is explicit and capability-bounded.**
+
+   Writing `exec` to `ctl` executes the current range or supplied text through
+   normal Alan Shell / process / routefs mechanisms. It must produce an event and
+   any side effect still depends on the process namespace, descriptors, and
+   policy. The buffer server does not become a privileged command runner.
+
+   Alternative considered: every click or newline on command-looking text
+   executes implicitly. That is faster but unsafe and hard to audit.
+
+## Risks / Trade-offs
+
+- [Risk] Text execution can hide side effects in prose. -> Mitigation: execution
+  is an explicit `ctl` operation, records an event, and uses normal capability
+  checks.
+- [Risk] A buffer file server could fork from terminal/shell conventions. ->
+  Mitigation: first implementation is headless and uses Alan Shell/process
+  adapters below it rather than owning a parallel command system.
+- [Risk] Range addresses can become invalid after concurrent edits. ->
+  Mitigation: events include revision metadata; stale `addr` commits fail with a
+  typed error instead of executing a different range.
+- [Risk] UI work could dominate the contract. -> Mitigation: this change's first
+  tasks stop at file contract and tests; native host work is a later change.

--- a/openspec/changes/define-editable-buffer-interaction/design.md
+++ b/openspec/changes/define-editable-buffer-interaction/design.md
@@ -54,6 +54,9 @@ future macOS view can all operate the same buffer through files.
    edits, range changes, and executions. Successful `body`/`tag` writes and
    range replacements update the text returned by later reads; accepting an
    edit event while keeping stale text is not conforming behavior.
+   `ctl` is a complete-document write entry point: implementations accumulate
+   writes and act only when the client clunks the file, never while an `exec`
+   document may still be partial.
 
    Alternative considered: one monolithic JSON document. That is easy to parse
    but not file-native; it would make shell usage and agent inspection worse.
@@ -74,18 +77,18 @@ future macOS view can all operate the same buffer through files.
 
 4. **Execution is explicit and capability-bounded.**
 
-   Writing `exec` to `ctl` executes the expected range or supplied text through
-   normal Alan Shell / process / routefs mechanisms. For range execution, the
-   operation includes the range, body revision, and address revision observed by
-   the caller; if any no longer matches, the server rejects the operation
-   instead of executing another client's selection or mutated bytes. It must
-   produce an event and any side effect still depends on the process namespace,
-   descriptors, policy, and the ADR-0027 D3 qualification: until ADR-0024 R1
-   lands, the mount set is an architectural discipline rather than a security
-   property, and native subprocesses still need OS sandbox projection as a
-   permanent second enforcement mechanism because they cannot see Alan
-   namespaces directly. The buffer server does not become a privileged command
-   runner.
+   Writing and clunking an `exec` document in `ctl` executes the expected range
+   or supplied text through normal Alan Shell / process / routefs mechanisms.
+   For range execution, the operation includes the range, body revision, and
+   address revision observed by the caller; if any no longer matches, the server
+   rejects the operation instead of executing another client's selection or
+   mutated bytes. It must produce an event and any side effect still depends on
+   the process namespace, descriptors, policy, and the ADR-0027 D3
+   qualification: until ADR-0024 R1 lands, the mount set is an architectural
+   discipline rather than a security property, and native subprocesses still
+   need OS sandbox projection as a permanent second enforcement mechanism
+   because they cannot see Alan namespaces directly. The buffer server does not
+   become a privileged command runner.
 
    Alternative considered: every click or newline on command-looking text
    executes implicitly. That is faster but unsafe and hard to audit.

--- a/openspec/changes/define-editable-buffer-interaction/proposal.md
+++ b/openspec/changes/define-editable-buffer-interaction/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+ADR-0026 D4 records the final Ring 4 idea in the North Star map: an editable
+buffer layer where text is the programmable surface and the interaction surface
+is itself a file server. The Ring 3 composition slices now have concrete changes,
+so this deferred M4+ layer needs a bounded OpenSpec contract before anyone starts
+copying Acme's UI details or mixing the idea into the M0-M2 `io/` + `ctl` path.
+
+## What Changes
+
+- Define the editable-buffer interaction surface as a future Alan OS file-server
+  contract above append-only agent `io/` streams.
+- Specify the durable file shape: `body`, `tag`, `ctl`, `addr`, and `event`
+  semantics adapted to Alan, not literal Acme behavior.
+- Define what "execute text" means in Alan: a selected text range resolves to an
+  explicit shell/action/process operation through normal namespace capabilities.
+- Preserve symmetry: humans and agents can both read, edit, observe, and drive
+  the same surface through files.
+- Keep this change scoped to the contract and first non-UI harness; native macOS
+  UI, mouse chords, syntax highlighting, and broad product workflow are later
+  implementation slices.
+
+## Capabilities
+
+### New Capabilities
+
+- `editable-buffer-interaction`: Defines the M4+ interaction file-server surface
+  for scriptable shared text buffers, executable text ranges, and observable
+  edit/control events.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Adds an OpenSpec owner for ADR-0026 D4 / ADR-0027 Ring 4.
+- Future implementation will add a user-space file-server crate above `alan-ap`
+  without changing `alan-kernel`.
+- The current M0-M2 agent path remains `io/` + `ctl`; this change must not be
+  used to delay the Ring 2 finish line or require native UI work before the
+  file contract exists.

--- a/openspec/changes/define-editable-buffer-interaction/proposal.md
+++ b/openspec/changes/define-editable-buffer-interaction/proposal.md
@@ -14,8 +14,10 @@ copying Acme's UI details or mixing the idea into the M0-M2 `io/` + `ctl` path.
   semantics adapted to Alan, not literal Acme behavior.
 - Define what "execute text" means in Alan: a selected text range resolves to an
   explicit shell/action/process operation through normal namespace capability
-  discipline, with the ADR-0027 D3 caveat that native subprocesses require OS
-  sandbox projection until the ADR-0024 R1 amplification check lands.
+  discipline, with the ADR-0027 D3 caveat that mount-set authority is not yet a
+  security property until the ADR-0024 R1 amplification check lands, and native
+  subprocesses permanently require OS sandbox projection because they cannot
+  inspect Alan namespaces directly.
 - Preserve symmetry: humans and agents can both read, edit, observe, and drive
   the same surface through files.
 - Keep this change scoped to the contract and first non-UI harness; native macOS

--- a/openspec/changes/define-editable-buffer-interaction/proposal.md
+++ b/openspec/changes/define-editable-buffer-interaction/proposal.md
@@ -13,7 +13,9 @@ copying Acme's UI details or mixing the idea into the M0-M2 `io/` + `ctl` path.
 - Specify the durable file shape: `body`, `tag`, `ctl`, `addr`, and `event`
   semantics adapted to Alan, not literal Acme behavior.
 - Define what "execute text" means in Alan: a selected text range resolves to an
-  explicit shell/action/process operation through normal namespace capabilities.
+  explicit shell/action/process operation through normal namespace capability
+  discipline, with the ADR-0027 D3 caveat that native subprocesses require OS
+  sandbox projection until the ADR-0024 R1 amplification check lands.
 - Preserve symmetry: humans and agents can both read, edit, observe, and drive
   the same surface through files.
 - Keep this change scoped to the contract and first non-UI harness; native macOS

--- a/openspec/changes/define-editable-buffer-interaction/specs/editable-buffer-interaction/spec.md
+++ b/openspec/changes/define-editable-buffer-interaction/specs/editable-buffer-interaction/spec.md
@@ -32,26 +32,27 @@ with `body`, `tag`, `ctl`, `addr`, and `event` files.
 
 Alan OS SHALL represent the active text range through an `addr` file that can be
 read and written by clients with write authority. The visible `addr` value SHALL
-include both the selected range and the revision of that address selection.
+include the selected range, the source `body` revision, and the revision of that
+address selection.
 
 #### Scenario: Client selects a body range
 
 - **WHEN** a client writes a valid range expression to `addr`
-- **THEN** subsequent reads of `addr` return that range with a new address
-  revision and operations that consume the active range can bind to that
-  revision
+- **THEN** subsequent reads of `addr` return that range with the current `body`
+  revision and a new address revision, and operations that consume the active
+  range can bind to both revisions
 
 #### Scenario: Stale range is rejected
 
-- **WHEN** a client commits an operation against an `addr` range whose source
-  body revision is no longer current
+- **WHEN** a client commits an operation against an `addr` range whose expected
+  source `body` revision is no longer current
 - **THEN** the operation fails with a typed aP error and does not apply to a
   different range
 
 #### Scenario: Stale address selection is rejected
 
-- **WHEN** a client commits an operation against an `addr` revision or range
-  that is no longer the current address selection
+- **WHEN** a client commits an operation against an `addr` revision, source
+  `body` revision, or range that is no longer the current address selection
 - **THEN** the operation fails with a typed aP error and does not consume a
   different client's selected range
 
@@ -59,22 +60,33 @@ include both the selected range and the revision of that address selection.
 
 Alan OS SHALL execute text from an editable buffer only through explicit `ctl`
 operations that resolve to normal Alan Shell, process, or routing behavior under
-the caller's namespace capabilities.
+the caller's namespace capability discipline. Until the ADR-0024 R1 amplification
+check lands, the mount set is an architectural discipline rather than a security
+property; native subprocesses such as shell commands cannot see the Alan
+namespace directly and still require OS sandbox projection.
 
 #### Scenario: Selected text is executed
 
 - **WHEN** a client writes an `exec` control operation carrying the expected
-  `addr` range and address revision
+  `addr` range, source `body` revision, and address revision
 - **THEN** Alan resolves the selected text through the normal shell/action/process
   path and records the execution in the buffer's `event` stream
 
 #### Scenario: Concurrent selection changes do not retarget execution
 
-- **WHEN** one client records an `addr` range and address revision, another
-  client changes `addr`, and the first client writes `exec` for the recorded
-  range and revision
+- **WHEN** one client records an `addr` range, source `body` revision, and
+  address revision, another client changes `addr`, and the first client writes
+  `exec` for the recorded range and revisions
 - **THEN** the operation fails with a typed aP error and does not execute text
   from the other client's range
+
+#### Scenario: Concurrent body edits do not retarget execution
+
+- **WHEN** one client records an `addr` range, source `body` revision, and
+  address revision, another client edits `body` without changing `addr`, and the
+  first client writes `exec` for the recorded range and revisions
+- **THEN** the operation fails with a typed aP error and does not execute the
+  mutated text at that range
 
 #### Scenario: Execution does not bypass authority
 
@@ -82,6 +94,13 @@ the caller's namespace capabilities.
   namespace or policy context
 - **THEN** execution is denied or yields through the normal policy path rather
   than being granted by the buffer surface
+
+#### Scenario: Native process execution keeps the OS sandbox boundary
+
+- **WHEN** selected text resolves to a native subprocess such as a shell command
+- **THEN** Alan projects the caller's allowed authority into the OS sandbox layer
+  instead of assuming the subprocess can inspect or enforce the Alan namespace
+  directly
 
 ### Requirement: Buffer activity is observable as events
 

--- a/openspec/changes/define-editable-buffer-interaction/specs/editable-buffer-interaction/spec.md
+++ b/openspec/changes/define-editable-buffer-interaction/specs/editable-buffer-interaction/spec.md
@@ -58,20 +58,27 @@ address selection.
 
 ### Requirement: Executable text uses explicit control operations
 
-Alan OS SHALL execute text from an editable buffer only through explicit `ctl`
-operations that resolve to normal Alan Shell, process, or routing behavior under
-the caller's namespace capability discipline. Until the ADR-0024 R1 amplification
-check lands, the mount set is an architectural discipline rather than a security
-property; native subprocesses such as shell commands cannot see the Alan
-namespace directly, so OS sandbox projection remains a permanent second
-enforcement mechanism for them.
+Alan OS SHALL execute text from an editable buffer only through explicit
+complete-document `ctl` operations that commit on `clunk` and resolve to normal
+Alan Shell, process, or routing behavior under the caller's namespace capability
+discipline. Until the ADR-0024 R1 amplification check lands, the mount set is an
+architectural discipline rather than a security property; native subprocesses
+such as shell commands cannot see the Alan namespace directly, so OS sandbox
+projection remains a permanent second enforcement mechanism for them.
 
 #### Scenario: Selected text is executed
 
-- **WHEN** a client writes an `exec` control operation carrying the expected
-  `addr` range, source `body` revision, and address revision
+- **WHEN** a client writes a complete `exec` control document carrying the
+  expected `addr` range, source `body` revision, and address revision and then
+  clunks `ctl`
 - **THEN** Alan resolves the selected text through the normal shell/action/process
   path and records the execution in the buffer's `event` stream
+
+#### Scenario: Partial control writes do not execute
+
+- **WHEN** a client writes only part of an `exec` control document to `ctl`
+- **THEN** Alan does not execute the selected text until the client completes the
+  control document and clunks `ctl`
 
 #### Scenario: Concurrent selection changes do not retarget execution
 

--- a/openspec/changes/define-editable-buffer-interaction/specs/editable-buffer-interaction/spec.md
+++ b/openspec/changes/define-editable-buffer-interaction/specs/editable-buffer-interaction/spec.md
@@ -63,7 +63,8 @@ operations that resolve to normal Alan Shell, process, or routing behavior under
 the caller's namespace capability discipline. Until the ADR-0024 R1 amplification
 check lands, the mount set is an architectural discipline rather than a security
 property; native subprocesses such as shell commands cannot see the Alan
-namespace directly and still require OS sandbox projection.
+namespace directly, so OS sandbox projection remains a permanent second
+enforcement mechanism for them.
 
 #### Scenario: Selected text is executed
 

--- a/openspec/changes/define-editable-buffer-interaction/specs/editable-buffer-interaction/spec.md
+++ b/openspec/changes/define-editable-buffer-interaction/specs/editable-buffer-interaction/spec.md
@@ -17,16 +17,29 @@ with `body`, `tag`, `ctl`, `addr`, and `event` files.
 - **THEN** the server returns UTF-8 text bytes representing the buffer content or
   command/status tag content
 
+#### Scenario: Successful text writes update the surface
+
+- **WHEN** a client successfully writes UTF-8 text to `body` or `tag`
+- **THEN** subsequent reads of that file return the updated text
+
+#### Scenario: Successful range replacement updates the body
+
+- **WHEN** a client successfully replaces text in a `body` range
+- **THEN** subsequent reads of `body` include the replacement at that range and
+  no longer return the replaced bytes at that range
+
 ### Requirement: Text ranges are addressable
 
 Alan OS SHALL represent the active text range through an `addr` file that can be
-read and written by clients with write authority.
+read and written by clients with write authority. The visible `addr` value SHALL
+include both the selected range and the revision of that address selection.
 
 #### Scenario: Client selects a body range
 
 - **WHEN** a client writes a valid range expression to `addr`
-- **THEN** subsequent reads of `addr` return that range and operations that
-  consume the active range use it
+- **THEN** subsequent reads of `addr` return that range with a new address
+  revision and operations that consume the active range can bind to that
+  revision
 
 #### Scenario: Stale range is rejected
 
@@ -34,6 +47,13 @@ read and written by clients with write authority.
   body revision is no longer current
 - **THEN** the operation fails with a typed aP error and does not apply to a
   different range
+
+#### Scenario: Stale address selection is rejected
+
+- **WHEN** a client commits an operation against an `addr` revision or range
+  that is no longer the current address selection
+- **THEN** the operation fails with a typed aP error and does not consume a
+  different client's selected range
 
 ### Requirement: Executable text uses explicit control operations
 
@@ -43,10 +63,18 @@ the caller's namespace capabilities.
 
 #### Scenario: Selected text is executed
 
-- **WHEN** a client writes an `exec` control operation for the active `addr`
-  range
+- **WHEN** a client writes an `exec` control operation carrying the expected
+  `addr` range and address revision
 - **THEN** Alan resolves the selected text through the normal shell/action/process
   path and records the execution in the buffer's `event` stream
+
+#### Scenario: Concurrent selection changes do not retarget execution
+
+- **WHEN** one client records an `addr` range and address revision, another
+  client changes `addr`, and the first client writes `exec` for the recorded
+  range and revision
+- **THEN** the operation fails with a typed aP error and does not execute text
+  from the other client's range
 
 #### Scenario: Execution does not bypass authority
 

--- a/openspec/changes/define-editable-buffer-interaction/specs/editable-buffer-interaction/spec.md
+++ b/openspec/changes/define-editable-buffer-interaction/specs/editable-buffer-interaction/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Editable buffers are file-server surfaces
+
+Alan OS SHALL expose an editable interaction buffer as a file-server directory
+with `body`, `tag`, `ctl`, `addr`, and `event` files.
+
+#### Scenario: Buffer files are inspectable
+
+- **WHEN** a client walks an editable buffer directory
+- **THEN** it can list and open `body`, `tag`, `ctl`, `addr`, and `event` using
+  normal aP operations
+
+#### Scenario: Body and tag are text surfaces
+
+- **WHEN** a client reads `body` or `tag`
+- **THEN** the server returns UTF-8 text bytes representing the buffer content or
+  command/status tag content
+
+### Requirement: Text ranges are addressable
+
+Alan OS SHALL represent the active text range through an `addr` file that can be
+read and written by clients with write authority.
+
+#### Scenario: Client selects a body range
+
+- **WHEN** a client writes a valid range expression to `addr`
+- **THEN** subsequent reads of `addr` return that range and operations that
+  consume the active range use it
+
+#### Scenario: Stale range is rejected
+
+- **WHEN** a client commits an operation against an `addr` range whose source
+  body revision is no longer current
+- **THEN** the operation fails with a typed aP error and does not apply to a
+  different range
+
+### Requirement: Executable text uses explicit control operations
+
+Alan OS SHALL execute text from an editable buffer only through explicit `ctl`
+operations that resolve to normal Alan Shell, process, or routing behavior under
+the caller's namespace capabilities.
+
+#### Scenario: Selected text is executed
+
+- **WHEN** a client writes an `exec` control operation for the active `addr`
+  range
+- **THEN** Alan resolves the selected text through the normal shell/action/process
+  path and records the execution in the buffer's `event` stream
+
+#### Scenario: Execution does not bypass authority
+
+- **WHEN** selected text would require a capability not present in the caller's
+  namespace or policy context
+- **THEN** execution is denied or yields through the normal policy path rather
+  than being granted by the buffer surface
+
+### Requirement: Buffer activity is observable as events
+
+Alan OS SHALL expose edits, address changes, and explicit executions through the
+buffer `event` stream using blocking-read semantics.
+
+#### Scenario: Edit event is observed
+
+- **WHEN** a client writes new content to `body`
+- **THEN** another client reading `event` at the live edge blocks until an edit
+  event is appended and then receives that event
+
+#### Scenario: Execution event is observed
+
+- **WHEN** a client executes selected text through `ctl`
+- **THEN** the `event` stream records the source range, command text, and
+  resulting accepted, denied, yielded, or failed status
+
+### Requirement: Editable buffers do not replace M0-M2 agent IO
+
+Alan OS SHALL keep editable buffers as an interaction layer above append-only
+agent `io/` streams; M0-M2 agent operation SHALL continue to work through `io/`
+and `ctl` without requiring editable buffers.
+
+#### Scenario: Agent IO remains sufficient
+
+- **WHEN** an agent process is driven through its existing `io/` and `ctl` files
+- **THEN** it does not require an editable buffer directory to start, receive
+  input, stream output, yield, or halt

--- a/openspec/changes/define-editable-buffer-interaction/tasks.md
+++ b/openspec/changes/define-editable-buffer-interaction/tasks.md
@@ -1,0 +1,41 @@
+## 1. Contract Definition
+
+- [x] 1.1 Capture ADR-0026 D4 as an OpenSpec proposal without changing M0-M2
+  runtime scope.
+  Done 2026-07-03: proposal records the editable-buffer layer as M4+ and keeps
+  current agent operation on `io/` + `ctl`.
+- [x] 1.2 Write the technical design for a headless file-server-first editable
+  buffer surface.
+  Done 2026-07-03: design defines `editfs`, one directory per buffer, explicit
+  `ctl` execution, and no first-slice native UI dependency.
+- [x] 1.3 Add the `editable-buffer-interaction` capability spec with testable
+  requirements.
+  Done 2026-07-03: spec covers `body`, `tag`, `ctl`, `addr`, `event`, range
+  addressing, explicit execution, event observation, and M0-M2 independence.
+
+## 2. Scope Guardrails
+
+- [x] 2.1 Make clear that this change absorbs the idea, not Acme's literal UI.
+  Done 2026-07-03: proposal and design explicitly exclude Acme mouse chords,
+  visual taste, and native macOS UI from this contract slice.
+- [x] 2.2 Make clear that execution remains capability-bounded and auditable.
+  Done 2026-07-03: spec requires explicit `ctl` execution, normal
+  namespace/policy checks, and event-stream records.
+
+## 3. Verification
+
+- [x] 3.1 Run `openspec validate define-editable-buffer-interaction --strict`.
+  Done 2026-07-03: strict OpenSpec validation passed.
+- [x] 3.2 Run `git diff --check`.
+  Done 2026-07-03: diff whitespace check passed.
+
+## 4. PR Hygiene
+
+- [x] 4.1 Commit this contract slice separately from the aP wire transport.
+  Done 2026-07-03: committed on
+  `feat/northstar-editable-buffer-contract` as
+  `docs(openspec): define editable buffer interaction layer`.
+- [x] 4.2 Open a stacked PR on top of `feat/northstar-ap-wire` and mark it ready
+  for review.
+  Done 2026-07-03: opened #592 on top of `feat/northstar-ap-wire`; GitHub
+  reports it is already ready for review.

--- a/openspec/changes/define-editable-buffer-interaction/tasks.md
+++ b/openspec/changes/define-editable-buffer-interaction/tasks.md
@@ -39,3 +39,8 @@
   for review.
   Done 2026-07-03: opened #592 on top of `feat/northstar-ap-wire`; GitHub
   reports it is already ready for review.
+
+## 5. Archive Readiness
+
+- [ ] 5.1 After this change merges, sync `editable-buffer-interaction` into
+  `openspec/specs/` without delta markers before archiving the change.


### PR DESCRIPTION
## Summary

- add `alan-editfs`, a headless aP editable-buffer file server
- expose `body`, `tag`, `addr`, `ctl`, and `event` files for the editable-buffer contract
- add commit-on-clunk UTF-8 edits, revision-bound ranges, policy-gated `ctl exec`, and JSON-line event observation
- add OpenSpec change `add-editable-buffer-file-server`

## Stack

- Stacks on #592 / `feat/northstar-editable-buffer-contract`
- Continues the North Star file-native runtime path as a separate PR, not a mega PR

## Verification

- `cargo test -p alan-editfs -- --nocapture`
- `cargo clippy -p alan-editfs --all-targets --all-features -- -D warnings`
- `openspec validate add-editable-buffer-file-server --strict`
- `git diff --check`
- `just verify`