### PR TITLE
North Star 14/14: apply mount grants to tool sandbox

### DIFF
--- a/crates/agent-engine/src/runtime/child_agents.rs
+++ b/crates/agent-engine/src/runtime/child_agents.rs
@@ -3315,6 +3315,31 @@ Body
     }
 
     #[tokio::test]
+    async fn build_child_tool_registry_preserves_inherited_sandbox_grants() {
+        let temp = TempDir::new().unwrap();
+        let approved = TempDir::new().unwrap();
+        let requests = RecordedRequests::default();
+        let response = completed_response("Child finished cleanly.");
+        let mut parent = make_parent_state(&temp, requests, response);
+        let workspace_root = parent.workspace_root_dir.clone().unwrap();
+        {
+            let parent_tools = parent.tool_catalog_mut_for_test();
+            parent_tools.set_default_workspace_root(workspace_root.clone());
+            assert!(parent_tools.add_default_sandbox_writable_root(approved.path().to_path_buf()));
+        }
+
+        let mut spec = launch_spec(workspace_root.join(".alan/agents/grader"));
+        spec.handles = vec![SpawnHandle::Workspace];
+
+        let child_tools = build_child_tool_registry(&parent, &spec, &parent.core_config).unwrap();
+        let roots = child_tools.default_sandbox_writable_roots();
+
+        assert_eq!(roots.len(), 2);
+        assert_eq!(roots[0], workspace_root);
+        assert_eq!(roots[1], dunce::canonicalize(approved.path()).unwrap());
+    }
+
+    #[tokio::test]
     async fn build_child_tool_registry_rejects_unavailable_requested_tool_profile_entries() {
         let temp = TempDir::new().unwrap();
         let requests = RecordedRequests::default();

--- a/crates/agent-engine/src/runtime/submission_handlers.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers.rs
@@ -513,15 +513,37 @@ fn handle_mount_escalation_resolution(
         };
     };
     let approved = choice_str == "approve";
-    let status = if approved {
-        "approved_not_applied"
-    } else {
-        "rejected"
-    };
+    let grant = parse_mount_grant_request(&mount_request);
+    let tool_sandbox_projection_changed = approved
+        && grant
+            .as_ref()
+            .is_some_and(|grant| grant.access == "read_write")
+        && grant.as_ref().is_some_and(|grant| {
+            state
+                .tool_catalog
+                .add_default_sandbox_writable_root(grant.host_path.clone())
+        });
+    let tool_sandbox_applied = approved
+        && grant
+            .as_ref()
+            .is_some_and(|grant| grant.access == "read_write")
+        && state
+            .tool_catalog
+            .default_sandbox_writable_roots()
+            .iter()
+            .any(|root| {
+                grant
+                    .as_ref()
+                    .is_some_and(|grant| root == &normalize_mount_grant_host_path(&grant.host_path))
+            });
+    let status = if approved { "approved" } else { "rejected" };
     let result = json!({
         "status": status,
         "approved": approved,
         "live_applied": false,
+        "namespace_applied": false,
+        "tool_sandbox_applied": tool_sandbox_applied,
+        "tool_sandbox_projection_changed": tool_sandbox_projection_changed,
         "checkpoint_id": pending.checkpoint_id.clone(),
         "checkpoint_type": pending.checkpoint_type.clone(),
         "choice": choice_str,
@@ -593,8 +615,32 @@ fn host_mount_grant_event_payload(
         "checkpoint_id": result.get("checkpoint_id").and_then(serde_json::Value::as_str),
         "approved": true,
         "live_applied": false,
+        "namespace_applied": false,
+        "tool_sandbox_applied": result.get("tool_sandbox_applied").and_then(serde_json::Value::as_bool),
+        "tool_sandbox_projection_changed": result.get("tool_sandbox_projection_changed").and_then(serde_json::Value::as_bool),
         "tool_call_id": details.get("tool_call_id").and_then(serde_json::Value::as_str),
     })
+}
+
+struct MountGrantDetails {
+    host_path: std::path::PathBuf,
+    access: String,
+}
+
+fn parse_mount_grant_request(request: &serde_json::Value) -> Option<MountGrantDetails> {
+    let host_path = request.get("host_path")?.as_str()?.trim();
+    let access = request.get("access")?.as_str()?.trim();
+    if host_path.is_empty() || access.is_empty() {
+        return None;
+    }
+    Some(MountGrantDetails {
+        host_path: std::path::PathBuf::from(host_path),
+        access: access.to_string(),
+    })
+}
+
+fn normalize_mount_grant_host_path(path: &std::path::Path) -> std::path::PathBuf {
+    dunce::canonicalize(path).unwrap_or_else(|_| dunce::simplified(path).to_path_buf())
 }
 
 fn is_unknown_effect_confirmation(pending: &crate::approval::PendingConfirmation) -> bool {
@@ -700,9 +746,11 @@ mod tests {
         }
     }
 
-    fn mount_escalation_pending_confirmation() -> crate::approval::PendingConfirmation {
-        let host_path = std::fs::canonicalize(std::env::current_dir().unwrap()).unwrap();
-        let host_path = host_path.display().to_string();
+    fn mount_escalation_pending_confirmation_with(
+        host_path: &str,
+        access: &str,
+        reason: &str,
+    ) -> crate::approval::PendingConfirmation {
         crate::approval::PendingConfirmation {
             checkpoint_id: "mount_escalation_call_mount".to_string(),
             checkpoint_type: crate::approval::MOUNT_ESCALATION_CHECKPOINT_TYPE.to_string(),
@@ -714,8 +762,8 @@ mod tests {
                 "mount_request": {
                     "namespace_path": "/mnt/project",
                     "host_path": host_path,
-                    "access": "read_write",
-                    "reason": "Need to edit project files"
+                    "access": access,
+                    "reason": reason
                 },
                 "live_applied": false
             }),
@@ -729,14 +777,21 @@ mod tests {
             .tape
             .messages()
             .iter()
+            .rev()
             .find_map(|message| match message {
                 crate::tape::Message::Tool { responses } => responses
                     .iter()
+                    .rev()
                     .find(|response| response.id == call_id)
                     .map(crate::tape::ToolResponse::text_content),
                 _ => None,
             })
             .expect("expected tool result")
+    }
+
+    fn tool_result_json_for_call(state: &RuntimeLoopState, call_id: &str) -> serde_json::Value {
+        serde_json::from_str(&tool_result_text_for_call(state, call_id))
+            .expect("tool result should be json")
     }
 
     #[tokio::test]
@@ -1014,14 +1069,23 @@ mod tests {
     #[tokio::test]
     async fn test_handle_mount_escalation_resume_approve_records_grant_and_tool_result() {
         let temp = TempDir::new().unwrap();
+        let workspace = TempDir::new().unwrap();
+        let approved_host = TempDir::new().unwrap();
         let mut state = create_test_state();
         state.session =
             Session::new_with_id_and_recorder_in_dir("mount-approve", "test-model", temp.path())
                 .await
                 .unwrap();
         state
+            .tool_catalog
+            .set_default_workspace_root(workspace.path().to_path_buf());
+        state
             .turn_state
-            .set_confirmation(mount_escalation_pending_confirmation());
+            .set_confirmation(mount_escalation_pending_confirmation_with(
+                approved_host.path().to_str().unwrap(),
+                "read_write",
+                "Need to edit project files",
+            ));
         let cancel = CancellationToken::new();
 
         let mut emit = |_event: Event| async {};
@@ -1040,10 +1104,20 @@ mod tests {
             }
         ));
 
-        let tool_result = tool_result_text_for_call(&state, "call_mount");
-        assert!(tool_result.contains("\"status\":\"approved_not_applied\""));
-        assert!(tool_result.contains("\"live_applied\":false"));
-        assert!(tool_result.contains("\"namespace_path\":\"/mnt/project\""));
+        let tool_result = tool_result_json_for_call(&state, "call_mount");
+        assert_eq!(tool_result["status"], "approved");
+        assert_eq!(tool_result["tool_sandbox_applied"], true);
+        assert_eq!(tool_result["tool_sandbox_projection_changed"], true);
+        assert_eq!(tool_result["namespace_applied"], false);
+        assert_eq!(tool_result["live_applied"], false);
+        assert_eq!(
+            tool_result["mount_request"]["namespace_path"],
+            "/mnt/project"
+        );
+        let roots = state.tool_catalog.default_sandbox_writable_roots();
+        assert_eq!(roots.len(), 2);
+        assert_eq!(roots[0], workspace.path());
+        assert_eq!(roots[1], dunce::canonicalize(approved_host.path()).unwrap());
 
         state.session.flush().await;
         let rollout_path = state.session.rollout_path().unwrap().clone();
@@ -1055,11 +1129,10 @@ mod tests {
                 _ => None,
             })
             .expect("expected approved mount grant event");
-        let expected_host_path = std::fs::canonicalize(std::env::current_dir().unwrap()).unwrap();
         assert_eq!(grant.payload["namespace_path"], "/mnt/project");
         assert_eq!(
             grant.payload["host_path"],
-            expected_host_path.display().to_string()
+            approved_host.path().to_str().unwrap()
         );
         assert_eq!(grant.payload["access"], "read_write");
         assert_eq!(grant.payload["reason"], "Need to edit project files");
@@ -1069,20 +1142,117 @@ mod tests {
         );
         assert_eq!(grant.payload["approved"], true);
         assert_eq!(grant.payload["live_applied"], false);
+        assert_eq!(grant.payload["namespace_applied"], false);
+        assert_eq!(grant.payload["tool_sandbox_applied"], true);
+        assert_eq!(grant.payload["tool_sandbox_projection_changed"], true);
         assert_eq!(grant.payload["tool_call_id"], "call_mount");
+    }
+
+    #[tokio::test]
+    async fn test_handle_mount_escalation_resume_duplicate_read_write_grant_is_idempotent() {
+        let workspace = TempDir::new().unwrap();
+        let approved_host = TempDir::new().unwrap();
+        let mut state = create_test_state();
+        state
+            .tool_catalog
+            .set_default_workspace_root(workspace.path().to_path_buf());
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+
+        for _ in 0..2 {
+            state
+                .turn_state
+                .set_confirmation(mount_escalation_pending_confirmation_with(
+                    approved_host.path().to_str().unwrap(),
+                    "read_write",
+                    "Need to edit project files",
+                ));
+            handle_runtime_op_with_cancel(
+                &mut state,
+                Op::Resume {
+                    request_id: "mount_escalation_call_mount".to_string(),
+                    content: vec![ContentPart::structured(json!({"choice": "approve"}))],
+                },
+                &mut emit,
+                &cancel,
+            )
+            .await
+            .unwrap();
+        }
+
+        let roots = state.tool_catalog.default_sandbox_writable_roots();
+        assert_eq!(
+            roots,
+            vec![
+                workspace.path().to_path_buf(),
+                dunce::canonicalize(approved_host.path()).unwrap()
+            ]
+        );
+        let latest = tool_result_json_for_call(&state, "call_mount");
+        assert_eq!(latest["tool_sandbox_applied"], true);
+        assert_eq!(latest["tool_sandbox_projection_changed"], false);
+    }
+
+    #[tokio::test]
+    async fn test_handle_mount_escalation_resume_read_only_grant_does_not_expand_tool_sandbox() {
+        let workspace = TempDir::new().unwrap();
+        let approved_host = TempDir::new().unwrap();
+        let mut state = create_test_state();
+        state
+            .tool_catalog
+            .set_default_workspace_root(workspace.path().to_path_buf());
+        state
+            .turn_state
+            .set_confirmation(mount_escalation_pending_confirmation_with(
+                approved_host.path().to_str().unwrap(),
+                "read_only",
+                "Need to inspect project files",
+            ));
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+
+        let result = handle_runtime_op_with_cancel(
+            &mut state,
+            Op::Resume {
+                request_id: "mount_escalation_call_mount".to_string(),
+                content: vec![ContentPart::structured(json!({"choice": "approve"}))],
+            },
+            &mut emit,
+            &cancel,
+        )
+        .await;
+        assert!(result.is_ok());
+
+        let tool_result = tool_result_json_for_call(&state, "call_mount");
+        assert_eq!(tool_result["status"], "approved");
+        assert_eq!(tool_result["tool_sandbox_applied"], false);
+        assert_eq!(tool_result["tool_sandbox_projection_changed"], false);
+        assert_eq!(
+            state.tool_catalog.default_sandbox_writable_roots(),
+            vec![workspace.path().to_path_buf()]
+        );
     }
 
     #[tokio::test]
     async fn test_handle_mount_escalation_resume_reject_returns_tool_result_without_grant() {
         let temp = TempDir::new().unwrap();
+        let workspace = TempDir::new().unwrap();
+        let approved_host = TempDir::new().unwrap();
         let mut state = create_test_state();
         state.session =
             Session::new_with_id_and_recorder_in_dir("mount-reject", "test-model", temp.path())
                 .await
                 .unwrap();
         state
+            .tool_catalog
+            .set_default_workspace_root(workspace.path().to_path_buf());
+        state
             .turn_state
-            .set_confirmation(mount_escalation_pending_confirmation());
+            .set_confirmation(mount_escalation_pending_confirmation_with(
+                approved_host.path().to_str().unwrap(),
+                "read_write",
+                "Need to edit project files",
+            ));
         let cancel = CancellationToken::new();
 
         let mut emit = |_event: Event| async {};
@@ -1101,10 +1271,16 @@ mod tests {
             }
         ));
 
-        let tool_result = tool_result_text_for_call(&state, "call_mount");
-        assert!(tool_result.contains("\"status\":\"rejected\""));
-        assert!(tool_result.contains("\"approved\":false"));
-        assert!(tool_result.contains("\"live_applied\":false"));
+        let tool_result = tool_result_json_for_call(&state, "call_mount");
+        assert_eq!(tool_result["status"], "rejected");
+        assert_eq!(tool_result["approved"], false);
+        assert_eq!(tool_result["tool_sandbox_applied"], false);
+        assert_eq!(tool_result["tool_sandbox_projection_changed"], false);
+        assert_eq!(tool_result["live_applied"], false);
+        assert_eq!(
+            state.tool_catalog.default_sandbox_writable_roots(),
+            vec![workspace.path().to_path_buf()]
+        );
 
         state.session.flush().await;
         let rollout_path = state.session.rollout_path().unwrap().clone();
@@ -1126,9 +1302,15 @@ mod tests {
         )
         .await
         .unwrap();
+        let host_path = std::fs::canonicalize(std::env::current_dir().unwrap()).unwrap();
+        let host_path = host_path.display().to_string();
         state
             .turn_state
-            .set_confirmation(mount_escalation_pending_confirmation());
+            .set_confirmation(mount_escalation_pending_confirmation_with(
+                &host_path,
+                "read_write",
+                "Need to edit project files",
+            ));
         let cancel = CancellationToken::new();
 
         let mut emit = |_event: Event| async {};

--- a/crates/agent-engine/src/runtime/tool_orchestrator.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator.rs
@@ -1288,8 +1288,11 @@ fn workspace_routing_preflight(
     capability: ToolCapability,
 ) -> Option<(Value, String, alan_agent_protocol::ToolDecisionAudit)> {
     let workspace_root = bound_workspace_root(state)?;
-    let sandbox =
-        crate::tools::Sandbox::from_spec(crate::tools::SandboxSpec::seed(workspace_root.clone()));
+    let sandbox_spec = state
+        .tool_catalog
+        .default_sandbox_spec()
+        .unwrap_or_else(|| crate::tools::SandboxSpec::seed(workspace_root.clone()));
+    let sandbox = crate::tools::Sandbox::from_spec(sandbox_spec);
     let current_cwd = state
         .default_tool_cwd()
         .unwrap_or_else(|| workspace_root.clone());
@@ -3212,6 +3215,48 @@ mod tests {
             }),
             "cross-workspace local bash should not trigger confirmation escalation"
         );
+    }
+
+    #[test]
+    fn test_approved_mount_root_bypasses_workspace_routing_preflight() {
+        let workspace_root = tempfile::TempDir::new().unwrap();
+        let approved_root = tempfile::TempDir::new().unwrap();
+        let session = Session::new();
+        let mut tools = ToolRegistry::new();
+        tools.register(StaticResultTool {
+            name: "bash",
+            capability: ToolCapability::Unknown,
+            workspace_local: true,
+        });
+        let mut state = create_test_state_with_session_and_tools(session, tools);
+        state.workspace_root_dir = Some(workspace_root.path().to_path_buf());
+        state
+            .tool_catalog_mut_for_test()
+            .set_default_workspace_binding(
+                workspace_root.path().to_path_buf(),
+                workspace_root.path().to_path_buf(),
+            );
+        let arguments = json!({
+            "command": format!("cd {} && pwd", approved_root.path().display()),
+            "timeout": 60
+        });
+        let blocked =
+            workspace_routing_preflight(&state, "bash", &arguments, ToolCapability::Unknown);
+        assert!(
+            blocked.is_some(),
+            "unapproved host root should require delegation"
+        );
+
+        assert!(
+            state
+                .tool_catalog_mut_for_test()
+                .add_default_sandbox_writable_root(approved_root.path().to_path_buf())
+        );
+
+        let preflight =
+            workspace_routing_preflight(&state, "bash", &arguments, ToolCapability::Unknown);
+
+        assert!(preflight.is_none(), "approved root should not be delegated");
     }
 
     #[tokio::test]

--- a/crates/agent-engine/src/tools/context.rs
+++ b/crates/agent-engine/src/tools/context.rs
@@ -15,6 +15,8 @@ pub struct ToolExecutionBinding {
     pub cwd: PathBuf,
     /// Scratch directory for temporary files.
     pub scratch_dir: PathBuf,
+    /// Runtime-projected sandbox authority for this execution binding.
+    pub sandbox_spec: Option<SandboxSpec>,
 }
 
 impl ToolExecutionBinding {
@@ -24,6 +26,7 @@ impl ToolExecutionBinding {
             workspace_root,
             cwd,
             scratch_dir,
+            sandbox_spec: None,
         }
     }
 
@@ -36,6 +39,12 @@ impl ToolExecutionBinding {
     pub fn with_workspace(workspace_root: PathBuf, cwd: PathBuf, scratch_dir: PathBuf) -> Self {
         Self::new(Some(workspace_root), cwd, scratch_dir)
     }
+
+    /// Return a copy of this binding with an explicit runtime sandbox projection.
+    pub fn with_sandbox_spec(mut self, sandbox_spec: SandboxSpec) -> Self {
+        self.sandbox_spec = Some(sandbox_spec);
+        self
+    }
 }
 
 /// Context provided to tools during execution.
@@ -47,6 +56,8 @@ pub struct ToolContext {
     pub cwd: PathBuf,
     /// Scratch directory for temporary files
     pub scratch_dir: PathBuf,
+    /// Runtime-projected sandbox authority for this context.
+    pub sandbox_spec: Option<SandboxSpec>,
     /// Global configuration
     pub config: Arc<Config>,
 }
@@ -84,6 +95,7 @@ impl ToolContext {
             workspace_root: binding.workspace_root,
             cwd: binding.cwd,
             scratch_dir: binding.scratch_dir,
+            sandbox_spec: binding.sandbox_spec,
             config,
         }
     }
@@ -94,6 +106,7 @@ impl ToolContext {
             workspace_root: self.workspace_root.clone(),
             cwd: self.cwd.clone(),
             scratch_dir: self.scratch_dir.clone(),
+            sandbox_spec: self.sandbox_spec.clone(),
         }
     }
 
@@ -110,6 +123,9 @@ impl ToolContext {
 
     /// Create a sandbox bound to the current workspace root.
     pub fn workspace_sandbox(&self) -> Result<Sandbox> {
+        if let Some(spec) = self.sandbox_spec.clone() {
+            return Ok(Sandbox::from_spec(spec));
+        }
         Ok(Sandbox::from_spec(SandboxSpec::seed(
             self.require_workspace_root()?.to_path_buf(),
         )))
@@ -171,5 +187,30 @@ mod tests {
                 PathBuf::from("/tmp/scratch")
             )
         );
+    }
+
+    #[test]
+    fn test_tool_context_uses_explicit_sandbox_spec() {
+        let config = Arc::new(Config::default());
+        let workspace_dir = tempfile::tempdir().unwrap();
+        let approved_dir = tempfile::tempdir().unwrap();
+        let workspace = workspace_dir.path().to_path_buf();
+        let approved = approved_dir.path().to_path_buf();
+        let spec = SandboxSpec {
+            writable_roots: vec![workspace.clone(), approved.clone()],
+            read_denylist: Vec::new(),
+            network: crate::tools::NetworkPosture::Deny,
+        };
+        let binding = ToolExecutionBinding::with_workspace(
+            workspace.clone(),
+            workspace.clone(),
+            PathBuf::from("/tmp/scratch"),
+        )
+        .with_sandbox_spec(spec.clone());
+        let ctx = ToolContext::from_binding(binding, config);
+
+        assert_eq!(ctx.binding().sandbox_spec, Some(spec));
+        let sandbox = ctx.workspace_sandbox().unwrap();
+        assert!(sandbox.is_in_workspace(&approved.join("file.txt")));
     }
 }

--- a/crates/agent-engine/src/tools/registry.rs
+++ b/crates/agent-engine/src/tools/registry.rs
@@ -1,13 +1,16 @@
 //! Tool registry for managing and executing tools.
 
-use super::context::{ToolContext, ToolExecutionBinding};
+use super::{
+    context::{ToolContext, ToolExecutionBinding},
+    sandbox::{SandboxSpec, protected_path_component},
+};
 use anyhow::Result;
 use jsonschema::{Draft, Validator};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tracing::debug;
 
 use crate::config::Config;
@@ -63,9 +66,11 @@ pub trait Tool: Send + Sync {
 pub struct ToolRegistry {
     tools: HashMap<String, Arc<dyn Tool>>,
     config: Arc<Config>,
-    schema_cache: Arc<std::sync::Mutex<HashMap<String, Arc<Validator>>>>,
+    schema_cache: Arc<Mutex<HashMap<String, Arc<Validator>>>>,
     tool_factories: HashMap<String, Arc<ToolFactory>>,
-    default_binding: Option<ToolExecutionBinding>,
+    /// Shared by ordinary clones so runtime state and namespace tool runners
+    /// observe approval-time changes to default execution authority.
+    default_binding: Arc<Mutex<Option<ToolExecutionBinding>>>,
 }
 
 impl ToolRegistry {
@@ -79,20 +84,75 @@ impl ToolRegistry {
         Self {
             tools: HashMap::new(),
             config,
-            schema_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            schema_cache: Arc::new(Mutex::new(HashMap::new())),
             tool_factories: HashMap::new(),
-            default_binding: None,
+            default_binding: Self::default_binding_cell(None),
         }
     }
 
     /// Set a default execution binding for `execute()` calls that don't provide context.
     pub fn set_default_execution_binding(&mut self, binding: ToolExecutionBinding) {
-        self.default_binding = Some(binding);
+        let mut default_binding = self
+            .default_binding
+            .lock()
+            .expect("default binding mutex poisoned");
+        *default_binding = Some(binding);
     }
 
     /// Get the configured default execution binding, if any.
     pub fn default_execution_binding(&self) -> Option<ToolExecutionBinding> {
-        self.default_binding.clone()
+        self.default_binding_snapshot()
+    }
+
+    /// Get the runtime-projected sandbox spec for default tool execution, if configured.
+    pub fn default_sandbox_spec(&self) -> Option<SandboxSpec> {
+        self.default_binding_snapshot()
+            .as_ref()
+            .and_then(|binding| binding.sandbox_spec.clone())
+    }
+
+    /// Get the writable roots that currently define default tool sandbox authority.
+    pub fn default_sandbox_writable_roots(&self) -> Vec<std::path::PathBuf> {
+        let Some(binding) = self.default_binding_snapshot() else {
+            return Vec::new();
+        };
+        if let Some(spec) = binding.sandbox_spec.as_ref() {
+            return spec.writable_roots.clone();
+        }
+        binding.workspace_root.clone().into_iter().collect()
+    }
+
+    /// Add a writable root to the default runtime sandbox projection.
+    ///
+    /// Returns true when the root was newly inserted. If the registry has no
+    /// workspace-bound default binding, no projection is changed and false is returned.
+    pub fn add_default_sandbox_writable_root(&mut self, path: std::path::PathBuf) -> bool {
+        let mut default_binding = self
+            .default_binding
+            .lock()
+            .expect("default binding mutex poisoned");
+        let Some(binding) = default_binding.as_mut() else {
+            return false;
+        };
+        let Some(workspace_root) = binding.workspace_root.clone() else {
+            return false;
+        };
+
+        let normalized = normalize_sandbox_root(path);
+        if protected_path_component(&normalized).is_some() {
+            return false;
+        }
+        let mut spec = binding
+            .sandbox_spec
+            .clone()
+            .unwrap_or_else(|| SandboxSpec::seed(workspace_root));
+        if spec.writable_roots.iter().any(|root| root == &normalized) {
+            binding.sandbox_spec = Some(spec);
+            return false;
+        }
+        spec.writable_roots.push(normalized);
+        binding.sandbox_spec = Some(spec);
+        true
     }
 
     /// Set a default workspace binding using the provided workspace root and cwd.
@@ -102,11 +162,22 @@ impl ToolRegistry {
         cwd: std::path::PathBuf,
     ) {
         let scratch_dir = default_scratch_dir_for_cwd(&cwd);
-        self.default_binding = Some(ToolExecutionBinding::with_workspace(
-            workspace_root,
-            cwd,
-            scratch_dir,
-        ));
+        let mut default_binding = self
+            .default_binding
+            .lock()
+            .expect("default binding mutex poisoned");
+        let sandbox_spec = default_binding
+            .as_ref()
+            .filter(|binding| {
+                binding.workspace_root.as_ref().is_some_and(|existing| {
+                    normalize_sandbox_root(existing.clone())
+                        == normalize_sandbox_root(workspace_root.clone())
+                })
+            })
+            .and_then(|binding| binding.sandbox_spec.clone());
+        let mut binding = ToolExecutionBinding::with_workspace(workspace_root, cwd, scratch_dir);
+        binding.sandbox_spec = sandbox_spec;
+        *default_binding = Some(binding);
     }
 
     /// Set a default workspace root using the workspace root as cwd.
@@ -117,23 +188,26 @@ impl ToolRegistry {
     /// Set a default working directory for `execute()` calls that don't provide context.
     pub fn set_default_cwd(&mut self, cwd: std::path::PathBuf) {
         let scratch_dir = default_scratch_dir_for_cwd(&cwd);
-        let workspace_root = self
+        let mut default_binding = self
             .default_binding
+            .lock()
+            .expect("default binding mutex poisoned");
+        let workspace_root = default_binding
             .as_ref()
             .and_then(|binding| binding.workspace_root.clone());
-        self.default_binding = Some(ToolExecutionBinding::new(workspace_root, cwd, scratch_dir));
+        *default_binding = Some(ToolExecutionBinding::new(workspace_root, cwd, scratch_dir));
     }
 
     /// Get the configured default working directory, if any.
     pub fn default_cwd(&self) -> Option<std::path::PathBuf> {
-        self.default_binding
+        self.default_binding_snapshot()
             .as_ref()
             .map(|binding| binding.cwd.clone())
     }
 
     /// Get the configured default workspace root, if any.
     pub fn default_workspace_root(&self) -> Option<std::path::PathBuf> {
-        self.default_binding
+        self.default_binding_snapshot()
             .as_ref()
             .and_then(|binding| binding.workspace_root.clone())
     }
@@ -233,9 +307,9 @@ impl ToolRegistry {
                 .map(|(name, tool)| (name.clone(), Arc::clone(tool)))
                 .collect(),
             config,
-            schema_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            schema_cache: Arc::new(Mutex::new(HashMap::new())),
             tool_factories: self.tool_factories.clone(),
-            default_binding: self.default_binding.clone(),
+            default_binding: Self::default_binding_cell(self.default_binding_snapshot()),
         }
     }
 
@@ -274,9 +348,9 @@ impl ToolRegistry {
         Self {
             tools,
             config,
-            schema_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            schema_cache: Arc::new(Mutex::new(HashMap::new())),
             tool_factories,
-            default_binding: self.default_binding.clone(),
+            default_binding: Self::default_binding_cell(self.default_binding_snapshot()),
         }
     }
 
@@ -297,14 +371,14 @@ impl ToolRegistry {
         let mut cloned = Self {
             tools: HashMap::new(),
             config,
-            schema_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            schema_cache: Arc::new(Mutex::new(HashMap::new())),
             tool_factories: self
                 .tool_factories
                 .iter()
                 .filter(|(name, _)| allowed.contains(name.as_str()))
                 .map(|(name, factory)| (name.clone(), Arc::clone(factory)))
                 .collect(),
-            default_binding: self.default_binding.clone(),
+            default_binding: Self::default_binding_cell(self.default_binding_snapshot()),
         };
 
         for name in allowed {
@@ -378,7 +452,7 @@ impl ToolRegistry {
     /// Execute a tool by name (backward compatible, uses default context)
     /// Note: This creates a default ToolContext. Prefer execute_with_context for production use.
     pub async fn execute(&self, name: &str, arguments: Value) -> Result<Value> {
-        let binding = self.default_binding.clone().unwrap_or_else(|| {
+        let binding = self.default_binding_snapshot().unwrap_or_else(|| {
             let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
             let scratch_dir = default_scratch_dir_for_cwd(&cwd);
             ToolExecutionBinding::without_workspace(cwd, scratch_dir)
@@ -434,6 +508,19 @@ impl ToolRegistry {
         Ok(())
     }
 
+    fn default_binding_cell(
+        binding: Option<ToolExecutionBinding>,
+    ) -> Arc<Mutex<Option<ToolExecutionBinding>>> {
+        Arc::new(Mutex::new(binding))
+    }
+
+    fn default_binding_snapshot(&self) -> Option<ToolExecutionBinding> {
+        self.default_binding
+            .lock()
+            .expect("default binding mutex poisoned")
+            .clone()
+    }
+
     /// Validate that required tools are available
     pub fn validate_required_tools(&self, required: &[String]) -> Result<Vec<String>> {
         let mut missing = Vec::new();
@@ -444,6 +531,10 @@ impl ToolRegistry {
         }
         Ok(missing)
     }
+}
+
+fn normalize_sandbox_root(path: std::path::PathBuf) -> std::path::PathBuf {
+    dunce::canonicalize(&path).unwrap_or_else(|_| dunce::simplified(&path).to_path_buf())
 }
 
 impl Default for ToolRegistry {
@@ -569,6 +660,36 @@ mod tests {
                     "cwd": cwd,
                 }))
             })
+        }
+    }
+
+    struct SandboxRootsEchoTool;
+
+    impl Tool for SandboxRootsEchoTool {
+        fn name(&self) -> &str {
+            "sandbox_roots_echo"
+        }
+
+        fn description(&self) -> &str {
+            "Return sandbox writable roots from tool context"
+        }
+
+        fn parameters_schema(&self) -> Value {
+            serde_json::json!({"type": "object"})
+        }
+
+        fn execute(&self, _arguments: Value, ctx: &ToolContext) -> ToolResult {
+            let writable_roots = ctx
+                .sandbox_spec
+                .as_ref()
+                .map(|spec| {
+                    spec.writable_roots
+                        .iter()
+                        .map(|path| path.display().to_string())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            Box::pin(async move { Ok(serde_json::json!({"writable_roots": writable_roots})) })
         }
     }
 
@@ -929,6 +1050,160 @@ mod tests {
 
         assert_eq!(result["workspace_root"], "/tmp/alan-test-workspace");
         assert_eq!(result["cwd"], "/tmp/alan-test-workspace/src");
+    }
+
+    #[test]
+    fn test_tool_registry_add_default_sandbox_writable_root_is_idempotent() {
+        let workspace = tempfile::tempdir().unwrap();
+        let approved = tempfile::tempdir().unwrap();
+        let mut registry = ToolRegistry::new();
+        registry.set_default_workspace_root(workspace.path().to_path_buf());
+
+        assert_eq!(
+            registry.default_sandbox_writable_roots(),
+            vec![workspace.path().to_path_buf()]
+        );
+        assert!(registry.add_default_sandbox_writable_root(approved.path().to_path_buf()));
+        assert!(!registry.add_default_sandbox_writable_root(approved.path().to_path_buf()));
+
+        let roots = registry.default_sandbox_writable_roots();
+        assert_eq!(roots.len(), 2);
+        assert_eq!(roots[0], workspace.path());
+        assert_eq!(roots[1], dunce::canonicalize(approved.path()).unwrap());
+        assert_eq!(
+            registry.default_sandbox_spec().unwrap().writable_roots,
+            roots
+        );
+    }
+
+    #[test]
+    fn test_tool_registry_rejects_protected_sandbox_writable_roots() {
+        let workspace = tempfile::tempdir().unwrap();
+        let host = tempfile::tempdir().unwrap();
+        let protected_root = host.path().join(".git");
+        let nested_protected_root = protected_root.join("objects");
+        std::fs::create_dir_all(&nested_protected_root).unwrap();
+        let mut registry = ToolRegistry::new();
+        registry.set_default_workspace_root(workspace.path().to_path_buf());
+
+        assert!(!registry.add_default_sandbox_writable_root(protected_root));
+        assert!(!registry.add_default_sandbox_writable_root(nested_protected_root));
+        assert_eq!(
+            registry.default_sandbox_writable_roots(),
+            vec![workspace.path().to_path_buf()]
+        );
+    }
+
+    #[test]
+    fn test_tool_registry_rebinding_same_workspace_preserves_sandbox_spec() {
+        let workspace = tempfile::tempdir().unwrap();
+        let approved = tempfile::tempdir().unwrap();
+        let mut registry = ToolRegistry::new();
+        registry.set_default_workspace_root(workspace.path().to_path_buf());
+        assert!(registry.add_default_sandbox_writable_root(approved.path().to_path_buf()));
+
+        registry.set_default_workspace_binding(
+            workspace.path().to_path_buf(),
+            workspace.path().join("child-cwd"),
+        );
+
+        let roots = registry.default_sandbox_writable_roots();
+        assert_eq!(roots.len(), 2);
+        assert_eq!(roots[0], workspace.path());
+        assert_eq!(roots[1], dunce::canonicalize(approved.path()).unwrap());
+    }
+
+    #[test]
+    fn test_tool_registry_rebinding_different_workspace_drops_sandbox_spec() {
+        let workspace = tempfile::tempdir().unwrap();
+        let next_workspace = tempfile::tempdir().unwrap();
+        let approved = tempfile::tempdir().unwrap();
+        let mut registry = ToolRegistry::new();
+        registry.set_default_workspace_root(workspace.path().to_path_buf());
+        assert!(registry.add_default_sandbox_writable_root(approved.path().to_path_buf()));
+
+        registry.set_default_workspace_root(next_workspace.path().to_path_buf());
+
+        assert_eq!(
+            registry.default_sandbox_writable_roots(),
+            vec![next_workspace.path().to_path_buf()]
+        );
+        assert!(registry.default_sandbox_spec().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_tool_registry_clone_shares_default_sandbox_binding() {
+        let workspace = tempfile::tempdir().unwrap();
+        let approved = tempfile::tempdir().unwrap();
+        let mut registry = ToolRegistry::new();
+        registry.register(SandboxRootsEchoTool);
+        registry.set_default_workspace_root(workspace.path().to_path_buf());
+
+        let runner_registry = registry.clone();
+        assert!(registry.add_default_sandbox_writable_root(approved.path().to_path_buf()));
+
+        let expected_roots = vec![
+            workspace.path().to_path_buf(),
+            dunce::canonicalize(approved.path()).unwrap(),
+        ];
+        assert_eq!(
+            runner_registry.default_sandbox_writable_roots(),
+            expected_roots
+        );
+
+        let result = runner_registry
+            .execute("sandbox_roots_echo", serde_json::json!({}))
+            .await
+            .unwrap();
+        let root_values = result["writable_roots"].as_array().unwrap();
+        assert_eq!(root_values.len(), 2);
+        assert_eq!(
+            root_values[0],
+            serde_json::json!(expected_roots[0].display().to_string())
+        );
+        assert_eq!(
+            root_values[1],
+            serde_json::json!(expected_roots[1].display().to_string())
+        );
+    }
+
+    #[test]
+    fn test_tool_registry_derived_clones_snapshot_default_sandbox_binding() {
+        let workspace = tempfile::tempdir().unwrap();
+        let approved = tempfile::tempdir().unwrap();
+        let mut registry = ToolRegistry::new();
+        registry.register(SandboxRootsEchoTool);
+        registry.set_default_workspace_root(workspace.path().to_path_buf());
+
+        let clone_with_config = registry.clone_with_config(Arc::new(Config::default()));
+        let filtered = registry.filtered_clone(["sandbox_roots_echo"]);
+        let catalog_filtered = registry.catalog_filtered_clone_with_config(
+            ["sandbox_roots_echo"],
+            Arc::new(Config::default()),
+        );
+
+        assert!(registry.add_default_sandbox_writable_root(approved.path().to_path_buf()));
+        let snapshot_roots = vec![workspace.path().to_path_buf()];
+
+        assert_eq!(
+            clone_with_config.default_sandbox_writable_roots(),
+            snapshot_roots
+        );
+        assert_eq!(filtered.default_sandbox_writable_roots(), snapshot_roots);
+        assert_eq!(
+            catalog_filtered.default_sandbox_writable_roots(),
+            snapshot_roots
+        );
+    }
+
+    #[test]
+    fn test_tool_registry_add_default_sandbox_writable_root_requires_workspace_binding() {
+        let approved = tempfile::tempdir().unwrap();
+        let mut registry = ToolRegistry::new();
+        registry.set_default_cwd(PathBuf::from("/tmp/alan-no-workspace"));
+
+        assert!(!registry.add_default_sandbox_writable_root(approved.path().to_path_buf()));
+        assert!(registry.default_sandbox_spec().is_none());
     }
 
     #[tokio::test]

--- a/crates/agent-engine/src/tools/sandbox.rs
+++ b/crates/agent-engine/src/tools/sandbox.rs
@@ -22,6 +22,21 @@ use crate::InstallChannel;
 const SANDBOX_BACKEND_WORKSPACE_PATH_GUARD: &str = "workspace_path_guard";
 pub(crate) const PROTECTED_SUBPATHS: [&str; 3] = [".git", ".alan", ".agents"];
 
+pub(crate) fn protected_path_component(path: &Path) -> Option<&'static str> {
+    path.components().find_map(protected_component)
+}
+
+fn protected_component(component: Component<'_>) -> Option<&'static str> {
+    let Component::Normal(name) = component else {
+        return None;
+    };
+    let candidate = name.to_str()?;
+    PROTECTED_SUBPATHS
+        .iter()
+        .copied()
+        .find(|protected| *protected == candidate)
+}
+
 /// How thoroughly to validate command paths. Under an OS sandbox the kernel
 /// enforces workspace containment, so only protected-subpath writes need the
 /// parser; on the path-guard fallback the full syntactic checks apply.
@@ -188,6 +203,15 @@ impl Sandbox {
         &self.spec.writable_roots[0]
     }
 
+    fn allowed_roots_label(&self) -> String {
+        self.spec
+            .writable_roots
+            .iter()
+            .map(|root| root.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
     /// The backend in effect (override for tests, else host detection).
     fn active_backend(&self) -> super::sandbox_backend::SandboxBackendKind {
         self.backend_override
@@ -217,9 +241,9 @@ impl Sandbox {
     pub fn bash_workspace_routing_reason(&self, cmd: &str, cwd: &Path) -> Option<String> {
         if !self.is_in_workspace(cwd) {
             return Some(format!(
-                "Working directory outside workspace: {} (workspace: {})",
+                "Working directory outside workspace roots: {} (allowed roots: {})",
                 cwd.display(),
-                self.workspace_root().display()
+                self.allowed_roots_label()
             ));
         }
 
@@ -240,13 +264,26 @@ impl Sandbox {
         } else {
             self.workspace_root().join(path)
         };
+        self.spec
+            .writable_roots
+            .iter()
+            .any(|root| self.is_path_in_root(&absolute_path, root))
+    }
+
+    fn is_path_in_root(&self, absolute_path: &Path, root: &Path) -> bool {
+        let canonical_root = self
+            .canonicalize(root)
+            .unwrap_or_else(|_| lexically_normalize_path(root));
+        let normalized_root = lexically_normalize_path(root);
 
         // For existing paths, use canonical path
         if absolute_path.exists() {
             let canonical_path = self
-                .canonicalize(&absolute_path)
-                .unwrap_or_else(|_| dunce::simplified(&absolute_path).to_path_buf());
-            return self.is_under_writable_root(&canonical_path);
+                .canonicalize(absolute_path)
+                .unwrap_or_else(|_| lexically_normalize_path(absolute_path));
+            let normalized_path = lexically_normalize_path(&canonical_path);
+            return canonical_path.starts_with(&canonical_root)
+                || normalized_path.starts_with(&normalized_root);
         }
 
         // For new files, check that existing parent directories are within an
@@ -256,23 +293,27 @@ impl Sandbox {
             if parent.exists() {
                 let canonical_parent = self
                     .canonicalize(parent)
-                    .unwrap_or_else(|_| dunce::simplified(parent).to_path_buf());
-                return self.is_under_writable_root(&canonical_parent);
+                    .unwrap_or_else(|_| lexically_normalize_path(parent));
+                let normalized_parent = lexically_normalize_path(&canonical_parent);
+                return canonical_parent.starts_with(&canonical_root)
+                    || normalized_parent.starts_with(&normalized_root);
             }
             current = parent.parent();
         }
 
-        // If no parent exists, check if the path itself starts with a writable root.
-        self.is_under_writable_root(&lexically_normalize_path(&absolute_path))
+        // If no parent exists, check if the path itself starts with the allowed root.
+        let normalized_path = lexically_normalize_path(absolute_path);
+        normalized_path.starts_with(&canonical_root)
+            || normalized_path.starts_with(&normalized_root)
     }
 
     /// Read a file within the workspace
     pub async fn read(&self, path: &Path) -> Result<Vec<u8>> {
         if !self.is_in_workspace(path) {
             return Err(anyhow!(
-                "Path outside workspace: {} (workspace: {})",
+                "Path outside workspace roots: {} (allowed roots: {})",
                 path.display(),
-                self.workspace_root().display()
+                self.allowed_roots_label()
             ));
         }
         self.ensure_path_not_read_denied(path, "read")?;
@@ -292,9 +333,9 @@ impl Sandbox {
     pub async fn write(&self, path: &Path, content: &[u8]) -> Result<()> {
         if !self.is_in_workspace(path) {
             return Err(anyhow!(
-                "Path outside workspace: {} (workspace: {})",
+                "Path outside workspace roots: {} (allowed roots: {})",
                 path.display(),
-                self.workspace_root().display()
+                self.allowed_roots_label()
             ));
         }
         self.ensure_path_not_protected(path, "write")?;
@@ -337,9 +378,9 @@ impl Sandbox {
     ) -> Result<ExecResult> {
         if !self.is_in_workspace(cwd) {
             return Err(anyhow!(
-                "Working directory outside workspace: {} (workspace: {})",
+                "Working directory outside workspace roots: {} (allowed roots: {})",
                 cwd.display(),
-                self.workspace_root().display()
+                self.allowed_roots_label()
             ));
         }
         self.ensure_path_not_protected(cwd, "process cwd")?;
@@ -456,9 +497,9 @@ impl Sandbox {
     pub async fn list_dir(&self, path: &Path) -> Result<Vec<tokio::fs::DirEntry>> {
         if !self.is_in_workspace(path) {
             return Err(anyhow!(
-                "Path outside workspace: {} (workspace: {})",
+                "Path outside workspace roots: {} (allowed roots: {})",
                 path.display(),
-                self.workspace_root().display()
+                self.allowed_roots_label()
             ));
         }
         self.ensure_path_not_read_denied(path, "list directory")?;
@@ -639,40 +680,25 @@ impl Sandbox {
                 .canonicalize(root)
                 .unwrap_or_else(|_| lexically_normalize_path(root));
             let normalized_root = lexically_normalize_path(root);
+            let root_protected = protected_path_component(&canonical_root)
+                .or_else(|| protected_path_component(&normalized_root));
             let Ok(relative) = resolved_path
                 .strip_prefix(&canonical_root)
                 .or_else(|_| resolved_path.strip_prefix(&normalized_root))
             else {
                 continue;
             };
+            if let Some(component) = root_protected {
+                return Some(component);
+            }
             if is_allowed_protected_relative_path(relative) {
                 return None;
             }
-            if let Some(component) = relative.components().find_map(|component| match component {
-                Component::Normal(name) => {
-                    let candidate = name.to_str()?;
-                    PROTECTED_SUBPATHS
-                        .iter()
-                        .copied()
-                        .find(|protected| *protected == candidate)
-                }
-                _ => None,
-            }) {
+            if let Some(component) = relative.components().find_map(protected_component) {
                 return Some(component);
             }
         }
         None
-    }
-
-    fn is_under_writable_root(&self, path: &Path) -> bool {
-        let normalized_path = lexically_normalize_path(path);
-        self.spec.writable_roots.iter().any(|root| {
-            let canonical_root = self
-                .canonicalize(root)
-                .unwrap_or_else(|_| lexically_normalize_path(root));
-            let normalized_root = lexically_normalize_path(root);
-            path.starts_with(&canonical_root) || normalized_path.starts_with(&normalized_root)
-        })
     }
 
     fn normalized_path(&self, path: &Path) -> PathBuf {

--- a/crates/agent-engine/src/tools/sandbox_tests.rs
+++ b/crates/agent-engine/src/tools/sandbox_tests.rs
@@ -97,6 +97,112 @@ async fn test_sandbox_read_write() {
 }
 
 #[tokio::test]
+async fn sandbox_allows_each_writable_root() {
+    let workspace = TempDir::new().unwrap();
+    let approved = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let sandbox = Sandbox::from_spec(SandboxSpec {
+        writable_roots: vec![
+            workspace.path().to_path_buf(),
+            approved.path().to_path_buf(),
+        ],
+        read_denylist: Vec::new(),
+        network: NetworkPosture::Deny,
+    });
+
+    let approved_file = approved.path().join("notes.txt");
+    sandbox.write(&approved_file, b"hello mount").await.unwrap();
+    assert_eq!(
+        sandbox.read_string(&approved_file).await.unwrap(),
+        "hello mount"
+    );
+    assert!(
+        sandbox
+            .list_dir(approved.path())
+            .await
+            .unwrap()
+            .iter()
+            .any(|entry| entry.file_name() == "notes.txt")
+    );
+    assert!(sandbox.is_in_workspace(&workspace.path().join("a.txt")));
+    assert!(sandbox.is_in_workspace(&approved.path().join("b.txt")));
+    assert!(!sandbox.is_in_workspace(&outside.path().join("c.txt")));
+
+    let outside_read = sandbox.read(&outside.path().join("secret.txt")).await;
+    assert!(outside_read.is_err());
+    assert!(
+        outside_read
+            .unwrap_err()
+            .to_string()
+            .contains("outside workspace")
+    );
+}
+
+#[tokio::test]
+async fn sandbox_exec_accepts_cwd_under_secondary_writable_root() {
+    let workspace = TempDir::new().unwrap();
+    let approved = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let sandbox = Sandbox::from_spec_with_backend(
+        SandboxSpec {
+            writable_roots: vec![
+                workspace.path().to_path_buf(),
+                approved.path().to_path_buf(),
+            ],
+            read_denylist: Vec::new(),
+            network: NetworkPosture::Deny,
+        },
+        crate::tools::SandboxBackendKind::WorkspacePathGuard,
+    );
+    tokio::fs::write(approved.path().join("in_mount.txt"), "ok")
+        .await
+        .unwrap();
+
+    let result = sandbox.exec("cat ./in_mount.txt", approved.path()).await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().stdout.trim(), "ok");
+
+    let outside_result = sandbox.exec("echo no", outside.path()).await;
+    assert!(outside_result.is_err());
+    assert!(
+        outside_result
+            .unwrap_err()
+            .to_string()
+            .contains("outside workspace")
+    );
+}
+
+#[tokio::test]
+async fn sandbox_protects_reserved_subpaths_under_secondary_writable_root() {
+    let workspace = TempDir::new().unwrap();
+    let approved = TempDir::new().unwrap();
+    let sandbox = Sandbox::from_spec_with_backend(
+        SandboxSpec {
+            writable_roots: vec![
+                workspace.path().to_path_buf(),
+                approved.path().to_path_buf(),
+            ],
+            read_denylist: Vec::new(),
+            network: NetworkPosture::Deny,
+        },
+        crate::tools::SandboxBackendKind::WorkspacePathGuard,
+    );
+    let protected = approved.path().join(".git/config");
+    tokio::fs::create_dir_all(protected.parent().unwrap())
+        .await
+        .unwrap();
+
+    let result = sandbox.write(&protected, b"[core]\n").await;
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("protected subpath")
+    );
+}
+
+#[tokio::test]
 async fn test_sandbox_blocks_outside_workspace() {
     let temp = TempDir::new().unwrap();
     let sandbox = Sandbox::with_backend(
@@ -152,6 +258,34 @@ async fn sandbox_spec_writable_roots_still_block_host_protected_subpaths() {
         .unwrap();
 
     let result = sandbox.write(&protected, b"[core]\n").await;
+
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("protected subpath .git")
+    );
+}
+
+#[tokio::test]
+async fn sandbox_spec_writable_roots_block_protected_roots_themselves() {
+    let workspace = TempDir::new().unwrap();
+    let host = TempDir::new().unwrap();
+    let protected_root = host.path().join(".git");
+    tokio::fs::create_dir_all(&protected_root).await.unwrap();
+    let sandbox = Sandbox::from_spec_with_backend(
+        SandboxSpec {
+            writable_roots: vec![workspace.path().to_path_buf(), protected_root.clone()],
+            read_denylist: Vec::new(),
+            network: NetworkPosture::Deny,
+        },
+        crate::tools::SandboxBackendKind::WorkspacePathGuard,
+    );
+
+    let result = sandbox
+        .write(&protected_root.join("config"), b"[core]\n")
+        .await;
 
     assert!(result.is_err());
     assert!(
@@ -510,6 +644,26 @@ async fn test_sandbox_blocks_symlink_alias_into_protected_subpath() {
             .to_string()
             .contains("protected subpath .git")
     );
+}
+
+#[tokio::test]
+async fn test_sandbox_blocks_symlink_alias_outside_writable_roots() {
+    let workspace = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let sandbox = Sandbox::with_backend(
+        workspace.path().to_path_buf(),
+        crate::tools::SandboxBackendKind::WorkspacePathGuard,
+    );
+    let outside_file = outside.path().join("secret.txt");
+    tokio::fs::write(&outside_file, "secret").await.unwrap();
+    let alias = workspace.path().join("safe.txt");
+    std::os::unix::fs::symlink(&outside_file, &alias).unwrap();
+
+    let read = sandbox.read_string(&alias).await.unwrap_err();
+    assert!(read.to_string().contains("outside workspace"), "{read}");
+
+    let write = sandbox.write(&alias, b"changed").await.unwrap_err();
+    assert!(write.to_string().contains("outside workspace"), "{write}");
 }
 
 #[tokio::test]

--- a/openspec/changes/apply-mount-grants-to-tool-sandbox/.openspec.yaml
+++ b/openspec/changes/apply-mount-grants-to-tool-sandbox/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/apply-mount-grants-to-tool-sandbox/design.md
+++ b/openspec/changes/apply-mount-grants-to-tool-sandbox/design.md
@@ -1,0 +1,81 @@
+## Context
+
+P2 introduced host mount declarations that can project human/config-declared
+host roots into both an Alan OS namespace and `SandboxSpec` at startup. P3 then
+added the agent-facing `request_mount` approval flow, but approval currently
+only records `host_mount_grant` and returns `approved_not_applied`.
+
+The runtime tool path has a separate static projection: `ToolContext` derives a
+fresh sandbox from the workspace root with `SandboxSpec::seed`, and
+`Sandbox::is_in_workspace` checks only the first writable root. Even if a host
+mount grant is approved, later `read_file`, `write_file`, `edit_file`, `list_dir`,
+and `bash` calls still behave as though only the original workspace root exists.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Carry a runtime-owned `SandboxSpec` through `ToolExecutionBinding` and
+  `ToolContext`.
+- Treat every `SandboxSpec.writable_roots` entry as an allowed execution root
+  for tool path checks and OS sandbox profile generation.
+- Apply approved `request_mount` grants with `access = read_write` to the
+  running runtime's tool sandbox for subsequent tool calls.
+- Return a `request_mount` result that distinguishes sandbox projection from
+  Alan OS namespace remounting.
+- Keep duplicate approved roots idempotent and canonical where possible.
+
+**Non-Goals:**
+
+- Live mutation of the Alan OS `/mnt/<name>` namespace or `MountFs`.
+- Adding explicit read-allow roots to `SandboxSpec`.
+- Persisting approved grants across session restart.
+- Linux mount namespace reification.
+
+## Decisions
+
+1. **Store the projected sandbox on the tool execution binding.**
+
+   `ToolExecutionBinding` already owns workspace root, cwd, and scratch state for
+   the runtime's tool execution context. Adding an optional `SandboxSpec` there
+   keeps sandbox authority in the same runtime-owned binding instead of adding
+   a parallel global registry.
+
+2. **Preserve workspace root as the first writable root.**
+
+   Existing callers and error messages assume the first root is the workspace
+   seed. Approved writable mounts append additional roots. This keeps backward
+   compatibility while allowing `SandboxSpec` to express the expanded authority.
+
+3. **Update the active default binding on approval.**
+
+   The runtime executes built-in tools through `state.tool_catalog`. When a
+   mount grant is approved, the resume handler updates the catalog's default
+   binding before the next turn resumes, so subsequent tool calls inherit the
+   expanded sandbox projection without replaying the approved `request_mount`
+   call.
+
+4. **Project read-write grants only.**
+
+   `SandboxSpec` currently models writable roots and a sensitive-read denylist;
+   it does not model read-only roots. A read-only mount approval remains
+   auditable but does not expand the tool sandbox until a read-allow projection
+   exists.
+
+5. **Keep `/mnt` namespace remounting separate.**
+
+   Applying a `HostDirFs` to the live Alan OS namespace belongs in a host
+   composition hook that can own `HostDirFs` construction and `MountFs`
+   mutation. This change avoids adding a hidden hostfs dependency to the generic
+   Agent Execution Engine.
+
+## Risks / Trade-offs
+
+- **Approved grant is usable by host-path tools but not `/mnt/<name>` yet** ->
+  The tool result states `tool_sandbox_applied` separately from
+  `namespace_applied`.
+- **Read-only approval remains audit-only** -> Keep the result explicit and
+  leave read-allow roots to a follow-up `SandboxSpec` extension.
+- **Path checks may still report "workspace" in some messages** -> Expand the
+  allow logic now, then polish wording where touched so failures name allowed
+  roots rather than only the workspace root.

--- a/openspec/changes/apply-mount-grants-to-tool-sandbox/proposal.md
+++ b/openspec/changes/apply-mount-grants-to-tool-sandbox/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+`add-agent-mount-escalation` records approved mount grants, but the running
+tool sandbox still derives from the original single workspace seed. That means
+an approved read-write host mount does not yet affect subsequent bash or
+workspace-local tool execution.
+
+This change applies approved read-write mount grants to the runtime's projected
+tool sandbox so the authorization decision has an immediate, auditable execution
+effect without pretending the Alan OS `/mnt` namespace has been live-remounted
+yet.
+
+## What Changes
+
+- Extend tool execution binding/context state so a runtime can carry a mutable
+  `SandboxSpec` instead of always deriving one from the workspace root.
+- Teach the sandbox workspace/root checks to treat every configured writable
+  root as an allowed execution root.
+- When `request_mount` is approved with `access = read_write`, add the approved
+  host path to the runtime tool sandbox's writable roots for subsequent tool
+  calls.
+- Keep read-only grants as audit-only for now because `SandboxSpec` currently
+  has writable roots and a sensitive read denylist, not an explicit read-allow
+  root set.
+- Keep Alan OS namespace live remounts out of this slice; `/mnt/<name>` remains
+  a recorded namespace grant until a host composition hook can mount `HostDirFs`
+  into the running `MountFs`.
+
+## Capabilities
+
+### New Capabilities
+
+- `mount-grant-tool-sandbox-projection`: Approved read-write mount grants are
+  projected into the running Agent Process tool sandbox for subsequent
+  workspace-local tool execution.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `crates/agent-engine/src/tools/context.rs`
+- `crates/agent-engine/src/tools/registry.rs`
+- `crates/agent-engine/src/tools/sandbox.rs`
+- `crates/agent-engine/src/runtime/submission_handlers.rs`
+- OpenSpec namespace/sandbox framing task state

--- a/openspec/changes/apply-mount-grants-to-tool-sandbox/specs/mount-grant-tool-sandbox-projection/spec.md
+++ b/openspec/changes/apply-mount-grants-to-tool-sandbox/specs/mount-grant-tool-sandbox-projection/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Approved read-write mount grants update the runtime tool sandbox
+The runtime SHALL add the normalized host path to the running tool sandbox's
+writable roots for subsequent tool calls when a pending `request_mount`
+confirmation is resumed with approval and the mount request has
+`access = read_write`. The update SHALL be idempotent for duplicate roots.
+
+#### Scenario: Approved read-write grant is applied to future tool calls
+- **WHEN** a pending `request_mount` request for `/mnt/project` and host path `/host/project` is approved with `access = read_write`
+- **THEN** the runtime adds `/host/project` to the active tool sandbox writable roots
+- **AND** the `request_mount` tool result reports that tool sandbox projection was applied
+
+#### Scenario: Duplicate approved grant is idempotent
+- **WHEN** the same read-write host path is approved more than once
+- **THEN** the active tool sandbox contains the host path only once
+
+### Requirement: Non-writable mount grants do not expand writable roots
+The runtime SHALL record approved non-writable mount grants but SHALL NOT add the
+host path to `SandboxSpec.writable_roots` when a pending `request_mount`
+confirmation is resumed with approval and the mount request has
+`access = read_only`.
+
+#### Scenario: Approved read-only grant remains audit-only for tool sandbox
+- **WHEN** a pending `request_mount` request is approved with `access = read_only`
+- **THEN** the runtime records the approved grant
+- **AND** the `request_mount` tool result reports that tool sandbox projection was not applied
+- **AND** the active tool sandbox writable roots are unchanged
+
+### Requirement: Tool sandbox path checks honor all writable roots
+Tool sandbox path checks SHALL treat every configured `SandboxSpec.writable_roots`
+entry as an allowed execution root. OS sandbox profile generation SHALL continue
+to receive the complete writable root list.
+
+#### Scenario: Workspace-local tool can access an approved writable root
+- **WHEN** the active tool sandbox writable roots contain the workspace root and an approved host root
+- **THEN** a workspace-local tool path under the approved host root passes sandbox containment checks
+- **AND** a path outside every writable root is still rejected
+
+#### Scenario: Bash can run from an approved writable root
+- **WHEN** the active tool sandbox writable roots contain the workspace root and an approved host root
+- **THEN** bash execution with cwd under the approved host root passes sandbox cwd containment checks
+- **AND** bash execution with cwd outside every writable root is rejected

--- a/openspec/changes/apply-mount-grants-to-tool-sandbox/tasks.md
+++ b/openspec/changes/apply-mount-grants-to-tool-sandbox/tasks.md
@@ -1,0 +1,35 @@
+## 1. Tool Sandbox Projection
+
+- [x] 1.1 Extend `ToolExecutionBinding` and `ToolContext` with an optional
+  runtime `SandboxSpec` while preserving existing workspace-root behavior.
+- [x] 1.2 Update `ToolContext::workspace_sandbox` to use the runtime
+  `SandboxSpec` when present and fall back to `SandboxSpec::seed`.
+- [x] 1.3 Teach `Sandbox` containment checks and error wording to honor every
+  configured writable root, not only the first workspace root.
+- [x] 1.4 Add unit tests for multi-root sandbox read/write/list/cwd containment
+  and out-of-root rejection.
+
+## 2. Mount Grant Application
+
+- [x] 2.1 Add `ToolRegistry` helpers to inspect and idempotently extend the
+  default binding's sandbox writable roots.
+- [x] 2.2 Parse approved mount confirmation details into a reusable mount grant
+  payload, including host path and access mode.
+- [x] 2.3 On approved `request_mount` resume, add read-write host paths to the
+  active tool sandbox before returning the tool result.
+- [x] 2.4 Keep approved read-only grants audit-only and report that tool sandbox
+  projection was not applied.
+- [x] 2.5 Cover read-write apply, duplicate apply, read-only no-op, and reject
+  no-op behavior with focused runtime tests.
+
+## 3. Verification And PR
+
+- [x] 3.1 Run focused Rust tests for sandbox multi-root behavior and mount grant
+  resume projection.
+- [x] 3.2 Run clippy for touched crates, OpenSpec strict validate, and diff
+  checks.
+- [x] 3.3 Update the parent namespace-driven sandbox task list to record this
+  tool-sandbox projection slice while leaving Alan OS `/mnt` live remount and
+  Linux reification pending.
+- [x] 3.4 Commit the slice and open a ready stacked PR above
+  `feat/northstar-agent-mount-escalation`.

--- a/openspec/changes/define-namespace-driven-sandbox/tasks.md
+++ b/openspec/changes/define-namespace-driven-sandbox/tasks.md
@@ -21,7 +21,9 @@ proposals out as their own OpenSpec changes. No application code lands here.
   separately) Linux reification for full read isolation. Created
   `add-seatbelt-sensitive-read-denylist` for the macOS sensitive-read slice and
   `add-agent-mount-escalation` for the request/approval/grant-record slice;
-  live mount reconfiguration and Linux reification remain pending.
+  `apply-mount-grants-to-tool-sandbox` for applying approved read-write grants
+  to the runtime tool sandbox projection. Alan OS `/mnt` live remount and Linux
+  reification remain pending.
 
 ## 2. Carry the framing forward
 


### PR DESCRIPTION
## Summary
- add runtime-projected SandboxSpec authority to tool execution bindings
- apply approved read_write request_mount grants to subsequent tool sandbox writable roots
- keep read_only grants audit-only and keep Alan OS /mnt live remounting out of this slice

## Verification
- cargo test -p alan-agent-engine sandbox -- --nocapture
- cargo test -p alan-agent-engine mount_escalation -- --nocapture
- cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings
- openspec validate apply-mount-grants-to-tool-sandbox --strict
- git diff --check