### PR TITLE
North Star 13/13: add agent mount escalation

### DIFF
--- a/crates/agent-engine/src/approval.rs
+++ b/crates/agent-engine/src/approval.rs
@@ -10,6 +10,9 @@ pub const EFFECT_REPLAY_CHECKPOINT_TYPE: &str = "effect_replay_confirmation";
 pub const EFFECT_REPLAY_CHECKPOINT_PREFIX: &str = "effect_replay_";
 pub const EFFECT_REPLAY_CONTROL_KIND: &str = "effect_replay_confirmation";
 
+pub const MOUNT_ESCALATION_CHECKPOINT_TYPE: &str = "mount_escalation";
+pub const MOUNT_ESCALATION_CHECKPOINT_PREFIX: &str = "mount_escalation_";
+
 pub const RUNTIME_CONFIRMATION_CONTROL_SOURCE: &str = "runtime/submission_handlers";
 pub const RUNTIME_CONFIRMATION_CONTROL_VERSION: u64 = 1;
 

--- a/crates/agent-engine/src/policy.rs
+++ b/crates/agent-engine/src/policy.rs
@@ -214,6 +214,15 @@ impl PolicyEngine {
                     action: PolicyAction::Escalate,
                     reason: Some("unknown capability needs human judgment".to_string()),
                 },
+                PolicyRule {
+                    id: Some("review-host-mount".to_string()),
+                    tool: Some("request_mount".to_string()),
+                    capability: None,
+                    match_command: None,
+                    match_path_prefix: None,
+                    action: PolicyAction::Escalate,
+                    reason: Some("host mount grants require approval".to_string()),
+                },
             ],
             // Reads and in-workspace writes proceed automatically; writes
             // outside the workspace are stopped by the execution path guard.
@@ -240,6 +249,16 @@ impl PolicyEngine {
             rules: Vec::new(),
             default_action: PolicyAction::Escalate,
             source: "test_escalate_all",
+        }
+    }
+
+    /// Test-only: a policy that denies everything.
+    #[cfg(test)]
+    pub fn deny_all() -> Self {
+        Self {
+            rules: Vec::new(),
+            default_action: PolicyAction::Deny,
+            source: "test_deny_all",
         }
     }
 
@@ -426,7 +445,15 @@ fn collect_path_candidates(
     arguments: &serde_json::Value,
     current_cwd: Option<&Path>,
 ) -> Vec<NormalizedPathMatchValue> {
-    const PATH_KEYS: &[&str] = &["path", "paths", "directory", "cwd", "workspace_root"];
+    const PATH_KEYS: &[&str] = &[
+        "path",
+        "paths",
+        "directory",
+        "cwd",
+        "workspace_root",
+        "host_path",
+        "namespace_path",
+    ];
     const BASE_PATH_KEYS: &[&str] = &["directory", "cwd", "workspace_root"];
 
     let Some(object) = arguments.as_object() else {
@@ -683,6 +710,23 @@ mod tests {
             decide("custom_tool", Cap::Unknown, serde_json::json!({})),
             PolicyAction::Escalate
         );
+        let mount_decision = engine.evaluate(PolicyContext {
+            tool_name: "request_mount",
+            arguments: &serde_json::json!({
+                "namespace_path": "/mnt/project",
+                "host_path": "/Users/morris/Developer/alan",
+                "access": "read_only",
+                "reason": "Need project files"
+            }),
+            capability: Cap::Write,
+            cwd: None,
+        });
+        assert_eq!(mount_decision.action, PolicyAction::Escalate);
+        assert_eq!(mount_decision.rule_id.as_deref(), Some("review-host-mount"));
+        assert_eq!(
+            mount_decision.reason.as_deref(),
+            Some("host mount grants require approval")
+        );
         // Catastrophic commands are denied outright.
         assert_eq!(
             decide(
@@ -840,6 +884,73 @@ default_action: allow
 
         assert_eq!(decision.action, PolicyAction::Escalate);
         assert_eq!(decision.rule_id.as_deref(), Some("review-workflows"));
+    }
+
+    #[test]
+    fn policy_rule_match_path_prefix_matches_request_mount_host_path() {
+        let engine = PolicyEngine {
+            rules: vec![PolicyRule {
+                id: Some("deny-private-mount".to_string()),
+                tool: Some("request_mount".to_string()),
+                capability: Some("write".to_string()),
+                match_command: None,
+                match_path_prefix: Some("/Users/me/private".to_string()),
+                action: PolicyAction::Deny,
+                reason: Some("private host mounts are not allowed".to_string()),
+            }],
+            default_action: PolicyAction::Allow,
+            source: "test",
+        };
+
+        let decision = engine.evaluate(PolicyContext {
+            tool_name: "request_mount",
+            arguments: &json!({
+                "namespace_path": "/mnt/private",
+                "host_path": "/Users/me/private/project",
+                "access": "read_only",
+                "reason": "Need files"
+            }),
+            capability: alan_agent_protocol::ToolCapability::Write,
+            cwd: None,
+        });
+
+        assert_eq!(decision.action, PolicyAction::Deny);
+        assert_eq!(decision.rule_id.as_deref(), Some("deny-private-mount"));
+    }
+
+    #[test]
+    fn policy_rule_match_path_prefix_matches_request_mount_namespace_path() {
+        let engine = PolicyEngine {
+            rules: vec![PolicyRule {
+                id: Some("review-private-namespace".to_string()),
+                tool: Some("request_mount".to_string()),
+                capability: Some("write".to_string()),
+                match_command: None,
+                match_path_prefix: Some("/mnt/private".to_string()),
+                action: PolicyAction::Escalate,
+                reason: Some("private namespace mounts need review".to_string()),
+            }],
+            default_action: PolicyAction::Allow,
+            source: "test",
+        };
+
+        let decision = engine.evaluate(PolicyContext {
+            tool_name: "request_mount",
+            arguments: &json!({
+                "namespace_path": "/mnt/private/project",
+                "host_path": "/Users/me/project",
+                "access": "read_only",
+                "reason": "Need files"
+            }),
+            capability: alan_agent_protocol::ToolCapability::Write,
+            cwd: None,
+        });
+
+        assert_eq!(decision.action, PolicyAction::Escalate);
+        assert_eq!(
+            decision.rule_id.as_deref(),
+            Some("review-private-namespace")
+        );
     }
 
     #[test]

--- a/crates/agent-engine/src/runtime/submission_handlers.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers.rs
@@ -5,8 +5,9 @@ use tokio_util::sync::CancellationToken;
 
 use crate::ROLLBACK_NON_DURABLE_WARNING;
 use crate::approval::{
-    RUNTIME_CONFIRMATION_CONTROL_SOURCE, RUNTIME_CONFIRMATION_CONTROL_VERSION,
-    is_effect_replay_confirmation, replays_tool_calls, runtime_confirmation_control_kind,
+    MOUNT_ESCALATION_CHECKPOINT_TYPE, RUNTIME_CONFIRMATION_CONTROL_SOURCE,
+    RUNTIME_CONFIRMATION_CONTROL_VERSION, is_effect_replay_confirmation, replays_tool_calls,
+    runtime_confirmation_control_kind,
 };
 use crate::tape::ContentPart;
 
@@ -271,7 +272,9 @@ where
                         .and_then(|v| v.as_str())
                         .map(ToString::to_string)
                         .or_else(|| first_resume_text(&content));
-                    let choice_str = choice.as_deref().unwrap_or("approve");
+                    let choice_str = choice
+                        .as_deref()
+                        .unwrap_or_else(|| default_confirmation_choice(&pending));
                     let modifications = result
                         .get("modifications")
                         .and_then(|v| v.as_str())
@@ -384,6 +387,14 @@ fn first_resume_text(content: &[ContentPart]) -> Option<String> {
     })
 }
 
+fn default_confirmation_choice(pending: &crate::approval::PendingConfirmation) -> &'static str {
+    if pending.checkpoint_type == MOUNT_ESCALATION_CHECKPOINT_TYPE {
+        "reject"
+    } else {
+        "approve"
+    }
+}
+
 fn handle_confirmation_resolution(
     state: &mut RuntimeLoopState,
     pending: crate::approval::PendingConfirmation,
@@ -406,6 +417,12 @@ fn handle_confirmation_resolution(
 
     if let Some(modifications) = modifications {
         payload["modifications"] = serde_json::Value::String(modifications);
+    }
+
+    if pending.checkpoint_type == MOUNT_ESCALATION_CHECKPOINT_TYPE {
+        return Ok(handle_mount_escalation_resolution(
+            state, pending, choice_str,
+        ));
     }
 
     if let Some(control_kind) = runtime_confirmation_control_kind(&pending.checkpoint_type) {
@@ -471,6 +488,115 @@ fn handle_confirmation_resolution(
     })
 }
 
+fn handle_mount_escalation_resolution(
+    state: &mut RuntimeLoopState,
+    pending: crate::approval::PendingConfirmation,
+    choice_str: &str,
+) -> RuntimeOpAction {
+    let Some((tool_call_id, mount_request)) = validated_mount_escalation_request(&pending) else {
+        let result = json!({
+            "status": "invalid_mount_escalation_checkpoint",
+            "approved": false,
+            "live_applied": false,
+            "checkpoint_id": pending.checkpoint_id.clone(),
+            "checkpoint_type": pending.checkpoint_type.clone(),
+            "choice": choice_str,
+            "error": "Invalid mount escalation checkpoint.",
+        });
+        state
+            .session
+            .add_tool_message(&pending.checkpoint_id, "request_mount", result);
+        return RuntimeOpAction::RunTurn {
+            turn_kind: TurnRunKind::ResumeTurn,
+            user_input: None,
+            activate_task: false,
+        };
+    };
+    let approved = choice_str == "approve";
+    let status = if approved {
+        "approved_not_applied"
+    } else {
+        "rejected"
+    };
+    let result = json!({
+        "status": status,
+        "approved": approved,
+        "live_applied": false,
+        "checkpoint_id": pending.checkpoint_id.clone(),
+        "checkpoint_type": pending.checkpoint_type.clone(),
+        "choice": choice_str,
+        "mount_request": mount_request,
+    });
+
+    if approved {
+        state.session.record_event(
+            "host_mount_grant",
+            host_mount_grant_event_payload(&pending.details, &result),
+        );
+    }
+    state
+        .session
+        .add_tool_message(&tool_call_id, "request_mount", result);
+
+    RuntimeOpAction::RunTurn {
+        turn_kind: TurnRunKind::ResumeTurn,
+        user_input: None,
+        activate_task: false,
+    }
+}
+
+fn validated_mount_escalation_request(
+    pending: &crate::approval::PendingConfirmation,
+) -> Option<(String, serde_json::Value)> {
+    if pending
+        .details
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        != Some("mount_escalation")
+    {
+        return None;
+    }
+    if pending
+        .details
+        .get("tool_name")
+        .and_then(serde_json::Value::as_str)
+        != Some("request_mount")
+    {
+        return None;
+    }
+    let tool_call_id = pending
+        .details
+        .get("tool_call_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|raw| !raw.is_empty())?
+        .to_string();
+    let mount_request = pending.details.get("mount_request")?;
+    let mount_request = super::virtual_tools::parse_mount_request(mount_request)
+        .ok()?
+        .payload();
+    Some((tool_call_id, mount_request))
+}
+
+fn host_mount_grant_event_payload(
+    details: &serde_json::Value,
+    result: &serde_json::Value,
+) -> serde_json::Value {
+    let request = result
+        .get("mount_request")
+        .unwrap_or(&serde_json::Value::Null);
+    json!({
+        "namespace_path": request.get("namespace_path").and_then(serde_json::Value::as_str),
+        "host_path": request.get("host_path").and_then(serde_json::Value::as_str),
+        "access": request.get("access").and_then(serde_json::Value::as_str),
+        "reason": request.get("reason").and_then(serde_json::Value::as_str),
+        "checkpoint_id": result.get("checkpoint_id").and_then(serde_json::Value::as_str),
+        "approved": true,
+        "live_applied": false,
+        "tool_call_id": details.get("tool_call_id").and_then(serde_json::Value::as_str),
+    })
+}
+
 fn is_unknown_effect_confirmation(pending: &crate::approval::PendingConfirmation) -> bool {
     pending
         .details
@@ -505,6 +631,7 @@ mod tests {
     use super::*;
     use crate::{
         config::Config,
+        rollout::{RolloutItem, RolloutRecorder},
         runtime::{NamespaceRuntimeEnvironment, RuntimeConfig, RuntimeEnvironment, TurnState},
         session::Session,
         tape::ContentPart,
@@ -513,6 +640,7 @@ mod tests {
     use alan_ap::InProcessTransport;
     use alan_kernel::{Access, MountFs, Namespace, ProcFs};
     use alan_shell::Shell;
+    use tempfile::TempDir;
 
     fn namespace_environment_for_test() -> RuntimeEnvironment {
         let mut namespace = Namespace::new();
@@ -570,6 +698,45 @@ mod tests {
             prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
             turn_state: TurnState::default(),
         }
+    }
+
+    fn mount_escalation_pending_confirmation() -> crate::approval::PendingConfirmation {
+        let host_path = std::fs::canonicalize(std::env::current_dir().unwrap()).unwrap();
+        let host_path = host_path.display().to_string();
+        crate::approval::PendingConfirmation {
+            checkpoint_id: "mount_escalation_call_mount".to_string(),
+            checkpoint_type: crate::approval::MOUNT_ESCALATION_CHECKPOINT_TYPE.to_string(),
+            summary: "Approve host mount?".to_string(),
+            details: json!({
+                "kind": "mount_escalation",
+                "tool_call_id": "call_mount",
+                "tool_name": "request_mount",
+                "mount_request": {
+                    "namespace_path": "/mnt/project",
+                    "host_path": host_path,
+                    "access": "read_write",
+                    "reason": "Need to edit project files"
+                },
+                "live_applied": false
+            }),
+            options: vec!["approve".to_string(), "reject".to_string()],
+        }
+    }
+
+    fn tool_result_text_for_call(state: &RuntimeLoopState, call_id: &str) -> String {
+        state
+            .session
+            .tape
+            .messages()
+            .iter()
+            .find_map(|message| match message {
+                crate::tape::Message::Tool { responses } => responses
+                    .iter()
+                    .find(|response| response.id == call_id)
+                    .map(crate::tape::ToolResponse::text_content),
+                _ => None,
+            })
+            .expect("expected tool result")
     }
 
     #[tokio::test]
@@ -842,6 +1009,215 @@ mod tests {
         let messages = state.session.tape.messages();
         assert!(!messages.is_empty());
         assert!(messages[0].text_content().contains("modify"));
+    }
+
+    #[tokio::test]
+    async fn test_handle_mount_escalation_resume_approve_records_grant_and_tool_result() {
+        let temp = TempDir::new().unwrap();
+        let mut state = create_test_state();
+        state.session =
+            Session::new_with_id_and_recorder_in_dir("mount-approve", "test-model", temp.path())
+                .await
+                .unwrap();
+        state
+            .turn_state
+            .set_confirmation(mount_escalation_pending_confirmation());
+        let cancel = CancellationToken::new();
+
+        let mut emit = |_event: Event| async {};
+        let op = Op::Resume {
+            request_id: "mount_escalation_call_mount".to_string(),
+            content: vec![ContentPart::structured(json!({"choice": "approve"}))],
+        };
+
+        let result = handle_runtime_op_with_cancel(&mut state, op, &mut emit, &cancel).await;
+        assert!(result.is_ok());
+        assert!(matches!(
+            result.unwrap(),
+            RuntimeOpAction::RunTurn {
+                turn_kind: TurnRunKind::ResumeTurn,
+                ..
+            }
+        ));
+
+        let tool_result = tool_result_text_for_call(&state, "call_mount");
+        assert!(tool_result.contains("\"status\":\"approved_not_applied\""));
+        assert!(tool_result.contains("\"live_applied\":false"));
+        assert!(tool_result.contains("\"namespace_path\":\"/mnt/project\""));
+
+        state.session.flush().await;
+        let rollout_path = state.session.rollout_path().unwrap().clone();
+        let items = RolloutRecorder::load_history(&rollout_path).await.unwrap();
+        let grant = items
+            .iter()
+            .find_map(|item| match item {
+                RolloutItem::Event(event) if event.event_type == "host_mount_grant" => Some(event),
+                _ => None,
+            })
+            .expect("expected approved mount grant event");
+        let expected_host_path = std::fs::canonicalize(std::env::current_dir().unwrap()).unwrap();
+        assert_eq!(grant.payload["namespace_path"], "/mnt/project");
+        assert_eq!(
+            grant.payload["host_path"],
+            expected_host_path.display().to_string()
+        );
+        assert_eq!(grant.payload["access"], "read_write");
+        assert_eq!(grant.payload["reason"], "Need to edit project files");
+        assert_eq!(
+            grant.payload["checkpoint_id"],
+            "mount_escalation_call_mount"
+        );
+        assert_eq!(grant.payload["approved"], true);
+        assert_eq!(grant.payload["live_applied"], false);
+        assert_eq!(grant.payload["tool_call_id"], "call_mount");
+    }
+
+    #[tokio::test]
+    async fn test_handle_mount_escalation_resume_reject_returns_tool_result_without_grant() {
+        let temp = TempDir::new().unwrap();
+        let mut state = create_test_state();
+        state.session =
+            Session::new_with_id_and_recorder_in_dir("mount-reject", "test-model", temp.path())
+                .await
+                .unwrap();
+        state
+            .turn_state
+            .set_confirmation(mount_escalation_pending_confirmation());
+        let cancel = CancellationToken::new();
+
+        let mut emit = |_event: Event| async {};
+        let op = Op::Resume {
+            request_id: "mount_escalation_call_mount".to_string(),
+            content: vec![ContentPart::structured(json!({"choice": "reject"}))],
+        };
+
+        let result = handle_runtime_op_with_cancel(&mut state, op, &mut emit, &cancel).await;
+        assert!(result.is_ok());
+        assert!(matches!(
+            result.unwrap(),
+            RuntimeOpAction::RunTurn {
+                turn_kind: TurnRunKind::ResumeTurn,
+                ..
+            }
+        ));
+
+        let tool_result = tool_result_text_for_call(&state, "call_mount");
+        assert!(tool_result.contains("\"status\":\"rejected\""));
+        assert!(tool_result.contains("\"approved\":false"));
+        assert!(tool_result.contains("\"live_applied\":false"));
+
+        state.session.flush().await;
+        let rollout_path = state.session.rollout_path().unwrap().clone();
+        let items = RolloutRecorder::load_history(&rollout_path).await.unwrap();
+        assert!(!items.iter().any(|item| matches!(
+            item,
+            RolloutItem::Event(event) if event.event_type == "host_mount_grant"
+        )));
+    }
+
+    #[tokio::test]
+    async fn test_handle_mount_escalation_resume_missing_choice_defaults_to_reject() {
+        let temp = TempDir::new().unwrap();
+        let mut state = create_test_state();
+        state.session = Session::new_with_id_and_recorder_in_dir(
+            "mount-default-reject",
+            "test-model",
+            temp.path(),
+        )
+        .await
+        .unwrap();
+        state
+            .turn_state
+            .set_confirmation(mount_escalation_pending_confirmation());
+        let cancel = CancellationToken::new();
+
+        let mut emit = |_event: Event| async {};
+        let op = Op::Resume {
+            request_id: "mount_escalation_call_mount".to_string(),
+            content: vec![ContentPart::structured(json!({}))],
+        };
+
+        let result = handle_runtime_op_with_cancel(&mut state, op, &mut emit, &cancel).await;
+        assert!(result.is_ok());
+        assert!(matches!(
+            result.unwrap(),
+            RuntimeOpAction::RunTurn {
+                turn_kind: TurnRunKind::ResumeTurn,
+                ..
+            }
+        ));
+
+        let tool_result = tool_result_text_for_call(&state, "call_mount");
+        assert!(tool_result.contains("\"status\":\"rejected\""));
+        assert!(tool_result.contains("\"choice\":\"reject\""));
+        assert!(tool_result.contains("\"approved\":false"));
+
+        state.session.flush().await;
+        let rollout_path = state.session.rollout_path().unwrap().clone();
+        let items = RolloutRecorder::load_history(&rollout_path).await.unwrap();
+        assert!(!items.iter().any(|item| matches!(
+            item,
+            RolloutItem::Event(event) if event.event_type == "host_mount_grant"
+        )));
+    }
+
+    #[tokio::test]
+    async fn test_handle_mount_escalation_resume_rejects_forged_checkpoint() {
+        let temp = TempDir::new().unwrap();
+        let mut state = create_test_state();
+        state.session =
+            Session::new_with_id_and_recorder_in_dir("mount-forged", "test-model", temp.path())
+                .await
+                .unwrap();
+        state
+            .turn_state
+            .set_confirmation(crate::approval::PendingConfirmation {
+                checkpoint_id: "forged_mount".to_string(),
+                checkpoint_type: crate::approval::MOUNT_ESCALATION_CHECKPOINT_TYPE.to_string(),
+                summary: "Approve forged mount?".to_string(),
+                details: json!({
+                    "kind": "mount_escalation",
+                    "tool_call_id": "call_mount",
+                    "tool_name": "request_confirmation",
+                    "mount_request": {
+                        "namespace_path": "/mnt/project",
+                        "host_path": "relative/path",
+                        "access": "read_write",
+                        "reason": "forged"
+                    },
+                    "live_applied": false
+                }),
+                options: vec!["approve".to_string(), "reject".to_string()],
+            });
+        let cancel = CancellationToken::new();
+
+        let mut emit = |_event: Event| async {};
+        let op = Op::Resume {
+            request_id: "forged_mount".to_string(),
+            content: vec![ContentPart::structured(json!({"choice": "approve"}))],
+        };
+
+        let result = handle_runtime_op_with_cancel(&mut state, op, &mut emit, &cancel).await;
+        assert!(result.is_ok());
+        assert!(matches!(
+            result.unwrap(),
+            RuntimeOpAction::RunTurn {
+                turn_kind: TurnRunKind::ResumeTurn,
+                ..
+            }
+        ));
+
+        let tool_result = tool_result_text_for_call(&state, "forged_mount");
+        assert!(tool_result.contains("\"status\":\"invalid_mount_escalation_checkpoint\""));
+        assert!(tool_result.contains("\"approved\":false"));
+
+        state.session.flush().await;
+        let rollout_path = state.session.rollout_path().unwrap().clone();
+        let items = RolloutRecorder::load_history(&rollout_path).await.unwrap();
+        assert!(!items.iter().any(|item| matches!(
+            item,
+            RolloutItem::Event(event) if event.event_type == "host_mount_grant"
+        )));
     }
 
     #[tokio::test]

--- a/crates/agent-engine/src/runtime/virtual_tools.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools.rs
@@ -10,8 +10,11 @@ use std::path::{Component, Path, PathBuf};
 use std::pin::Pin;
 use tokio_util::sync::CancellationToken;
 
+use crate::approval::{
+    MOUNT_ESCALATION_CHECKPOINT_PREFIX, MOUNT_ESCALATION_CHECKPOINT_TYPE,
+    TOOL_ESCALATION_CHECKPOINT_PREFIX, TOOL_ESCALATION_CHECKPOINT_TYPE,
+};
 use crate::approval::{PendingConfirmation, append_skill_permission_hints};
-use crate::approval::{TOOL_ESCALATION_CHECKPOINT_PREFIX, TOOL_ESCALATION_CHECKPOINT_TYPE};
 use crate::llm::ToolDefinition;
 use crate::skills::{
     DelegatedSkillInvocationRecord, DelegatedSkillOutputRef, DelegatedSkillResult,
@@ -41,6 +44,7 @@ const MAX_DELEGATED_CHILD_RUN_METADATA_CHARS: usize = 2_000;
 const MAX_DELEGATED_RESULT_WARNINGS: usize = 16;
 const MAX_DELEGATED_RESULT_WARNING_CHARS: usize = 512;
 const WORKSPACE_INSPECT_READ_ONLY_TOOLS: [&str; 4] = ["read_file", "grep", "glob", "list_dir"];
+const RESERVED_MOUNT_NAMESPACE_ROOTS: &[&str] = &["llm", "mem", "route"];
 
 type DelegatedSkillSpawnResult<T> = std::result::Result<T, Box<DelegatedSkillResult>>;
 
@@ -55,6 +59,7 @@ pub(super) enum VirtualToolOutcome {
 pub(super) fn virtual_tool_definitions(include_delegated_skill: bool) -> Vec<ToolDefinition> {
     let mut defs = vec![
         request_confirmation_tool_definition(),
+        request_mount_tool_definition(),
         request_user_input_tool_definition(),
         update_plan_tool_definition(),
     ];
@@ -170,6 +175,7 @@ where
             }
             Ok(VirtualToolOutcome::PauseTurn)
         }
+        "request_mount" => handle_request_mount(state, tool_call, tool_arguments, emit).await,
         "request_user_input" => {
             emit(Event::ToolCallStarted {
                 title: None,
@@ -355,6 +361,422 @@ where
             .await
         }
         _ => Ok(VirtualToolOutcome::NotVirtual),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum MountRequestAccess {
+    ReadOnly,
+    ReadWrite,
+}
+
+impl MountRequestAccess {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "read_only",
+            Self::ReadWrite => "read_write",
+        }
+    }
+
+    fn policy_capability(self) -> alan_agent_protocol::ToolCapability {
+        match self {
+            Self::ReadOnly => alan_agent_protocol::ToolCapability::Read,
+            Self::ReadWrite => alan_agent_protocol::ToolCapability::Write,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(super) struct MountRequest {
+    pub namespace_path: String,
+    pub host_path: PathBuf,
+    pub access: MountRequestAccess,
+    pub reason: String,
+}
+
+impl MountRequest {
+    pub(super) fn payload(&self) -> serde_json::Value {
+        json!({
+            "namespace_path": &self.namespace_path,
+            "host_path": self.host_path.display().to_string(),
+            "access": self.access.as_str(),
+            "reason": &self.reason,
+        })
+    }
+}
+
+async fn handle_request_mount<E, F>(
+    state: &mut RuntimeLoopState,
+    tool_call: &NormalizedToolCall,
+    tool_arguments: &serde_json::Value,
+    emit: &mut E,
+) -> Result<VirtualToolOutcome>
+where
+    E: FnMut(Event) -> F,
+    F: std::future::Future<Output = ()>,
+{
+    emit(Event::ToolCallStarted {
+        title: None,
+        id: tool_call.id.clone(),
+        name: tool_call.name.clone(),
+        audit: None,
+    })
+    .await;
+
+    let mount_request = match parse_mount_request(tool_arguments) {
+        Ok(request) => request,
+        Err(error) => {
+            let payload = json!({
+                "status": "invalid_request",
+                "error": error,
+            });
+            emit(Event::ToolCallCompleted {
+                presentation: None,
+                id: tool_call.id.clone(),
+                name: Some(tool_call.name.clone()),
+                success: Some(false),
+                result_preview: tool_result_preview(&payload),
+                audit: None,
+            })
+            .await;
+            state.session.record_tool_call(
+                &tool_call.name,
+                tool_arguments.clone(),
+                payload.clone(),
+                false,
+            );
+            state
+                .session
+                .add_tool_message(&tool_call.id, &tool_call.name, payload);
+            return Ok(VirtualToolOutcome::Continue {
+                refresh_context: true,
+            });
+        }
+    };
+    let mount_payload = mount_request.payload();
+    let sandbox_confinement = super::tool_policy::SandboxConfinement::detect();
+
+    let mut decision = evaluate_tool_policy(
+        &state.runtime_config.policy_engine,
+        &state.runtime_config.governance,
+        &tool_call.name,
+        &mount_payload,
+        mount_request.access.policy_capability(),
+        state.default_tool_cwd().as_deref(),
+        sandbox_confinement,
+    );
+    if mount_request.access == MountRequestAccess::ReadWrite {
+        let read_decision = evaluate_tool_policy(
+            &state.runtime_config.policy_engine,
+            &state.runtime_config.governance,
+            &tool_call.name,
+            &mount_payload,
+            alan_agent_protocol::ToolCapability::Read,
+            state.default_tool_cwd().as_deref(),
+            sandbox_confinement,
+        );
+        decision = merge_mount_policy_decision(decision, read_decision);
+    }
+    let decision_audit = match &decision {
+        ToolPolicyDecision::Allow { audit }
+        | ToolPolicyDecision::Escalate { audit, .. }
+        | ToolPolicyDecision::Forbidden { audit, .. } => audit.clone(),
+    };
+
+    if let ToolPolicyDecision::Forbidden { reason, audit } = decision {
+        let payload = json!({
+            "status": "blocked_by_policy",
+            "error": reason,
+            "mount_request": mount_payload,
+        });
+        state.session.record_event(
+            "tool_policy_decision",
+            json!({
+                "tool_call_id": tool_call.id,
+                "tool_name": tool_call.name,
+                "policy_source": audit.policy_source,
+                "rule_id": audit.rule_id,
+                "action": audit.action,
+                "reason": audit.reason,
+                "capability": audit.capability,
+                "sandbox_backend": audit.sandbox_backend,
+            }),
+        );
+        emit(Event::Error {
+            message: payload["error"]
+                .as_str()
+                .unwrap_or("Mount request blocked by policy")
+                .to_string(),
+            recoverable: true,
+        })
+        .await;
+        emit(Event::ToolCallCompleted {
+            presentation: None,
+            id: tool_call.id.clone(),
+            name: Some(tool_call.name.clone()),
+            success: Some(false),
+            result_preview: tool_result_preview(&payload),
+            audit: Some(audit.clone()),
+        })
+        .await;
+        state.session.record_tool_call_with_audit(
+            &tool_call.name,
+            tool_arguments.clone(),
+            payload.clone(),
+            false,
+            Some(audit),
+        );
+        state
+            .session
+            .add_tool_message(&tool_call.id, &tool_call.name, payload);
+        return Ok(VirtualToolOutcome::Continue {
+            refresh_context: false,
+        });
+    }
+
+    let escalation_audit = alan_agent_protocol::ToolDecisionAudit {
+        policy_source: decision_audit.policy_source.clone(),
+        rule_id: decision_audit
+            .rule_id
+            .clone()
+            .or_else(|| Some("review-host-mount".to_string())),
+        action: "escalate".to_string(),
+        reason: Some("host mount grants require approval".to_string()),
+        capability: decision_audit.capability.clone(),
+        sandbox_backend: decision_audit.sandbox_backend.clone(),
+    };
+    state.session.record_event(
+        "tool_policy_decision",
+        json!({
+            "tool_call_id": tool_call.id,
+            "tool_name": tool_call.name,
+            "policy_source": escalation_audit.policy_source,
+            "rule_id": escalation_audit.rule_id,
+            "action": escalation_audit.action,
+            "reason": escalation_audit.reason,
+            "capability": escalation_audit.capability,
+            "sandbox_backend": escalation_audit.sandbox_backend,
+            "original_action": decision_audit.action,
+        }),
+    );
+
+    let mut details = json!({
+        "kind": "mount_escalation",
+        "tool_call_id": tool_call.id,
+        "tool_name": tool_call.name,
+        "mount_request": mount_payload,
+        "policy": {
+            "policy_source": escalation_audit.policy_source,
+            "rule_id": escalation_audit.rule_id,
+            "action": escalation_audit.action,
+            "reason": escalation_audit.reason,
+            "capability": escalation_audit.capability,
+            "sandbox_backend": escalation_audit.sandbox_backend,
+        },
+        "live_applied": false,
+    });
+    details = append_skill_permission_hints(details, state.turn_state.active_skills());
+
+    let pending = PendingConfirmation {
+        checkpoint_id: format!("{MOUNT_ESCALATION_CHECKPOINT_PREFIX}{}", tool_call.id),
+        checkpoint_type: MOUNT_ESCALATION_CHECKPOINT_TYPE.to_string(),
+        summary: format!(
+            "Approve host mount {} at {}?",
+            mount_request.host_path.display(),
+            mount_request.namespace_path
+        ),
+        details,
+        options: vec!["approve".to_string(), "reject".to_string()],
+    };
+
+    let request_id = state
+        .write_namespace_confirmation_request(&pending)
+        .await?
+        .unwrap_or_else(|| pending.checkpoint_id.clone());
+    let payload = json!({
+        "status": "pending_mount_approval",
+        "request_id": request_id.clone(),
+        "mount_request": mount_payload,
+        "live_applied": false,
+    });
+    emit(Event::ToolCallCompleted {
+        presentation: None,
+        id: tool_call.id.clone(),
+        name: Some(tool_call.name.clone()),
+        success: Some(true),
+        result_preview: tool_result_preview(&payload),
+        audit: Some(escalation_audit.clone()),
+    })
+    .await;
+    state.session.record_tool_call_with_audit(
+        &tool_call.name,
+        tool_arguments.clone(),
+        payload.clone(),
+        true,
+        Some(escalation_audit),
+    );
+    state
+        .turn_state
+        .set_confirmation_for_request(request_id.clone(), pending.clone());
+    emit(Event::Yield {
+        request_id,
+        kind: YieldKind::Confirmation,
+        payload: serde_json::to_value(ConfirmationYieldPayload {
+            checkpoint_type: pending.checkpoint_type.clone(),
+            summary: pending.summary.clone(),
+            details: Some(pending.details.clone()),
+            options: pending.options.clone(),
+            default_option: Some("reject".to_string()),
+            presentation_hints: vec![AdaptivePresentationHint::Dangerous],
+        })
+        .unwrap_or_else(|_| json!({})),
+    })
+    .await;
+
+    Ok(VirtualToolOutcome::PauseTurn)
+}
+
+fn merge_mount_policy_decision(
+    primary_decision: ToolPolicyDecision,
+    read_decision: ToolPolicyDecision,
+) -> ToolPolicyDecision {
+    let primary_allows = matches!(&primary_decision, ToolPolicyDecision::Allow { .. });
+    match read_decision {
+        decision @ ToolPolicyDecision::Forbidden { .. } => decision,
+        decision @ ToolPolicyDecision::Escalate { .. } if primary_allows => decision,
+        _ => primary_decision,
+    }
+}
+
+pub(super) fn parse_mount_request(
+    args: &serde_json::Value,
+) -> std::result::Result<MountRequest, String> {
+    let namespace_path = parse_mount_namespace_path(required_string(args, "namespace_path")?)?;
+    let host_path = parse_mount_host_path(required_string(args, "host_path")?)?;
+    let access = parse_mount_access(required_string(args, "access")?)?;
+    let reason = required_string(args, "reason")?;
+
+    if reason.trim().is_empty() {
+        return Err("reason must be a non-empty string".to_string());
+    }
+
+    Ok(MountRequest {
+        namespace_path,
+        host_path,
+        access,
+        reason: reason.trim().to_string(),
+    })
+}
+
+fn required_string<'a>(
+    args: &'a serde_json::Value,
+    field: &str,
+) -> std::result::Result<&'a str, String> {
+    args.get(field)
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| format!("{field} must be a string"))
+}
+
+fn parse_mount_namespace_path(raw: &str) -> std::result::Result<String, String> {
+    let trimmed = raw.trim();
+    if !trimmed.starts_with("/mnt/") {
+        return Err("namespace_path must be an absolute path under /mnt/<name>".to_string());
+    }
+
+    let components = trimmed
+        .trim_start_matches('/')
+        .split('/')
+        .collect::<Vec<_>>();
+    if components.len() < 2 || components.first() != Some(&"mnt") {
+        return Err("namespace_path must be an absolute path under /mnt/<name>".to_string());
+    }
+    if components
+        .iter()
+        .any(|component| component.is_empty() || *component == "." || *component == "..")
+    {
+        return Err(
+            "namespace_path must not contain empty, '.', or '..' path components".to_string(),
+        );
+    }
+    if RESERVED_MOUNT_NAMESPACE_ROOTS.contains(&components[1]) {
+        return Err("namespace_path targets a reserved mount root".to_string());
+    }
+
+    Ok(format!("/{}", components.join("/")))
+}
+
+fn parse_mount_host_path(raw: &str) -> std::result::Result<PathBuf, String> {
+    let trimmed = raw.trim();
+    let path = Path::new(trimmed);
+    if is_windows_filesystem_root_path(trimmed) || path == Path::new("/") {
+        return Err("host_path must not be the host filesystem root".to_string());
+    }
+    if !path.is_absolute() {
+        return Err("host_path must be absolute".to_string());
+    }
+    if has_invalid_raw_host_path_segment(trimmed)
+        || path
+            .components()
+            .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+    {
+        return Err("host_path must not contain '.', '..', or empty components".to_string());
+    }
+    Ok(path.to_path_buf())
+}
+
+fn is_windows_filesystem_root_path(path: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    is_windows_drive_root_path(normalized.as_str())
+        || normalized
+            .strip_prefix("//?/")
+            .is_some_and(is_windows_drive_root_path)
+        || normalized
+            .strip_prefix("//./")
+            .is_some_and(is_windows_drive_root_path)
+        || normalized
+            .strip_prefix("//?/UNC/")
+            .is_some_and(is_windows_unc_share_root_path)
+        || normalized
+            .strip_prefix("//./UNC/")
+            .is_some_and(is_windows_unc_share_root_path)
+        || normalized
+            .strip_prefix("//")
+            .is_some_and(is_windows_unc_share_root_path)
+}
+
+fn is_windows_drive_root_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && bytes[2..].iter().all(|byte| *byte == b'/')
+}
+
+fn is_windows_unc_share_root_path(path: &str) -> bool {
+    let parts = path
+        .split('/')
+        .filter(|component| !component.is_empty())
+        .collect::<Vec<_>>();
+    parts.len() == 2
+}
+
+fn has_invalid_raw_host_path_segment(path: &str) -> bool {
+    let mut segments = path.split('/');
+    let Some(first) = segments.next() else {
+        return true;
+    };
+    if !first.is_empty() {
+        return false;
+    }
+    segments.any(|segment| segment.is_empty() || segment == "." || segment == "..")
+}
+
+fn parse_mount_access(raw: &str) -> std::result::Result<MountRequestAccess, String> {
+    match raw.trim() {
+        "read_only" => Ok(MountRequestAccess::ReadOnly),
+        "read_write" => Ok(MountRequestAccess::ReadWrite),
+        _ => Err("access must be one of: read_only, read_write".to_string()),
     }
 }
 
@@ -1533,6 +1955,9 @@ pub(super) fn parse_confirmation_request(
         .filter(|v| !v.trim().is_empty())
         .unwrap_or("confirmation")
         .to_string();
+    if checkpoint_type == MOUNT_ESCALATION_CHECKPOINT_TYPE {
+        return None;
+    }
     let summary = args.get("summary")?.as_str()?.trim().to_string();
     if summary.is_empty() {
         return None;
@@ -2049,6 +2474,36 @@ fn request_confirmation_tool_definition() -> ToolDefinition {
                 }
             },
             "required": ["summary"]
+        }),
+    }
+}
+
+fn request_mount_tool_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "request_mount".to_string(),
+        description: "Request an approval-gated host directory mount under /mnt. This asks the host to authorize a mount grant; it does not apply the mount directly.".to_string(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "namespace_path": {
+                    "type": "string",
+                    "description": "Absolute Alan OS namespace path under /mnt/<name>, without '.', '..', or empty path components."
+                },
+                "host_path": {
+                    "type": "string",
+                    "description": "Absolute host directory path to request access to."
+                },
+                "access": {
+                    "type": "string",
+                    "enum": ["read_only", "read_write"],
+                    "description": "Requested access mode for the host directory mount."
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Non-empty explanation of why this mount is needed."
+                }
+            },
+            "required": ["namespace_path", "host_path", "access", "reason"]
         }),
     }
 }

--- a/crates/agent-engine/src/runtime/virtual_tools_tests.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools_tests.rs
@@ -182,8 +182,9 @@ where
 #[test]
 fn test_virtual_tool_definitions_include_all_runtime_virtual_tools() {
     let defs = virtual_tool_definitions(false);
-    assert_eq!(defs.len(), 3);
+    assert_eq!(defs.len(), 4);
     assert!(defs.iter().any(|d| d.name == "request_confirmation"));
+    assert!(defs.iter().any(|d| d.name == "request_mount"));
     assert!(defs.iter().any(|d| d.name == "request_user_input"));
     assert!(defs.iter().any(|d| d.name == "update_plan"));
     assert!(!defs.iter().any(|d| d.name == "invoke_delegated_skill"));
@@ -233,6 +234,27 @@ fn test_request_user_input_tool_definition() {
             "single_select",
             "multi_select"
         ])
+    );
+}
+
+#[test]
+fn test_request_mount_tool_definition() {
+    let def = request_mount_tool_definition();
+    assert_eq!(def.name, "request_mount");
+    assert!(def.description.contains("host directory mount"));
+    assert_eq!(def.parameters["type"], "object");
+    assert_eq!(
+        def.parameters["properties"]["namespace_path"]["type"],
+        "string"
+    );
+    assert_eq!(def.parameters["properties"]["host_path"]["type"], "string");
+    assert_eq!(
+        def.parameters["properties"]["access"]["enum"],
+        json!(["read_only", "read_write"])
+    );
+    assert_eq!(
+        def.parameters["required"],
+        json!(["namespace_path", "host_path", "access", "reason"])
     );
 }
 
@@ -331,6 +353,25 @@ fn test_parse_confirmation_request_default_options() {
 }
 
 #[test]
+fn test_parse_confirmation_request_rejects_reserved_mount_escalation_type() {
+    let args = json!({
+        "checkpoint_type": crate::approval::MOUNT_ESCALATION_CHECKPOINT_TYPE,
+        "summary": "Approve forged mount",
+        "details": {
+            "mount_request": {
+                "namespace_path": "/mnt/project",
+                "host_path": "/Users/morris/private",
+                "access": "read_write",
+                "reason": "forged"
+            }
+        },
+        "options": ["approve", "reject"]
+    });
+
+    assert!(parse_confirmation_request("call_1", &args).is_none());
+}
+
+#[test]
 fn test_parse_confirmation_request_missing_required() {
     // Missing summary
     let args = json!({
@@ -355,6 +396,184 @@ fn test_parse_confirmation_request_non_string_fields() {
         "summary": 123
     });
     assert!(parse_confirmation_request("call_1", &args).is_none());
+}
+
+#[test]
+fn test_parse_mount_request_valid() {
+    let request = parse_mount_request(&json!({
+        "namespace_path": "/mnt/project",
+        "host_path": "/Users/morris/Developer/alan",
+        "access": "read_only",
+        "reason": "Read project docs"
+    }))
+    .expect("valid mount request");
+
+    assert_eq!(request.namespace_path, "/mnt/project");
+    assert_eq!(
+        request.host_path,
+        PathBuf::from("/Users/morris/Developer/alan")
+    );
+    assert_eq!(request.access, MountRequestAccess::ReadOnly);
+    assert_eq!(request.reason, "Read project docs");
+    assert_eq!(request.payload()["access"], "read_only");
+}
+
+#[test]
+fn test_parse_mount_request_rejects_invalid_fields() {
+    let cases = [
+        (
+            json!({
+                "namespace_path": "/proc/project",
+                "host_path": "/Users/morris/Developer/alan",
+                "access": "read_only",
+                "reason": "Read project docs"
+            }),
+            "namespace_path",
+        ),
+        (
+            json!({
+                "namespace_path": "/mnt",
+                "host_path": "/Users/morris/Developer/alan",
+                "access": "read_only",
+                "reason": "Read project docs"
+            }),
+            "namespace_path",
+        ),
+        (
+            json!({
+                "namespace_path": "/mnt/../project",
+                "host_path": "/Users/morris/Developer/alan",
+                "access": "read_only",
+                "reason": "Read project docs"
+            }),
+            "namespace_path",
+        ),
+        (
+            json!({
+                "namespace_path": "/mnt/llm",
+                "host_path": "/Users/morris/Developer/alan",
+                "access": "read_only",
+                "reason": "Read project docs"
+            }),
+            "namespace_path",
+        ),
+        (
+            json!({
+                "namespace_path": "/mnt/llm/connections",
+                "host_path": "/Users/morris/Developer/alan",
+                "access": "read_only",
+                "reason": "Read project docs"
+            }),
+            "namespace_path",
+        ),
+        (
+            json!({
+                "namespace_path": "/mnt/mem",
+                "host_path": "/Users/morris/Developer/alan",
+                "access": "read_only",
+                "reason": "Read project docs"
+            }),
+            "namespace_path",
+        ),
+        (
+            json!({
+                "namespace_path": "/mnt/route/send",
+                "host_path": "/Users/morris/Developer/alan",
+                "access": "read_only",
+                "reason": "Read project docs"
+            }),
+            "namespace_path",
+        ),
+        (
+            json!({
+                "namespace_path": "/mnt/project",
+                "host_path": "relative/path",
+                "access": "read_only",
+                "reason": "Read project docs"
+            }),
+            "host_path",
+        ),
+        (
+            json!({
+                "namespace_path": "/mnt/project",
+                "host_path": "/",
+                "access": "read_only",
+                "reason": "Read project docs"
+            }),
+            "host_path",
+        ),
+        (
+            json!({
+                "namespace_path": "/mnt/project",
+                "host_path": "C:\\",
+                "access": "read_only",
+                "reason": "Read project docs"
+            }),
+            "host_path",
+        ),
+        (
+            json!({
+                "namespace_path": "/mnt/project",
+                "host_path": "\\\\server\\share\\",
+                "access": "read_only",
+                "reason": "Read project docs"
+            }),
+            "host_path",
+        ),
+        (
+            json!({
+                "namespace_path": "/mnt/project",
+                "host_path": "/Users/morris/./alan",
+                "access": "read_only",
+                "reason": "Read project docs"
+            }),
+            "host_path",
+        ),
+        (
+            json!({
+                "namespace_path": "/mnt/project",
+                "host_path": "/Users/morris//alan",
+                "access": "read_only",
+                "reason": "Read project docs"
+            }),
+            "host_path",
+        ),
+        (
+            json!({
+                "namespace_path": "/mnt/project",
+                "host_path": "/Users/morris/alan/",
+                "access": "read_only",
+                "reason": "Read project docs"
+            }),
+            "host_path",
+        ),
+        (
+            json!({
+                "namespace_path": "/mnt/project",
+                "host_path": "/Users/morris/Developer/alan",
+                "access": "admin",
+                "reason": "Read project docs"
+            }),
+            "access",
+        ),
+        (
+            json!({
+                "namespace_path": "/mnt/project",
+                "host_path": "/Users/morris/Developer/alan",
+                "access": "read_only",
+                "reason": "   "
+            }),
+            "reason",
+        ),
+    ];
+
+    for (args, expected_error_field) in cases {
+        let error = parse_mount_request(&args).expect_err("expected invalid mount request");
+        assert!(
+            error.contains(expected_error_field),
+            "expected error for {expected_error_field}, got {error}"
+        );
+    }
 }
 
 // Tests for parse_structured_user_input_request
@@ -1305,6 +1524,360 @@ async fn test_try_handle_virtual_tool_call_invalid_confirmation() {
     let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(result.unwrap(), VirtualToolOutcome::EndTurn));
+}
+
+#[tokio::test]
+async fn test_try_handle_virtual_tool_call_request_mount_escalates_even_when_allowed() {
+    let mut state = create_test_agent_loop_state();
+    state.runtime_config.policy_engine = crate::policy::PolicyEngine::allow_all();
+    let temp = TempDir::new().unwrap();
+    let host_path = std::fs::canonicalize(temp.path()).unwrap();
+    let host_path_text = host_path.display().to_string();
+
+    let tool_call = NormalizedToolCall {
+        id: "call_mount".to_string(),
+        name: "request_mount".to_string(),
+        arguments: json!({
+            "namespace_path": "/mnt/project",
+            "host_path": host_path_text.clone(),
+            "access": "read_write",
+            "reason": "Need to edit project files"
+        }),
+    };
+
+    let mut events = vec![];
+    let mut emit = |event: Event| {
+        events.push(event);
+        async {}
+    };
+
+    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    assert!(result.is_ok());
+    assert!(matches!(result.unwrap(), VirtualToolOutcome::PauseTurn));
+
+    let pending = state
+        .turn_state
+        .pending_confirmation()
+        .expect("mount request should pause for confirmation");
+    assert_eq!(
+        pending.checkpoint_type,
+        crate::approval::MOUNT_ESCALATION_CHECKPOINT_TYPE
+    );
+    assert_eq!(pending.checkpoint_id, "mount_escalation_call_mount");
+    assert_eq!(pending.details["tool_call_id"], "call_mount");
+    assert_eq!(
+        pending.details["mount_request"]["namespace_path"],
+        "/mnt/project"
+    );
+    assert_eq!(
+        pending.details["mount_request"]["host_path"],
+        host_path_text
+    );
+    assert_eq!(pending.details["mount_request"]["access"], "read_write");
+    assert_eq!(pending.details["policy"]["action"], "escalate");
+    assert_eq!(
+        pending.details["policy"]["reason"],
+        "host mount grants require approval"
+    );
+
+    assert!(events.iter().any(|event| matches!(
+        event,
+        Event::ToolCallStarted { id, name, audit: None, .. }
+            if id == "call_mount" && name == "request_mount"
+    )));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        Event::ToolCallCompleted { id, success: Some(true), audit: Some(audit), .. }
+            if id == "call_mount"
+                && audit.action == "escalate"
+                && audit.reason.as_deref() == Some("host mount grants require approval")
+    )));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        Event::Yield { kind: alan_agent_protocol::YieldKind::Confirmation, payload, .. }
+            if payload["checkpoint_type"] == json!(crate::approval::MOUNT_ESCALATION_CHECKPOINT_TYPE)
+                && payload["details"]["mount_request"]["host_path"] == json!(host_path_text.clone())
+                && payload["default_option"] == json!("reject")
+    )));
+}
+
+#[tokio::test]
+async fn test_try_handle_virtual_tool_call_request_mount_does_not_probe_host_existence() {
+    let mut state = create_test_agent_loop_state();
+    state.runtime_config.policy_engine = crate::policy::PolicyEngine::allow_all();
+    let missing_host_path = TempDir::new()
+        .unwrap()
+        .path()
+        .join("missing-host-mount-root");
+    let missing_host_path_text = missing_host_path.display().to_string();
+
+    let tool_call = NormalizedToolCall {
+        id: "call_mount".to_string(),
+        name: "request_mount".to_string(),
+        arguments: json!({
+            "namespace_path": "/mnt/missing",
+            "host_path": missing_host_path_text.clone(),
+            "access": "read_only",
+            "reason": "Need to inspect files if available"
+        }),
+    };
+
+    let mut events = vec![];
+    let mut emit = |event: Event| {
+        events.push(event);
+        async {}
+    };
+
+    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    assert!(result.is_ok());
+    assert!(matches!(result.unwrap(), VirtualToolOutcome::PauseTurn));
+
+    let pending = state
+        .turn_state
+        .pending_confirmation()
+        .expect("syntactically valid mount request should pause for confirmation");
+    assert_eq!(
+        pending.details["mount_request"]["host_path"],
+        missing_host_path_text
+    );
+    assert!(events.iter().any(|event| matches!(
+        event,
+        Event::Yield { kind: alan_agent_protocol::YieldKind::Confirmation, payload, .. }
+            if payload["details"]["mount_request"]["host_path"] == json!(missing_host_path_text.clone())
+                && payload["default_option"] == json!("reject")
+    )));
+}
+
+#[tokio::test]
+async fn test_try_handle_virtual_tool_call_request_mount_denied_by_policy() {
+    let mut state = create_test_agent_loop_state();
+    state.runtime_config.policy_engine = crate::policy::PolicyEngine::deny_all();
+    let temp = TempDir::new().unwrap();
+    let host_path = std::fs::canonicalize(temp.path()).unwrap();
+
+    let tool_call = NormalizedToolCall {
+        id: "call_mount".to_string(),
+        name: "request_mount".to_string(),
+        arguments: json!({
+            "namespace_path": "/mnt/project",
+            "host_path": host_path.display().to_string(),
+            "access": "read_only",
+            "reason": "Need to inspect project files"
+        }),
+    };
+
+    let mut events = vec![];
+    let mut emit = |event: Event| {
+        events.push(event);
+        async {}
+    };
+
+    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    assert!(result.is_ok());
+    assert!(matches!(
+        result.unwrap(),
+        VirtualToolOutcome::Continue {
+            refresh_context: false
+        }
+    ));
+    assert!(state.turn_state.pending_confirmation().is_none());
+    assert!(!events.iter().any(|event| matches!(
+        event,
+        Event::Yield {
+            kind: alan_agent_protocol::YieldKind::Confirmation,
+            ..
+        }
+    )));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        Event::ToolCallCompleted { success: Some(false), audit: Some(audit), .. }
+            if audit.action == "deny"
+    )));
+
+    let tool_result = tool_result_text_for_call(&state, "call_mount");
+    assert!(tool_result.contains("\"status\":\"blocked_by_policy\""));
+    assert!(tool_result.contains("/mnt/project"));
+}
+
+#[tokio::test]
+async fn test_try_handle_virtual_tool_call_request_mount_read_only_uses_read_policy() {
+    let mut state = create_test_agent_loop_state();
+    let temp = TempDir::new().unwrap();
+    let host_dir = temp.path().join("ssh");
+    let host_path = host_dir.display().to_string();
+    std::fs::write(
+        temp.path().join("policy.yaml"),
+        format!(
+            r#"
+rules:
+  - id: deny-sensitive-read-mount
+    tool: request_mount
+    capability: read
+    match_path_prefix: "{}"
+    action: deny
+    reason: sensitive host reads are not allowed
+default_action: allow
+"#,
+            host_path
+        ),
+    )
+    .unwrap();
+    state.runtime_config.policy_engine =
+        crate::policy::PolicyEngine::load_or_default(Some(temp.path()));
+
+    let tool_call = NormalizedToolCall {
+        id: "call_mount".to_string(),
+        name: "request_mount".to_string(),
+        arguments: json!({
+            "namespace_path": "/mnt/ssh",
+            "host_path": host_path,
+            "access": "read_only",
+            "reason": "Need to inspect SSH configuration"
+        }),
+    };
+
+    let mut events = vec![];
+    let mut emit = |event: Event| {
+        events.push(event);
+        async {}
+    };
+
+    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    assert!(result.is_ok());
+    assert!(matches!(
+        result.unwrap(),
+        VirtualToolOutcome::Continue {
+            refresh_context: false
+        }
+    ));
+    assert!(state.turn_state.pending_confirmation().is_none());
+    assert!(events.iter().any(|event| matches!(
+        event,
+        Event::ToolCallCompleted { success: Some(false), audit: Some(audit), .. }
+            if audit.action == "deny"
+                && audit.capability == "read"
+                && audit.rule_id.as_deref() == Some("deny-sensitive-read-mount")
+    )));
+
+    let tool_result = tool_result_text_for_call(&state, "call_mount");
+    assert!(tool_result.contains("\"status\":\"blocked_by_policy\""));
+    assert!(tool_result.contains("sensitive host reads are not allowed"));
+}
+
+#[tokio::test]
+async fn test_try_handle_virtual_tool_call_request_mount_read_write_honors_read_denies() {
+    let mut state = create_test_agent_loop_state();
+    let temp = TempDir::new().unwrap();
+    let host_dir = temp.path().join("ssh");
+    let host_path = host_dir.display().to_string();
+    std::fs::write(
+        temp.path().join("policy.yaml"),
+        format!(
+            r#"
+rules:
+  - id: deny-sensitive-read-mount
+    tool: request_mount
+    capability: read
+    match_path_prefix: "{}"
+    action: deny
+    reason: sensitive host reads are not allowed
+default_action: allow
+"#,
+            host_path
+        ),
+    )
+    .unwrap();
+    state.runtime_config.policy_engine =
+        crate::policy::PolicyEngine::load_or_default(Some(temp.path()));
+
+    let tool_call = NormalizedToolCall {
+        id: "call_mount".to_string(),
+        name: "request_mount".to_string(),
+        arguments: json!({
+            "namespace_path": "/mnt/ssh",
+            "host_path": host_path,
+            "access": "read_write",
+            "reason": "Need to update SSH configuration"
+        }),
+    };
+
+    let mut events = vec![];
+    let mut emit = |event: Event| {
+        events.push(event);
+        async {}
+    };
+
+    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    assert!(result.is_ok());
+    assert!(matches!(
+        result.unwrap(),
+        VirtualToolOutcome::Continue {
+            refresh_context: false
+        }
+    ));
+    assert!(state.turn_state.pending_confirmation().is_none());
+    assert!(events.iter().any(|event| matches!(
+        event,
+        Event::ToolCallCompleted { success: Some(false), audit: Some(audit), .. }
+            if audit.action == "deny"
+                && audit.capability == "read"
+                && audit.rule_id.as_deref() == Some("deny-sensitive-read-mount")
+    )));
+
+    let tool_result = tool_result_text_for_call(&state, "call_mount");
+    assert!(tool_result.contains("\"status\":\"blocked_by_policy\""));
+    assert!(tool_result.contains("sensitive host reads are not allowed"));
+}
+
+#[tokio::test]
+async fn test_try_handle_virtual_tool_call_request_mount_rejects_invalid_request() {
+    let mut state = create_test_agent_loop_state();
+
+    let tool_call = NormalizedToolCall {
+        id: "call_mount".to_string(),
+        name: "request_mount".to_string(),
+        arguments: json!({
+            "namespace_path": "/proc/project",
+            "host_path": "relative/path",
+            "access": "read_only",
+            "reason": "Need files"
+        }),
+    };
+
+    let mut events = vec![];
+    let mut emit = |event: Event| {
+        events.push(event);
+        async {}
+    };
+
+    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    assert!(result.is_ok());
+    assert!(matches!(
+        result.unwrap(),
+        VirtualToolOutcome::Continue {
+            refresh_context: true
+        }
+    ));
+    assert!(state.turn_state.pending_confirmation().is_none());
+    assert!(!events.iter().any(|event| matches!(
+        event,
+        Event::Yield {
+            kind: alan_agent_protocol::YieldKind::Confirmation,
+            ..
+        }
+    )));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        Event::ToolCallCompleted {
+            success: Some(false),
+            audit: None,
+            ..
+        }
+    )));
+
+    let tool_result = tool_result_text_for_call(&state, "call_mount");
+    assert!(tool_result.contains("\"status\":\"invalid_request\""));
+    assert!(tool_result.contains("namespace_path"));
 }
 
 #[tokio::test]

--- a/crates/agent-engine/src/skills/types.rs
+++ b/crates/agent-engine/src/skills/types.rs
@@ -823,7 +823,12 @@ impl SkillHostCapabilities {
     }
 
     pub fn with_runtime_defaults(mut self) -> Self {
-        self.extend_tools(["request_confirmation", "request_user_input", "update_plan"]);
+        self.extend_tools([
+            "request_confirmation",
+            "request_mount",
+            "request_user_input",
+            "update_plan",
+        ]);
         self
     }
 
@@ -952,6 +957,7 @@ fn is_reserved_runtime_tool_name(tool: &str) -> bool {
             | "glob"
             | "list_dir"
             | "request_confirmation"
+            | "request_mount"
             | "request_user_input"
             | "update_plan"
             | "invoke_delegated_skill"
@@ -2585,6 +2591,7 @@ enabled = true
     fn test_skill_host_capabilities_runtime_defaults_include_virtual_tools() {
         let capabilities = SkillHostCapabilities::default().with_runtime_defaults();
         assert!(capabilities.tools.contains("request_confirmation"));
+        assert!(capabilities.tools.contains("request_mount"));
         assert!(capabilities.tools.contains("request_user_input"));
         assert!(capabilities.tools.contains("update_plan"));
         assert!(!capabilities.tools.contains("invoke_delegated_skill"));
@@ -2609,6 +2616,16 @@ enabled = true
         assert!(capabilities.tools.contains("invoke_delegated_skill"));
         assert!(!capabilities.supports_delegated_skill_invocation());
         assert!(!capabilities.supports_required_tool("invoke_delegated_skill"));
+    }
+
+    #[test]
+    fn test_request_mount_required_tool_is_runtime_backed() {
+        let capabilities = SkillHostCapabilities::default().with_runtime_defaults();
+
+        assert!(capabilities.supports_required_tool("request_mount"));
+
+        let executable_only = SkillHostCapabilities::default().with_executables(["request_mount"]);
+        assert!(!executable_only.supports_required_tool("request_mount"));
     }
 
     #[test]

--- a/openspec/changes/add-agent-mount-escalation/.openspec.yaml
+++ b/openspec/changes/add-agent-mount-escalation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/add-agent-mount-escalation/design.md
+++ b/openspec/changes/add-agent-mount-escalation/design.md
@@ -1,0 +1,76 @@
+## Context
+
+P2 added `HostDirFs` and an `alan` composition-root helper that projects human
+declared host mounts into both the namespace and `SandboxSpec`. D5 in
+`define-namespace-driven-sandbox` keeps the landing model intentionally static:
+the agent has no mount tool, because a mount grants authority over a host path.
+
+The current runtime can already pause for confirmation through
+`request_confirmation` and policy-driven tool escalation. `MountFs`, however,
+wraps an already assembled namespace as a static file server; the runtime does
+not yet have a composition-root mutator that can add a `HostDirFs` mount and
+re-derive the `SandboxSpec` while a session is running.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a built-in `request_mount` virtual tool with a narrow host-directory mount
+  request schema.
+- Validate mount requests before presenting them for approval.
+- Ensure mount requests are never auto-allowed, even if the active policy would
+  otherwise allow write-like operations.
+- Reuse the existing confirmation/Yield mechanism so approvals flow through the
+  same client and recorder surfaces as other runtime approvals.
+- Record approved mount grants as structured audit events that a later
+  reconfiguration slice can consume.
+
+**Non-Goals:**
+
+- Live mutation of `MountFs` or the running process namespace.
+- Re-deriving the active `SandboxSpec` after approval.
+- Persisting mount grants as durable user configuration.
+- Linux mount namespace reification.
+
+## Decisions
+
+1. **Expose `request_mount` as a runtime virtual tool.**
+
+   This matches existing agent-facing request tools (`request_confirmation`,
+   `request_user_input`) and keeps the request in the Agent Process tool loop.
+   The tool does not grant access directly; it only asks the host to authorize a
+   host-path grant.
+
+2. **Use confirmation/Yield rather than adding a new protocol operation.**
+
+   A mount request is an approval, not a new transport primitive. `Op::Resume`
+   already carries approve/reject choices and works across TUI/daemon clients.
+   The mount-specific shape lives in the confirmation payload details and the
+   final tool result.
+
+3. **Force escalation after policy evaluation.**
+
+   Policy may deny a mount request, and policy metadata should appear in the
+   audit trail. But an `Allow` result is upgraded to `Escalate` because a mount
+   is an authority grant and must be authorized outside agent control. This
+   preserves the D5 security boundary even under permissive policy files.
+
+4. **Record approved grants, do not apply them yet.**
+
+   On approval, the runtime records a `host_mount_grant` event and returns a
+   structured `request_mount` tool result. The grant includes normalized
+   `namespace_path`, `host_path`, `access`, `reason`, `checkpoint_id`, and
+   `approved` status. A follow-up change can add the composition-root mutator
+   that consumes these grants and rebuilds namespace/sandbox projections.
+
+## Risks / Trade-offs
+
+- **Approved grants are not live mounts yet** -> The tool result and spec state
+  this explicitly; the next slice owns live namespace/sandbox reconfiguration.
+- **Permissive policy might otherwise authorize mounts** -> The handler upgrades
+  `Allow` to `Escalate` for this tool.
+- **A malformed request could target reserved Alan OS roots** -> Validation
+  accepts only absolute namespace paths under `/mnt/<name>` and rejects relative
+  components, `/mnt` itself, known service-owned `/mnt` roots (`/mnt/llm`,
+  `/mnt/mem`, `/mnt/route`), host filesystem roots including Windows drive/UNC
+  roots, and non-absolute host paths.

--- a/openspec/changes/add-agent-mount-escalation/proposal.md
+++ b/openspec/changes/add-agent-mount-escalation/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+`define-namespace-driven-sandbox` D5 says a mount is an authorization act: an
+agent must not be able to expand its own host filesystem access without an
+external approval path. P2 added human/config-declared host mounts, but agents
+still have no explicit way to request a new host-path grant.
+
+This change adds the first P3 mount-escalation slice: agents can request a host
+directory mount through the runtime's existing Policy/Yield machinery, and an
+approved request is recorded as a mount grant for a follow-up composition-root
+reconfiguration slice.
+
+## What Changes
+
+- Add a built-in virtual `request_mount` tool exposed to Agent Processes.
+- Validate mount requests before escalation: namespace path, host path, access
+  mode, and reason must be well-formed.
+- Route every valid mount request through confirmation/Yield; policy may deny a
+  request, but it may not silently auto-allow one.
+- On approval or rejection, return a structured `request_mount` tool result to
+  the agent.
+- On approval, record a normalized `host_mount_grant` audit event containing the
+  namespace path, host path, access mode, and approval metadata.
+- Keep live namespace/sandbox reconfiguration out of this slice. The runtime
+  currently owns a static `MountFs` root, so applying approved grants to the
+  running namespace and `SandboxSpec` remains a separate follow-up slice.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-mount-escalation`: Agent Processes can request host directory mounts
+  through an approval-gated runtime surface, producing auditable mount grants.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `crates/agent-engine/src/runtime/virtual_tools.rs`
+- `crates/agent-engine/src/runtime/submission_handlers.rs`
+- `crates/agent-engine/src/approval.rs`
+- `crates/agent-engine/src/policy.rs`
+- OpenSpec namespace/sandbox framing task state

--- a/openspec/changes/add-agent-mount-escalation/specs/agent-mount-escalation/spec.md
+++ b/openspec/changes/add-agent-mount-escalation/specs/agent-mount-escalation/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Agent-requested host mounts require approval
+Agent Processes SHALL be able to request host directory mounts through a
+runtime-provided `request_mount` tool. The tool SHALL validate the requested
+namespace path, host path, access mode, and reason before creating an approval
+request. A valid mount request SHALL pause the turn with a confirmation Yield and
+SHALL NOT grant access before approval.
+
+#### Scenario: Valid mount request pauses for approval
+- **WHEN** an Agent Process calls `request_mount` with an absolute `/mnt/<name>` namespace path, an absolute host path, a supported access mode, and a non-empty reason
+- **THEN** the runtime emits a confirmation Yield for that request
+- **AND** the turn pauses without changing the mounted namespace
+
+#### Scenario: Invalid mount request is rejected before approval
+- **WHEN** an Agent Process calls `request_mount` with a reserved namespace path, relative path component, relative host path, unsupported access mode, or blank reason
+- **THEN** the runtime completes the tool call with an invalid-request result
+- **AND** no approval Yield or mount grant is created
+
+### Requirement: Mount authorization cannot be auto-allowed
+The runtime SHALL treat every valid mount request as an authorization boundary.
+Policy evaluation MAY deny the request, but an allow decision SHALL be upgraded
+to escalation so the request is approved outside the agent's control.
+
+#### Scenario: Policy allow is upgraded to escalation
+- **WHEN** policy evaluation allows a valid `request_mount` call
+- **THEN** the runtime still emits an approval Yield
+- **AND** the audit reason states that host mount grants require approval
+
+#### Scenario: Policy deny blocks a mount request
+- **WHEN** policy evaluation denies a valid `request_mount` call
+- **THEN** the runtime returns a blocked-by-policy result
+- **AND** no approval Yield or mount grant is created
+
+### Requirement: Approved mount requests produce auditable grants
+When a mount request is approved, the runtime SHALL return a structured
+`request_mount` tool result and record a normalized `host_mount_grant` audit
+event. This slice SHALL NOT claim the approved grant has already reconfigured
+the live namespace or OS sandbox.
+
+#### Scenario: Approved request is recorded
+- **WHEN** a pending mount request is resumed with an approve choice
+- **THEN** the runtime records a `host_mount_grant` event with namespace path, host path, access, reason, checkpoint id, and approved status
+- **AND** the agent receives a `request_mount` tool result that states the grant is approved but not yet applied live
+
+#### Scenario: Rejected request returns a rejection result
+- **WHEN** a pending mount request is resumed with a reject choice
+- **THEN** the runtime returns a `request_mount` tool result with rejected status
+- **AND** no approved `host_mount_grant` event is recorded

--- a/openspec/changes/add-agent-mount-escalation/tasks.md
+++ b/openspec/changes/add-agent-mount-escalation/tasks.md
@@ -1,0 +1,36 @@
+## 1. Request Contract
+
+- [x] 1.1 Add `request_mount` to the built-in virtual tool definitions with a
+  schema for `namespace_path`, `host_path`, `access`, and `reason`.
+- [x] 1.2 Implement mount request parsing and validation for `/mnt/<name>`
+  namespace paths, absolute host paths, supported access modes, and non-empty
+  reasons.
+- [x] 1.3 Cover valid and invalid mount request parsing with unit tests.
+
+## 2. Approval Flow
+
+- [x] 2.1 Add mount-escalation checkpoint constants and a policy rule/handler
+  path that denies when policy denies but otherwise forces confirmation Yield.
+- [x] 2.2 Implement `request_mount` virtual tool handling with ToolCallStarted,
+  ToolCallCompleted, pending confirmation, and Yield emission.
+- [x] 2.3 Cover valid request escalation, policy-denied requests, and invalid
+  request behavior with focused runtime tests.
+
+## 3. Resume And Audit
+
+- [x] 3.1 Handle approved and rejected mount confirmations in `Op::Resume`.
+- [x] 3.2 Record approved `host_mount_grant` events and return structured
+  `request_mount` tool results without claiming live remount.
+- [x] 3.3 Cover approve/reject resume behavior with tests.
+
+## 4. Verification And PR
+
+- [x] 4.1 Run focused Rust tests for mount request parsing, virtual-tool Yield,
+  policy behavior, and resume handling.
+- [x] 4.2 Run clippy for touched crates, OpenSpec strict validate, and diff
+  checks.
+- [x] 4.3 Update the parent namespace-driven sandbox task list to record this P3
+  mount-escalation slice while leaving live reconfiguration and Linux
+  reification pending.
+- [x] 4.4 Commit the slice and open a ready stacked PR above
+  `feat/northstar-sensitive-read-denylist`.

--- a/openspec/changes/define-namespace-driven-sandbox/tasks.md
+++ b/openspec/changes/define-namespace-driven-sandbox/tasks.md
@@ -19,8 +19,9 @@ proposals out as their own OpenSpec changes. No application code lands here.
 - [ ] 1.3 Create change(s) for P3+ hardening: macOS Seatbelt sensitive-read
   denylist; agent-requestable `mount` via `PolicyEngine` escalation; (later,
   separately) Linux reification for full read isolation. Created
-  `add-seatbelt-sensitive-read-denylist` for the macOS sensitive-read slice;
-  mount escalation and Linux reification remain pending.
+  `add-seatbelt-sensitive-read-denylist` for the macOS sensitive-read slice and
+  `add-agent-mount-escalation` for the request/approval/grant-record slice;
+  live mount reconfiguration and Linux reification remain pending.
 
 ## 2. Carry the framing forward
 


### PR DESCRIPTION
## Summary
- add the `request_mount` virtual tool with validation for `/mnt/<name>` namespace paths, absolute host paths, access mode, and reason
- force valid mount requests through confirmation Yield while preserving policy deny behavior
- return approved/rejected `request_mount` tool results and record approved `host_mount_grant` audit events without claiming live remount
- add the `add-agent-mount-escalation` OpenSpec change and update the parent namespace sandbox task state

## Verification
- `cargo test -p alan-agent-engine request_mount -- --nocapture`
- `cargo test -p alan-agent-engine parse_mount_request -- --nocapture`
- `cargo test -p alan-agent-engine mount_escalation -- --nocapture`
- `cargo test -p alan-agent-engine auto_approve_boundary_matches_human_in_the_end_posture -- --nocapture`
- `cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings`
- `openspec validate add-agent-mount-escalation --strict`
- `git diff --check`