### PR TITLE
North Star 9/9: add branching execution file server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "alan-branchfs"
+version = "0.1.0"
+dependencies = [
+ "alan-ap",
+ "alan-knowledge",
+ "async-trait",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "alan-editfs"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/memfs",
     "crates/routefs",
     "crates/editfs",
+    "crates/branchfs",
     "crates/agent-protocol",
     "crates/llm",
     "crates/llmfs",
@@ -124,6 +125,7 @@ alan-knowledge = { path = "crates/knowledge" }
 alan-memfs = { path = "crates/memfs" }
 alan-routefs = { path = "crates/routefs" }
 alan-editfs = { path = "crates/editfs" }
+alan-branchfs = { path = "crates/branchfs" }
 alan-swebench-tooling = { path = "crates/agent-engine/skills/swebench/tooling" }
 alan-shell-core = { path = "crates/shell-core" }
 alan-shell-core-ffi = { path = "crates/shell-core-ffi" }

--- a/crates/branchfs/Cargo.toml
+++ b/crates/branchfs/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "alan-branchfs"
+description = "Branching execution file server for Alan OS."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+alan-ap = { path = "../ap" }
+alan-knowledge = { path = "../knowledge" }
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true }

--- a/crates/branchfs/src/lib.rs
+++ b/crates/branchfs/src/lib.rs
@@ -344,6 +344,9 @@ impl State {
         let summary = branch.summary.clone();
         self.versions
             .bump(node_identity(&Node::Branch(id.clone())).1);
+        if self.selected.as_deref() == Some(&id) {
+            self.versions.bump(node_identity(&Node::Selected).1);
+        }
         self.append_event(EventRecord::Score {
             id: &id,
             score,

--- a/crates/branchfs/src/lib.rs
+++ b/crates/branchfs/src/lib.rs
@@ -1,0 +1,629 @@
+//! alan-branchfs — headless branching execution as an aP file server.
+//!
+//! The server exposes speculative checkpoint branches as files. It does not run
+//! a scheduler or model calls; it proves the file boundary that a later
+//! scheduler can drive: create cheap forks, score branches, select a branch,
+//! discard branches, and tail lifecycle events.
+
+use std::collections::{BTreeMap, HashMap};
+use std::hash::{Hash, Hasher};
+
+use alan_ap::{
+    ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat, Stream, VersionTable,
+};
+use alan_knowledge::{ContentHash, KnowledgeStore};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+const MAX_DOC_BYTES: usize = 1 << 20; // 1 MiB
+
+/// Canonical `/srv` handle name for the branching execution file server.
+pub const SRV_HANDLE: &str = "branch";
+/// Conventional mount path for branching execution surfaces.
+pub const MOUNT_PATH: &str = "/mnt/branch";
+
+/// Branch lifecycle state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BranchStatus {
+    /// Branch is visible and can be scored, selected, or discarded.
+    Active,
+    /// Branch is the explicitly selected candidate.
+    Selected,
+}
+
+/// Inspectable branch metadata served at `branches/<id>`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BranchRecord {
+    pub version: u16,
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base: Option<String>,
+    pub root: ContentHash,
+    pub status: BranchStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub score: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+}
+
+impl BranchRecord {
+    fn base(id: String, root: ContentHash) -> Self {
+        Self {
+            version: 1,
+            id,
+            base: None,
+            root,
+            status: BranchStatus::Active,
+            score: None,
+            summary: None,
+        }
+    }
+
+    fn fork(id: String, base: String, root: ContentHash) -> Self {
+        Self {
+            version: 1,
+            id,
+            base: Some(base),
+            root,
+            status: BranchStatus::Active,
+            score: None,
+            summary: None,
+        }
+    }
+}
+
+/// JSON command document accepted by `ctl`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum BranchCommand {
+    /// Fork a new candidate from an existing visible branch.
+    Fork {
+        id: String,
+        from: String,
+        delta: String,
+    },
+    /// Record an explicit branch score and optional summary.
+    Score {
+        id: String,
+        score: f64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        summary: Option<String>,
+    },
+    /// Explicitly select a visible branch.
+    Select { id: String },
+    /// Hide a visible branch while retaining lifecycle evidence in `events`.
+    Discard { id: String },
+}
+
+#[derive(Serialize)]
+struct SelectedBranch<'a> {
+    id: &'a str,
+    root: &'a ContentHash,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    score: Option<f64>,
+}
+
+struct State {
+    store: KnowledgeStore,
+    branches: BTreeMap<String, BranchRecord>,
+    selected: Option<String>,
+    events: Stream,
+    versions: VersionTable,
+    fids: HashMap<Fid, BranchFid>,
+}
+
+struct BranchFid {
+    node: Node,
+    mode: Option<OpenMode>,
+    write_buf: Vec<u8>,
+    wrote: bool,
+}
+
+#[derive(Debug, Clone)]
+enum Node {
+    Root,
+    Ctl,
+    BranchesDir,
+    Branch(String),
+    Selected,
+    Events,
+}
+
+/// Branching execution file server.
+pub struct BranchFs {
+    state: Mutex<State>,
+}
+
+impl Default for BranchFs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BranchFs {
+    /// Create an empty branchfs.
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(State {
+                store: KnowledgeStore::new(),
+                branches: BTreeMap::new(),
+                selected: None,
+                events: Stream::new(),
+                versions: VersionTable::new(),
+                fids: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Install a visible base branch backed by a new checkpoint.
+    pub async fn install_base_branch<I, B>(
+        &self,
+        id: impl Into<String>,
+        blocks: I,
+    ) -> Result<ContentHash, ErrorCode>
+    where
+        I: IntoIterator<Item = B> + Send,
+        I::IntoIter: Send,
+        B: AsRef<[u8]> + Send,
+    {
+        let mut state = self.state.lock().await;
+        let id = id.into();
+        validate_branch_id(&id)?;
+        if state.branches.contains_key(&id) {
+            return Err(ErrorCode::BadRequest);
+        }
+        let root = state
+            .store
+            .checkpoint_from_bytes(blocks)
+            .map_err(knowledge_error)?;
+        state
+            .branches
+            .insert(id.clone(), BranchRecord::base(id.clone(), root.clone()));
+        state.versions.bump(node_identity(&Node::BranchesDir).1);
+        state
+            .versions
+            .bump(node_identity(&Node::Branch(id.clone())).1);
+        state
+            .append_event(EventRecord::Base {
+                id: &id,
+                root: &root,
+            })
+            .await?;
+        Ok(root)
+    }
+
+    /// Return a visible branch record for tests and bootstrap code.
+    pub async fn branch(&self, id: &str) -> Option<BranchRecord> {
+        self.state.lock().await.branches.get(id).cloned()
+    }
+
+    /// Number of stored raw knowledge blocks.
+    pub async fn block_count(&self) -> usize {
+        self.state.lock().await.store.block_count()
+    }
+
+    /// Number of stored knowledge DAG nodes.
+    pub async fn node_count(&self) -> usize {
+        self.state.lock().await.store.node_count()
+    }
+}
+
+impl State {
+    fn node_of(&self, fid: Fid) -> Result<Node, ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(Node::Root);
+        }
+        self.fids
+            .get(&fid)
+            .map(|f| f.node.clone())
+            .ok_or(ErrorCode::NotFound)
+    }
+
+    fn qid(&self, node: &Node) -> Qid {
+        let (kind, path) = node_identity(node);
+        Qid {
+            kind,
+            version: self.versions.get(path),
+            path,
+        }
+    }
+
+    fn child(&self, node: &Node, name: &str) -> Result<Node, ErrorCode> {
+        match node {
+            Node::Root => match name {
+                "ctl" => Ok(Node::Ctl),
+                "branches" => Ok(Node::BranchesDir),
+                "selected" => Ok(Node::Selected),
+                "events" => Ok(Node::Events),
+                _ => Err(ErrorCode::NotFound),
+            },
+            Node::BranchesDir => {
+                if self.branches.contains_key(name) {
+                    Ok(Node::Branch(name.to_string()))
+                } else {
+                    Err(ErrorCode::NotFound)
+                }
+            }
+            _ => Err(ErrorCode::NotDirectory),
+        }
+    }
+
+    fn computed_bytes(&self, node: &Node) -> Result<Vec<u8>, ErrorCode> {
+        let bytes = match node {
+            Node::Root => b"ctl\nbranches\nselected\nevents".to_vec(),
+            Node::Ctl => {
+                b"# branchfs ctl: write one branch command JSON document, then clunk\n".to_vec()
+            }
+            Node::BranchesDir => listing(self.branches.keys()),
+            Node::Branch(id) => json_line(self.branches.get(id).ok_or(ErrorCode::NotFound)?)?,
+            Node::Selected => self.selected_bytes()?,
+            Node::Events => return Err(ErrorCode::Unsupported),
+        };
+        Ok(bytes)
+    }
+
+    fn stream_for(&self, node: &Node) -> Option<Stream> {
+        match node {
+            Node::Events => Some(self.events.clone()),
+            _ => None,
+        }
+    }
+
+    fn selected_bytes(&self) -> Result<Vec<u8>, ErrorCode> {
+        let Some(id) = self.selected.as_deref() else {
+            return Ok(b"null\n".to_vec());
+        };
+        let branch = self.branches.get(id).ok_or(ErrorCode::NotFound)?;
+        json_line(&SelectedBranch {
+            id,
+            root: &branch.root,
+            score: branch.score,
+        })
+    }
+
+    async fn commit_ctl(&mut self, bytes: Vec<u8>) -> Result<(), ErrorCode> {
+        let text = String::from_utf8(bytes).map_err(|_| ErrorCode::BadRequest)?;
+        let command: BranchCommand =
+            serde_json::from_str(&text).map_err(|_| ErrorCode::BadRequest)?;
+        match command {
+            BranchCommand::Fork { id, from, delta } => self.fork_branch(id, from, delta).await,
+            BranchCommand::Score { id, score, summary } => {
+                self.score_branch(id, score, summary).await
+            }
+            BranchCommand::Select { id } => self.select_branch(id).await,
+            BranchCommand::Discard { id } => self.discard_branch(id).await,
+        }
+    }
+
+    async fn fork_branch(
+        &mut self,
+        id: String,
+        from: String,
+        delta: String,
+    ) -> Result<(), ErrorCode> {
+        validate_branch_id(&id)?;
+        validate_branch_id(&from)?;
+        if self.branches.contains_key(&id) {
+            return Err(ErrorCode::BadRequest);
+        }
+        let base = self.branches.get(&from).ok_or(ErrorCode::NotFound)?;
+        let root = self
+            .store
+            .fork_append_bytes(&base.root, [delta.into_bytes()])
+            .map_err(knowledge_error)?;
+        self.branches.insert(
+            id.clone(),
+            BranchRecord::fork(id.clone(), from.clone(), root.clone()),
+        );
+        self.versions.bump(node_identity(&Node::BranchesDir).1);
+        self.versions
+            .bump(node_identity(&Node::Branch(id.clone())).1);
+        self.append_event(EventRecord::Fork {
+            id: &id,
+            from: &from,
+            root: &root,
+        })
+        .await
+    }
+
+    async fn score_branch(
+        &mut self,
+        id: String,
+        score: f64,
+        summary: Option<String>,
+    ) -> Result<(), ErrorCode> {
+        validate_branch_id(&id)?;
+        if !score.is_finite() {
+            return Err(ErrorCode::BadRequest);
+        }
+        let branch = self.branches.get_mut(&id).ok_or(ErrorCode::NotFound)?;
+        branch.score = Some(score);
+        branch.summary = summary;
+        let summary = branch.summary.clone();
+        self.versions
+            .bump(node_identity(&Node::Branch(id.clone())).1);
+        self.append_event(EventRecord::Score {
+            id: &id,
+            score,
+            summary: summary.as_deref(),
+        })
+        .await
+    }
+
+    async fn select_branch(&mut self, id: String) -> Result<(), ErrorCode> {
+        validate_branch_id(&id)?;
+        if !self.branches.contains_key(&id) {
+            return Err(ErrorCode::NotFound);
+        }
+        if let Some(previous) = self.selected.take()
+            && let Some(branch) = self.branches.get_mut(&previous)
+        {
+            branch.status = BranchStatus::Active;
+            self.versions.bump(node_identity(&Node::Branch(previous)).1);
+        }
+        let branch = self.branches.get_mut(&id).ok_or(ErrorCode::NotFound)?;
+        branch.status = BranchStatus::Selected;
+        let root = branch.root.clone();
+        self.selected = Some(id.clone());
+        self.versions.bump(node_identity(&Node::Selected).1);
+        self.versions
+            .bump(node_identity(&Node::Branch(id.clone())).1);
+        self.append_event(EventRecord::Select {
+            id: &id,
+            root: &root,
+        })
+        .await
+    }
+
+    async fn discard_branch(&mut self, id: String) -> Result<(), ErrorCode> {
+        validate_branch_id(&id)?;
+        let branch = self.branches.remove(&id).ok_or(ErrorCode::NotFound)?;
+        if self.selected.as_deref() == Some(&id) {
+            self.selected = None;
+            self.versions.bump(node_identity(&Node::Selected).1);
+        }
+        self.versions.bump(node_identity(&Node::BranchesDir).1);
+        self.versions
+            .bump(node_identity(&Node::Branch(id.clone())).1);
+        self.append_event(EventRecord::Discard {
+            id: &id,
+            root: &branch.root,
+        })
+        .await
+    }
+
+    async fn append_event(&self, event: EventRecord<'_>) -> Result<(), ErrorCode> {
+        let mut bytes = serde_json::to_vec(&event).map_err(|_| ErrorCode::BadRequest)?;
+        bytes.push(b'\n');
+        self.events.append(&bytes).await;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl FileServer for BranchFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        let mut state = self.state.lock().await;
+        if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
+            return Err(ErrorCode::BadRequest);
+        }
+        let mut node = state.node_of(fid)?;
+        for name in names {
+            node = state.child(&node, name)?;
+        }
+        let qid = state.qid(&node);
+        state.fids.insert(newfid, BranchFid::at(node));
+        Ok(qid)
+    }
+
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
+        let mut state = self.state.lock().await;
+        let node = state.node_of(fid)?;
+        if fid != Fid::ROOT && state.fids.get(&fid).is_some_and(|f| f.mode.is_some()) {
+            return Err(ErrorCode::BadRequest);
+        }
+        if matches!(mode, OpenMode::Write | OpenMode::ReadWrite) && !is_writable(&node) {
+            return Err(ErrorCode::NoAccess);
+        }
+        if fid != Fid::ROOT {
+            let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
+            f.mode = Some(mode);
+        }
+        Ok(state.qid(&node))
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let (node, stream) = {
+            let state = self.state.lock().await;
+            if fid != Fid::ROOT {
+                let f = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+                if !matches!(f.mode, Some(OpenMode::Read | OpenMode::ReadWrite)) {
+                    return Err(ErrorCode::NoAccess);
+                }
+            }
+            let node = state.node_of(fid)?;
+            let stream = state.stream_for(&node);
+            (node, stream)
+        };
+        if let Some(stream) = stream {
+            return Ok(stream.read(offset, count).await);
+        }
+        let state = self.state.lock().await;
+        Ok(slice(state.computed_bytes(&node)?, offset, count))
+    }
+
+    async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        let mut state = self.state.lock().await;
+        let node = state.node_of(fid)?;
+        let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
+        if !matches!(f.mode, Some(OpenMode::Write | OpenMode::ReadWrite)) {
+            return Err(ErrorCode::NoAccess);
+        }
+        if !is_writable(&node) {
+            return Err(ErrorCode::Unsupported);
+        }
+        let start = usize::try_from(offset).map_err(|_| ErrorCode::BadRequest)?;
+        let end = start.checked_add(data.len()).ok_or(ErrorCode::BadRequest)?;
+        if end > MAX_DOC_BYTES {
+            return Err(ErrorCode::BadRequest);
+        }
+        if f.write_buf.len() < end {
+            f.write_buf.resize(end, 0);
+        }
+        f.write_buf[start..end].copy_from_slice(data);
+        f.wrote = true;
+        Ok(data.len() as u32)
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        let state = self.state.lock().await;
+        let node = state.node_of(fid)?;
+        let length = match &node {
+            Node::Events => {
+                state
+                    .stream_for(&node)
+                    .ok_or(ErrorCode::NotFound)?
+                    .len()
+                    .await
+            }
+            other => state.computed_bytes(other)?.len() as u64,
+        };
+        Ok(Stat {
+            name: String::new(),
+            qid: state.qid(&node),
+            length,
+            writable: is_writable(&node),
+        })
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(());
+        }
+        let mut state = self.state.lock().await;
+        let f = state.fids.remove(&fid).ok_or(ErrorCode::NotFound)?;
+        if !f.wrote {
+            return Ok(());
+        }
+        match f.node {
+            Node::Ctl => state.commit_ctl(f.write_buf).await,
+            _ => Ok(()),
+        }
+    }
+}
+
+impl BranchFid {
+    fn at(node: Node) -> Self {
+        Self {
+            node,
+            mode: None,
+            write_buf: Vec::new(),
+            wrote: false,
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+enum EventRecord<'a> {
+    Base {
+        id: &'a str,
+        root: &'a ContentHash,
+    },
+    Fork {
+        id: &'a str,
+        from: &'a str,
+        root: &'a ContentHash,
+    },
+    Score {
+        id: &'a str,
+        score: f64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        summary: Option<&'a str>,
+    },
+    Select {
+        id: &'a str,
+        root: &'a ContentHash,
+    },
+    Discard {
+        id: &'a str,
+        root: &'a ContentHash,
+    },
+}
+
+fn is_writable(node: &Node) -> bool {
+    matches!(node, Node::Ctl)
+}
+
+fn validate_branch_id(id: &str) -> Result<(), ErrorCode> {
+    if id.is_empty()
+        || !id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(ErrorCode::BadRequest);
+    }
+    Ok(())
+}
+
+fn knowledge_error(error: alan_knowledge::KnowledgeError) -> ErrorCode {
+    match error {
+        alan_knowledge::KnowledgeError::MissingBlock(_)
+        | alan_knowledge::KnowledgeError::MissingNode(_)
+        | alan_knowledge::KnowledgeError::UnknownRoot(_) => ErrorCode::NotFound,
+        alan_knowledge::KnowledgeError::NoAccess => ErrorCode::NoAccess,
+        alan_knowledge::KnowledgeError::HashMismatch(_)
+        | alan_knowledge::KnowledgeError::Cycle(_) => ErrorCode::BadRequest,
+    }
+}
+
+fn json_line(value: &impl Serialize) -> Result<Vec<u8>, ErrorCode> {
+    let mut bytes = serde_json::to_vec(value).map_err(|_| ErrorCode::BadRequest)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn listing<'a>(names: impl Iterator<Item = &'a String>) -> Vec<u8> {
+    let mut out = Vec::new();
+    for name in names {
+        out.extend_from_slice(name.as_bytes());
+        out.push(b'\n');
+    }
+    out
+}
+
+fn node_identity(node: &Node) -> (FileKind, u64) {
+    let (kind, key) = match node {
+        Node::Root => (FileKind::Dir, "/".to_string()),
+        Node::Ctl => (FileKind::File, "ctl".to_string()),
+        Node::BranchesDir => (FileKind::Dir, "branches".to_string()),
+        Node::Branch(id) => (FileKind::File, format!("branches/{id}")),
+        Node::Selected => (FileKind::File, "selected".to_string()),
+        Node::Events => (FileKind::Stream, "events".to_string()),
+    };
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut h);
+    (kind, h.finish())
+}
+
+fn slice(bytes: Vec<u8>, offset: Offset, count: u32) -> Vec<u8> {
+    let start = (offset as usize).min(bytes.len());
+    let end = bytes.len().min(start + count as usize);
+    bytes[start..end].to_vec()
+}

--- a/crates/branchfs/tests/branchfs.rs
+++ b/crates/branchfs/tests/branchfs.rs
@@ -157,6 +157,49 @@ async fn score_and_select_are_explicit_and_inspectable() {
 }
 
 #[tokio::test]
+async fn scoring_selected_branch_bumps_selected_qid_version() {
+    let fs = BranchFs::new();
+    fs.install_base_branch("base", [b"a\n".to_vec()])
+        .await
+        .unwrap();
+    write_ctl(
+        &fs,
+        Fid(1),
+        json!({"op": "fork", "id": "candidate-a", "from": "base", "delta": "b\n"}),
+    )
+    .await
+    .unwrap();
+    write_ctl(&fs, Fid(2), json!({"op": "select", "id": "candidate-a"}))
+        .await
+        .unwrap();
+
+    fs.walk(Fid::ROOT, Fid(3), &["selected".into()])
+        .await
+        .unwrap();
+    let before = fs.stat(Fid(3)).await.unwrap().qid.version;
+    fs.clunk(Fid(3)).await.unwrap();
+
+    write_ctl(
+        &fs,
+        Fid(4),
+        json!({"op": "score", "id": "candidate-a", "score": 0.91, "summary": "higher"}),
+    )
+    .await
+    .unwrap();
+
+    fs.walk(Fid::ROOT, Fid(5), &["selected".into()])
+        .await
+        .unwrap();
+    let after = fs.stat(Fid(5)).await.unwrap().qid.version;
+    fs.clunk(Fid(5)).await.unwrap();
+
+    assert!(after > before, "selected qid version did not advance");
+    let selected: Value =
+        serde_json::from_str(&read_text(&fs, &["selected"], Fid(6)).await).expect("selected json");
+    assert_eq!(selected["score"], 0.91);
+}
+
+#[tokio::test]
 async fn discard_hides_branch_but_retains_event() {
     let fs = BranchFs::new();
     fs.install_base_branch("base", [b"a\n".to_vec()])

--- a/crates/branchfs/tests/branchfs.rs
+++ b/crates/branchfs/tests/branchfs.rs
@@ -1,0 +1,227 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use alan_ap::{ErrorCode, Fid, FileServer, OpenMode};
+use alan_branchfs::{BranchFs, BranchRecord, BranchStatus};
+use serde_json::{Value, json};
+
+async fn read_text(fs: &BranchFs, path: &[&str], fid: Fid) -> String {
+    let names = path.iter().map(|name| name.to_string()).collect::<Vec<_>>();
+    fs.walk(Fid::ROOT, fid, &names).await.expect("walk");
+    fs.open(fid, OpenMode::Read).await.expect("open");
+    let bytes = fs.read(fid, 0, 4096).await.expect("read");
+    fs.clunk(fid).await.expect("clunk");
+    String::from_utf8(bytes).expect("utf8")
+}
+
+async fn write_doc(fs: &BranchFs, path: &[&str], fid: Fid, bytes: &[u8]) -> Result<(), ErrorCode> {
+    let names = path.iter().map(|name| name.to_string()).collect::<Vec<_>>();
+    fs.walk(Fid::ROOT, fid, &names).await?;
+    fs.open(fid, OpenMode::Write).await?;
+    fs.write(fid, 0, bytes).await?;
+    fs.clunk(fid).await
+}
+
+async fn write_ctl(fs: &BranchFs, fid: Fid, command: Value) -> Result<(), ErrorCode> {
+    write_doc(fs, &["ctl"], fid, command.to_string().as_bytes()).await
+}
+
+async fn event_len(fs: &BranchFs, fid: Fid) -> u64 {
+    fs.walk(Fid::ROOT, fid, &["events".into()])
+        .await
+        .expect("walk events");
+    let stat = fs.stat(fid).await.expect("stat events");
+    fs.clunk(fid).await.expect("clunk events");
+    stat.length
+}
+
+#[tokio::test]
+async fn root_lists_branch_files() {
+    let fs = BranchFs::new();
+    let root = read_text(&fs, &[], Fid(1)).await;
+    for entry in ["ctl", "branches", "selected", "events"] {
+        assert!(root.lines().any(|line| line == entry), "{root}");
+    }
+}
+
+#[tokio::test]
+async fn base_branch_is_visible_as_json() {
+    let fs = BranchFs::new();
+    let root = fs
+        .install_base_branch("base", [b"record-1\n".to_vec()])
+        .await
+        .unwrap();
+
+    let branches = read_text(&fs, &["branches"], Fid(1)).await;
+    assert_eq!(branches.trim(), "base");
+
+    let branch: BranchRecord =
+        serde_json::from_str(&read_text(&fs, &["branches", "base"], Fid(2)).await).unwrap();
+    assert_eq!(branch.id, "base");
+    assert_eq!(branch.base, None);
+    assert_eq!(branch.root, root);
+    assert_eq!(branch.status, BranchStatus::Active);
+}
+
+#[tokio::test]
+async fn fork_creates_candidate_with_shared_base_blocks_and_event() {
+    let fs = BranchFs::new();
+    let base = fs
+        .install_base_branch("base", [b"a\n".to_vec(), b"b\n".to_vec()])
+        .await
+        .unwrap();
+    let initial_blocks = fs.block_count().await;
+    let initial_nodes = fs.node_count().await;
+
+    write_ctl(
+        &fs,
+        Fid(1),
+        json!({"op": "fork", "id": "candidate-a", "from": "base", "delta": "c\n"}),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(fs.block_count().await, initial_blocks + 1);
+    assert_eq!(fs.node_count().await, initial_nodes + 1);
+
+    let candidate: BranchRecord =
+        serde_json::from_str(&read_text(&fs, &["branches", "candidate-a"], Fid(2)).await).unwrap();
+    assert_eq!(candidate.id, "candidate-a");
+    assert_eq!(candidate.base.as_deref(), Some("base"));
+    assert_ne!(candidate.root, base);
+
+    let events = read_text(&fs, &["events"], Fid(3)).await;
+    assert!(events.contains(r#""type":"fork""#), "{events}");
+    assert!(events.contains(r#""id":"candidate-a""#), "{events}");
+}
+
+#[tokio::test]
+async fn fork_rejects_unknown_source_branch() {
+    let fs = BranchFs::new();
+    fs.install_base_branch("base", [b"a\n".to_vec()])
+        .await
+        .unwrap();
+
+    let err = write_ctl(
+        &fs,
+        Fid(1),
+        json!({"op": "fork", "id": "candidate-a", "from": "missing", "delta": "b\n"}),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(err, ErrorCode::NotFound);
+    let branches = read_text(&fs, &["branches"], Fid(2)).await;
+    assert!(!branches.lines().any(|line| line == "candidate-a"));
+}
+
+#[tokio::test]
+async fn score_and_select_are_explicit_and_inspectable() {
+    let fs = BranchFs::new();
+    fs.install_base_branch("base", [b"a\n".to_vec()])
+        .await
+        .unwrap();
+    write_ctl(
+        &fs,
+        Fid(1),
+        json!({"op": "fork", "id": "candidate-a", "from": "base", "delta": "b\n"}),
+    )
+    .await
+    .unwrap();
+
+    write_ctl(
+        &fs,
+        Fid(2),
+        json!({"op": "score", "id": "candidate-a", "score": 0.82, "summary": "best trace"}),
+    )
+    .await
+    .unwrap();
+    write_ctl(&fs, Fid(3), json!({"op": "select", "id": "candidate-a"}))
+        .await
+        .unwrap();
+
+    let branch: BranchRecord =
+        serde_json::from_str(&read_text(&fs, &["branches", "candidate-a"], Fid(4)).await).unwrap();
+    assert_eq!(branch.score, Some(0.82));
+    assert_eq!(branch.summary.as_deref(), Some("best trace"));
+    assert_eq!(branch.status, BranchStatus::Selected);
+
+    let selected: Value =
+        serde_json::from_str(&read_text(&fs, &["selected"], Fid(5)).await).expect("selected json");
+    assert_eq!(selected["id"], "candidate-a");
+    assert_eq!(selected["score"], 0.82);
+
+    let events = read_text(&fs, &["events"], Fid(6)).await;
+    assert!(events.contains(r#""type":"score""#), "{events}");
+    assert!(events.contains(r#""type":"select""#), "{events}");
+}
+
+#[tokio::test]
+async fn discard_hides_branch_but_retains_event() {
+    let fs = BranchFs::new();
+    fs.install_base_branch("base", [b"a\n".to_vec()])
+        .await
+        .unwrap();
+    write_ctl(
+        &fs,
+        Fid(1),
+        json!({"op": "fork", "id": "candidate-a", "from": "base", "delta": "b\n"}),
+    )
+    .await
+    .unwrap();
+
+    write_ctl(&fs, Fid(2), json!({"op": "discard", "id": "candidate-a"}))
+        .await
+        .unwrap();
+
+    let branches = read_text(&fs, &["branches"], Fid(3)).await;
+    assert!(!branches.lines().any(|line| line == "candidate-a"));
+    let err = fs
+        .walk(
+            Fid::ROOT,
+            Fid(4),
+            &["branches".into(), "candidate-a".into()],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(err, ErrorCode::NotFound);
+
+    let events = read_text(&fs, &["events"], Fid(5)).await;
+    assert!(events.contains(r#""type":"discard""#), "{events}");
+    assert!(events.contains(r#""id":"candidate-a""#), "{events}");
+}
+
+#[tokio::test]
+async fn event_read_blocks_until_branch_activity_is_appended() {
+    let fs = Arc::new(BranchFs::new());
+    fs.install_base_branch("base", [b"a\n".to_vec()])
+        .await
+        .unwrap();
+    let start = event_len(&fs, Fid(1)).await;
+
+    fs.walk(Fid::ROOT, Fid(2), &["events".into()])
+        .await
+        .expect("walk events");
+    fs.open(Fid(2), OpenMode::Read).await.expect("open events");
+
+    let reader = {
+        let fs = fs.clone();
+        tokio::spawn(async move { fs.read(Fid(2), start, 4096).await })
+    };
+    assert!(
+        tokio::time::timeout(Duration::from_millis(30), reader)
+            .await
+            .is_err(),
+        "events read should block at the live edge"
+    );
+
+    write_ctl(
+        &fs,
+        Fid(3),
+        json!({"op": "fork", "id": "candidate-a", "from": "base", "delta": "b\n"}),
+    )
+    .await
+    .unwrap();
+    let events = read_text(&fs, &["events"], Fid(4)).await;
+    assert!(events.contains(r#""type":"fork""#), "{events}");
+}

--- a/openspec/changes/add-branching-execution-file-server/.openspec.yaml
+++ b/openspec/changes/add-branching-execution-file-server/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/add-branching-execution-file-server/design.md
+++ b/openspec/changes/add-branching-execution-file-server/design.md
@@ -1,0 +1,88 @@
+## Context
+
+`alan-knowledge` already stores tape/memory/context as content-addressed blocks
+and Merkle checkpoint roots. It can fork a root by referencing the base root and
+appending only divergent blocks. ADR-0027 names the payoff: speculative /
+branching execution over cheap forks.
+
+This change adds the missing file boundary before adding a scheduler. A mounted
+`branchfs` gives agents, tools, or future schedulers one file-shaped place to
+create candidate branches, record scores, select a winner, and observe branch
+lifecycle events.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add `alan-branchfs` as a user-space aP file-server crate.
+- Serve `ctl`, `branches/`, `selected`, and `events`.
+- Use `alan-knowledge` checkpoint roots for branch state and cheap fork sharing.
+- Require fork commands to name an existing visible branch id, not a bare content
+  hash.
+- Record branch lifecycle as JSON-line events on a retained blocking-read stream.
+
+**Non-Goals:**
+
+- Running automatic model calls or tools for each branch.
+- Implementing tree-search strategy, ranking heuristics, or budget policy.
+- Replacing daemon session fork, child-agent spawning, or AgentFS checkpoint
+  commands.
+- Persisting branchfs state across process restarts.
+
+## Decisions
+
+1. **Expose a small branch tree, not a scheduler.**
+
+   The server root lists `ctl`, `branches`, `selected`, and `events`.
+   `branches/<id>` is an inspectable JSON document with the base branch id,
+   current root hash, status, optional score, and optional summary. This proves
+   the file contract and leaves scheduling policy for a later mounted service.
+
+2. **`ctl` accepts one JSON command document committed on clunk.**
+
+   Commands are structured because branch creation needs multiple fields:
+   `{"op":"fork","id":"candidate-a","from":"base","delta":"..."}`,
+   `{"op":"score","id":"candidate-a","score":0.82,"summary":"..."}`,
+   `{"op":"select","id":"candidate-a"}`, and
+   `{"op":"discard","id":"candidate-a"}`. Commit-on-clunk matches the other
+   Alan OS document-style control surfaces.
+
+3. **Forks name visible branch ids, not content hashes.**
+
+   A content hash is not authority. `branchfs` can be initialized with a visible
+   base branch through bootstrap code, and later forks must name an existing
+   `branches/<id>` entry. The server then uses the internal `alan-knowledge`
+   store to fork from that branch's root. Knowing a root hash string is never
+   enough to create a branch.
+
+4. **Selection is explicit and inspectable.**
+
+   Writing `select` to `ctl` updates `selected` and marks the selected branch.
+   No branch is selected implicitly by score. This keeps judgment policy outside
+   the file server while making the decision durable enough for future clients to
+   tail or read.
+
+5. **Discard hides the branch but keeps lifecycle evidence.**
+
+   Discarded branches are removed from `branches/` so clients stop considering
+   them. The discard record remains in `events`. Knowledge-store GC remains the
+   backing store's job; this change does not add retention policy.
+
+## Risks / Trade-offs
+
+- [Risk] This can look weaker than "real" speculative execution because no model
+  work is scheduled. -> Mitigation: the file boundary is the load-bearing piece;
+  schedulers can later drive it with ordinary file operations.
+- [Risk] JSON control documents are less shell-like than single-word ctl verbs.
+  -> Mitigation: branch operations need typed fields; keeping them in one
+  commit-on-clunk document avoids partial multi-file transactions.
+- [Risk] Branch state is in-memory. -> Mitigation: v1 is a headless contract
+  slice; persistence follows once the scheduler and durable home integration are
+  specified.
+
+## Migration Plan
+
+1. Add `alan-branchfs` and focused tests.
+2. Keep it unmounted by default.
+3. Later mount it under a scheduler or Agent Runtime Service namespace when the
+   speculative-execution policy exists.

--- a/openspec/changes/add-branching-execution-file-server/proposal.md
+++ b/openspec/changes/add-branching-execution-file-server/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+`add-content-addressed-knowledge` made checkpoint forks cheap, but branching
+execution is still only an implied payoff. The next useful Ring 3 slice is a
+headless file server that makes speculative branches inspectable and selectable
+through Alan OS file operations before a scheduler starts driving them.
+
+## What Changes
+
+- Add `alan-branchfs`, a user-space aP file server for branch planning over
+  content-addressed checkpoint roots.
+- Expose a branch tree with `ctl`, `branches/`, `selected`, and `events` files.
+- Support explicit `ctl` commands to fork a branch from a base root, score a
+  branch, select a branch, and discard a branch.
+- Store branch roots as `alan-knowledge` Merkle forks so unchanged state is
+  shared and branch state remains tamper-evident.
+- Emit JSON-line branch lifecycle records to a retained blocking-read `events`
+  stream.
+- Keep this slice headless: no automatic model calls, no daemon session fork
+  replacement, no ranking strategy, and no native UI.
+
+## Capabilities
+
+### New Capabilities
+
+- `branching-execution-file-server`: Defines the headless file-server contract
+  for creating, observing, scoring, selecting, and discarding speculative
+  checkpoint branches over the content-addressed knowledge store.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Adds a new workspace crate, `alan-branchfs`, depending on `alan-ap` and
+  `alan-knowledge`.
+- Adds focused aP integration tests for branch creation, cheap fork sharing,
+  selected-branch publication, discard behavior, and event observation.
+- Does not change `alan-kernel`, daemon `/api/v1/sessions/{id}/fork`, the agent
+  runtime scheduler, macOS UI, or existing AgentFS surfaces.

--- a/openspec/changes/add-branching-execution-file-server/specs/branching-execution-file-server/spec.md
+++ b/openspec/changes/add-branching-execution-file-server/specs/branching-execution-file-server/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: branchfs exposes a branching execution tree
+
+Alan SHALL provide a headless `branchfs` aP file server whose root directory
+contains `ctl`, `branches`, `selected`, and `events`.
+
+#### Scenario: Root lists branch files
+
+- **WHEN** a client reads the `branchfs` root directory
+- **THEN** the listing includes `ctl`, `branches`, `selected`, and `events`
+
+### Requirement: Branches fork from visible branch roots
+
+Alan SHALL create branch candidates by writing a complete fork command to `ctl`
+and clunking the fid. A fork command SHALL name an existing visible branch id as
+its source; a bare content hash SHALL NOT authorize branch creation.
+
+#### Scenario: Candidate branch is forked
+
+- **WHEN** `branches/base` is visible
+- **AND** a client writes a fork command naming `from = "base"` to `ctl` and
+  clunks the fid
+- **THEN** `branches/<candidate>` appears as an inspectable JSON file
+- **AND** the candidate root is a content-addressed fork sharing unchanged state
+  with the base root
+- **AND** a fork event is appended to `events`
+
+#### Scenario: Unknown source branch is rejected
+
+- **WHEN** a client writes a fork command naming a source branch that is not
+  visible under `branches/`
+- **THEN** the clunk fails with `ErrorCode::NotFound`
+- **AND** no candidate branch is created
+
+### Requirement: Branches can be scored explicitly
+
+Alan SHALL allow clients to record an explicit score and summary for a visible
+branch by writing a score command to `ctl`.
+
+#### Scenario: Branch is scored
+
+- **WHEN** a client scores a visible branch through `ctl`
+- **THEN** `branches/<id>` reports the score and summary
+- **AND** a score event is appended to `events`
+
+### Requirement: Branch selection is explicit
+
+Alan SHALL publish the selected branch through the `selected` file only after a
+client writes an explicit select command to `ctl`.
+
+#### Scenario: Branch is selected
+
+- **WHEN** a client selects a visible branch through `ctl`
+- **THEN** `selected` reports that branch id and root hash
+- **AND** the selected branch remains inspectable under `branches/`
+- **AND** a select event is appended to `events`
+
+### Requirement: Branches can be discarded without deleting lifecycle evidence
+
+Alan SHALL allow clients to discard a visible branch through `ctl`. Discarded
+branches SHALL stop appearing under `branches/`, while the event stream retains
+the discard record.
+
+#### Scenario: Branch is discarded
+
+- **WHEN** a client discards a visible branch through `ctl`
+- **THEN** `branches/` no longer lists that branch
+- **AND** a discard event is appended to `events`
+
+### Requirement: Branch observation uses blocking reads
+
+Alan SHALL expose `events` as a retained blocking-read stream of JSON-line branch
+lifecycle records.
+
+#### Scenario: Event read blocks until branch activity
+
+- **WHEN** a client reads `events` at the live edge before new branch activity
+  exists
+- **THEN** the read remains pending until a fork, score, select, or discard
+  record is appended

--- a/openspec/changes/add-branching-execution-file-server/tasks.md
+++ b/openspec/changes/add-branching-execution-file-server/tasks.md
@@ -1,0 +1,78 @@
+## 1. Crate Setup
+
+- [x] 1.1 Add `crates/branchfs` as workspace crate `alan-branchfs`.
+  Done 2026-07-03: added `crates/branchfs` to the workspace and workspace
+  dependency table.
+- [x] 1.2 Export public `BranchFs`, `BranchRecord`, and branch command/status
+  types plus mount/handle constants.
+  Done 2026-07-03: `alan-branchfs` exports `BranchFs`, `BranchRecord`,
+  `BranchStatus`, `BranchCommand`, and mount/handle constants.
+
+## 2. File Surface
+
+- [x] 2.1 Serve root directory entries `ctl`, `branches`, `selected`, and
+  `events`.
+  Done 2026-07-03: root reads list all four files.
+- [x] 2.2 Serve `branches/` as the listing of visible branch ids and
+  `branches/<id>` as inspectable JSON branch metadata.
+  Done 2026-07-03: `branches/` lists visible ids and `branches/<id>` returns
+  `BranchRecord` JSON.
+- [x] 2.3 Serve `selected` as the explicit selected-branch JSON view.
+  Done 2026-07-03: `selected` returns `null` before selection and branch id/root
+  JSON after explicit selection.
+- [x] 2.4 Expose `events` as a retained blocking-read stream.
+  Done 2026-07-03: `events` is backed by `alan_ap::Stream`.
+
+## 3. Branch Operations
+
+- [x] 3.1 Implement bootstrap helpers for installing a visible base branch backed
+  by an `alan-knowledge` checkpoint root.
+  Done 2026-07-03: `install_base_branch` creates a checkpoint root and visible
+  base branch.
+- [x] 3.2 Implement `ctl` fork commands that name an existing visible source
+  branch and write only divergent delta blocks through cheap knowledge forks.
+  Done 2026-07-03: fork commands call `KnowledgeStore::fork_append_bytes` and
+  tests verify one new block/node for a divergent branch.
+- [x] 3.3 Reject fork commands whose source branch is not visible.
+  Done 2026-07-03: unknown source branches fail with `ErrorCode::NotFound`.
+- [x] 3.4 Implement explicit score commands and publish score/summary in
+  `branches/<id>`.
+  Done 2026-07-03: score commands update branch JSON and append score events.
+- [x] 3.5 Implement explicit select commands and publish the selected branch
+  through `selected`.
+  Done 2026-07-03: select commands mark the selected branch and update
+  `selected`.
+- [x] 3.6 Implement discard commands that hide discarded branches while retaining
+  discard events.
+  Done 2026-07-03: discard removes the branch from `branches/` and appends a
+  discard event.
+
+## 4. Verification
+
+- [x] 4.1 Add focused `alan-branchfs` integration tests for root listing, branch
+  JSON, cheap fork sharing, unknown-source rejection, scoring, selection,
+  discard, and blocking event reads.
+  Done 2026-07-03: `crates/branchfs/tests/branchfs.rs` covers all listed cases.
+- [x] 4.2 Run `cargo test -p alan-branchfs -- --nocapture`.
+  Done 2026-07-03: focused branchfs tests passed.
+- [x] 4.3 Run `cargo clippy -p alan-branchfs --all-targets --all-features -- -D
+  warnings`.
+  Done 2026-07-03: focused branchfs clippy passed with warnings denied.
+- [x] 4.4 Run `openspec validate add-branching-execution-file-server --strict`.
+  Done 2026-07-03: strict OpenSpec validation passed.
+- [x] 4.5 Run `git diff --check`.
+  Done 2026-07-03: diff whitespace check passed.
+- [x] 4.6 Run `just verify`.
+  Done 2026-07-03: full workspace verification passed.
+
+## 5. PR Hygiene
+
+- [x] 5.1 Mark `add-content-addressed-knowledge` follow-up 5.1 as covered by
+  this separate change.
+  Done 2026-07-03: `add-content-addressed-knowledge` now points this follow-up
+  to `add-branching-execution-file-server`.
+- [x] 5.2 Commit this slice separately from the `editfs` PR.
+  Done 2026-07-03: committed as `5501fa92`.
+- [x] 5.3 Open a stacked PR on top of `feat/northstar-editfs` and mark it ready
+  for review.
+  Done 2026-07-03: opened ready PR #594 on top of `feat/northstar-editfs`.

--- a/openspec/changes/add-content-addressed-knowledge/tasks.md
+++ b/openspec/changes/add-content-addressed-knowledge/tasks.md
@@ -73,5 +73,9 @@
 
 ## 5. Follow-up (separate change)
 
-- [ ] 5.1 Speculative / branching agent execution over cheap forks (tree search
+- [x] 5.1 Speculative / branching agent execution over cheap forks (tree search
   across agent states).
+  Done 2026-07-03: covered as a separate Ring 3 follow-up by
+  `add-branching-execution-file-server`, which adds a headless `branchfs`
+  file-server boundary for creating, scoring, selecting, and discarding
+  checkpoint branches over cheap knowledge forks.


### PR DESCRIPTION
## Summary

- add `alan-branchfs`, a headless aP file server for speculative checkpoint branches
- expose `ctl`, `branches/`, `selected`, and `events` as file operations over cheap `alan-knowledge` forks
- support explicit fork, score, select, and discard commands with JSON-line lifecycle events
- add OpenSpec change `add-branching-execution-file-server`
- mark the `add-content-addressed-knowledge` cheap-fork follow-up as covered by this separate change

## Stack

- Stacks on #593 / `feat/northstar-editfs`
- Continues the North Star Ring 3 path as a separate PR, not a mega PR

## Verification

- `cargo test -p alan-branchfs -- --nocapture`
- `cargo clippy -p alan-branchfs --all-targets --all-features -- -D warnings`
- `openspec validate add-branching-execution-file-server --strict`
- `openspec validate add-content-addressed-knowledge --strict`
- `git diff --check`
- `just verify`