### PR TITLE
North Star 16/16: apply mount grants to live namespace

### DIFF
--- a/crates/agent-engine/src/runtime/agent_loop.rs
+++ b/crates/agent-engine/src/runtime/agent_loop.rs
@@ -7,8 +7,10 @@ mod namespace_environment;
 #[cfg(test)]
 pub(super) use namespace_environment::NamespaceRequestRecord;
 pub use namespace_environment::{
-    NamespaceRuntimeEnvironment, NamespaceToolActionOutput, NamespaceTurnOutput,
-    NamespaceTurnRuntime, NamespaceTurnRuntimeConfig,
+    ApprovedMountGrant, ApprovedMountGrantAccess, MountGrantApplicator,
+    MountGrantApplicatorFactory, NamespaceMountApplication, NamespaceRuntimeEnvironment,
+    NamespaceToolActionOutput, NamespaceTurnOutput, NamespaceTurnRuntime,
+    NamespaceTurnRuntimeConfig,
 };
 
 use alan_agent_protocol::{Event, Submission, ToolCapability};

--- a/crates/agent-engine/src/runtime/agent_loop/namespace_environment.rs
+++ b/crates/agent-engine/src/runtime/agent_loop/namespace_environment.rs
@@ -7,6 +7,7 @@
 
 use std::{
     collections::BTreeMap,
+    path::PathBuf,
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
@@ -134,6 +135,92 @@ pub struct NamespaceToolActionOutput {
     pub exit_code: i32,
 }
 
+/// Access mode for an approved host mount grant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApprovedMountGrantAccess {
+    ReadOnly,
+    ReadWrite,
+}
+
+impl ApprovedMountGrantAccess {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "read_only",
+            Self::ReadWrite => "read_write",
+        }
+    }
+}
+
+/// A host mount grant that has already passed the approval boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApprovedMountGrant {
+    pub namespace_path: String,
+    pub host_path: PathBuf,
+    pub access: ApprovedMountGrantAccess,
+    pub reason: String,
+}
+
+impl ApprovedMountGrant {
+    pub fn new(
+        namespace_path: impl Into<String>,
+        host_path: PathBuf,
+        access: ApprovedMountGrantAccess,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            namespace_path: namespace_path.into(),
+            host_path,
+            access,
+            reason: reason.into(),
+        }
+    }
+}
+
+/// Host-provided hook for applying approved mount grants to a live namespace.
+///
+/// The engine owns the approval flow, but the host composition root owns
+/// host-backed file-server construction. Implementations must keep hostfs
+/// dependencies out of `alan-agent-engine`.
+pub trait MountGrantApplicator: std::fmt::Debug + Send + Sync {
+    fn apply_mount_grant(&self, grant: &ApprovedMountGrant) -> Result<()>;
+}
+
+/// Host-provided factory that can build a mount grant applicator once the engine
+/// has created the live namespace handle for a runtime.
+pub trait MountGrantApplicatorFactory: std::fmt::Debug + Send + Sync {
+    fn create(&self, live_namespace: alan_kernel::LiveNamespace) -> Arc<dyn MountGrantApplicator>;
+}
+
+/// Result of attempting live namespace projection for an approved grant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamespaceMountApplication {
+    pub namespace_applied: bool,
+    pub namespace_error: Option<String>,
+}
+
+impl NamespaceMountApplication {
+    pub fn applied() -> Self {
+        Self {
+            namespace_applied: true,
+            namespace_error: None,
+        }
+    }
+
+    pub fn unavailable(reason: impl Into<String>) -> Self {
+        Self {
+            namespace_applied: false,
+            namespace_error: Some(reason.into()),
+        }
+    }
+
+    pub fn failed(error: anyhow::Error) -> Self {
+        Self {
+            namespace_applied: false,
+            namespace_error: Some(error.to_string()),
+        }
+    }
+}
+
 /// Namespace-backed environment for an Agent Process.
 #[derive(Clone)]
 pub struct NamespaceRuntimeEnvironment {
@@ -142,6 +229,8 @@ pub struct NamespaceRuntimeEnvironment {
     llm_connection: String,
     shared_services: Option<NamespaceSharedServices>,
     input_offset: Arc<AtomicU64>,
+    mount_grant_applicator: Option<Arc<dyn MountGrantApplicator>>,
+    mount_grant_applicator_factory: Option<Arc<dyn MountGrantApplicatorFactory>>,
 }
 
 #[derive(Clone)]
@@ -156,6 +245,14 @@ impl std::fmt::Debug for NamespaceRuntimeEnvironment {
             .field("agent_path", &self.agent_path)
             .field("llm_connection", &self.llm_connection)
             .field("has_shared_services", &self.shared_services.is_some())
+            .field(
+                "mount_grant_applicator",
+                &self.mount_grant_applicator.is_some(),
+            )
+            .field(
+                "mount_grant_applicator_factory",
+                &self.mount_grant_applicator_factory.is_some(),
+            )
             .finish_non_exhaustive()
     }
 }
@@ -172,6 +269,8 @@ impl NamespaceRuntimeEnvironment {
             llm_connection: llm_connection.into(),
             shared_services: None,
             input_offset: Arc::new(AtomicU64::new(0)),
+            mount_grant_applicator: None,
+            mount_grant_applicator_factory: None,
         }
     }
 
@@ -188,6 +287,24 @@ impl NamespaceRuntimeEnvironment {
         self.shared_services.clone()
     }
 
+    pub fn with_mount_grant_applicator(
+        mut self,
+        applicator: Arc<dyn MountGrantApplicator>,
+    ) -> Self {
+        self.mount_grant_applicator = Some(applicator);
+        self
+    }
+
+    pub fn with_mount_grant_applicator_factory(
+        mut self,
+        factory: Arc<dyn MountGrantApplicatorFactory>,
+        live_namespace: alan_kernel::LiveNamespace,
+    ) -> Self {
+        self.mount_grant_applicator = Some(factory.create(live_namespace));
+        self.mount_grant_applicator_factory = Some(factory);
+        self
+    }
+
     pub fn agent_path(&self) -> &str {
         &self.agent_path
     }
@@ -199,6 +316,25 @@ impl NamespaceRuntimeEnvironment {
     #[cfg(test)]
     pub(crate) fn root_transport(&self) -> InProcessTransport {
         self.root.clone()
+    }
+
+    pub fn mount_grant_applicator_factory(&self) -> Option<Arc<dyn MountGrantApplicatorFactory>> {
+        self.mount_grant_applicator_factory.clone()
+    }
+
+    pub fn apply_approved_mount_grant(
+        &self,
+        grant: &ApprovedMountGrant,
+    ) -> NamespaceMountApplication {
+        let Some(applicator) = self.mount_grant_applicator.as_ref() else {
+            return NamespaceMountApplication::unavailable(
+                "live namespace mount applicator unavailable",
+            );
+        };
+        applicator
+            .apply_mount_grant(grant)
+            .map(|()| NamespaceMountApplication::applied())
+            .unwrap_or_else(NamespaceMountApplication::failed)
     }
 
     pub async fn read_llm_connection_capabilities(&self) -> Result<NamespaceLlmCapabilities> {

--- a/crates/agent-engine/src/runtime/child_agents.rs
+++ b/crates/agent-engine/src/runtime/child_agents.rs
@@ -322,6 +322,9 @@ where
         default_cwd_override,
         agent_home_paths: parent_agent_home_paths(parent),
         chatgpt_auth_storage_path: parent.runtime_config.chatgpt_auth_storage_path.clone(),
+        mount_grant_applicator_factory: parent
+            .namespace_environment()
+            .mount_grant_applicator_factory(),
     };
     let resolved_child_definition =
         crate::ResolvedAgentDefinition::from_runtime_config(&child_config)
@@ -380,6 +383,7 @@ where
         &runtime_procfs,
         &child_namespace_plan,
         handles,
+        child_config.mount_grant_applicator_factory.clone(),
         "/bin/alan-agent",
     )
     .await
@@ -1421,6 +1425,7 @@ async fn spawn_child_namespace_runtime_environment(
     runtime_procfs: &alan_kernel::ProcFs,
     plan: &ChildNamespaceAssemblyPlan,
     handles: ChildNamespaceLaunchHandles,
+    mount_grant_applicator_factory: Option<Arc<dyn super::MountGrantApplicatorFactory>>,
     executable: &str,
 ) -> Result<ChildNamespaceRuntimeLaunch> {
     validate_child_namespace_launch_handles(plan, &handles)?;
@@ -1472,24 +1477,34 @@ async fn spawn_child_namespace_runtime_environment(
     );
     let child_namespace =
         child_runtime_namespace_from_launch_handles(plan, agent_root_tree, &handles);
-    let child_procfs = runtime_procfs.for_spawner(
+    let live_namespace = alan_kernel::LiveNamespace::new(child_namespace);
+    runtime_procfs
+        .bind_live_namespace(child_pid, live_namespace.clone())
+        .await;
+    let child_procfs = runtime_procfs.for_live_spawner(
         Some(child_pid),
-        child_namespace.clone(),
+        live_namespace.clone(),
         alan_kernel::Credentials::user("child-agent"),
     );
-    let mut root_namespace = child_namespace;
-    root_namespace.mount(
+    live_namespace.mount(
         "/proc",
         InProcessTransport::new(Arc::new(child_procfs)),
         alan_kernel::Access::ReadWrite,
     );
-    let root = InProcessTransport::new(Arc::new(alan_kernel::MountFs::new(root_namespace)));
+    let root = InProcessTransport::new(Arc::new(alan_kernel::MountFs::from_live_namespace(
+        live_namespace.clone(),
+    )));
     let environment = super::NamespaceRuntimeEnvironment::new(
         root,
         format!("/agent/{pid}"),
         plan.llm_connection_name()?,
     )
     .with_shared_services(handles.srv.clone(), handles.route.clone());
+    let environment = if let Some(factory) = mount_grant_applicator_factory {
+        environment.with_mount_grant_applicator_factory(factory, live_namespace)
+    } else {
+        environment
+    };
 
     Ok(ChildNamespaceRuntimeLaunch {
         pid,
@@ -2000,7 +2015,10 @@ fn truncate_chars(text: &str, limit: usize) -> String {
 mod tests {
     use super::*;
     use crate::llm::{GenerationRequest, GenerationResponse, StreamChunk, TokenUsage};
-    use crate::runtime::{RuntimeConfig, RuntimeEnvironment};
+    use crate::runtime::{
+        ApprovedMountGrant, ApprovedMountGrantAccess, MountGrantApplicator,
+        MountGrantApplicatorFactory, RuntimeConfig, RuntimeEnvironment,
+    };
     use crate::skills::SkillHostCapabilities;
     use crate::tools::Tool;
     use alan_ap::{Fid, FileServer, InProcessTransport, OpenMode};
@@ -2164,6 +2182,50 @@ mod tests {
             _ctx: &crate::tools::ToolContext,
         ) -> crate::tools::ToolResult {
             Box::pin(async { Ok(json!({"ok": true})) })
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingMountGrantApplicatorFactory {
+        created: Arc<Mutex<usize>>,
+    }
+
+    impl RecordingMountGrantApplicatorFactory {
+        fn created_count(&self) -> usize {
+            *self
+                .created
+                .lock()
+                .expect("created count lock should not be poisoned")
+        }
+    }
+
+    impl MountGrantApplicatorFactory for RecordingMountGrantApplicatorFactory {
+        fn create(
+            &self,
+            live_namespace: alan_kernel::LiveNamespace,
+        ) -> Arc<dyn MountGrantApplicator> {
+            *self
+                .created
+                .lock()
+                .expect("created count lock should not be poisoned") += 1;
+            Arc::new(RecordingMountGrantApplicator { live_namespace })
+        }
+    }
+
+    #[derive(Debug)]
+    struct RecordingMountGrantApplicator {
+        live_namespace: alan_kernel::LiveNamespace,
+    }
+
+    impl MountGrantApplicator for RecordingMountGrantApplicator {
+        fn apply_mount_grant(&self, grant: &ApprovedMountGrant) -> anyhow::Result<()> {
+            let access = match grant.access {
+                ApprovedMountGrantAccess::ReadOnly => KernelAccess::ReadOnly,
+                ApprovedMountGrantAccess::ReadWrite => KernelAccess::ReadWrite,
+            };
+            self.live_namespace
+                .mount(&grant.namespace_path, memfs_transport(), access);
+            Ok(())
         }
     }
 
@@ -2906,6 +2968,7 @@ Body
             &runtime_procfs,
             &plan,
             handles,
+            None,
             "/bin/alan-agent",
         )
         .await
@@ -2993,6 +3056,79 @@ Body
     }
 
     #[tokio::test]
+    async fn child_namespace_launch_attaches_mount_grant_applicator_factory() {
+        let temp = TempDir::new().unwrap();
+        let requests = RecordedRequests::default();
+        let response = completed_response("Child finished cleanly.");
+        let parent = make_parent_state(&temp, requests, response);
+        let root_dir = temp.path().join("repo/.alan/agents/grader");
+        let mut spec = launch_spec(root_dir);
+        spec.handles = vec![SpawnHandle::Workspace];
+        let plan =
+            build_child_namespace_assembly_plan(&parent, &spec, &parent.core_config).unwrap();
+        let child_tools = build_child_tool_registry_from_namespace_plan(
+            &parent,
+            &spec,
+            &parent.core_config,
+            &plan,
+        )
+        .unwrap();
+        let launch_procfs = KernelProcFs::new();
+        let runtime_procfs = launch_procfs
+            .clone()
+            .with_runner(Arc::new(ChildToolProcessRunner::new(child_tools)));
+        let handles = ChildNamespaceLaunchHandles::new(
+            Arc::new(alan_agentfs::AgentFs::new()),
+            memfs_transport(),
+            memfs_transport(),
+            memfs_transport(),
+        )
+        .with_bin_tool("/bin/alpha", memfs_transport())
+        .with_bin_tool("/bin/beta", memfs_transport());
+        let factory = Arc::new(RecordingMountGrantApplicatorFactory::default());
+
+        let launch = spawn_child_namespace_runtime_environment(
+            &launch_procfs,
+            &runtime_procfs,
+            &plan,
+            handles,
+            Some(factory.clone()),
+            "/bin/alan-agent",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(factory.created_count(), 1);
+        assert!(
+            launch
+                .environment
+                .mount_grant_applicator_factory()
+                .is_some()
+        );
+        let applied = launch
+            .environment
+            .apply_approved_mount_grant(&ApprovedMountGrant::new(
+                "/mnt/project",
+                PathBuf::from("/unused/by/test/applicator"),
+                ApprovedMountGrantAccess::ReadWrite,
+                "Need project files",
+            ));
+        assert!(applied.namespace_applied);
+        assert_eq!(applied.namespace_error, None);
+
+        let namespace = read_proc_path(
+            &launch_procfs,
+            vec![launch.pid.clone(), "namespace".to_string()],
+            Fid(94),
+        )
+        .await;
+        assert!(
+            namespace.lines().any(|line| line == "/mnt/project rw"),
+            "child process namespace should reflect applicator live mounts: {namespace:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn child_namespace_launch_handles_share_parent_routefs() {
         let temp = TempDir::new().unwrap();
         let requests = RecordedRequests::default();
@@ -3045,6 +3181,7 @@ Body
             &runtime_procfs,
             &plan,
             handles,
+            None,
             "/bin/alan-agent",
         )
         .await

--- a/crates/agent-engine/src/runtime/engine.rs
+++ b/crates/agent-engine/src/runtime/engine.rs
@@ -124,6 +124,7 @@ enum RuntimeEnvironmentBootstrap {
     NamespaceRoot {
         llm_client: LlmClient,
         tools: crate::tools::ToolRegistry,
+        mount_grant_applicator_factory: Option<Arc<dyn super::MountGrantApplicatorFactory>>,
     },
 }
 
@@ -131,8 +132,13 @@ impl RuntimeEnvironmentBootstrap {
     async fn into_environment(self) -> Result<RuntimeEnvironment> {
         match self {
             Self::Ready(environment) => Ok(environment),
-            Self::NamespaceRoot { llm_client, tools } => {
-                build_root_namespace_environment(llm_client, tools).await
+            Self::NamespaceRoot {
+                llm_client,
+                tools,
+                mount_grant_applicator_factory,
+            } => {
+                build_root_namespace_environment(llm_client, tools, mount_grant_applicator_factory)
+                    .await
             }
         }
     }
@@ -842,6 +848,8 @@ pub struct WorkspaceRuntimeConfig {
     pub agent_home_paths: Option<crate::AlanHomePaths>,
     /// Optional host-selected ChatGPT auth storage path shared with provider auth flows.
     pub chatgpt_auth_storage_path: Option<std::path::PathBuf>,
+    /// Optional host factory for applying approved mount grants to the live namespace.
+    pub mount_grant_applicator_factory: Option<Arc<dyn super::MountGrantApplicatorFactory>>,
 }
 
 impl Default for WorkspaceRuntimeConfig {
@@ -862,6 +870,7 @@ impl Default for WorkspaceRuntimeConfig {
             default_cwd_override: None,
             agent_home_paths: None,
             chatgpt_auth_storage_path: None,
+            mount_grant_applicator_factory: None,
         }
     }
 }
@@ -884,6 +893,7 @@ impl From<crate::config::Config> for WorkspaceRuntimeConfig {
             default_cwd_override: None,
             agent_home_paths: None,
             chatgpt_auth_storage_path: None,
+            mount_grant_applicator_factory: None,
         }
     }
 }
@@ -906,6 +916,7 @@ impl From<crate::LoadedConfig> for WorkspaceRuntimeConfig {
             default_cwd_override: None,
             agent_home_paths: None,
             chatgpt_auth_storage_path: None,
+            mount_grant_applicator_factory: None,
         }
     }
 }
@@ -1143,6 +1154,7 @@ pub fn effective_core_config_for_runtime(
 async fn build_root_namespace_environment(
     llm_client: LlmClient,
     tools: crate::tools::ToolRegistry,
+    mount_grant_applicator_factory: Option<Arc<dyn super::MountGrantApplicatorFactory>>,
 ) -> Result<RuntimeEnvironment> {
     let tool_definitions = tools.get_tool_definitions();
     let tool_names = tools
@@ -1178,7 +1190,8 @@ async fn build_root_namespace_environment(
         );
     }
 
-    let root_pid = spawn_root_agent_process(&procfs, process_namespace.clone()).await?;
+    let live_namespace = alan_kernel::LiveNamespace::new(process_namespace);
+    let root_pid = spawn_root_agent_process(&procfs, live_namespace.clone()).await?;
     agent_root
         .bind_process(root_pid.clone(), agentfs.clone())
         .await;
@@ -1189,23 +1202,35 @@ async fn build_root_namespace_environment(
             .parse::<u64>()
             .with_context(|| format!("parse root agent pid '{root_pid}'"))?,
     );
-    let procfs_with_runner = procfs.with_runner(Arc::new(RuntimeToolProcessRunner::new(tools)));
-    let process_procfs = procfs_with_runner.for_spawner(
+    let procfs_with_runner = procfs
+        .clone()
+        .with_runner(Arc::new(RuntimeToolProcessRunner::new(tools)));
+    procfs
+        .bind_live_namespace(root_pid_value, live_namespace.clone())
+        .await;
+    let process_procfs = procfs_with_runner.for_live_spawner(
         Some(root_pid_value),
-        process_namespace.clone(),
+        live_namespace.clone(),
         alan_kernel::Credentials::user("root-agent"),
     );
-    process_namespace.mount(
+    live_namespace.mount(
         "/proc",
         InProcessTransport::new(Arc::new(process_procfs)),
         alan_kernel::Access::ReadWrite,
     );
-    let root = InProcessTransport::new(Arc::new(alan_kernel::MountFs::new(process_namespace)));
-    let namespace =
+    let root = InProcessTransport::new(Arc::new(alan_kernel::MountFs::from_live_namespace(
+        live_namespace.clone(),
+    )));
+    let namespace_environment =
         super::NamespaceRuntimeEnvironment::new(root, format!("/agent/{root_pid}"), "default")
             .with_shared_services(InProcessTransport::new(srvfs), route_tree);
+    let namespace_environment = if let Some(factory) = mount_grant_applicator_factory {
+        namespace_environment.with_mount_grant_applicator_factory(factory, live_namespace)
+    } else {
+        namespace_environment
+    };
     Ok(RuntimeEnvironment::namespace_with_tool_definitions(
-        namespace,
+        namespace_environment,
         tool_definitions,
     ))
 }
@@ -1262,9 +1287,9 @@ async fn mount_routefs_standard_handles(
 
 async fn spawn_root_agent_process(
     procfs: &alan_kernel::ProcFs,
-    process_namespace: alan_kernel::Namespace,
+    process_namespace: alan_kernel::LiveNamespace,
 ) -> Result<String> {
-    let spawner_procfs = procfs.for_spawner(
+    let spawner_procfs = procfs.for_live_spawner(
         None,
         process_namespace.clone(),
         alan_kernel::Credentials::user("service-manager"),
@@ -1289,7 +1314,7 @@ async fn spawn_root_agent_process(
         executable: "/bin/alan-agent".to_string(),
         args: Vec::new(),
         namespace: Some(alan_kernel::ExecNamespaceManifest::from_namespace(
-            &process_namespace,
+            &process_namespace.snapshot(),
         )),
     };
     let exec_bytes = serde_json::to_vec(&exec).context("serialize root agent exec spec")?;
@@ -1347,9 +1372,14 @@ pub fn spawn_with_llm_client_and_tools(
 
     let generation_capabilities = llm_client.capabilities();
     let host_tools = tools.clone();
+    let mount_grant_applicator_factory = config.mount_grant_applicator_factory.clone();
     spawn_with_prepared_runtime_environment(
         config,
-        RuntimeEnvironmentBootstrap::NamespaceRoot { llm_client, tools },
+        RuntimeEnvironmentBootstrap::NamespaceRoot {
+            llm_client,
+            tools,
+            mount_grant_applicator_factory,
+        },
         host_tools,
         generation_capabilities,
     )
@@ -1957,6 +1987,7 @@ mod tests {
         let environment = build_root_namespace_environment(
             LlmClient::new(MockLlmProvider::new()),
             crate::tools::ToolRegistry::new(),
+            None,
         )
         .await
         .unwrap();

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -26,8 +26,10 @@ mod turn_support;
 mod virtual_tools;
 
 pub use agent_loop::{
-    NamespaceRuntimeEnvironment, NamespaceToolActionOutput, NamespaceTurnOutput,
-    NamespaceTurnRuntime, NamespaceTurnRuntimeConfig,
+    ApprovedMountGrant, ApprovedMountGrantAccess, MountGrantApplicator,
+    MountGrantApplicatorFactory, NamespaceMountApplication, NamespaceRuntimeEnvironment,
+    NamespaceToolActionOutput, NamespaceTurnOutput, NamespaceTurnRuntime,
+    NamespaceTurnRuntimeConfig,
 };
 pub use child_runs::{
     ChildRunRecord, ChildRunRegistryError, ChildRunStatus, ChildRunTerminationMode,

--- a/crates/agent-engine/src/runtime/submission_handlers.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers.rs
@@ -11,7 +11,10 @@ use crate::approval::{
 };
 use crate::tape::ContentPart;
 
-use super::agent_loop::{NormalizedToolCall, RuntimeLoopState};
+use super::agent_loop::{
+    ApprovedMountGrant, ApprovedMountGrantAccess, NamespaceMountApplication, NormalizedToolCall,
+    RuntimeLoopState,
+};
 use super::compaction::{CompactionRequest, maybe_compact_context_for_request};
 use super::turn_executor::TurnRunKind;
 use super::turn_state::PendingYield;
@@ -514,10 +517,27 @@ fn handle_mount_escalation_resolution(
     };
     let approved = choice_str == "approve";
     let grant = parse_mount_grant_request(&mount_request);
+    let namespace_application = if approved {
+        grant
+            .as_ref()
+            .map(|grant| {
+                state
+                    .namespace_environment()
+                    .apply_approved_mount_grant(&grant.approved_mount_grant())
+            })
+            .unwrap_or_else(|| {
+                NamespaceMountApplication::unavailable("missing approved mount grant details")
+            })
+    } else {
+        NamespaceMountApplication {
+            namespace_applied: false,
+            namespace_error: None,
+        }
+    };
     let tool_sandbox_projection_changed = approved
         && grant
             .as_ref()
-            .is_some_and(|grant| grant.access == "read_write")
+            .is_some_and(|grant| grant.access == ApprovedMountGrantAccess::ReadWrite)
         && grant.as_ref().is_some_and(|grant| {
             state
                 .tool_catalog
@@ -526,7 +546,7 @@ fn handle_mount_escalation_resolution(
     let tool_sandbox_applied = approved
         && grant
             .as_ref()
-            .is_some_and(|grant| grant.access == "read_write")
+            .is_some_and(|grant| grant.access == ApprovedMountGrantAccess::ReadWrite)
         && state
             .tool_catalog
             .default_sandbox_writable_roots()
@@ -541,7 +561,8 @@ fn handle_mount_escalation_resolution(
         "status": status,
         "approved": approved,
         "live_applied": false,
-        "namespace_applied": false,
+        "namespace_applied": namespace_application.namespace_applied,
+        "namespace_error": namespace_application.namespace_error,
         "tool_sandbox_applied": tool_sandbox_applied,
         "tool_sandbox_projection_changed": tool_sandbox_projection_changed,
         "checkpoint_id": pending.checkpoint_id.clone(),
@@ -615,7 +636,8 @@ fn host_mount_grant_event_payload(
         "checkpoint_id": result.get("checkpoint_id").and_then(serde_json::Value::as_str),
         "approved": true,
         "live_applied": false,
-        "namespace_applied": false,
+        "namespace_applied": result.get("namespace_applied").and_then(serde_json::Value::as_bool),
+        "namespace_error": result.get("namespace_error").and_then(serde_json::Value::as_str),
         "tool_sandbox_applied": result.get("tool_sandbox_applied").and_then(serde_json::Value::as_bool),
         "tool_sandbox_projection_changed": result.get("tool_sandbox_projection_changed").and_then(serde_json::Value::as_bool),
         "tool_call_id": details.get("tool_call_id").and_then(serde_json::Value::as_str),
@@ -623,19 +645,41 @@ fn host_mount_grant_event_payload(
 }
 
 struct MountGrantDetails {
+    namespace_path: String,
     host_path: std::path::PathBuf,
-    access: String,
+    access: ApprovedMountGrantAccess,
+    reason: String,
+}
+
+impl MountGrantDetails {
+    fn approved_mount_grant(&self) -> ApprovedMountGrant {
+        ApprovedMountGrant::new(
+            self.namespace_path.clone(),
+            self.host_path.clone(),
+            self.access,
+            self.reason.clone(),
+        )
+    }
 }
 
 fn parse_mount_grant_request(request: &serde_json::Value) -> Option<MountGrantDetails> {
+    let namespace_path = request.get("namespace_path")?.as_str()?.trim();
     let host_path = request.get("host_path")?.as_str()?.trim();
     let access = request.get("access")?.as_str()?.trim();
-    if host_path.is_empty() || access.is_empty() {
+    let reason = request.get("reason")?.as_str()?.trim();
+    if namespace_path.is_empty() || host_path.is_empty() || reason.is_empty() {
         return None;
     }
+    let access = match access {
+        "read_only" => ApprovedMountGrantAccess::ReadOnly,
+        "read_write" => ApprovedMountGrantAccess::ReadWrite,
+        _ => return None,
+    };
     Some(MountGrantDetails {
+        namespace_path: namespace_path.to_string(),
         host_path: std::path::PathBuf::from(host_path),
-        access: access.to_string(),
+        access,
+        reason: reason.to_string(),
     })
 }
 
@@ -672,13 +716,16 @@ fn parse_replay_tool_call_from_confirmation_details(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     use super::*;
     use crate::{
         config::Config,
         rollout::{RolloutItem, RolloutRecorder},
-        runtime::{NamespaceRuntimeEnvironment, RuntimeConfig, RuntimeEnvironment, TurnState},
+        runtime::{
+            MountGrantApplicator, NamespaceRuntimeEnvironment, RuntimeConfig, RuntimeEnvironment,
+            TurnState,
+        },
         session::Session,
         tape::ContentPart,
         tools::ToolRegistry,
@@ -687,6 +734,35 @@ mod tests {
     use alan_kernel::{Access, MountFs, Namespace, ProcFs};
     use alan_shell::Shell;
     use tempfile::TempDir;
+
+    #[derive(Debug, Default)]
+    struct RecordingMountGrantApplicator {
+        grants: Mutex<Vec<ApprovedMountGrant>>,
+        fail_with: Option<&'static str>,
+    }
+
+    impl RecordingMountGrantApplicator {
+        fn failing(message: &'static str) -> Self {
+            Self {
+                grants: Mutex::new(Vec::new()),
+                fail_with: Some(message),
+            }
+        }
+
+        fn grants(&self) -> Vec<ApprovedMountGrant> {
+            self.grants.lock().unwrap().clone()
+        }
+    }
+
+    impl MountGrantApplicator for RecordingMountGrantApplicator {
+        fn apply_mount_grant(&self, grant: &ApprovedMountGrant) -> Result<()> {
+            self.grants.lock().unwrap().push(grant.clone());
+            if let Some(message) = self.fail_with {
+                anyhow::bail!(message);
+            }
+            Ok(())
+        }
+    }
 
     fn namespace_environment_for_test() -> RuntimeEnvironment {
         let mut namespace = Namespace::new();
@@ -699,6 +775,22 @@ mod tests {
         RuntimeEnvironment::namespace(NamespaceRuntimeEnvironment::new(
             root, "/agent/1", "default",
         ))
+    }
+
+    fn namespace_environment_with_mount_applicator_for_test(
+        applicator: Arc<dyn MountGrantApplicator>,
+    ) -> RuntimeEnvironment {
+        let mut namespace = Namespace::new();
+        namespace.mount(
+            "/agent/1",
+            InProcessTransport::new(Arc::new(alan_agentfs::AgentFs::new())),
+            Access::ReadWrite,
+        );
+        let root = InProcessTransport::new(Arc::new(MountFs::new(namespace)));
+        RuntimeEnvironment::namespace(
+            NamespaceRuntimeEnvironment::new(root, "/agent/1", "default")
+                .with_mount_grant_applicator(applicator),
+        )
     }
 
     async fn namespace_environment_with_live_process_for_test() -> (RuntimeEnvironment, Shell) {
@@ -1109,6 +1201,10 @@ mod tests {
         assert_eq!(tool_result["tool_sandbox_applied"], true);
         assert_eq!(tool_result["tool_sandbox_projection_changed"], true);
         assert_eq!(tool_result["namespace_applied"], false);
+        assert_eq!(
+            tool_result["namespace_error"],
+            "live namespace mount applicator unavailable"
+        );
         assert_eq!(tool_result["live_applied"], false);
         assert_eq!(
             tool_result["mount_request"]["namespace_path"],
@@ -1143,9 +1239,144 @@ mod tests {
         assert_eq!(grant.payload["approved"], true);
         assert_eq!(grant.payload["live_applied"], false);
         assert_eq!(grant.payload["namespace_applied"], false);
+        assert_eq!(
+            grant.payload["namespace_error"],
+            "live namespace mount applicator unavailable"
+        );
         assert_eq!(grant.payload["tool_sandbox_applied"], true);
         assert_eq!(grant.payload["tool_sandbox_projection_changed"], true);
         assert_eq!(grant.payload["tool_call_id"], "call_mount");
+    }
+
+    #[tokio::test]
+    async fn test_handle_mount_escalation_resume_applies_namespace_with_applicator() {
+        let workspace = TempDir::new().unwrap();
+        let approved_host = TempDir::new().unwrap();
+        let applicator = Arc::new(RecordingMountGrantApplicator::default());
+        let mut state = create_test_state();
+        state.environment =
+            namespace_environment_with_mount_applicator_for_test(applicator.clone());
+        state
+            .tool_catalog
+            .set_default_workspace_root(workspace.path().to_path_buf());
+        state
+            .turn_state
+            .set_confirmation(mount_escalation_pending_confirmation_with(
+                approved_host.path().to_str().unwrap(),
+                "read_write",
+                "Need to edit project files",
+            ));
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+
+        handle_runtime_op_with_cancel(
+            &mut state,
+            Op::Resume {
+                request_id: "mount_escalation_call_mount".to_string(),
+                content: vec![ContentPart::structured(json!({"choice": "approve"}))],
+            },
+            &mut emit,
+            &cancel,
+        )
+        .await
+        .unwrap();
+
+        let tool_result = tool_result_json_for_call(&state, "call_mount");
+        assert_eq!(tool_result["namespace_applied"], true);
+        assert_eq!(tool_result["namespace_error"], serde_json::Value::Null);
+        assert_eq!(tool_result["tool_sandbox_applied"], true);
+        let grants = applicator.grants();
+        assert_eq!(grants.len(), 1);
+        assert_eq!(grants[0].namespace_path, "/mnt/project");
+        assert_eq!(grants[0].host_path, approved_host.path());
+        assert_eq!(grants[0].access, ApprovedMountGrantAccess::ReadWrite);
+        assert_eq!(grants[0].reason, "Need to edit project files");
+    }
+
+    #[tokio::test]
+    async fn test_handle_mount_escalation_resume_read_only_applies_namespace_only() {
+        let workspace = TempDir::new().unwrap();
+        let approved_host = TempDir::new().unwrap();
+        let applicator = Arc::new(RecordingMountGrantApplicator::default());
+        let mut state = create_test_state();
+        state.environment =
+            namespace_environment_with_mount_applicator_for_test(applicator.clone());
+        state
+            .tool_catalog
+            .set_default_workspace_root(workspace.path().to_path_buf());
+        state
+            .turn_state
+            .set_confirmation(mount_escalation_pending_confirmation_with(
+                approved_host.path().to_str().unwrap(),
+                "read_only",
+                "Need to inspect project files",
+            ));
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+
+        handle_runtime_op_with_cancel(
+            &mut state,
+            Op::Resume {
+                request_id: "mount_escalation_call_mount".to_string(),
+                content: vec![ContentPart::structured(json!({"choice": "approve"}))],
+            },
+            &mut emit,
+            &cancel,
+        )
+        .await
+        .unwrap();
+
+        let tool_result = tool_result_json_for_call(&state, "call_mount");
+        assert_eq!(tool_result["namespace_applied"], true);
+        assert_eq!(tool_result["tool_sandbox_applied"], false);
+        assert_eq!(
+            state.tool_catalog.default_sandbox_writable_roots(),
+            vec![workspace.path().to_path_buf()]
+        );
+        let grants = applicator.grants();
+        assert_eq!(grants.len(), 1);
+        assert_eq!(grants[0].access, ApprovedMountGrantAccess::ReadOnly);
+    }
+
+    #[tokio::test]
+    async fn test_handle_mount_escalation_resume_reports_namespace_apply_failure() {
+        let workspace = TempDir::new().unwrap();
+        let approved_host = TempDir::new().unwrap();
+        let applicator = Arc::new(RecordingMountGrantApplicator::failing("mount failed"));
+        let mut state = create_test_state();
+        state.environment =
+            namespace_environment_with_mount_applicator_for_test(applicator.clone());
+        state
+            .tool_catalog
+            .set_default_workspace_root(workspace.path().to_path_buf());
+        state
+            .turn_state
+            .set_confirmation(mount_escalation_pending_confirmation_with(
+                approved_host.path().to_str().unwrap(),
+                "read_write",
+                "Need to edit project files",
+            ));
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+
+        handle_runtime_op_with_cancel(
+            &mut state,
+            Op::Resume {
+                request_id: "mount_escalation_call_mount".to_string(),
+                content: vec![ContentPart::structured(json!({"choice": "approve"}))],
+            },
+            &mut emit,
+            &cancel,
+        )
+        .await
+        .unwrap();
+
+        let tool_result = tool_result_json_for_call(&state, "call_mount");
+        assert_eq!(tool_result["namespace_applied"], false);
+        assert_eq!(tool_result["namespace_error"], "mount failed");
+        assert_eq!(tool_result["tool_sandbox_applied"], true);
+        let grants = applicator.grants();
+        assert_eq!(grants.len(), 1);
     }
 
     #[tokio::test]

--- a/crates/alan/src/daemon/runtime_manager.rs
+++ b/crates/alan/src/daemon/runtime_manager.rs
@@ -221,6 +221,9 @@ impl RuntimeManager {
         }
         runtime_config.workspace_root_dir = Some(workspace_root_path.clone());
         runtime_config.workspace_alan_dir = Some(workspace_alan_dir.clone());
+        runtime_config.mount_grant_applicator_factory = Some(Arc::new(
+            crate::host_mounts::LiveNamespaceMountGrantApplicatorFactory,
+        ));
         runtime_config.resume_rollout_path = resume_rollout_path;
         runtime_config.agent_config.runtime_config.governance = session_policy.governance;
         runtime_config

--- a/crates/alan/src/host_mounts.rs
+++ b/crates/alan/src/host_mounts.rs
@@ -4,13 +4,20 @@
 //! applied to the Alan OS namespace and projected into `SandboxSpec` here, while
 //! `alan-kernel` remains host-path agnostic.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
-use alan_agent_engine::tools::SandboxSpec;
+use alan_agent_engine::{
+    runtime::{
+        ApprovedMountGrant, ApprovedMountGrantAccess, MountGrantApplicator,
+        MountGrantApplicatorFactory,
+    },
+    tools::SandboxSpec,
+};
 use alan_ap::InProcessTransport;
 use alan_hostfs::{HostDirAccess, HostDirFs};
-use alan_kernel::{Access, Namespace};
+use alan_kernel::{Access, LiveNamespace, Namespace};
 use anyhow::{Context, Result};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -194,6 +201,95 @@ fn host_paths_overlap(left: &Path, right: &Path) -> bool {
     left.starts_with(right) || right.starts_with(left)
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct LiveNamespaceMountGrantApplicatorFactory;
+
+impl MountGrantApplicatorFactory for LiveNamespaceMountGrantApplicatorFactory {
+    fn create(&self, live_namespace: LiveNamespace) -> Arc<dyn MountGrantApplicator> {
+        Arc::new(LiveNamespaceMountGrantApplicator {
+            live_namespace,
+            granted_paths: Mutex::new(HashSet::new()),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct LiveNamespaceMountGrantApplicator {
+    live_namespace: LiveNamespace,
+    granted_paths: Mutex<HashSet<String>>,
+}
+
+impl MountGrantApplicator for LiveNamespaceMountGrantApplicator {
+    fn apply_mount_grant(&self, grant: &ApprovedMountGrant) -> Result<()> {
+        let namespace_path = canonical_namespace_path(&grant.namespace_path)?;
+        let mut granted_paths = self
+            .granted_paths
+            .lock()
+            .expect("live namespace grant path set lock poisoned");
+        validate_live_mount_grant_path(&self.live_namespace, &namespace_path, &granted_paths)?;
+        let access = match grant.access {
+            ApprovedMountGrantAccess::ReadOnly => Access::ReadOnly,
+            ApprovedMountGrantAccess::ReadWrite => Access::ReadWrite,
+        };
+        let declaration =
+            HostMountDeclaration::new(namespace_path.clone(), grant.host_path.clone(), access);
+        let hostfs = HostDirFs::new(&declaration.host_path, declaration.hostfs_access())
+            .with_context(|| {
+                format!(
+                    "failed to apply approved host mount {} at {}",
+                    declaration.host_path.display(),
+                    declaration.namespace_path
+                )
+            })?;
+        self.live_namespace.replace_mount(
+            &declaration.namespace_path,
+            InProcessTransport::new(Arc::new(hostfs)),
+            declaration.access,
+        );
+        granted_paths.insert(namespace_path);
+        Ok(())
+    }
+}
+
+fn canonical_namespace_path(path: &str) -> Result<String> {
+    let components = normalized_namespace_components(path)?;
+    if components.is_empty() {
+        Ok("/".to_string())
+    } else {
+        Ok(format!("/{}", components.join("/")))
+    }
+}
+
+fn validate_live_mount_grant_path(
+    live_namespace: &LiveNamespace,
+    namespace_path: &str,
+    granted_paths: &HashSet<String>,
+) -> Result<()> {
+    let requested_components = normalized_namespace_components(namespace_path)?;
+    anyhow::ensure!(
+        requested_components.first() == Some(&"mnt") && requested_components.len() >= 2,
+        "approved host mount grants must target a user mount under /mnt: {}",
+        namespace_path
+    );
+
+    for (existing_path, _) in live_namespace.describe() {
+        let existing_path = canonical_namespace_path(&existing_path)?;
+        let existing_components = normalized_namespace_components(&existing_path)?;
+        let exact_previously_granted =
+            existing_path == namespace_path && granted_paths.contains(namespace_path);
+        if namespace_paths_overlap(&requested_components, &existing_components)
+            && !exact_previously_granted
+        {
+            anyhow::bail!(
+                "approved host mount {} would shadow existing namespace mount {}",
+                namespace_path,
+                existing_path
+            );
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -265,6 +361,161 @@ mod tests {
         let host_path = std::fs::canonicalize(host.path()).unwrap();
         assert_eq!(spec.writable_roots, vec![workspace.path().to_path_buf()]);
         assert!(!spec.writable_roots.contains(&host_path));
+    }
+
+    #[tokio::test]
+    async fn live_namespace_applicator_mounts_read_write_grant() {
+        let host = tempfile::tempdir().unwrap();
+        std::fs::write(host.path().join("notes.txt"), "hello").unwrap();
+        let live_namespace = LiveNamespace::new(Namespace::new());
+        let applicator = LiveNamespaceMountGrantApplicatorFactory.create(live_namespace.clone());
+
+        applicator
+            .apply_mount_grant(&ApprovedMountGrant::new(
+                "/mnt/project",
+                host.path().to_path_buf(),
+                ApprovedMountGrantAccess::ReadWrite,
+                "Need to edit project files",
+            ))
+            .unwrap();
+
+        assert_eq!(
+            live_namespace.describe(),
+            vec![("/mnt/project".to_string(), Access::ReadWrite)]
+        );
+        let root = InProcessTransport::new(Arc::new(MountFs::from_live_namespace(live_namespace)));
+        assert_file_bytes(&root, Fid(1), &["mnt", "project", "notes.txt"], b"hello").await;
+        root.call(Request::Walk {
+            fid: Fid::ROOT,
+            newfid: Fid(2),
+            names: ["mnt", "project", "notes.txt"]
+                .iter()
+                .map(|name| (*name).to_string())
+                .collect(),
+        })
+        .await
+        .unwrap();
+        root.call(Request::Open {
+            fid: Fid(2),
+            mode: OpenMode::Write,
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn live_namespace_applicator_mounts_read_only_grant_as_read_only() {
+        let host = tempfile::tempdir().unwrap();
+        std::fs::write(host.path().join("manual.txt"), "read me").unwrap();
+        let live_namespace = LiveNamespace::new(Namespace::new());
+        let applicator = LiveNamespaceMountGrantApplicatorFactory.create(live_namespace.clone());
+
+        applicator
+            .apply_mount_grant(&ApprovedMountGrant::new(
+                "/mnt/docs",
+                host.path().to_path_buf(),
+                ApprovedMountGrantAccess::ReadOnly,
+                "Need to inspect docs",
+            ))
+            .unwrap();
+
+        assert_eq!(
+            live_namespace.describe(),
+            vec![("/mnt/docs".to_string(), Access::ReadOnly)]
+        );
+        let root = InProcessTransport::new(Arc::new(MountFs::from_live_namespace(live_namespace)));
+        assert_file_bytes(&root, Fid(1), &["mnt", "docs", "manual.txt"], b"read me").await;
+        assert_eq!(
+            root.call(Request::Open {
+                fid: Fid(1),
+                mode: OpenMode::Write,
+            })
+            .await,
+            Err(alan_ap::ErrorCode::NoAccess)
+        );
+    }
+
+    #[tokio::test]
+    async fn live_namespace_applicator_rejects_existing_system_mount_shadow() {
+        let host = tempfile::tempdir().unwrap();
+        let mut namespace = Namespace::new();
+        namespace.mount(
+            "/mnt/llm",
+            InProcessTransport::new(Arc::new(alan_ap::reference::MemFs::new())),
+            Access::ReadWrite,
+        );
+        let live_namespace = LiveNamespace::new(namespace);
+        let applicator = LiveNamespaceMountGrantApplicatorFactory.create(live_namespace);
+
+        let exact = applicator
+            .apply_mount_grant(&ApprovedMountGrant::new(
+                "/mnt/llm",
+                host.path().to_path_buf(),
+                ApprovedMountGrantAccess::ReadWrite,
+                "Need to inspect provider state",
+            ))
+            .unwrap_err();
+        assert!(
+            exact
+                .to_string()
+                .contains("would shadow existing namespace mount")
+        );
+
+        let nested = applicator
+            .apply_mount_grant(&ApprovedMountGrant::new(
+                "/mnt/llm/connections/default",
+                host.path().to_path_buf(),
+                ApprovedMountGrantAccess::ReadOnly,
+                "Need to inspect provider state",
+            ))
+            .unwrap_err();
+        assert!(
+            nested
+                .to_string()
+                .contains("would shadow existing namespace mount")
+        );
+    }
+
+    #[tokio::test]
+    async fn live_namespace_applicator_allows_replacing_previous_user_grant() {
+        let old_host = tempfile::tempdir().unwrap();
+        let new_host = tempfile::tempdir().unwrap();
+        std::fs::write(old_host.path().join("notes.txt"), "old").unwrap();
+        std::fs::write(new_host.path().join("notes.txt"), "new").unwrap();
+        let live_namespace = LiveNamespace::new(Namespace::new());
+        let applicator = LiveNamespaceMountGrantApplicatorFactory.create(live_namespace.clone());
+
+        applicator
+            .apply_mount_grant(&ApprovedMountGrant::new(
+                "/mnt/project",
+                old_host.path().to_path_buf(),
+                ApprovedMountGrantAccess::ReadWrite,
+                "Need to edit project files",
+            ))
+            .unwrap();
+        applicator
+            .apply_mount_grant(&ApprovedMountGrant::new(
+                "/mnt/project",
+                new_host.path().to_path_buf(),
+                ApprovedMountGrantAccess::ReadOnly,
+                "Need to inspect project files",
+            ))
+            .unwrap();
+
+        assert_eq!(
+            live_namespace.describe(),
+            vec![("/mnt/project".to_string(), Access::ReadOnly)]
+        );
+        let root = InProcessTransport::new(Arc::new(MountFs::from_live_namespace(live_namespace)));
+        assert_file_bytes(&root, Fid(10), &["mnt", "project", "notes.txt"], b"new").await;
+        assert_eq!(
+            root.call(Request::Open {
+                fid: Fid(10),
+                mode: OpenMode::Write,
+            })
+            .await,
+            Err(alan_ap::ErrorCode::NoAccess)
+        );
     }
 
     #[test]

--- a/crates/alan/src/main.rs
+++ b/crates/alan/src/main.rs
@@ -8,6 +8,8 @@
 mod cli;
 mod daemon;
 mod host_config;
+#[allow(dead_code)]
+mod host_mounts;
 pub mod registry;
 mod skill_catalog;
 

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -20,7 +20,7 @@ mod procfs;
 mod srvfs;
 
 pub use bootstrap::KernelRoot;
-pub use mountfs::MountFs;
+pub use mountfs::{LiveNamespace, MountFs};
 pub use namespace::{Access, Namespace, Resolved, Unreachable};
 pub use process::{
     Credentials, ExecNamespaceAccess, ExecNamespaceManifest, ExecNamespaceMount, ExecSpec, Pid,

--- a/crates/kernel/src/mountfs.rs
+++ b/crates/kernel/src/mountfs.rs
@@ -16,10 +16,12 @@
 //!   holds exactly as it does for a directly-mounted server.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
 
 use alan_ap::{
-    ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Request, Response, Stat,
+    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode, Qid, Request,
+    Response, Stat,
 };
 use async_trait::async_trait;
 use tokio::sync::Mutex;
@@ -76,13 +78,93 @@ struct State {
 
 /// The namespace-as-`FileServer`.
 pub struct MountFs {
-    ns: Namespace,
+    ns: LiveNamespace,
     state: Mutex<State>,
+}
+
+/// Shared, live mount table for a running namespace.
+///
+/// The handle is host-agnostic: callers provide an already-constructed aP file
+/// server transport plus mount access. Existing `MountFs` fids keep their
+/// resolved backing server; future walks observe mount-table changes.
+#[derive(Clone)]
+pub struct LiveNamespace {
+    ns: Arc<RwLock<Namespace>>,
+    generation: Arc<AtomicU32>,
+}
+
+impl std::fmt::Debug for LiveNamespace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LiveNamespace")
+            .field("mounts", &self.describe())
+            .finish()
+    }
+}
+
+impl LiveNamespace {
+    /// Create a live handle around an assembled namespace.
+    pub fn new(ns: Namespace) -> Self {
+        Self {
+            ns: Arc::new(RwLock::new(ns)),
+            generation: Arc::new(AtomicU32::new(0)),
+        }
+    }
+
+    /// Mount a file server at `at`, preserving normal namespace stacking rules.
+    pub fn mount(&self, at: &str, tree: InProcessTransport, access: crate::Access) {
+        self.write().mount(at, tree, access);
+        self.bump_generation();
+    }
+
+    /// Replace every exact mount at `at`, then mount the supplied file server.
+    pub fn replace_mount(&self, at: &str, tree: InProcessTransport, access: crate::Access) {
+        let mut ns = self.write();
+        ns.unmount(at);
+        ns.mount(at, tree, access);
+        drop(ns);
+        self.bump_generation();
+    }
+
+    /// Return an inspectable summary of the current mount table.
+    pub fn describe(&self) -> Vec<(String, crate::Access)> {
+        self.read().describe()
+    }
+
+    /// Return a point-in-time namespace snapshot for process spawn inheritance.
+    pub fn snapshot(&self) -> Namespace {
+        self.read().clone()
+    }
+
+    /// Monotonic mount-table version used by qid/cache invalidation.
+    pub fn generation(&self) -> u32 {
+        self.generation.load(Ordering::Relaxed)
+    }
+
+    fn resolve_candidates(&self, path: &str) -> Vec<Resolved> {
+        self.read().resolve_candidates(path)
+    }
+
+    fn bump_generation(&self) {
+        self.generation.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn read(&self) -> std::sync::RwLockReadGuard<'_, Namespace> {
+        self.ns.read().expect("live namespace lock poisoned")
+    }
+
+    fn write(&self) -> std::sync::RwLockWriteGuard<'_, Namespace> {
+        self.ns.write().expect("live namespace lock poisoned")
+    }
 }
 
 impl MountFs {
     /// Wrap an assembled [`Namespace`] as a single aP file server.
     pub fn new(ns: Namespace) -> Self {
+        Self::from_live_namespace(LiveNamespace::new(ns))
+    }
+
+    /// Wrap a live namespace mount handle as a single aP file server.
+    pub fn from_live_namespace(ns: LiveNamespace) -> Self {
         let mut fids = HashMap::new();
         // The root fid is the namespace root: the synthetic directory at `/`.
         fids.insert(
@@ -97,6 +179,11 @@ impl MountFs {
             ns,
             state: Mutex::new(State { fids }),
         }
+    }
+
+    /// Return the live namespace handle backing this file server.
+    pub fn live_namespace(&self) -> LiveNamespace {
+        self.ns.clone()
     }
 
     /// The mount prefixes of the namespace, as component vectors.
@@ -260,7 +347,7 @@ impl FileServer for MountFs {
         // not contain that component — so a component-at-a-time walk still reaches
         // the deeper mount.
         if path.is_empty() || self.is_synthetic_dir(&path) {
-            let qid = synthetic_qid(&path);
+            let qid = synthetic_qid(&path, self.ns.generation());
             state.fids.insert(
                 newfid,
                 Entry {
@@ -298,7 +385,7 @@ impl FileServer for MountFs {
                 if matches!(mode, OpenMode::Write | OpenMode::ReadWrite) {
                     return Err(ErrorCode::NoAccess);
                 }
-                Ok(synthetic_qid(&path))
+                Ok(synthetic_qid(&path, self.ns.generation()))
             }
         }
     }
@@ -383,7 +470,7 @@ impl FileServer for MountFs {
                 let length = self.synthetic_children(&path).join("\n").len() as u64;
                 Ok(Stat {
                     name: String::new(),
-                    qid: synthetic_qid(&path),
+                    qid: synthetic_qid(&path, self.ns.generation()),
                     length,
                     writable: false,
                 })
@@ -602,14 +689,14 @@ fn join_path(components: &[String]) -> String {
 
 /// A stable directory qid for a synthetic namespace path, keyed by the path so
 /// distinct synthetic directories never share a qid.
-fn synthetic_qid(path: &[String]) -> Qid {
+fn synthetic_qid(path: &[String], version: u32) -> Qid {
     use std::hash::{Hash, Hasher};
     let mut h = std::collections::hash_map::DefaultHasher::new();
     "synthetic".hash(&mut h);
     path.hash(&mut h);
     Qid {
         kind: FileKind::Dir,
-        version: 0,
+        version,
         path: h.finish(),
     }
 }

--- a/crates/kernel/src/process.rs
+++ b/crates/kernel/src/process.rs
@@ -220,6 +220,14 @@ impl ProcessTable {
         self.versions.get(pid.0)
     }
 
+    /// Bump a committed process's file generation after externally visible
+    /// metadata changes.
+    pub fn bump_generation(&mut self, pid: Pid) {
+        if self.processes.contains_key(&pid) {
+            self.versions.bump(pid.0);
+        }
+    }
+
     fn alloc_pid(&mut self) -> Pid {
         let pid = Pid(self.next);
         self.next += 1;

--- a/crates/kernel/src/procfs.rs
+++ b/crates/kernel/src/procfs.rs
@@ -42,7 +42,7 @@ use alan_ap::{
 use async_trait::async_trait;
 use tokio::sync::Mutex;
 
-use crate::{Access, Credentials, ExecSpec, Namespace, Pid, ProcessTable, Status};
+use crate::{Access, Credentials, ExecSpec, LiveNamespace, Namespace, Pid, ProcessTable, Status};
 
 /// One committed process invocation handed to user-space execution.
 #[derive(Clone)]
@@ -134,6 +134,7 @@ static NEXT_PROCFS_VIEW_ID: AtomicU64 = AtomicU64::new(1);
 struct State {
     table: ProcessTable,
     fids: HashMap<ProcFidKey, ProcFid>,
+    live_namespaces: HashMap<Pid, LiveNamespace>,
     /// Generic IO streams per committed process. The kernel owns the files; user
     /// space supplies the execution semantics layered above them.
     inputs: HashMap<Pid, Stream>,
@@ -188,8 +189,28 @@ impl OrderedProcessIoEventObserver {
 #[derive(Clone)]
 struct SpawnContext {
     parent: Option<Pid>,
-    namespace: Namespace,
+    namespace: NamespaceSource,
     credentials: Credentials,
+}
+
+#[derive(Clone)]
+enum NamespaceSource {
+    Snapshot(Namespace),
+    Live(LiveNamespace),
+}
+
+impl NamespaceSource {
+    fn snapshot(&self) -> Namespace {
+        match self {
+            Self::Snapshot(namespace) => namespace.clone(),
+            Self::Live(namespace) => namespace.snapshot(),
+        }
+    }
+
+    fn child_with_path_substitution(&self, placeholder: &str, pid: &str) -> Namespace {
+        self.snapshot()
+            .child_with_path_substitution(placeholder, pid)
+    }
 }
 
 /// The `/proc` file server.
@@ -214,6 +235,7 @@ impl ProcFs {
             state: Arc::new(Mutex::new(State {
                 table: ProcessTable::new(),
                 fids: HashMap::new(),
+                live_namespaces: HashMap::new(),
                 inputs: HashMap::new(),
                 outputs: HashMap::new(),
                 io_events: HashMap::new(),
@@ -228,7 +250,7 @@ impl ProcFs {
             root_node: Node::Root,
             spawn_context: SpawnContext {
                 parent: None,
-                namespace: Namespace::new(),
+                namespace: NamespaceSource::Snapshot(Namespace::new()),
                 credentials: Credentials::system(),
             },
             runner: None,
@@ -258,7 +280,29 @@ impl ProcFs {
             root_node: Node::Root,
             spawn_context: SpawnContext {
                 parent,
-                namespace,
+                namespace: NamespaceSource::Snapshot(namespace),
+                credentials,
+            },
+            runner: self.runner.clone(),
+        }
+    }
+
+    /// Create a `/proc` view whose spawner inherits from a live namespace handle.
+    /// Children snapshot the handle at clone time, so grants approved before spawn
+    /// are visible without making every child share later mutations by default.
+    pub fn for_live_spawner(
+        &self,
+        parent: Option<Pid>,
+        namespace: LiveNamespace,
+        credentials: Credentials,
+    ) -> Self {
+        Self {
+            state: self.state.clone(),
+            view_id: next_view_id(),
+            root_node: Node::Root,
+            spawn_context: SpawnContext {
+                parent,
+                namespace: NamespaceSource::Live(namespace),
                 credentials,
             },
             runner: self.runner.clone(),
@@ -276,6 +320,17 @@ impl ProcFs {
         let mut view = self.for_spawner(parent, namespace, credentials);
         view.root_node = Node::Clone;
         view
+    }
+
+    /// Bind a committed process's namespace description to a live namespace
+    /// handle. This is used for long-lived root processes whose namespace can gain
+    /// approved mounts after the process has started.
+    pub async fn bind_live_namespace(&self, pid: Pid, namespace: LiveNamespace) {
+        let mut state = self.state.lock().await;
+        if state.table.get(pid).is_some() {
+            state.live_namespaces.insert(pid, namespace);
+            state.table.bump_generation(pid);
+        }
     }
 
     fn child_namespace_for_spawn(&self, pid: Pid) -> Namespace {
@@ -550,8 +605,12 @@ impl State {
             | Node::Parent(p)
             | Node::Credentials(p)
             | Node::Exit(p)
-            | Node::Ctl(p)
-            | Node::NamespaceInfo(p) => self.table.generation(*p),
+            | Node::Ctl(p) => self.table.generation(*p),
+            Node::NamespaceInfo(p) => self.table.generation(*p).wrapping_add(
+                self.live_namespaces
+                    .get(p)
+                    .map_or(0, LiveNamespace::generation),
+            ),
         };
         Qid {
             kind,
@@ -629,8 +688,10 @@ impl State {
             }
             Node::NamespaceInfo(pid) => {
                 let p = self.table.get(*pid).ok_or(ErrorCode::NotFound)?;
-                p.namespace
-                    .describe()
+                self.live_namespaces
+                    .get(pid)
+                    .map(LiveNamespace::describe)
+                    .unwrap_or_else(|| p.namespace.describe())
                     .iter()
                     .map(|(path, access)| {
                         let rights = match access {

--- a/crates/kernel/tests/mountfs.rs
+++ b/crates/kernel/tests/mountfs.rs
@@ -15,7 +15,7 @@ use alan_ap::reference::MemFs;
 use alan_ap::{
     ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode, Qid, Stat, Stream,
 };
-use alan_kernel::{Access, MountFs, Namespace, ProcFs};
+use alan_kernel::{Access, LiveNamespace, MountFs, Namespace, ProcFs};
 use tokio::sync::Notify;
 
 fn memfs() -> InProcessTransport {
@@ -28,6 +28,13 @@ fn procfs() -> InProcessTransport {
 
 fn createfs() -> InProcessTransport {
     InProcessTransport::new(Arc::new(CreateFs::default()))
+}
+
+fn static_filefs(content: &'static [u8]) -> InProcessTransport {
+    InProcessTransport::new(Arc::new(StaticFileFs {
+        content,
+        fids: tokio::sync::Mutex::new(HashMap::new()),
+    }))
 }
 
 /// A namespace with `/proc` (ProcFs) and `/data` (MemFs), both read-write.
@@ -48,6 +55,13 @@ async fn read_lines(fs: &MountFs, path: &[&str], fid: Fid) -> Vec<String> {
         .lines()
         .map(str::to_string)
         .collect()
+}
+
+async fn read_file(fs: &MountFs, path: &[&str], fid: Fid) -> Vec<u8> {
+    let names: Vec<String> = path.iter().map(|s| s.to_string()).collect();
+    fs.walk(Fid::ROOT, fid, &names).await.unwrap();
+    fs.open(fid, OpenMode::Read).await.unwrap();
+    fs.read(fid, 0, 4096).await.unwrap()
 }
 
 #[derive(Clone)]
@@ -236,6 +250,84 @@ impl FileServer for CreateFs {
     }
 }
 
+/// A tiny read-only server with one file at `value`.
+struct StaticFileFs {
+    content: &'static [u8],
+    fids: tokio::sync::Mutex<HashMap<Fid, bool>>, // fid -> is `value`
+}
+
+#[async_trait::async_trait]
+impl FileServer for StaticFileFs {
+    async fn walk(&self, _fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        let (is_value, kind) = match names {
+            [] => (false, FileKind::Dir),
+            [name] if name == "value" => (true, FileKind::File),
+            _ => return Err(ErrorCode::NotFound),
+        };
+        self.fids.lock().await.insert(newfid, is_value);
+        Ok(Qid {
+            kind,
+            version: 0,
+            path: 0,
+        })
+    }
+
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
+        if matches!(mode, OpenMode::Write | OpenMode::ReadWrite) {
+            return Err(ErrorCode::NoAccess);
+        }
+        let kind = if *self.fids.lock().await.get(&fid).unwrap_or(&false) {
+            FileKind::File
+        } else {
+            FileKind::Dir
+        };
+        Ok(Qid {
+            kind,
+            version: 0,
+            path: 0,
+        })
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        if !*self.fids.lock().await.get(&fid).unwrap_or(&false) {
+            return Ok(b"value".to_vec());
+        }
+        let start = (offset as usize).min(self.content.len());
+        let end = self.content.len().min(start + count as usize);
+        Ok(self.content[start..end].to_vec())
+    }
+
+    async fn write(&self, _: Fid, _: Offset, _: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::NoAccess)
+    }
+
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Ok(Stat {
+            name: String::new(),
+            qid: Qid {
+                kind: FileKind::File,
+                version: 0,
+                path: 0,
+            },
+            length: self.content.len() as u64,
+            writable: false,
+        })
+    }
+
+    async fn create(&self, _: Fid, _: Fid, _: &str, _: FileKind) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.fids.lock().await.remove(&fid);
+        Ok(())
+    }
+}
+
 #[tokio::test]
 async fn root_lists_its_mount_points_as_a_synthetic_directory() {
     let fs = MountFs::new(ns());
@@ -419,6 +511,100 @@ async fn a_nested_mount_appears_through_synthetic_parents() {
     .unwrap();
     fs.open(Fid(3), OpenMode::Read).await.unwrap();
     assert_eq!(fs.read(Fid(3), 0, 64).await.unwrap(), b"hi");
+}
+
+#[tokio::test]
+async fn live_namespace_mount_is_visible_to_future_walks() {
+    let live = LiveNamespace::new(Namespace::new());
+    let fs = MountFs::from_live_namespace(live.clone());
+
+    assert_eq!(
+        fs.walk(Fid::ROOT, Fid(1), &["mnt".into(), "project".into()])
+            .await,
+        Err(ErrorCode::NotFound)
+    );
+
+    live.mount("/mnt/project", static_filefs(b"mounted"), Access::ReadWrite);
+
+    assert_eq!(
+        read_file(&fs, &["mnt", "project", "value"], Fid(2)).await,
+        b"mounted"
+    );
+    assert_eq!(read_lines(&fs, &["mnt"], Fid(3)).await, vec!["project"]);
+}
+
+#[tokio::test]
+async fn live_namespace_mutation_bumps_synthetic_directory_qids() {
+    let live = LiveNamespace::new(Namespace::new());
+    let fs = MountFs::from_live_namespace(live.clone());
+
+    live.mount("/mnt/old", static_filefs(b"old"), Access::ReadWrite);
+    let before_walk = fs.walk(Fid::ROOT, Fid(1), &["mnt".into()]).await.unwrap();
+    let before_stat = fs.stat(Fid(1)).await.unwrap();
+    assert_eq!(before_walk.version, live.generation());
+    assert_eq!(before_stat.qid.version, live.generation());
+
+    live.mount("/mnt/project", static_filefs(b"new"), Access::ReadWrite);
+
+    let after_stat = fs.stat(Fid(1)).await.unwrap();
+    assert_ne!(after_stat.qid.version, before_stat.qid.version);
+    assert_eq!(after_stat.qid.version, live.generation());
+    let mut entries = read_lines(&fs, &["mnt"], Fid(2)).await;
+    entries.sort();
+    assert_eq!(entries, vec!["old", "project"]);
+}
+
+#[tokio::test]
+async fn live_namespace_replace_mount_does_not_accumulate_duplicate_descriptions() {
+    let live = LiveNamespace::new(Namespace::new());
+    let fs = MountFs::from_live_namespace(live.clone());
+
+    live.replace_mount("/mnt/project", static_filefs(b"old"), Access::ReadWrite);
+    live.replace_mount("/mnt/project", static_filefs(b"new"), Access::ReadOnly);
+
+    assert_eq!(
+        live.describe(),
+        vec![("/mnt/project".to_string(), Access::ReadOnly)]
+    );
+    assert_eq!(
+        read_file(&fs, &["mnt", "project", "value"], Fid(1)).await,
+        b"new"
+    );
+    fs.walk(
+        Fid::ROOT,
+        Fid(2),
+        &["mnt".into(), "project".into(), "value".into()],
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        fs.open(Fid(2), OpenMode::Write).await,
+        Err(ErrorCode::NoAccess)
+    );
+}
+
+#[tokio::test]
+async fn live_namespace_replacement_preserves_already_open_fids() {
+    let live = LiveNamespace::new(Namespace::new());
+    let fs = MountFs::from_live_namespace(live.clone());
+
+    live.replace_mount("/mnt/project", static_filefs(b"old"), Access::ReadWrite);
+    fs.walk(
+        Fid::ROOT,
+        Fid(1),
+        &["mnt".into(), "project".into(), "value".into()],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(1), OpenMode::Read).await.unwrap();
+
+    live.replace_mount("/mnt/project", static_filefs(b"new"), Access::ReadWrite);
+
+    assert_eq!(fs.read(Fid(1), 0, 4096).await.unwrap(), b"old");
+    assert_eq!(
+        read_file(&fs, &["mnt", "project", "value"], Fid(2)).await,
+        b"new"
+    );
 }
 
 #[tokio::test]

--- a/crates/kernel/tests/procfs.rs
+++ b/crates/kernel/tests/procfs.rs
@@ -11,7 +11,8 @@ use alan_ap::{
     ProcessOutputEventSource, Request, Response,
 };
 use alan_kernel::{
-    Access, Credentials, Namespace, Pid, ProcFs, ProcessInvocation, ProcessOutcome, ProcessRunner,
+    Access, Credentials, LiveNamespace, Namespace, Pid, ProcFs, ProcessInvocation, ProcessOutcome,
+    ProcessRunner,
 };
 use std::sync::{
     Arc, Mutex,
@@ -1094,6 +1095,53 @@ async fn clone_uses_the_spawner_context_for_child_identity() {
     assert!(
         namespace.lines().any(|line| line == "/data ro"),
         "child namespace inherits the spawner namespace: {namespace:?}"
+    );
+}
+
+#[tokio::test]
+async fn live_spawner_namespace_reads_and_children_observe_live_mounts() {
+    let fs = proc();
+    let mut namespace = Namespace::new();
+    namespace.mount(
+        "/data",
+        alan_ap::InProcessTransport::new(Arc::new(alan_ap::reference::MemFs::new())),
+        Access::ReadOnly,
+    );
+    let live_namespace = LiveNamespace::new(namespace);
+    let spawner = fs.for_live_spawner(None, live_namespace.clone(), Credentials::user("alan"));
+
+    let pid = spawn(&spawner, Fid(60)).await;
+    let pid_value = Pid(pid.parse::<u64>().unwrap());
+    fs.bind_live_namespace(pid_value, live_namespace.clone())
+        .await;
+    fs.walk(Fid::ROOT, Fid(61), &[pid.clone(), "namespace".to_string()])
+        .await
+        .unwrap();
+    fs.open(Fid(61), OpenMode::Read).await.unwrap();
+    let before = fs.stat(Fid(61)).await.unwrap().qid.version;
+
+    live_namespace.mount(
+        "/mnt/project",
+        alan_ap::InProcessTransport::new(Arc::new(alan_ap::reference::MemFs::new())),
+        Access::ReadWrite,
+    );
+
+    let after = fs.stat(Fid(61)).await.unwrap().qid.version;
+    assert_ne!(after, before);
+    let namespace = String::from_utf8(fs.read(Fid(61), 0, 4096).await.unwrap()).unwrap();
+    assert!(
+        namespace.lines().any(|line| line == "/mnt/project rw"),
+        "live process namespace should include approved grant: {namespace:?}"
+    );
+
+    let child = spawn(&spawner, Fid(62)).await;
+    let child_namespace =
+        String::from_utf8(read_at(&fs, &[&child, "namespace"], Fid(63)).await.unwrap()).unwrap();
+    assert!(
+        child_namespace
+            .lines()
+            .any(|line| line == "/mnt/project rw"),
+        "child namespace should snapshot live grants visible at spawn: {child_namespace:?}"
     );
 }
 

--- a/openspec/changes/apply-mount-grants-to-live-namespace/tasks.md
+++ b/openspec/changes/apply-mount-grants-to-live-namespace/tasks.md
@@ -1,13 +1,13 @@
 ## 1. Live Process Namespace Mount Handle
 
-- [ ] 1.1 Add a host-agnostic live namespace mount handle in Alan Kernel that can
+- [x] 1.1 Add a host-agnostic live namespace mount handle in Alan Kernel that can
   mount or replace an exact namespace path using `InProcessTransport` and
   `Access`, and increments a generation on successful live mutation.
-- [ ] 1.2 Update `MountFs`, `ProcFs::for_spawner`, process namespace
+- [x] 1.2 Update `MountFs`, `ProcFs::for_spawner`, process namespace
   descriptions, and `/proc/clone` child namespace snapshots to read or snapshot
   from the same live handle while preserving `MountFs::new(namespace)`
   compatibility.
-- [ ] 1.3 Add kernel tests proving future walks see a newly mounted path,
+- [x] 1.3 Add kernel tests proving future walks see a newly mounted path,
   `/proc/<pid>/namespace` reads see the new path, child spawns inherit the new
   path, `/mnt` synthetic listing qids/versions and `/proc/<pid>/namespace`
   qids/versions change after mutation, duplicate exact-path replacement does not
@@ -16,47 +16,47 @@
 
 ## 2. Runtime Applicator Boundary
 
-- [ ] 2.1 Add an engine-owned approved mount grant payload and
+- [x] 2.1 Add an engine-owned approved mount grant payload and
   host-provided applicator interface without importing `alan_hostfs` into
   `alan-agent-engine`.
-- [ ] 2.2 Thread the optional applicator through namespace runtime environment
+- [x] 2.2 Thread the optional applicator through namespace runtime environment
   state so `request_mount` resume can attempt live namespace application.
-- [ ] 2.3 Preserve current behavior for runtimes without an applicator, including
+- [x] 2.3 Preserve current behavior for runtimes without an applicator, including
   explicit `namespace_applied = false` reporting.
 
 ## 3. Alan Composition Applicator
 
-- [ ] 3.1 Implement the `alan` composition-root applicator by converting approved
+- [x] 3.1 Implement the `alan` composition-root applicator by converting approved
   grants into `HostMountDeclaration` / `HostDirFs` and applying them through the
   live namespace handle.
-- [ ] 3.2 Wire standard namespace runtime assembly to create one live process
+- [x] 3.2 Wire standard namespace runtime assembly to create one live process
   namespace handle and pass it to `MountFs`, `ProcFs`/spawner state, process
   records, and the applicator.
-- [ ] 3.3 Add tests proving read-write grants become writable aP mounts and
+- [x] 3.3 Add tests proving read-write grants become writable aP mounts and
   read-only grants become read-only aP mounts without expanding sandbox writable
   roots.
 
 ## 4. Request Mount Resume Reporting
 
-- [ ] 4.1 Update mount escalation resume handling to call the applicator on
+- [x] 4.1 Update mount escalation resume handling to call the applicator on
   approval and include `namespace_applied` / `namespace_error` in both tool
   result and `host_mount_grant` event.
-- [ ] 4.2 Cover approved read-write apply, approved read-only apply, duplicate
+- [x] 4.2 Cover approved read-write apply, approved read-only apply, duplicate
   replacement, rejected no-op, missing applicator, and applicator failure with
   focused runtime tests.
-- [ ] 4.3 Keep `tool_sandbox_applied` and `namespace_applied` independent and
+- [x] 4.3 Keep `tool_sandbox_applied` and `namespace_applied` independent and
   ensure no result claims Linux reification or native `/mnt` visibility.
-- [ ] 4.4 Update the `agent-mount-escalation` capability delta to retire the
+- [x] 4.4 Update the `agent-mount-escalation` capability delta to retire the
   earlier approved-but-not-live-applied result language for runtimes with live
   namespace application.
 
 ## 5. Verification And PR
 
-- [ ] 5.1 Run focused Rust tests for kernel live namespace mutation, host mount
+- [x] 5.1 Run focused Rust tests for kernel live namespace mutation, host mount
   application, and mount escalation resume reporting.
-- [ ] 5.2 Run clippy for touched crates, OpenSpec strict validate, and diff
+- [x] 5.2 Run clippy for touched crates, OpenSpec strict validate, and diff
   checks.
-- [ ] 5.3 Update parent namespace-driven sandbox task state to record this live
+- [x] 5.3 Update parent namespace-driven sandbox task state to record this live
   namespace projection slice while leaving Linux reification pending.
-- [ ] 5.4 Commit the slice and open a ready stacked PR above
-  `feat/northstar-tool-sandbox-mount-grants`.
+- [x] 5.4 Commit the slice and open a ready stacked PR above
+  `feat/northstar-live-namespace-mount-grants`.

--- a/openspec/changes/define-namespace-driven-sandbox/tasks.md
+++ b/openspec/changes/define-namespace-driven-sandbox/tasks.md
@@ -24,7 +24,9 @@ proposals out as their own OpenSpec changes. No application code lands here.
   `apply-mount-grants-to-tool-sandbox` for applying approved read-write grants
   to the runtime tool sandbox projection; and
   `apply-mount-grants-to-live-namespace` for applying approved grants to the
-  running Agent Process Alan OS namespace. Linux reification remains pending.
+  running Agent Process Alan OS namespace; this slice now adds the live kernel
+  mount handle, host applicator boundary, and resume reporting. Linux
+  reification remains pending.
 
 ## 2. Carry the framing forward
 


### PR DESCRIPTION
## Summary
- add a live Alan Kernel namespace mount handle and teach MountFs future walks/listings to read it
- add engine-owned approved mount grant/applicator boundaries and wire namespace application into request_mount resume reporting
- implement the alan host applicator with HostDirFs and inject it into daemon runtime startup

## Verification
- cargo test -p alan-kernel live_namespace -- --nocapture
- cargo test -p alan live_namespace_applicator -- --nocapture
- cargo test -p alan-agent-engine mount_escalation -- --nocapture
- cargo clippy -p alan-kernel -p alan-agent-engine -p alan --all-targets --all-features -- -D warnings
- openspec validate apply-mount-grants-to-live-namespace --strict
- openspec validate define-namespace-driven-sandbox --strict
- git diff --check