### PR TITLE
North Star 15/15: propose live namespace mount grants

### DIFF
--- a/openspec/changes/apply-mount-grants-to-live-namespace/.openspec.yaml
+++ b/openspec/changes/apply-mount-grants-to-live-namespace/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/apply-mount-grants-to-live-namespace/design.md
+++ b/openspec/changes/apply-mount-grants-to-live-namespace/design.md
@@ -1,0 +1,200 @@
+## Context
+
+The current P3 stack has three pieces:
+
+- P2 added `HostDirFs` and `HostMountDeclaration` in the `alan` composition root.
+  Human/config-declared host mounts can already be projected into both
+  `Namespace` and `SandboxSpec` at session assembly.
+- `add-agent-mount-escalation` added `request_mount`, approval, and
+  `host_mount_grant` audit events, but approval originally did not apply the
+  grant to any live enforcement surface.
+- `apply-mount-grants-to-tool-sandbox` applies approved read-write grants to the
+  runtime tool sandbox projection for later host-path tool calls. It deliberately
+  leaves `namespace_applied = false`.
+
+The remaining split is Alan OS namespace visibility. After a read-only grant,
+the approved path should be reachable to aP file tools under `/mnt/<name>` even
+though it does not expand native-subprocess writable roots. After a read-write
+grant, both the namespace and tool sandbox projections should report their own
+application state.
+
+Today `NamespaceRuntimeEnvironment` holds an `InProcessTransport` over a
+`MountFs` built from a static `Namespace`. `MountFs` owns the namespace table
+privately. Live grant application therefore needs a narrow, kernel-native way to
+mutate the mount table for future path walks without exposing host paths or
+backing-server construction to Alan Kernel or `alan-agent-engine`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Apply approved `request_mount` grants to the running Agent Process Alan OS
+  namespace.
+- Keep host-backed file-server construction in the `alan` composition root.
+- Keep `alan-agent-engine` hosting-agnostic: it may request application of a
+  mount grant, but it must not depend on `alan_hostfs`.
+- Keep Alan Kernel host-path agnostic: live mutation takes a mountable
+  `InProcessTransport` and `Access`, not a host path.
+- Report namespace projection independently from tool sandbox projection.
+- Mount read-only grants into the namespace as read-only aP trees while keeping
+  them out of `SandboxSpec.writable_roots`.
+
+**Non-Goals:**
+
+- Linux mount namespace reification or a unified host `/mnt` path space for
+  native subprocesses.
+- Persisting approved grants across session restart.
+- Adding a general agent-controlled `mount` command. `request_mount` remains an
+  approval-gated escalation surface.
+- Teaching `alan-kernel` to remember host provenance.
+
+## Decisions
+
+### D1. Add a live process namespace mount handle in Alan Kernel
+
+Alan Kernel needs a single live mount table handle for the running process
+namespace, not only a mutable `MountFs` view. Standard runtime assembly already
+passes namespace clones into `MountFs`, `ProcFs::for_spawner`, and process-table
+state; mutating only the file-server view would let later `MountFs` walks see a
+grant while `/proc/<pid>/namespace` reads and `/proc/clone` child spawns keep a
+stale namespace snapshot.
+
+The live handle exposes host-agnostic operations such as:
+
+```rust
+mount(at: &str, tree: InProcessTransport, access: Access)
+replace_mount(at: &str, tree: InProcessTransport, access: Access)
+describe()
+snapshot()
+generation()
+```
+
+Internally this can be an `Arc` around a lock-protected `Namespace`. `MountFs`
+walks and synthetic directory listings read from the handle. `ProcFs` spawner
+state and process namespace descriptions must also read or snapshot from the
+same handle, so a mount grant approved after runtime assembly becomes visible to
+future `/proc/<pid>/namespace` reads and child process namespaces. Existing fids
+keep their already-resolved backing transport; new walks and newly cloned child
+namespaces see the updated mount table. That matches process namespace behavior
+well enough for this slice and avoids invalidating active file handles.
+
+`MountFs::new(namespace)` should remain available for tests and static call
+sites. It can wrap the namespace in the same live handle internally, while the
+standard runtime path should construct one handle and share it with `MountFs`,
+`ProcFs`, process records, and the host mount applicator.
+
+Every successful mount or exact-path replacement must increment a monotonic
+namespace generation. Metadata exposed from the live namespace must reflect that
+generation: `MountFs` synthetic directory qids for mount-table-derived listings
+such as `/mnt`, and `ProcFs` namespace information qids/content versions, must
+change after the grant is applied. Implementations can either derive the qid
+version directly from the live handle generation or bump the process-table
+generation when the handle mutates, but cached clients must be able to observe
+that namespace listings/descriptions changed.
+
+### D2. Agent engine calls a host-provided mount grant applicator
+
+`alan-agent-engine` already knows the approved request payload
+`(namespace_path, host_path, access, reason)` because `request_mount` is an
+agent-facing authorization request. It should not know how to turn that host path
+into a file server.
+
+Introduce a small runtime interface, owned by the engine but implemented by the
+host composition layer:
+
+```rust
+trait MountGrantApplicator {
+    fn apply_mount_grant(&self, grant: ApprovedMountGrant) -> Result<MountGrantApplication>;
+}
+```
+
+The default is absent, in which case approval still records the grant and may
+apply the tool sandbox projection, but `namespace_applied` remains `false` with
+an explicit reason.
+
+### D3. The `alan` composition root owns HostDirFs construction
+
+The concrete applicator in `crates/alan` converts an approved grant into a
+`HostMountDeclaration`, builds `HostDirFs::new(host_path, access)`, and calls the
+live namespace handle with the resulting `InProcessTransport` and `Access`.
+
+This preserves the P2 layering:
+
+- `alan-kernel` receives only a mounted file server and access mode.
+- `alan-agent-engine` receives only the application outcome.
+- host path canonicalization and `HostDirFs` safety stay with the host-facing
+  file-server crate and composition helper.
+
+### D4. Replace exact namespace paths for idempotence
+
+A repeated approval for the same `namespace_path` should not accumulate duplicate
+mount entries. The live applicator should replace the exact mount path for future
+walks before mounting the approved file server. This gives a simple rule:
+
+- the latest approved grant at a namespace path wins for future walks;
+- already-open fids keep their previous resolved backing server; and
+- rejected requests never change the namespace.
+
+This is intentionally path-scoped. It does not unmount descendants or sibling
+mounts.
+
+### D5. Read-only and read-write grants share namespace projection
+
+Read-only host grants are meaningful for Alan OS: aP file tools should be able
+to walk and read the requested `/mnt/<name>` tree, and `MountFs` should reject
+mutating operations through `Access::ReadOnly`.
+
+Only read-write grants expand `SandboxSpec.writable_roots`. The result can
+therefore be:
+
+```json
+{
+  "namespace_applied": true,
+  "tool_sandbox_applied": false
+}
+```
+
+for a successful read-only grant.
+
+### D6. Report partial application honestly
+
+Namespace application and tool sandbox projection remain independent result
+fields. If namespace application fails, the tool result and `host_mount_grant`
+event should include `namespace_applied = false` and a concise
+`namespace_error`, while preserving the approval record. If the tool sandbox was
+already updated, it should continue to report its actual state.
+
+The result must never imply Linux reification or native subprocess visibility at
+`/mnt/<name>`.
+
+## Risks / Trade-offs
+
+- **Live mount mutation can race with active reads** -> Existing fids keep their
+  resolved backing server; only future walks see replacements.
+- **Host path construction failure after approval** -> Keep the approval audit
+  event, report `namespace_applied = false`, and do not hide partial state.
+- **Layering pressure toward engine->hostfs dependency** -> Use the applicator
+  trait boundary; do not import `alan_hostfs` from `alan-agent-engine`.
+- **Path replacement can shadow an existing mount** -> This is an approved
+  authorization act. Exact-path replacement is simpler and safer than stacking
+  duplicates.
+- **Namespace and native subprocess paths still differ** -> Keep the result
+  fields explicit; reification remains a later Linux-only change.
+
+## Migration Plan
+
+1. Add the host-agnostic live process namespace handle in Alan Kernel and keep
+   `MountFs::new(namespace)` compatibility.
+2. Add the engine-level approved mount grant applicator interface and thread it
+   through namespace runtime state.
+3. Implement the concrete `alan` applicator using `HostMountDeclaration` /
+   `HostDirFs` and the live process namespace handle shared by `MountFs` and
+   `ProcFs`.
+4. Update `request_mount` resume to call the applicator and report
+   `namespace_applied`, `namespace_error`, and existing tool sandbox fields.
+5. Add tests for read-write apply, read-only apply, duplicate replacement,
+   rejected no-op, missing applicator, and failed application reporting.
+
+Rollback is local: leave the applicator unset and the runtime reverts to the
+current behavior of recording grants plus sandbox projection while reporting
+`namespace_applied = false`.

--- a/openspec/changes/apply-mount-grants-to-live-namespace/proposal.md
+++ b/openspec/changes/apply-mount-grants-to-live-namespace/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+`apply-mount-grants-to-tool-sandbox` makes approved read-write mount grants usable
+by later host-path tools, but Alan OS `/mnt/<name>` still remains a recorded
+grant rather than a live namespace mount. That leaves a split: `bash` can use the
+approved host path through the projected sandbox, while aP file tools still
+cannot reach the approved directory through the requested namespace path.
+
+This change closes that projection gap by applying approved mount grants to the
+running Agent Process namespace through a host-owned composition hook, without
+coupling `alan-agent-engine` to `alan_hostfs` or teaching Alan Kernel about host
+paths.
+
+## What Changes
+
+- Add a runtime-facing namespace mount applicator boundary that can apply an
+  approved host mount grant to the current Agent Process namespace, including
+  the process namespace state used by `/proc/<pid>/namespace` and child spawns.
+- Keep host filesystem construction in the `alan` composition root:
+  approved grants become `HostMountDeclaration` values there, not inside
+  `alan-agent-engine`.
+- Update `request_mount` approval resume so successful namespace application
+  reports `namespace_applied = true` and records the same state in the
+  `host_mount_grant` event.
+- Preserve current explicit reporting for partial application:
+  `tool_sandbox_applied` and `namespace_applied` remain independent fields.
+- Keep read-only namespace grants live-applicable. Read-only grants do not expand
+  writable `SandboxSpec` roots, but they can be mounted into Alan OS as read-only
+  aP trees.
+- Keep Linux mount namespace reification out of this slice.
+
+## Capabilities
+
+### New Capabilities
+
+- `live-mount-grant-namespace-projection`: Approved host mount grants can be
+  projected into the running Agent Process Alan OS namespace so aP file tools can
+  reach them at their requested `/mnt/<name>` path.
+
+### Modified Capabilities
+
+- `agent-mount-escalation`: Approved `request_mount` results no longer
+  unconditionally state that grants are not applied live. They now report the
+  actual namespace application outcome with `namespace_applied` and a concise
+  error/reason when live namespace application is unavailable or fails.
+
+## Impact
+
+- `crates/agent-engine/src/runtime/agent_loop/namespace_environment.rs`
+- `crates/agent-engine/src/runtime/submission_handlers.rs`
+- `crates/alan/src/host_mounts.rs`
+- `crates/kernel/src/mountfs.rs` and `crates/kernel/src/procfs.rs`, or a narrow
+  shared runtime wrapper if needed to expose safe live mutation of the process
+  namespace mount table
+- Tests for approved read-write apply, approved read-only namespace-only apply,
+  duplicate/idempotent apply, rejected no-op, and failure reporting
+- Parent OpenSpec task state in `define-namespace-driven-sandbox`

--- a/openspec/changes/apply-mount-grants-to-live-namespace/specs/agent-mount-escalation/spec.md
+++ b/openspec/changes/apply-mount-grants-to-live-namespace/specs/agent-mount-escalation/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Approved mount requests produce auditable grants
+When a mount request is approved, the runtime SHALL return a structured
+`request_mount` tool result and record a normalized `host_mount_grant` audit
+event. The result and event SHALL preserve the approved grant record and SHALL
+report live namespace application state independently through
+`namespace_applied` and, when application is unavailable or fails, a concise
+`namespace_error` or equivalent reason. The result SHALL NOT imply Linux
+reification or native subprocess visibility at the requested `/mnt/<name>` path.
+
+#### Scenario: Approved request records successful namespace application
+- **WHEN** a pending mount request is resumed with an approve choice and the namespace applicator applies the grant successfully
+- **THEN** the runtime records a `host_mount_grant` event with namespace path, host path, access, reason, checkpoint id, and approved status
+- **AND** the agent receives a `request_mount` tool result that states the grant is approved
+- **AND** the tool result and audit event report `namespace_applied = true`
+
+#### Scenario: Approved request reports unavailable or failed namespace application
+- **WHEN** a pending mount request is resumed with an approve choice but no namespace applicator is available or namespace application fails
+- **THEN** the runtime records a `host_mount_grant` event with namespace path, host path, access, reason, checkpoint id, and approved status
+- **AND** the agent receives a `request_mount` tool result that states the grant is approved
+- **AND** the tool result and audit event report `namespace_applied = false`
+- **AND** the result includes a concise `namespace_error` or equivalent reason
+- **AND** the result does not claim Linux reification or native subprocess visibility at `/mnt/<name>`
+
+#### Scenario: Rejected request returns a rejection result
+- **WHEN** a pending mount request is resumed with a reject choice
+- **THEN** the runtime returns a `request_mount` tool result with rejected status
+- **AND** no approved `host_mount_grant` event is recorded

--- a/openspec/changes/apply-mount-grants-to-live-namespace/specs/live-mount-grant-namespace-projection/spec.md
+++ b/openspec/changes/apply-mount-grants-to-live-namespace/specs/live-mount-grant-namespace-projection/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: Approved mount grants update the live Agent Process namespace
+The runtime SHALL apply an approved `request_mount` grant to the running Agent
+Process Alan OS namespace when a pending mount confirmation is resumed with
+approval and a namespace mount applicator is available. The mounted path SHALL
+be the requested absolute `/mnt/<name>` namespace path, and future aP file-tool
+walks SHALL resolve through that namespace path. The same live namespace handle
+SHALL be the process namespace source of truth for file walks,
+`/proc/<pid>/namespace` descriptions, and namespace snapshots used for later
+child process spawns.
+
+#### Scenario: Approved read-write grant is mounted into the namespace
+- **WHEN** a pending `request_mount` request for `/mnt/project`, host path `/host/project`, and `access = read_write` is approved
+- **THEN** future aP file-tool walks under `/mnt/project` resolve to the approved host directory
+- **AND** aP mutating operations under `/mnt/project` are permitted by the namespace mount access
+- **AND** the `request_mount` tool result reports `namespace_applied = true`
+
+#### Scenario: Approved read-only grant is mounted into the namespace
+- **WHEN** a pending `request_mount` request for `/mnt/docs`, host path `/host/docs`, and `access = read_only` is approved
+- **THEN** future aP file-tool walks and reads under `/mnt/docs` resolve to the approved host directory
+- **AND** aP mutating operations under `/mnt/docs` are rejected by the namespace mount access
+- **AND** the `request_mount` tool result reports `namespace_applied = true`
+- **AND** the active tool sandbox writable roots are unchanged
+
+#### Scenario: Proc namespace views and child spawns observe live grants
+- **GIVEN** standard runtime assembly created `MountFs` and `ProcFs` before a mount grant was approved
+- **WHEN** a pending `request_mount` request for `/mnt/project` is approved and applied to the live namespace
+- **THEN** future `/proc/<pid>/namespace` reads include the `/mnt/project` mount
+- **AND** future child processes spawned through `/proc/clone` inherit a namespace snapshot that includes `/mnt/project`
+- **AND** the runtime does not report `namespace_applied = true` from a `MountFs`-only mutation while process namespace state remains stale
+
+#### Scenario: Live namespace mutation invalidates namespace metadata
+- **GIVEN** a client has observed qids or versions for mount-table-derived namespace metadata such as `/mnt` listings and `/proc/<pid>/namespace`
+- **WHEN** an approved grant mutates the live namespace
+- **THEN** the live namespace generation changes
+- **AND** qids or versions for affected `MountFs` synthetic listings change
+- **AND** qids or versions for affected `ProcFs` namespace descriptions change
+- **AND** cache-by-qid clients can detect that namespace metadata should be reread
+
+### Requirement: Namespace projection preserves host/kernel/engine layering
+The runtime SHALL apply approved live namespace grants through a host-provided
+mount applicator. `alan-agent-engine` SHALL NOT construct `HostDirFs` or depend
+on `alan_hostfs`, and Alan Kernel SHALL NOT store host path provenance. Alan
+Kernel live mutation SHALL accept only a namespace path, an `InProcessTransport`,
+and `Access`.
+
+#### Scenario: Host composition owns HostDirFs construction
+- **WHEN** an approved mount grant is applied live
+- **THEN** the host composition layer constructs the host-backed file server from the host path
+- **AND** the engine observes only the application outcome
+- **AND** Alan Kernel records only the mounted file server and access mode
+
+#### Scenario: Missing applicator does not pretend success
+- **WHEN** a pending mount request is approved in a runtime without a namespace mount applicator
+- **THEN** the approval is still recorded
+- **AND** the `request_mount` tool result reports `namespace_applied = false`
+- **AND** the result includes a concise reason that live namespace application is unavailable
+
+### Requirement: Namespace projection is idempotent by namespace path
+The live namespace applicator SHALL replace the exact requested namespace mount
+path for future walks instead of accumulating duplicate mounts at the same path.
+Rejected mount requests SHALL NOT change the live namespace.
+
+#### Scenario: Duplicate approved grant replaces the same namespace path
+- **WHEN** the same namespace path is approved more than once
+- **THEN** future walks under that namespace path resolve through one latest mounted backing tree
+- **AND** namespace descriptions do not accumulate duplicate exact-path entries for the repeated grant
+
+#### Scenario: Rejected grant leaves the namespace unchanged
+- **WHEN** a pending mount request is resumed with a reject choice
+- **THEN** the requested namespace path is not mounted
+- **AND** the `request_mount` tool result reports `namespace_applied = false`
+
+### Requirement: Namespace application outcome is audited independently
+The `request_mount` tool result and `host_mount_grant` audit event SHALL report
+namespace projection independently from tool sandbox projection. If namespace
+application fails after approval, the runtime SHALL record the approval and SHALL
+report `namespace_applied = false` with a concise `namespace_error`.
+
+#### Scenario: Namespace apply failure is reported without hiding approval
+- **WHEN** a pending mount request is approved but the host applicator cannot construct or mount the backing file server
+- **THEN** the runtime records the approved `host_mount_grant` event
+- **AND** the tool result reports `namespace_applied = false`
+- **AND** the tool result includes `namespace_error`
+- **AND** the tool result does not claim Linux reification or native subprocess visibility at `/mnt/<name>`
+
+#### Scenario: Tool sandbox and namespace projection can differ
+- **WHEN** an approved read-only grant is mounted into the namespace
+- **THEN** the tool result reports `namespace_applied = true`
+- **AND** the tool result reports `tool_sandbox_applied = false`

--- a/openspec/changes/apply-mount-grants-to-live-namespace/tasks.md
+++ b/openspec/changes/apply-mount-grants-to-live-namespace/tasks.md
@@ -1,0 +1,62 @@
+## 1. Live Process Namespace Mount Handle
+
+- [ ] 1.1 Add a host-agnostic live namespace mount handle in Alan Kernel that can
+  mount or replace an exact namespace path using `InProcessTransport` and
+  `Access`, and increments a generation on successful live mutation.
+- [ ] 1.2 Update `MountFs`, `ProcFs::for_spawner`, process namespace
+  descriptions, and `/proc/clone` child namespace snapshots to read or snapshot
+  from the same live handle while preserving `MountFs::new(namespace)`
+  compatibility.
+- [ ] 1.3 Add kernel tests proving future walks see a newly mounted path,
+  `/proc/<pid>/namespace` reads see the new path, child spawns inherit the new
+  path, `/mnt` synthetic listing qids/versions and `/proc/<pid>/namespace`
+  qids/versions change after mutation, duplicate exact-path replacement does not
+  accumulate duplicate descriptions, and already-open fids continue to use their
+  resolved backing tree.
+
+## 2. Runtime Applicator Boundary
+
+- [ ] 2.1 Add an engine-owned approved mount grant payload and
+  host-provided applicator interface without importing `alan_hostfs` into
+  `alan-agent-engine`.
+- [ ] 2.2 Thread the optional applicator through namespace runtime environment
+  state so `request_mount` resume can attempt live namespace application.
+- [ ] 2.3 Preserve current behavior for runtimes without an applicator, including
+  explicit `namespace_applied = false` reporting.
+
+## 3. Alan Composition Applicator
+
+- [ ] 3.1 Implement the `alan` composition-root applicator by converting approved
+  grants into `HostMountDeclaration` / `HostDirFs` and applying them through the
+  live namespace handle.
+- [ ] 3.2 Wire standard namespace runtime assembly to create one live process
+  namespace handle and pass it to `MountFs`, `ProcFs`/spawner state, process
+  records, and the applicator.
+- [ ] 3.3 Add tests proving read-write grants become writable aP mounts and
+  read-only grants become read-only aP mounts without expanding sandbox writable
+  roots.
+
+## 4. Request Mount Resume Reporting
+
+- [ ] 4.1 Update mount escalation resume handling to call the applicator on
+  approval and include `namespace_applied` / `namespace_error` in both tool
+  result and `host_mount_grant` event.
+- [ ] 4.2 Cover approved read-write apply, approved read-only apply, duplicate
+  replacement, rejected no-op, missing applicator, and applicator failure with
+  focused runtime tests.
+- [ ] 4.3 Keep `tool_sandbox_applied` and `namespace_applied` independent and
+  ensure no result claims Linux reification or native `/mnt` visibility.
+- [ ] 4.4 Update the `agent-mount-escalation` capability delta to retire the
+  earlier approved-but-not-live-applied result language for runtimes with live
+  namespace application.
+
+## 5. Verification And PR
+
+- [ ] 5.1 Run focused Rust tests for kernel live namespace mutation, host mount
+  application, and mount escalation resume reporting.
+- [ ] 5.2 Run clippy for touched crates, OpenSpec strict validate, and diff
+  checks.
+- [ ] 5.3 Update parent namespace-driven sandbox task state to record this live
+  namespace projection slice while leaving Linux reification pending.
+- [ ] 5.4 Commit the slice and open a ready stacked PR above
+  `feat/northstar-tool-sandbox-mount-grants`.

--- a/openspec/changes/define-namespace-driven-sandbox/tasks.md
+++ b/openspec/changes/define-namespace-driven-sandbox/tasks.md
@@ -22,8 +22,9 @@ proposals out as their own OpenSpec changes. No application code lands here.
   `add-seatbelt-sensitive-read-denylist` for the macOS sensitive-read slice and
   `add-agent-mount-escalation` for the request/approval/grant-record slice;
   `apply-mount-grants-to-tool-sandbox` for applying approved read-write grants
-  to the runtime tool sandbox projection. Alan OS `/mnt` live remount and Linux
-  reification remain pending.
+  to the runtime tool sandbox projection; and
+  `apply-mount-grants-to-live-namespace` for applying approved grants to the
+  running Agent Process Alan OS namespace. Linux reification remains pending.
 
 ## 2. Carry the framing forward
 


### PR DESCRIPTION
## Summary
- add OpenSpec change for applying approved request_mount grants to the live Alan OS namespace
- define the host applicator boundary so alan-agent-engine does not depend on alan_hostfs
- keep Linux reification explicitly out of this slice and update the parent framing task state

## Verification
- openspec validate apply-mount-grants-to-live-namespace --strict
- openspec validate define-namespace-driven-sandbox --strict
- git diff --check