### PR TITLE
North Star 17/17: define Linux namespace reification

### DIFF
--- a/openspec/changes/define-linux-namespace-reification/.openspec.yaml
+++ b/openspec/changes/define-linux-namespace-reification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/define-linux-namespace-reification/design.md
+++ b/openspec/changes/define-linux-namespace-reification/design.md
@@ -1,0 +1,213 @@
+## Context
+
+Alan's current native subprocess confinement is projection-based:
+
+- macOS uses Seatbelt profiles generated from `SandboxSpec`.
+- Linux uses Landlock plus network controls where available.
+- `SandboxSpec.writable_roots` now follows approved host mounts, but the Linux
+  subprocess still sees the ambient host filesystem. Landlock cannot express
+  "read everything except these sensitive paths" or "read only mounted host
+  paths" while still allowing binaries, dynamic libraries, locale data, and shell
+  support files.
+
+The namespace-driven sandbox framing records the faithful Linux solution as
+reification: build a real per-process filesystem view where only declared mounts
+and required execution substrate are visible. In that model, native subprocesses
+do not merely receive rules about host paths; they run inside a mount namespace
+where `/mnt/project` is a bind mount and `/home/user/.ssh` is absent unless
+explicitly declared.
+
+This is Linux-only. macOS remains on Seatbelt because unprivileged bind-mount
+namespace construction is not available there.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define the runtime contract for a Linux reified namespace backend.
+- Preserve the existing projection backend as fallback.
+- Make full read isolation concrete: deny-by-default host reads, not just
+  sensitive-read denylist.
+- Keep namespace/path semantics honest: native subprocesses see reified `/mnt`
+  paths only for host-backed mounts.
+- Keep Alan Kernel host-path agnostic and keep `alan-agent-engine` decoupled from
+  Alan Kernel.
+- Sequence implementation so capability detection and plan generation land
+  before privileged/namespace execution mechanics.
+
+**Non-Goals:**
+
+- macOS reification.
+- Exposing virtual aP file servers (`/agent`, `/mnt/llm`, `/srv`, `/proc`) as
+  native filesystem paths.
+- A setuid helper, root daemon, or privileged install path in the first slice.
+- Replacing Seatbelt or the existing Linux Landlock path.
+- Making every Linux distribution support reification. Unsupported hosts must
+  degrade safely.
+
+## Decisions
+
+### D1. Add a third sandbox execution mode: Linux reified namespace
+
+Current backend selection is roughly:
+
+```text
+macOS Seatbelt -> Linux Landlock -> workspace path guard
+```
+
+Reification adds a Linux-only mode that ranks above Landlock when all required
+capabilities are present:
+
+```text
+macOS Seatbelt
+Linux ReifiedNamespace (if available)
+Linux Landlock (projection fallback)
+WorkspacePathGuard
+```
+
+The backend name and decision audit must distinguish `linux_reified_namespace`
+from `landlock`, because their read-isolation semantics differ.
+
+### D2. Introduce a reified plan model before a runner
+
+The first implementation slice should create a pure planning model, not jump
+straight into `unshare`:
+
+```rust
+struct ReifiedNamespacePlan {
+    root: ReifiedRoot,
+    mounts: Vec<ReifiedMount>,
+    cwd: PathBuf,
+    argv: Vec<String>,
+    network: NetworkPosture,
+}
+```
+
+The plan is derived from host-backed mount declarations / `SandboxSpec` plus the
+requested command. It is unit-testable on macOS and Linux because it does not
+perform namespace operations.
+
+Plan validation must keep three categories separate:
+
+- **declared host mounts**: user/workspace data that becomes visible under
+  reified namespace paths such as `/mnt/project`;
+- **execution substrate**: read-only system paths needed for `/bin/sh`, dynamic
+  linking, locale, certificates, and temporary runtime files;
+- **virtual Alan OS mounts**: aP-only resources that are not exposed natively.
+
+### D3. Reified paths are not the same as projected host paths
+
+Projection lets `bash` access the real host path:
+
+```text
+aP:   /mnt/project/file.txt
+bash: /Users/me/project/file.txt
+```
+
+Reification makes the native subprocess see the namespace path:
+
+```text
+aP:   /mnt/project/file.txt
+bash: /mnt/project/file.txt
+```
+
+That means command execution needs path translation at the tool boundary. A bash
+request whose cwd is the approved host path may continue to work under projection,
+but under reification the host must map it to the declared namespace path when
+possible. If a path cannot be mapped into the reified view, the operation must be
+rejected or fall back through explicit policy, not silently run against ambient
+host paths.
+
+### D4. Build the runner as an unprivileged helper path
+
+The runner should be implemented behind a narrow trait, for example:
+
+```rust
+trait ReifiedNamespaceRunner {
+    fn run(&self, plan: ReifiedNamespacePlan) -> Result<ExecResult>;
+}
+```
+
+The first concrete runner should use unprivileged Linux user and mount
+namespaces when available. It may be an internal helper executable if UID/GID map
+setup or fork/exec sequencing is cleaner outside `pre_exec`; it must not require
+a setuid binary in the initial path.
+
+If the helper cannot create the namespace, cannot bind required paths, or cannot
+set up the network policy, selection must fall back to Landlock/path-guard
+according to existing safety rules.
+
+### D5. Read isolation comes from absence, not parser heuristics
+
+Under the reified backend, read isolation is enforced because unmounted host
+paths do not exist in the subprocess filesystem view. The command-shape parser
+may still reject suspicious or unsupported invocations as preflight, but it is
+not the read isolation mechanism.
+
+This is the key semantic upgrade over Landlock:
+
+- declared workspace/mount paths are visible;
+- required OS substrate is visible read-only;
+- user home, secret stores, and arbitrary host paths are absent by default.
+
+### D6. Network confinement remains required
+
+Reification is about filesystem visibility. Network confinement still has to be
+applied through seccomp, Landlock network rules, namespace configuration, or an
+equivalent host mechanism before the backend is considered fully enforcing.
+
+If the filesystem view can be reified but network cannot be confined for a
+network-denied command, the backend must report degraded state and the policy
+layer must route network-capable operations to a human, deny them, or fall back
+to a backend with a network-confinement backstop. The autonomous reviewer is not
+eligible to approve network-capable execution while network is unconfined.
+
+### D7. Capability detection is explicit and auditable
+
+Backend detection should report which requirements are available:
+
+- Linux host;
+- unprivileged user namespaces;
+- mount namespace creation;
+- bind mounts;
+- read-only remount support;
+- private `/tmp` or scratch mount support;
+- network confinement support.
+
+Audit output must say whether reification is active, unavailable, or degraded,
+and why.
+
+## Risks / Trade-offs
+
+- **Container-runtime scope creep** -> Land capability detection and plan
+  generation first; keep the concrete runner behind a trait.
+- **Breaking normal shell tools by hiding too much OS substrate** -> Maintain a
+  minimal execution substrate list and test common shell commands before making
+  reification the preferred backend.
+- **Linux distro variance** -> Treat missing user namespace or mount namespace
+  support as expected fallback, not test failure.
+- **Path confusion during migration** -> Make backend audit and tool results
+  report whether paths are projected host paths or reified namespace paths.
+- **Security mistakes in helper sequencing** -> Prefer a small helper surface,
+  no setuid initial path, and tests that inspect the generated plan separately
+  from privileged operations.
+
+## Migration Plan
+
+1. Add `linux_reified_namespace` as a detectable-but-not-selected backend state
+   plus an auditable capability probe.
+2. Add `ReifiedNamespacePlan` and pure plan tests for workspace seed mounts,
+   additional host mounts, read-only mounts, virtual mount exclusion, cwd/path
+   translation, and execution substrate.
+3. Implement a Linux-only runner behind a trait and keep it opt-in or capability
+   gated.
+4. Add Linux-only smoke tests that verify:
+   - `/mnt/project` is visible when declared;
+   - arbitrary home paths are absent;
+   - write access follows mount access;
+   - network-denied commands cannot connect.
+5. Make backend selection prefer reification over Landlock only after the smoke
+   gates pass and degradation reporting is precise.
+
+Rollback is straightforward while Landlock remains the fallback: disable
+`linux_reified_namespace` selection and continue using projection.

--- a/openspec/changes/define-linux-namespace-reification/proposal.md
+++ b/openspec/changes/define-linux-namespace-reification/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+The projection path now keeps Alan OS namespace grants and native-subprocess
+sandbox writable roots in sync, but Linux still lacks full read isolation:
+Landlock can confine writes and network, yet broad host reads remain visible to
+native subprocesses. `define-namespace-driven-sandbox` records Linux reification
+as the future path where a subprocess sees a real, reduced filesystem view
+instead of the ambient host filesystem.
+
+This change defines the Linux-only reification contract and implementation
+sequence before building a container-runtime-class backend.
+
+## What Changes
+
+- Define a Linux reified namespace backend for native subprocess execution:
+  materialize a per-process filesystem view from the mount declaration list.
+- Reify host-backed Alan OS mounts as bind mounts in the subprocess view, so a
+  mounted `/mnt/project` path is the path the subprocess sees.
+- Preserve virtual Alan OS mounts as non-native: `/agent`, `/proc`, `/srv`,
+  `/mnt/llm`, and other pure aP file servers are not exposed as host filesystem
+  paths unless a later bridge explicitly implements one.
+- Add explicit capability detection and safe degradation:
+  if user namespaces, mount namespaces, bind mounts, or required helper support
+  are unavailable, Linux continues using the existing Landlock path and reports
+  that full read isolation is unavailable.
+- Keep macOS on Seatbelt projection. macOS reification is a non-goal.
+- Sequence implementation as incremental slices: capability probe and planning
+  model first, then a minimal runner, then enforcement hardening and verification.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `os-sandbox-enforcement`: Linux may select a reified namespace backend that
+  gives native subprocesses a reduced filesystem view with deny-by-default host
+  reads, while preserving safe fallback to Landlock/path-guard behavior when
+  reification is unavailable.
+
+## Impact
+
+- `crates/agent-engine/src/tools/sandbox_backend.rs`
+- `crates/agent-engine/src/tools/sandbox.rs`
+- Linux-specific subprocess launch path for `bash`
+- A new Linux reification planner/runner module or crate if the implementation
+  needs privileged helper isolation
+- Tests that model reified mount plans without requiring Linux namespaces, plus
+  Linux-only smoke tests guarded by capability detection
+- Parent OpenSpec task state in `define-namespace-driven-sandbox`

--- a/openspec/changes/define-linux-namespace-reification/specs/os-sandbox-enforcement/spec.md
+++ b/openspec/changes/define-linux-namespace-reification/specs/os-sandbox-enforcement/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Linux reified namespace backend provides full read isolation
+The Linux reified namespace backend SHALL run native subprocesses inside a
+reified filesystem view derived from host-backed Alan OS mount declarations when
+the host has the required namespace capabilities. In this mode, undeclared host
+paths SHALL be absent from the subprocess view by default, providing full read
+isolation through filesystem reification rather than command parsing or a
+sensitive-read denylist.
+
+#### Scenario: Reified backend exposes declared host mounts at namespace paths
+- **WHEN** a Linux runtime starts a native subprocess with a declared host-backed mount `/mnt/project`
+- **THEN** the subprocess sees the mounted content at `/mnt/project`
+- **AND** the subprocess does not need to use the original host path to access that mount
+
+#### Scenario: Undeclared host paths are absent
+- **WHEN** a command running under the reified backend attempts to read an undeclared host path such as the user's home secret directory
+- **THEN** that path is absent or unreachable from the subprocess filesystem view
+- **AND** read isolation does not depend on the command-shape parser
+
+#### Scenario: Virtual Alan OS mounts are not exposed as native paths
+- **WHEN** the Alan OS namespace contains virtual mounts such as `/agent`, `/srv`, `/proc`, or `/mnt/llm`
+- **THEN** the reified native subprocess view does not expose those mounts as host filesystem paths
+- **AND** only host-backed declarations contribute native bind mounts
+
+### Requirement: Reification preserves mount access and execution substrate boundaries
+The reified Linux backend SHALL distinguish declared host mounts from execution
+substrate. Declared read-write host mounts SHALL be writable where mounted;
+declared read-only host mounts SHALL be readable but not writable; execution
+substrate needed to launch commands SHALL be mounted read-only and SHALL NOT
+grant access to user data outside declared mounts.
+
+#### Scenario: Read-write host mount permits mutation at the reified path
+- **WHEN** a declared host mount has read-write access
+- **THEN** a native subprocess running under the reified backend can write under the corresponding reified namespace path
+- **AND** writes outside declared writable mounts are rejected
+
+#### Scenario: Read-only host mount rejects mutation at the reified path
+- **WHEN** a declared host mount has read-only access
+- **THEN** a native subprocess running under the reified backend can read under the corresponding reified namespace path
+- **AND** write attempts under that path are rejected
+
+#### Scenario: Execution substrate does not expose user data
+- **WHEN** the reified backend mounts system paths needed to execute `/bin/sh` and common tools
+- **THEN** those system paths are mounted only as execution substrate
+- **AND** user home directories and secret stores are not exposed unless explicitly declared
+
+### Requirement: Linux reification degrades safely
+The Linux reified namespace backend SHALL be selected only when the host can
+create the required user namespace, mount namespace, bind mounts, read-only
+mounts, and network confinement. If any required capability is unavailable, the
+runtime SHALL fall back to the existing Linux projection backend or path guard
+according to current safe-degradation rules and SHALL report why reification is
+unavailable.
+
+#### Scenario: Missing namespace capability falls back
+- **WHEN** the host cannot create an unprivileged user or mount namespace
+- **THEN** the Linux reified backend is not selected
+- **AND** backend reporting includes the missing capability reason
+- **AND** the runtime continues with Landlock or path-guard fallback behavior
+
+#### Scenario: Missing network confinement is degraded
+- **WHEN** the filesystem view can be reified but network confinement is unavailable for a network-denied command
+- **THEN** the backend reports degraded network confinement
+- **AND** policy routes network-capable operations to a human, denies them, or
+  falls back to a backend with network confinement
+- **AND** the autonomous reviewer cannot approve network-capable execution
+  without an OS network-confinement backstop
+
+#### Scenario: Backend audit names the active path
+- **WHEN** a native subprocess is evaluated or executed
+- **THEN** the decision audit identifies whether the active Linux path is `linux_reified_namespace`, `landlock`, or `workspace_path_guard`
+- **AND** the audit distinguishes reified namespace paths from projected host paths

--- a/openspec/changes/define-linux-namespace-reification/tasks.md
+++ b/openspec/changes/define-linux-namespace-reification/tasks.md
@@ -1,0 +1,54 @@
+## 1. Capability Probe And Backend Reporting
+
+- [ ] 1.1 Add a Linux reification capability probe that reports user namespace,
+  mount namespace, bind mount, read-only remount, scratch/tmp mount, and network
+  confinement support.
+- [ ] 1.2 Add a distinct `linux_reified_namespace` backend state/name and audit
+  fields without selecting it by default.
+- [ ] 1.3 Add unit tests for capability-report formatting, unavailable reasons,
+  and safe fallback ordering to Landlock/path guard.
+
+## 2. Reified Namespace Plan Model
+
+- [ ] 2.1 Add a pure `ReifiedNamespacePlan` model that separates declared host
+  mounts, read-only execution substrate, cwd, argv, scratch/tmp, and network
+  posture.
+- [ ] 2.2 Build plan derivation from the host-backed mount declaration /
+  sandbox authority data while excluding virtual Alan OS mounts.
+- [ ] 2.3 Add path translation helpers that map projected host paths to reified
+  namespace paths when a declared mount matches.
+- [ ] 2.4 Add unit tests for workspace seed mounts, extra read-write mounts,
+  read-only mounts, virtual mount exclusion, cwd translation, and out-of-view
+  rejection.
+
+## 3. Linux Runner Slice
+
+- [ ] 3.1 Add a `ReifiedNamespaceRunner` trait and keep the existing Landlock
+  execution path as fallback.
+- [ ] 3.2 Implement an opt-in Linux runner that attempts unprivileged user/mount
+  namespace creation, bind mounts the plan, applies read-only remounts, and execs
+  the requested command.
+- [ ] 3.3 Preserve safe degradation when namespace setup fails, including explicit
+  error/audit reporting and no silent ambient-host execution.
+
+## 4. Enforcement And Policy Integration
+
+- [ ] 4.1 Wire backend selection to prefer `linux_reified_namespace` only when the
+  probe and runner smoke checks pass.
+- [ ] 4.2 Ensure network-denied commands remain denied under the reified backend,
+  route to a human, or fall back to a network-confined backend when degraded;
+  never allow autonomous reviewer approval without network confinement.
+- [ ] 4.3 Update bash/tool policy audits to distinguish reified namespace paths
+  from projected host paths.
+
+## 5. Verification And PRs
+
+- [ ] 5.1 Add Linux-only smoke tests gated by capability detection for visible
+  `/mnt/<name>` mounts, absent undeclared home paths, read-only mount mutation
+  rejection, writable mount mutation, and network denial.
+- [ ] 5.2 Run focused Rust tests for the probe, plan model, path translation, and
+  fallback behavior; run Linux smoke tests when host capabilities are available.
+- [ ] 5.3 Run clippy for touched crates, OpenSpec strict validate, and diff
+  checks.
+- [ ] 5.4 Update parent namespace-driven sandbox task state and open stacked PRs
+  for each landed implementation slice.

--- a/openspec/changes/define-namespace-driven-sandbox/tasks.md
+++ b/openspec/changes/define-namespace-driven-sandbox/tasks.md
@@ -16,7 +16,7 @@ proposals out as their own OpenSpec changes. No application code lands here.
   `(host_path, access)` into the manifest + multi-entry projection in `alan`.
   Created 2026-07-02; first implementation slice adds `alan-hostfs`,
   composition-root host mount declarations, and `SandboxSpec` projection.
-- [ ] 1.3 Create change(s) for P3+ hardening: macOS Seatbelt sensitive-read
+- [x] 1.3 Create change(s) for P3+ hardening: macOS Seatbelt sensitive-read
   denylist; agent-requestable `mount` via `PolicyEngine` escalation; (later,
   separately) Linux reification for full read isolation. Created
   `add-seatbelt-sensitive-read-denylist` for the macOS sensitive-read slice and
@@ -25,8 +25,9 @@ proposals out as their own OpenSpec changes. No application code lands here.
   to the runtime tool sandbox projection; and
   `apply-mount-grants-to-live-namespace` for applying approved grants to the
   running Agent Process Alan OS namespace; this slice now adds the live kernel
-  mount handle, host applicator boundary, and resume reporting. Linux
-  reification remains pending.
+  mount handle, host applicator boundary, and resume reporting; and
+  `define-linux-namespace-reification` for the Linux-only full read isolation
+  path.
 
 ## 2. Carry the framing forward
 


### PR DESCRIPTION
## Summary
- add OpenSpec change for Linux-only namespace reification as the full read-isolation path
- extend os-sandbox-enforcement with reified filesystem-view requirements and safe fallback behavior
- mark the parent namespace/sandbox framing P3+ spinout complete while leaving archive pending until the stack lands

## Verification
- openspec validate define-linux-namespace-reification --strict
- openspec validate define-namespace-driven-sandbox --strict
- git diff --check