### PR TITLE
North Star 20/20: add reified namespace runner

### DIFF
--- a/crates/agent-engine/src/tools/mod.rs
+++ b/crates/agent-engine/src/tools/mod.rs
@@ -14,9 +14,11 @@ pub use context::{ToolContext, ToolExecutionBinding};
 pub use registry::{Tool, ToolLocality, ToolRegistry, ToolResult};
 pub use reified_namespace::{
     DEFAULT_SCRATCH_TMP_NAMESPACE_PATH, DEFAULT_WORKSPACE_NAMESPACE_PATH,
-    ReifiedExecutionSubstrateMount, ReifiedHostMount, ReifiedMountAccess, ReifiedMountDeclaration,
-    ReifiedMountSource, ReifiedNamespacePlan, ReifiedNamespacePlanError, ReifiedNamespacePlanInput,
-    ReifiedScratchTmpMount, default_execution_substrate,
+    LinuxReifiedNamespaceRunner, ReifiedExecutionSubstrateMount, ReifiedHostMount,
+    ReifiedMountAccess, ReifiedMountDeclaration, ReifiedMountSource, ReifiedNamespaceCommandSpec,
+    ReifiedNamespacePlan, ReifiedNamespacePlanError, ReifiedNamespacePlanInput,
+    ReifiedNamespaceRunError, ReifiedNamespaceRunner, ReifiedScratchTmpMount,
+    default_execution_substrate,
 };
 pub use sandbox::{ExecResult, NetworkPosture, Sandbox, SandboxSpec};
 pub use sandbox_backend::{

--- a/crates/agent-engine/src/tools/reified_namespace.rs
+++ b/crates/agent-engine/src/tools/reified_namespace.rs
@@ -4,11 +4,18 @@
 //! host-backed mount authority that the native runner will consume into a stable
 //! plan that can be tested on any host.
 
+#[cfg(target_os = "linux")]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
+#[cfg(target_os = "linux")]
+use std::process::Command;
 
 use thiserror::Error;
 
-use super::sandbox::NetworkPosture;
+use super::sandbox::{ExecResult, NetworkPosture};
+use super::sandbox_backend::{SandboxBackendKind, detect_backend};
+#[cfg(target_os = "linux")]
+use super::sandbox_backend::{preferred_linux_backend_with_reification, probe_linux_reification};
 
 /// Default namespace path for the workspace seed mount.
 pub const DEFAULT_WORKSPACE_NAMESPACE_PATH: &str = "/mnt/workspace";
@@ -315,6 +322,555 @@ pub enum ReifiedNamespacePlanError {
     CwdOutsideView { cwd: PathBuf },
 }
 
+/// Runner abstraction for an opt-in reified namespace backend.
+pub trait ReifiedNamespaceRunner: std::fmt::Debug + Send + Sync {
+    /// Run the command described by a reified namespace plan.
+    fn run(&self, plan: &ReifiedNamespacePlan) -> Result<ExecResult, ReifiedNamespaceRunError>;
+}
+
+/// Opt-in Linux implementation backed by unprivileged user/mount namespaces.
+#[derive(Debug, Clone)]
+pub struct LinuxReifiedNamespaceRunner {
+    fallback_backend: SandboxBackendKind,
+}
+
+impl Default for LinuxReifiedNamespaceRunner {
+    fn default() -> Self {
+        Self {
+            fallback_backend: detect_backend(),
+        }
+    }
+}
+
+impl LinuxReifiedNamespaceRunner {
+    /// Create a runner that reports the supplied backend when reification cannot run.
+    pub const fn with_fallback_backend(fallback_backend: SandboxBackendKind) -> Self {
+        Self { fallback_backend }
+    }
+
+    /// Backend that callers should use when this opt-in runner reports unavailable.
+    pub const fn fallback_backend(&self) -> SandboxBackendKind {
+        self.fallback_backend
+    }
+}
+
+impl ReifiedNamespaceRunner for LinuxReifiedNamespaceRunner {
+    fn run(&self, plan: &ReifiedNamespacePlan) -> Result<ExecResult, ReifiedNamespaceRunError> {
+        self.run_inner(plan)
+    }
+}
+
+/// Error returned when reified namespace execution cannot run safely.
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+#[error(
+    "linux_reified_namespace unavailable: {reason}; fallback_backend={}",
+    fallback_backend.name()
+)]
+pub struct ReifiedNamespaceRunError {
+    pub reason: String,
+    pub fallback_backend: SandboxBackendKind,
+    pub audit_fields: Vec<(&'static str, String)>,
+}
+
+impl ReifiedNamespaceRunError {
+    fn new(
+        reason: impl Into<String>,
+        fallback_backend: SandboxBackendKind,
+        audit_fields: Vec<(&'static str, String)>,
+    ) -> Self {
+        Self {
+            reason: reason.into(),
+            fallback_backend,
+            audit_fields,
+        }
+    }
+}
+
+/// Command line produced for the Linux helper path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReifiedNamespaceCommandSpec {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+impl ReifiedNamespaceCommandSpec {
+    #[cfg(target_os = "linux")]
+    fn command(&self) -> Command {
+        let mut command = Command::new(&self.program);
+        command.args(&self.args);
+        command.env("PATH", TRUSTED_LINUX_SETUP_PATH);
+        command
+    }
+}
+
+#[cfg(target_os = "linux")]
+const SETUP_FAILURE_PREFIX: &str = "alan reified namespace setup failed:";
+
+#[cfg(target_os = "linux")]
+const TRUSTED_LINUX_SETUP_PATH: &str = "/usr/sbin:/usr/bin:/sbin:/bin";
+
+#[cfg(target_os = "linux")]
+const LINUX_REIFIED_NAMESPACE_SCRIPT: &str = r#"
+set -u
+PATH='/usr/sbin:/usr/bin:/sbin:/bin'
+export PATH
+fail() {
+  printf '%s %s\n' 'alan reified namespace setup failed:' "$*" >&2
+  exit 125
+}
+
+root="$1"; shift
+setup_marker="$1"; shift
+mount_bin="$1"; shift
+chroot_bin="$1"; shift
+namespace_shell="$1"; shift
+namespace_setpriv="$1"; shift
+
+"$mount_bin" --make-rprivate / || fail "make root private"
+"$mount_bin" --bind "$root" "$root" || fail "bind root"
+"$mount_bin" -o remount,bind,ro "$root" || fail "remount root read-only"
+
+mount_count="$1"; shift
+while [ "$mount_count" -gt 0 ]; do
+  namespace_path="$1"; shift
+  host_path="$1"; shift
+  access="$1"; shift
+  destination="${root}${namespace_path}"
+  "$mount_bin" --bind "$host_path" "$destination" || fail "bind mount ${namespace_path}"
+  if [ "$access" = "read_only" ]; then
+    "$mount_bin" -o remount,bind,ro "$destination" || fail "remount ${namespace_path} read-only"
+  fi
+  mount_count=$((mount_count - 1))
+done
+
+substrate_count="$1"; shift
+while [ "$substrate_count" -gt 0 ]; do
+  namespace_path="$1"; shift
+  host_path="$1"; shift
+  destination="${root}${namespace_path}"
+  "$mount_bin" --bind "$host_path" "$destination" || fail "bind substrate ${namespace_path}"
+  "$mount_bin" -o remount,bind,ro "$destination" || fail "remount substrate ${namespace_path} read-only"
+  substrate_count=$((substrate_count - 1))
+done
+
+"$mount_bin" --bind /dev/null "${root}/dev/null" || fail "bind /dev/null"
+
+scratch_tmp="$1"; shift
+scratch_destination="${root}${scratch_tmp}"
+"$mount_bin" -t tmpfs tmpfs "$scratch_destination" || fail "mount scratch tmp"
+
+cwd="$1"; shift
+"$chroot_bin" "$root" "$namespace_shell" -c 'cd "$1" || exit 126; shift; setpriv_bin="$1"; shift; shell_bin="$1"; shift; exec "$setpriv_bin" --no-new-privs --bounding-set=-all --inh-caps=-all --ambient-caps=-all "$shell_bin" -c '"'"'printf "%s\n" ok >&3 || exit 125; exec 3>&-; exec "$@"'"'"' alan-reified-command "$@"' alan-reified-command "$cwd" "$namespace_setpriv" "$namespace_shell" "$@" 3>"$setup_marker"
+"#;
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LinuxSetupHelpers {
+    unshare: PathBuf,
+    host_shell: PathBuf,
+    mount: PathBuf,
+    chroot: PathBuf,
+    namespace_shell: PathBuf,
+    namespace_setpriv: PathBuf,
+}
+
+#[cfg(target_os = "linux")]
+impl LinuxSetupHelpers {
+    fn resolve() -> Result<Self, String> {
+        Ok(Self {
+            unshare: resolve_trusted_linux_helper(
+                "unshare",
+                &["/usr/bin/unshare", "/bin/unshare"],
+            )?,
+            host_shell: resolve_trusted_linux_helper("sh", &["/bin/sh", "/usr/bin/sh"])?,
+            mount: resolve_trusted_linux_helper("mount", &["/usr/bin/mount", "/bin/mount"])?,
+            chroot: resolve_trusted_linux_helper(
+                "chroot",
+                &[
+                    "/usr/sbin/chroot",
+                    "/usr/bin/chroot",
+                    "/sbin/chroot",
+                    "/bin/chroot",
+                ],
+            )?,
+            namespace_shell: resolve_trusted_linux_helper("sh", &["/bin/sh", "/usr/bin/sh"])?,
+            namespace_setpriv: resolve_trusted_linux_helper(
+                "setpriv",
+                &["/usr/bin/setpriv", "/bin/setpriv"],
+            )?,
+        })
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+impl LinuxReifiedNamespaceRunner {
+    fn run_inner(
+        &self,
+        _plan: &ReifiedNamespacePlan,
+    ) -> Result<ExecResult, ReifiedNamespaceRunError> {
+        Err(ReifiedNamespaceRunError::new(
+            "linux reified namespace runner is only available on Linux",
+            self.fallback_backend,
+            vec![
+                (
+                    "backend",
+                    SandboxBackendKind::LinuxReifiedNamespace.name().to_string(),
+                ),
+                ("status", "unavailable".to_string()),
+                ("reason", "not a linux host".to_string()),
+                ("fallback_backend", self.fallback_backend.name().to_string()),
+            ],
+        ))
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl LinuxReifiedNamespaceRunner {
+    fn run_inner(
+        &self,
+        plan: &ReifiedNamespacePlan,
+    ) -> Result<ExecResult, ReifiedNamespaceRunError> {
+        if plan.argv.is_empty() {
+            return Err(self.error("argv must not be empty", Vec::new()));
+        }
+
+        let report = probe_linux_reification();
+        let fallback_backend = preferred_linux_backend_with_reification(
+            &report,
+            matches!(self.fallback_backend, SandboxBackendKind::Landlock),
+        );
+        if !report.is_selectable() {
+            return Err(ReifiedNamespaceRunError::new(
+                format!(
+                    "capability probe did not select reification: {}",
+                    report.unavailable_reasons().join("; ")
+                ),
+                if matches!(fallback_backend, SandboxBackendKind::LinuxReifiedNamespace) {
+                    self.fallback_backend
+                } else {
+                    fallback_backend
+                },
+                report.audit_fields(),
+            ));
+        }
+
+        let temp_root = ReifiedRunnerTemp::create(plan)
+            .map_err(|err| self.error(format!("create reified root failed: {err}"), Vec::new()))?;
+        let command_spec = build_linux_reified_namespace_command(plan, &temp_root)
+            .map_err(|err| self.error(err, Vec::new()))?;
+        let output = command_spec
+            .command()
+            .output()
+            .map_err(|err| self.error(format!("failed to start unshare: {err}"), Vec::new()))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let exit_code = output.status.code().unwrap_or(-1);
+        if setup_marker_was_written(&temp_root.setup_marker) {
+            return Ok(ExecResult {
+                stdout,
+                stderr,
+                exit_code,
+            });
+        }
+
+        let reason = if stderr.contains(SETUP_FAILURE_PREFIX) {
+            stderr.trim().to_string()
+        } else {
+            format!("namespace setup failed before command execution: exit_code={exit_code}")
+        };
+        Err(self.error(reason, command_spec.audit_fields()))
+    }
+
+    fn error(
+        &self,
+        reason: impl Into<String>,
+        mut audit_fields: Vec<(&'static str, String)>,
+    ) -> ReifiedNamespaceRunError {
+        audit_fields.extend([
+            (
+                "backend",
+                SandboxBackendKind::LinuxReifiedNamespace.name().to_string(),
+            ),
+            ("status", "unavailable".to_string()),
+            ("fallback_backend", self.fallback_backend.name().to_string()),
+        ]);
+        ReifiedNamespaceRunError::new(reason, self.fallback_backend, audit_fields)
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug)]
+struct ReifiedRunnerTemp {
+    parent: PathBuf,
+    root: PathBuf,
+    setup_marker: PathBuf,
+}
+
+#[cfg(target_os = "linux")]
+impl ReifiedRunnerTemp {
+    fn create(plan: &ReifiedNamespacePlan) -> std::io::Result<Self> {
+        let mut last_error = None;
+        for base in reified_runner_temp_base_candidates() {
+            let base = canonicalize_existing_host_path(&base);
+            for _ in 0..8 {
+                let parent = base.join(format!(
+                    "alan-reified-runner-{}-{}",
+                    std::process::id(),
+                    uuid::Uuid::new_v4()
+                ));
+                if temp_parent_is_exposed_to_writable_mount(&parent, &plan.declared_host_mounts) {
+                    continue;
+                }
+
+                let root = parent.join("root");
+                match std::fs::create_dir_all(&root) {
+                    Ok(()) => {
+                        return Ok(Self {
+                            setup_marker: parent.join("setup-ok"),
+                            parent,
+                            root,
+                        });
+                    }
+                    Err(err) => last_error = Some(err),
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "no reified runner temp directory outside writable mounts",
+            )
+        }))
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for ReifiedRunnerTemp {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.parent);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn build_linux_reified_namespace_command(
+    plan: &ReifiedNamespacePlan,
+    temp_root: &ReifiedRunnerTemp,
+) -> Result<ReifiedNamespaceCommandSpec, String> {
+    let helpers = LinuxSetupHelpers::resolve()?;
+    build_linux_reified_namespace_command_with_helpers(plan, temp_root, &helpers)
+}
+
+#[cfg(target_os = "linux")]
+fn build_linux_reified_namespace_command_with_helpers(
+    plan: &ReifiedNamespacePlan,
+    temp_root: &ReifiedRunnerTemp,
+    helpers: &LinuxSetupHelpers,
+) -> Result<ReifiedNamespaceCommandSpec, String> {
+    if plan.argv.is_empty() {
+        return Err("argv must not be empty".to_string());
+    }
+    prepare_reified_root(plan, &temp_root.root)?;
+
+    let mut args = vec![
+        "--user".to_string(),
+        "--map-root-user".to_string(),
+        "--mount".to_string(),
+    ];
+    if matches!(plan.network, NetworkPosture::Deny) {
+        args.push("--net".to_string());
+    }
+    args.extend([
+        "--".to_string(),
+        helpers.host_shell.display().to_string(),
+        "-c".to_string(),
+        LINUX_REIFIED_NAMESPACE_SCRIPT.to_string(),
+        "alan-reified-runner".to_string(),
+        temp_root.root.display().to_string(),
+        temp_root.setup_marker.display().to_string(),
+        helpers.mount.display().to_string(),
+        helpers.chroot.display().to_string(),
+        helpers.namespace_shell.display().to_string(),
+        helpers.namespace_setpriv.display().to_string(),
+        plan.declared_host_mounts.len().to_string(),
+    ]);
+    for mount in &plan.declared_host_mounts {
+        args.push(mount.namespace_path.display().to_string());
+        args.push(mount.host_path.display().to_string());
+        args.push(mount.access.as_str().to_string());
+    }
+
+    let execution_substrate = existing_execution_substrate(plan);
+    args.push(execution_substrate.len().to_string());
+    for mount in &execution_substrate {
+        args.push(mount.namespace_path.display().to_string());
+        args.push(mount.host_path.display().to_string());
+    }
+
+    args.push(plan.scratch_tmp.namespace_path.display().to_string());
+    args.push(plan.cwd.display().to_string());
+    args.extend(plan.argv.iter().cloned());
+
+    Ok(ReifiedNamespaceCommandSpec {
+        program: helpers.unshare.display().to_string(),
+        args,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn resolve_trusted_linux_helper(name: &str, candidates: &[&str]) -> Result<PathBuf, String> {
+    candidates
+        .iter()
+        .map(Path::new)
+        .find(|path| {
+            std::fs::metadata(path)
+                .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+                .unwrap_or(false)
+        })
+        .map(Path::to_path_buf)
+        .ok_or_else(|| {
+            format!(
+                "trusted linux helper {name} not found in {}",
+                candidates.join(", ")
+            )
+        })
+}
+
+#[cfg(target_os = "linux")]
+fn setup_marker_was_written(path: &Path) -> bool {
+    matches!(std::fs::read(path), Ok(contents) if contents == b"ok\n")
+}
+
+#[cfg(target_os = "linux")]
+impl ReifiedNamespaceCommandSpec {
+    fn audit_fields(&self) -> Vec<(&'static str, String)> {
+        vec![
+            ("program", self.program.clone()),
+            ("arg_count", self.args.len().to_string()),
+        ]
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn existing_execution_substrate(
+    plan: &ReifiedNamespacePlan,
+) -> Vec<ReifiedExecutionSubstrateMount> {
+    plan.execution_substrate
+        .iter()
+        .filter(|mount| mount.host_path.exists())
+        .cloned()
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn reified_runner_temp_base_candidates() -> Vec<PathBuf> {
+    let mut candidates = vec![std::env::temp_dir(), PathBuf::from("/var/tmp")];
+    if !candidates
+        .iter()
+        .any(|candidate| candidate == Path::new("/tmp"))
+    {
+        candidates.push(PathBuf::from("/tmp"));
+    }
+    candidates
+}
+
+#[cfg(target_os = "linux")]
+fn temp_parent_is_exposed_to_writable_mount(parent: &Path, mounts: &[ReifiedHostMount]) -> bool {
+    mounts
+        .iter()
+        .filter(|mount| mount.access.is_writable())
+        .any(|mount| paths_overlap(parent, &mount.host_path))
+}
+
+#[cfg(target_os = "linux")]
+fn prepare_reified_root(plan: &ReifiedNamespacePlan, root: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(root).map_err(|err| format!("create root failed: {err}"))?;
+
+    prepare_dev_null_destination(root)?;
+    for mount in &plan.declared_host_mounts {
+        prepare_mount_destination(root, &mount.namespace_path, &mount.host_path, true)?;
+    }
+    for mount in existing_execution_substrate(plan) {
+        prepare_mount_destination(root, &mount.namespace_path, &mount.host_path, false)?;
+    }
+    let scratch_destination = namespace_path_under_root(root, &plan.scratch_tmp.namespace_path)?;
+    std::fs::create_dir_all(&scratch_destination)
+        .map_err(|err| format!("create scratch tmp mountpoint failed: {err}"))?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn prepare_dev_null_destination(root: &Path) -> Result<(), String> {
+    let dev_dir = root.join("dev");
+    std::fs::create_dir_all(&dev_dir)
+        .map_err(|err| format!("create /dev mountpoint parent failed: {err}"))?;
+    let dev_null = dev_dir.join("null");
+    std::fs::File::create(&dev_null)
+        .map_err(|err| format!("create /dev/null mountpoint failed: {err}"))?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn prepare_mount_destination(
+    root: &Path,
+    namespace_path: &Path,
+    host_path: &Path,
+    required: bool,
+) -> Result<(), String> {
+    let metadata = match std::fs::metadata(host_path) {
+        Ok(metadata) => metadata,
+        Err(err) if required => {
+            return Err(format!(
+                "host mount source {} unavailable: {err}",
+                host_path.display()
+            ));
+        }
+        Err(_) => return Ok(()),
+    };
+    let destination = namespace_path_under_root(root, namespace_path)?;
+    if metadata.is_file() {
+        if let Some(parent) = destination.parent() {
+            std::fs::create_dir_all(parent).map_err(|err| {
+                format!(
+                    "create mountpoint parent {} failed: {err}",
+                    parent.display()
+                )
+            })?;
+        }
+        std::fs::File::create(&destination)
+            .map_err(|err| format!("create mountpoint {} failed: {err}", destination.display()))?;
+    } else {
+        std::fs::create_dir_all(&destination)
+            .map_err(|err| format!("create mountpoint {} failed: {err}", destination.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn namespace_path_under_root(root: &Path, namespace_path: &Path) -> Result<PathBuf, String> {
+    if !namespace_path.is_absolute() || contains_parent_component(namespace_path) {
+        return Err(format!(
+            "invalid namespace path {}",
+            namespace_path.display()
+        ));
+    }
+    let mut destination = root.to_path_buf();
+    for component in namespace_path.components() {
+        match component {
+            Component::RootDir | Component::CurDir => {}
+            Component::Normal(part) => destination.push(part),
+            Component::ParentDir | Component::Prefix(_) => {
+                return Err(format!(
+                    "invalid namespace path {}",
+                    namespace_path.display()
+                ));
+            }
+        }
+    }
+    Ok(destination)
+}
+
 fn translate_host_path_with_mounts(
     mounts: &[ReifiedHostMount],
     host_path: &Path,
@@ -487,6 +1043,18 @@ mod tests {
 
     fn shell_argv() -> Vec<String> {
         vec!["sh".to_string(), "-c".to_string(), "pwd".to_string()]
+    }
+
+    #[cfg(target_os = "linux")]
+    fn test_linux_setup_helpers() -> LinuxSetupHelpers {
+        LinuxSetupHelpers {
+            unshare: PathBuf::from("/usr/bin/unshare"),
+            host_shell: PathBuf::from("/bin/sh"),
+            mount: PathBuf::from("/usr/bin/mount"),
+            chroot: PathBuf::from("/usr/sbin/chroot"),
+            namespace_shell: PathBuf::from("/bin/sh"),
+            namespace_setpriv: PathBuf::from("/usr/bin/setpriv"),
+        }
     }
 
     #[test]
@@ -1062,5 +1630,187 @@ mod tests {
             ReifiedNamespacePlan::derive(input),
             Err(ReifiedNamespacePlanError::RootNamespacePath)
         );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn linux_runner_reports_non_linux_unavailable_without_ambient_execution() {
+        let plan = ReifiedNamespacePlan::workspace_seed(
+            "/host/workspace",
+            "/host/workspace",
+            shell_argv(),
+            NetworkPosture::Deny,
+        )
+        .unwrap();
+        let runner = LinuxReifiedNamespaceRunner::with_fallback_backend(
+            SandboxBackendKind::WorkspacePathGuard,
+        );
+
+        let error = runner.run(&plan).unwrap_err();
+
+        assert_eq!(
+            error.reason,
+            "linux reified namespace runner is only available on Linux"
+        );
+        assert_eq!(
+            error.fallback_backend,
+            SandboxBackendKind::WorkspacePathGuard
+        );
+        assert!(
+            error
+                .audit_fields
+                .contains(&("backend", "linux_reified_namespace".to_string()))
+        );
+        assert!(
+            error
+                .audit_fields
+                .contains(&("fallback_backend", "workspace_path_guard".to_string()))
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_runner_command_uses_unshare_mount_chroot_and_network_namespace() {
+        let workspace = tempfile::tempdir().unwrap();
+        let docs = tempfile::tempdir().unwrap();
+        let substrate = tempfile::tempdir().unwrap();
+        let plan = ReifiedNamespacePlan::derive(
+            ReifiedNamespacePlanInput::new(
+                vec![
+                    ReifiedMountDeclaration::host(
+                        "/mnt/project",
+                        workspace.path(),
+                        ReifiedMountAccess::ReadWrite,
+                    ),
+                    ReifiedMountDeclaration::host(
+                        "/mnt/docs",
+                        docs.path(),
+                        ReifiedMountAccess::ReadOnly,
+                    ),
+                ],
+                workspace.path(),
+                vec!["sh".to_string(), "-c".to_string(), "pwd".to_string()],
+                NetworkPosture::Deny,
+            )
+            .with_execution_substrate(vec![ReifiedExecutionSubstrateMount::new(
+                "/bin",
+                substrate.path(),
+            )]),
+        )
+        .unwrap();
+        let temp_root = ReifiedRunnerTemp::create(&plan).unwrap();
+
+        let helpers = test_linux_setup_helpers();
+        let command =
+            build_linux_reified_namespace_command_with_helpers(&plan, &temp_root, &helpers)
+                .unwrap();
+
+        assert_eq!(command.program, "/usr/bin/unshare");
+        assert!(command.args.contains(&"--user".to_string()));
+        assert!(command.args.contains(&"--map-root-user".to_string()));
+        assert!(command.args.contains(&"--mount".to_string()));
+        assert!(command.args.contains(&"--net".to_string()));
+        assert!(
+            command
+                .args
+                .iter()
+                .any(|arg| arg.contains("remount,bind,ro \"$root\""))
+        );
+        assert!(command.args.contains(&"/mnt/project".to_string()));
+        assert!(command.args.contains(&"/mnt/docs".to_string()));
+        assert!(command.args.contains(&"read_only".to_string()));
+        assert!(temp_root.root.join("dev/null").exists());
+        assert!(command.args.contains(&"/bin".to_string()));
+        assert!(command.args.contains(&"/mnt/project".to_string()));
+        let script = command
+            .args
+            .iter()
+            .find(|arg| arg.contains("alan reified namespace setup failed"))
+            .unwrap();
+        assert!(script.contains("PATH='/usr/sbin:/usr/bin:/sbin:/bin'"));
+        assert!(script.contains("\"$mount_bin\" --make-rprivate / || fail \"make root private\""));
+        assert!(!script.contains("--make-rprivate / 2>/dev/null || true"));
+        assert!(script.contains("\"$mount_bin\" --bind /dev/null \"${root}/dev/null\""));
+        assert!(script.contains("\"$mount_bin\" --bind \"$host_path\" \"$destination\""));
+        assert!(script.contains("\"$chroot_bin\" \"$root\" \"$namespace_shell\""));
+        assert!(!script.contains("chroot \"$root\""));
+        assert!(!script.contains("exec setpriv --no-new-privs"));
+        assert!(script.contains("exec \"$setpriv_bin\" --no-new-privs"));
+        assert!(script.contains("--bounding-set=-all"));
+        assert!(script.contains("--inh-caps=-all"));
+        assert!(script.contains("--ambient-caps=-all"));
+        assert!(script.contains("printf \"%s\\n\" ok >&3"));
+        assert!(script.contains("exec 3>&-; exec \"$@\""));
+        assert!(script.contains("3>\"$setup_marker\""));
+        assert!(command.args.contains(&"/bin/sh".to_string()));
+        assert!(command.args.contains(&"/usr/bin/mount".to_string()));
+        assert!(command.args.contains(&"/usr/sbin/chroot".to_string()));
+        assert!(command.args.contains(&"/usr/bin/setpriv".to_string()));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_runner_command_allows_network_by_omitting_network_namespace() {
+        let workspace = tempfile::tempdir().unwrap();
+        let plan = ReifiedNamespacePlan::workspace_seed(
+            workspace.path(),
+            workspace.path(),
+            vec!["sh".to_string(), "-c".to_string(), "true".to_string()],
+            NetworkPosture::Allow,
+        )
+        .unwrap();
+        let temp_root = ReifiedRunnerTemp::create(&plan).unwrap();
+
+        let helpers = test_linux_setup_helpers();
+        let command =
+            build_linux_reified_namespace_command_with_helpers(&plan, &temp_root, &helpers)
+                .unwrap();
+
+        assert!(!command.args.contains(&"--net".to_string()));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_runner_temp_parent_must_not_overlap_writable_mounts() {
+        let mounts = vec![
+            ReifiedHostMount {
+                namespace_path: PathBuf::from("/mnt/tmp"),
+                host_path: PathBuf::from("/tmp"),
+                access: ReifiedMountAccess::ReadWrite,
+            },
+            ReifiedHostMount {
+                namespace_path: PathBuf::from("/mnt/docs"),
+                host_path: PathBuf::from("/var/docs"),
+                access: ReifiedMountAccess::ReadOnly,
+            },
+        ];
+
+        assert!(temp_parent_is_exposed_to_writable_mount(
+            Path::new("/tmp/alan-reified-runner-1"),
+            &mounts
+        ));
+        assert!(!temp_parent_is_exposed_to_writable_mount(
+            Path::new("/var/docs/alan-reified-runner-1"),
+            &mounts
+        ));
+        assert!(!temp_parent_is_exposed_to_writable_mount(
+            Path::new("/var/tmp/alan-reified-runner-1"),
+            &mounts
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_runner_setup_marker_requires_success_content() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let marker = temp_dir.path().join("setup-ok");
+
+        assert!(!setup_marker_was_written(&marker));
+
+        std::fs::write(&marker, b"").unwrap();
+        assert!(!setup_marker_was_written(&marker));
+
+        std::fs::write(&marker, b"ok\n").unwrap();
+        assert!(setup_marker_was_written(&marker));
     }
 }

--- a/crates/agent-engine/src/tools/reified_namespace.rs
+++ b/crates/agent-engine/src/tools/reified_namespace.rs
@@ -13,6 +13,8 @@ use std::process::Command;
 use thiserror::Error;
 
 use super::sandbox::{ExecResult, NetworkPosture};
+#[cfg(any(test, target_os = "linux"))]
+use super::sandbox_backend::{LinuxReificationCapability, LinuxReificationCapabilityReport};
 use super::sandbox_backend::{SandboxBackendKind, detect_backend};
 #[cfg(target_os = "linux")]
 use super::sandbox_backend::{preferred_linux_backend_with_reification, probe_linux_reification};
@@ -398,6 +400,7 @@ impl ReifiedNamespaceCommandSpec {
     fn command(&self) -> Command {
         let mut command = Command::new(&self.program);
         command.args(&self.args);
+        command.env_clear();
         command.env("PATH", TRUSTED_LINUX_SETUP_PATH);
         command
     }
@@ -539,11 +542,12 @@ impl LinuxReifiedNamespaceRunner {
             &report,
             matches!(self.fallback_backend, SandboxBackendKind::Landlock),
         );
-        if !report.is_selectable() {
+        if !linux_reification_report_supports_plan(&report, plan.network) {
             return Err(ReifiedNamespaceRunError::new(
                 format!(
                     "capability probe did not select reification: {}",
-                    report.unavailable_reasons().join("; ")
+                    linux_reification_unavailable_reasons_for_plan(&report, plan.network)
+                        .join("; ")
                 ),
                 if matches!(fallback_backend, SandboxBackendKind::LinuxReifiedNamespace) {
                     self.fallback_backend
@@ -596,6 +600,70 @@ impl LinuxReifiedNamespaceRunner {
             ("fallback_backend", self.fallback_backend.name().to_string()),
         ]);
         ReifiedNamespaceRunError::new(reason, self.fallback_backend, audit_fields)
+    }
+}
+
+#[cfg(any(test, target_os = "linux"))]
+fn linux_reification_report_supports_plan(
+    report: &LinuxReificationCapabilityReport,
+    network: NetworkPosture,
+) -> bool {
+    report.linux_host.is_available()
+        && report.user_namespace.is_available()
+        && report.mount_namespace.is_available()
+        && report.bind_mount.is_available()
+        && report.read_only_remount.is_available()
+        && report.scratch_tmp_mount.is_available()
+        && (matches!(network, NetworkPosture::Allow) || report.network_confinement.is_available())
+}
+
+#[cfg(any(test, target_os = "linux"))]
+fn linux_reification_unavailable_reasons_for_plan(
+    report: &LinuxReificationCapabilityReport,
+    network: NetworkPosture,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    push_missing_linux_reification_requirement(&mut reasons, "linux_host", &report.linux_host);
+    push_missing_linux_reification_requirement(
+        &mut reasons,
+        "user_namespace",
+        &report.user_namespace,
+    );
+    push_missing_linux_reification_requirement(
+        &mut reasons,
+        "mount_namespace",
+        &report.mount_namespace,
+    );
+    push_missing_linux_reification_requirement(&mut reasons, "bind_mount", &report.bind_mount);
+    push_missing_linux_reification_requirement(
+        &mut reasons,
+        "read_only_remount",
+        &report.read_only_remount,
+    );
+    push_missing_linux_reification_requirement(
+        &mut reasons,
+        "scratch_tmp_mount",
+        &report.scratch_tmp_mount,
+    );
+    if matches!(network, NetworkPosture::Deny) {
+        push_missing_linux_reification_requirement(
+            &mut reasons,
+            "network_confinement",
+            &report.network_confinement,
+        );
+    }
+    reasons
+}
+
+#[cfg(any(test, target_os = "linux"))]
+fn push_missing_linux_reification_requirement(
+    reasons: &mut Vec<String>,
+    name: &'static str,
+    capability: &LinuxReificationCapability,
+) {
+    if !capability.is_available() {
+        let reason = capability.reason().unwrap_or("no reason reported");
+        reasons.push(format!("{name}: {reason}"));
     }
 }
 
@@ -1665,6 +1733,54 @@ mod tests {
             error
                 .audit_fields
                 .contains(&("fallback_backend", "workspace_path_guard".to_string()))
+        );
+    }
+
+    #[test]
+    fn reification_report_selection_requires_network_only_for_denied_plans() {
+        let report = LinuxReificationCapabilityReport::new(
+            LinuxReificationCapability::available(),
+            LinuxReificationCapability::available(),
+            LinuxReificationCapability::available(),
+            LinuxReificationCapability::available(),
+            LinuxReificationCapability::available(),
+            LinuxReificationCapability::available(),
+            LinuxReificationCapability::unavailable("network namespaces disabled"),
+        );
+
+        assert!(linux_reification_report_supports_plan(
+            &report,
+            NetworkPosture::Allow
+        ));
+        assert!(!linux_reification_report_supports_plan(
+            &report,
+            NetworkPosture::Deny
+        ));
+        assert_eq!(
+            linux_reification_unavailable_reasons_for_plan(&report, NetworkPosture::Allow),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            linux_reification_unavailable_reasons_for_plan(&report, NetworkPosture::Deny),
+            vec!["network_confinement: network namespaces disabled".to_string()]
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_runner_command_clears_inherited_environment() {
+        let output = ReifiedNamespaceCommandSpec {
+            program: "/usr/bin/env".to_string(),
+            args: Vec::new(),
+        }
+        .command()
+        .output()
+        .unwrap();
+
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8(output.stdout).unwrap(),
+            format!("PATH={TRUSTED_LINUX_SETUP_PATH}\n")
         );
     }
 

--- a/crates/agent-engine/src/tools/sandbox_backend.rs
+++ b/crates/agent-engine/src/tools/sandbox_backend.rs
@@ -17,6 +17,8 @@
 //! not auto-run — the policy escalates it).
 
 use std::fmt;
+#[cfg(target_os = "linux")]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
 
 /// Available sandbox enforcement backends, in order of strength.
@@ -316,14 +318,17 @@ fn probe_linux_reification_for_host() -> LinuxReificationCapabilityReport {
 }
 
 #[cfg(target_os = "linux")]
+const TRUSTED_LINUX_PROBE_PATH: &str = "/usr/sbin:/usr/bin:/sbin:/bin";
+
+#[cfg(target_os = "linux")]
 fn probe_linux_reification_for_host() -> LinuxReificationCapabilityReport {
     let linux_host = LinuxReificationCapability::available();
-    let user_namespace = run_linux_probe(
+    let user_namespace = run_linux_probe_command(
         "user namespace",
         linux_unshare_command(&["--user", "--map-root-user"]),
     );
     let mount_namespace = if user_namespace.is_available() {
-        run_linux_probe(
+        run_linux_probe_command(
             "mount namespace",
             linux_unshare_command(&["--user", "--map-root-user", "--mount"]),
         )
@@ -334,8 +339,8 @@ fn probe_linux_reification_for_host() -> LinuxReificationCapabilityReport {
     let bind_mount = if mount_namespace.is_available() {
         run_mount_probe(
             "bind mount",
-            "mount --make-rprivate / 2>/dev/null || true; \
-             mount --bind \"$1\" \"$2\"; \
+            "\"$ALAN_PROBE_MOUNT_BIN\" --make-rprivate / && \
+             \"$ALAN_PROBE_MOUNT_BIN\" --bind \"$1\" \"$2\" && \
              test -f \"$2/probe-file\"",
         )
     } else {
@@ -345,10 +350,10 @@ fn probe_linux_reification_for_host() -> LinuxReificationCapabilityReport {
     let read_only_remount = if mount_namespace.is_available() {
         run_mount_probe(
             "read-only remount",
-            "mount --make-rprivate / 2>/dev/null || true; \
-             mount --bind \"$1\" \"$2\"; \
-             mount -o remount,bind,ro \"$2\"; \
-             if sh -c 'printf x > \"$1/probe-file\"' sh \"$2\" 2>/dev/null; then exit 1; fi",
+            "\"$ALAN_PROBE_MOUNT_BIN\" --make-rprivate / && \
+             \"$ALAN_PROBE_MOUNT_BIN\" --bind \"$1\" \"$2\" && \
+             \"$ALAN_PROBE_MOUNT_BIN\" -o remount,bind,ro \"$2\" && \
+             if \"$ALAN_PROBE_SHELL_BIN\" -c 'printf x > \"$1/probe-file\"' sh \"$2\" 2>/dev/null; then exit 1; fi",
         )
     } else {
         LinuxReificationCapability::unavailable("requires available mount namespace")
@@ -360,10 +365,13 @@ fn probe_linux_reification_for_host() -> LinuxReificationCapabilityReport {
         LinuxReificationCapability::unavailable("requires available mount namespace")
     };
 
-    let network_confinement = if landlock_supports_network() {
-        LinuxReificationCapability::available()
+    let network_confinement = if mount_namespace.is_available() {
+        run_linux_probe_command(
+            "network namespace",
+            linux_unshare_command(&["--user", "--map-root-user", "--mount", "--net"]),
+        )
     } else {
-        LinuxReificationCapability::unavailable("Landlock network confinement unavailable")
+        LinuxReificationCapability::unavailable("requires available mount namespace")
     };
 
     LinuxReificationCapabilityReport::new(
@@ -378,10 +386,14 @@ fn probe_linux_reification_for_host() -> LinuxReificationCapabilityReport {
 }
 
 #[cfg(target_os = "linux")]
-fn linux_unshare_command(flags: &[&str]) -> std::process::Command {
-    let mut command = std::process::Command::new("unshare");
+fn linux_unshare_command(flags: &[&str]) -> Result<std::process::Command, String> {
+    let mut command = std::process::Command::new(resolve_trusted_linux_helper(
+        "unshare",
+        &["/usr/bin/unshare", "/bin/unshare"],
+    )?);
     command.args(flags).arg("true");
-    command
+    command.env("PATH", TRUSTED_LINUX_PROBE_PATH);
+    Ok(command)
 }
 
 #[cfg(target_os = "linux")]
@@ -395,7 +407,7 @@ fn run_mount_probe(label: &str, script: &str) -> LinuxReificationCapability {
         script,
         &[probe_root.source.as_path(), probe_root.target.as_path()],
     );
-    run_linux_probe(label, command)
+    run_linux_probe_command(label, command)
 }
 
 #[cfg(target_os = "linux")]
@@ -406,23 +418,45 @@ fn run_scratch_tmp_probe() -> LinuxReificationCapability {
     };
 
     let command = linux_unshare_shell_command(
-        "mount --make-rprivate / 2>/dev/null || true; \
-         mount -t tmpfs tmpfs \"$1\" && \
+        "\"$ALAN_PROBE_MOUNT_BIN\" --make-rprivate / && \
+         \"$ALAN_PROBE_MOUNT_BIN\" -t tmpfs tmpfs \"$1\" && \
          printf ok > \"$1/probe-file\" && \
          test -f \"$1/probe-file\"",
         &[probe_root.scratch.as_path()],
     );
-    run_linux_probe("scratch tmp mount", command)
+    run_linux_probe_command("scratch tmp mount", command)
 }
 
 #[cfg(target_os = "linux")]
-fn linux_unshare_shell_command(script: &str, args: &[&Path]) -> std::process::Command {
-    let mut command = std::process::Command::new("unshare");
+fn linux_unshare_shell_command(
+    script: &str,
+    args: &[&Path],
+) -> Result<std::process::Command, String> {
+    let unshare = resolve_trusted_linux_helper("unshare", &["/usr/bin/unshare", "/bin/unshare"])?;
+    let shell = resolve_trusted_linux_helper("sh", &["/bin/sh", "/usr/bin/sh"])?;
+    let mount = resolve_trusted_linux_helper("mount", &["/usr/bin/mount", "/bin/mount"])?;
+    let mut command = std::process::Command::new(unshare);
     command
-        .args(["--user", "--map-root-user", "--mount", "sh", "-c", script])
+        .env("PATH", TRUSTED_LINUX_PROBE_PATH)
+        .env("ALAN_PROBE_MOUNT_BIN", mount)
+        .env("ALAN_PROBE_SHELL_BIN", &shell)
+        .args(["--user", "--map-root-user", "--mount"])
+        .arg(shell)
+        .args(["-c", script])
         .arg("alan-linux-reification-probe")
         .args(args);
-    command
+    Ok(command)
+}
+
+#[cfg(target_os = "linux")]
+fn run_linux_probe_command(
+    label: &str,
+    command: Result<std::process::Command, String>,
+) -> LinuxReificationCapability {
+    match command {
+        Ok(command) => run_linux_probe(label, command),
+        Err(reason) => LinuxReificationCapability::unavailable(reason),
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -437,6 +471,25 @@ fn run_linux_probe(label: &str, mut command: std::process::Command) -> LinuxReif
             LinuxReificationCapability::unavailable(format!("{label} probe failed to start: {err}"))
         }
     }
+}
+
+#[cfg(target_os = "linux")]
+fn resolve_trusted_linux_helper(name: &str, candidates: &[&str]) -> Result<PathBuf, String> {
+    candidates
+        .iter()
+        .map(Path::new)
+        .find(|path| {
+            std::fs::metadata(path)
+                .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+                .unwrap_or(false)
+        })
+        .map(Path::to_path_buf)
+        .ok_or_else(|| {
+            format!(
+                "trusted linux helper {name} not found in {}",
+                candidates.join(", ")
+            )
+        })
 }
 
 #[cfg(target_os = "linux")]
@@ -1050,7 +1103,7 @@ mod tests {
             available_capability(),
             available_capability(),
             available_capability(),
-            unavailable_capability("Landlock network confinement unavailable"),
+            unavailable_capability("network namespace unavailable"),
         );
 
         assert_eq!(report.backend_name(), "linux_reified_namespace");
@@ -1068,7 +1121,7 @@ mod tests {
                 ("scratch_tmp_mount", "available".to_string()),
                 (
                     "network_confinement",
-                    "unavailable(Landlock network confinement unavailable)".to_string()
+                    "unavailable(network namespace unavailable)".to_string()
                 ),
             ]
         );
@@ -1077,7 +1130,7 @@ mod tests {
             "linux_reified_namespace: degraded (linux_host=available, \
              user_namespace=available, mount_namespace=available, bind_mount=available, \
              read_only_remount=available, scratch_tmp_mount=available, \
-             network_confinement=unavailable(Landlock network confinement unavailable))"
+             network_confinement=unavailable(network namespace unavailable))"
         );
     }
 
@@ -1090,7 +1143,7 @@ mod tests {
             unavailable_capability("requires available mount namespace"),
             available_capability(),
             available_capability(),
-            unavailable_capability("Landlock network confinement unavailable"),
+            unavailable_capability("network namespace unavailable"),
         );
 
         assert_eq!(
@@ -1100,7 +1153,7 @@ mod tests {
                 "user_namespace: not a linux host".to_string(),
                 "mount_namespace: requires available user namespace".to_string(),
                 "bind_mount: requires available mount namespace".to_string(),
-                "network_confinement: Landlock network confinement unavailable".to_string(),
+                "network_confinement: network namespace unavailable".to_string(),
             ]
         );
     }

--- a/openspec/changes/define-linux-namespace-reification/tasks.md
+++ b/openspec/changes/define-linux-namespace-reification/tasks.md
@@ -23,12 +23,12 @@
 
 ## 3. Linux Runner Slice
 
-- [ ] 3.1 Add a `ReifiedNamespaceRunner` trait and keep the existing Landlock
+- [x] 3.1 Add a `ReifiedNamespaceRunner` trait and keep the existing Landlock
   execution path as fallback.
-- [ ] 3.2 Implement an opt-in Linux runner that attempts unprivileged user/mount
+- [x] 3.2 Implement an opt-in Linux runner that attempts unprivileged user/mount
   namespace creation, bind mounts the plan, applies read-only remounts, and execs
   the requested command.
-- [ ] 3.3 Preserve safe degradation when namespace setup fails, including explicit
+- [x] 3.3 Preserve safe degradation when namespace setup fails, including explicit
   error/audit reporting and no silent ambient-host execution.
 
 ## 4. Enforcement And Policy Integration


### PR DESCRIPTION
## Summary
- add the ReifiedNamespaceRunner trait and opt-in LinuxReifiedNamespaceRunner
- build the Linux runner command around unprivileged user/mount namespaces, bind mounts, read-only remounts, private tmpfs, and chroot execution
- report safe fallback backend and audit fields on unsupported hosts or setup failure without running ambient shell
- mark OpenSpec tasks 3.1-3.3 complete for define-linux-namespace-reification

## Verification
- cargo test -p alan-agent-engine reified_namespace -- --nocapture
- cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings
- openspec validate define-linux-namespace-reification --strict
- openspec validate define-namespace-driven-sandbox --strict
- git diff --check

Note: this machine only has macOS Rust targets installed, so Linux-only command construction tests are cfg-gated and the Linux runner path still needs Linux smoke coverage in the later 5.1 task.