### PR TITLE
North Star 21/21: integrate reified namespace backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
  "include_dir",
  "jsonschema",
  "landlock",
+ "libc",
  "pin-utils",
  "rand 0.10.1",
  "regex",

--- a/crates/agent-engine/Cargo.toml
+++ b/crates/agent-engine/Cargo.toml
@@ -45,6 +45,7 @@ pin-utils.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 landlock = "0.4"
+libc.workspace = true
 
 [dev-dependencies]
 tracing-subscriber.workspace = true

--- a/crates/agent-engine/src/runtime/tool_orchestrator.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator.rs
@@ -560,6 +560,7 @@ where
                 "reason": routing_audit.reason,
                 "capability": routing_audit.capability,
                 "sandbox_backend": routing_audit.sandbox_backend,
+                "path_mode": routing_audit.path_mode,
             }),
         );
         emit(Event::Error {
@@ -622,6 +623,7 @@ where
             "reason": policy_audit.reason,
             "capability": policy_audit.capability,
             "sandbox_backend": policy_audit.sandbox_backend,
+            "path_mode": policy_audit.path_mode,
         }),
     );
 
@@ -1326,6 +1328,7 @@ fn workspace_routing_preflight(
         reason: payload["error"].as_str().map(ToString::to_string),
         capability: capability_label(capability).to_string(),
         sandbox_backend: crate::tools::active_backend_name().to_string(),
+        path_mode: Some(crate::tools::active_backend_path_mode().to_string()),
     };
     Some((payload, preview, audit))
 }

--- a/crates/agent-engine/src/runtime/tool_policy.rs
+++ b/crates/agent-engine/src/runtime/tool_policy.rs
@@ -234,6 +234,7 @@ pub(super) fn evaluate_tool_policy(
     confinement: SandboxConfinement,
 ) -> ToolPolicyDecision {
     let sandbox_backend = crate::tools::active_backend_name();
+    let path_mode = crate::tools::active_backend_path_mode().to_string();
     // The bash-shape preflight is the workspace-path-guard parser standing in for
     // confinement. With a kernel-enforced OS sandbox active, confinement is
     // independent of command syntax, so this syntactic deny must not block
@@ -251,6 +252,7 @@ pub(super) fn evaluate_tool_policy(
                 reason: Some(reason),
                 capability: capability_label(capability).to_string(),
                 sandbox_backend: sandbox_backend.to_string(),
+                path_mode: Some(path_mode.clone()),
             },
         };
     }
@@ -373,6 +375,7 @@ pub(super) fn evaluate_tool_policy(
                 reason: policy_reason.clone(),
                 capability: capability_kind,
                 sandbox_backend: sandbox_backend.to_string(),
+                path_mode: Some(path_mode.clone()),
             },
         },
         crate::policy::PolicyAction::Deny => ToolPolicyDecision::Forbidden {
@@ -386,6 +389,7 @@ pub(super) fn evaluate_tool_policy(
                 reason: policy_reason.clone(),
                 capability: capability_kind,
                 sandbox_backend: sandbox_backend.to_string(),
+                path_mode: Some(path_mode.clone()),
             },
         },
         crate::policy::PolicyAction::Escalate => ToolPolicyDecision::Escalate {
@@ -420,7 +424,8 @@ pub(super) fn evaluate_tool_policy(
                     "reason": policy_reason,
                     "action": "escalate"
                 },
-                "sandbox_backend": sandbox_backend
+                "sandbox_backend": sandbox_backend,
+                "path_mode": path_mode.clone()
             }),
             audit: alan_agent_protocol::ToolDecisionAudit {
                 policy_source,
@@ -429,6 +434,7 @@ pub(super) fn evaluate_tool_policy(
                 reason: policy_reason,
                 capability: capability_kind,
                 sandbox_backend: sandbox_backend.to_string(),
+                path_mode: Some(path_mode),
             },
         },
     }
@@ -962,6 +968,30 @@ mod tests {
                 assert_eq!(audit.capability, "network");
             }
             other => panic!("expected escalation, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_tool_policy_audit_reports_active_path_mode() {
+        let policy = crate::policy::PolicyEngine::autonomous();
+        let result = evaluate_tool_policy(
+            &policy,
+            &alan_agent_protocol::GovernanceConfig::default(),
+            "bash",
+            &json!({"command":"ls"}),
+            alan_agent_protocol::ToolCapability::Read,
+            None,
+            SandboxConfinement::os_enforced(),
+        );
+
+        match result {
+            ToolPolicyDecision::Allow { audit } | ToolPolicyDecision::Escalate { audit, .. } => {
+                assert_eq!(
+                    audit.path_mode.as_deref(),
+                    Some(crate::tools::active_backend_path_mode())
+                );
+            }
+            other => panic!("expected policy decision with audit, got {:?}", other),
         }
     }
 

--- a/crates/agent-engine/src/runtime/virtual_tools.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools.rs
@@ -501,6 +501,7 @@ where
                 "reason": audit.reason,
                 "capability": audit.capability,
                 "sandbox_backend": audit.sandbox_backend,
+                "path_mode": audit.path_mode,
             }),
         );
         emit(Event::Error {
@@ -545,6 +546,7 @@ where
         reason: Some("host mount grants require approval".to_string()),
         capability: decision_audit.capability.clone(),
         sandbox_backend: decision_audit.sandbox_backend.clone(),
+        path_mode: decision_audit.path_mode.clone(),
     };
     state.session.record_event(
         "tool_policy_decision",
@@ -557,6 +559,7 @@ where
             "reason": escalation_audit.reason,
             "capability": escalation_audit.capability,
             "sandbox_backend": escalation_audit.sandbox_backend,
+            "path_mode": escalation_audit.path_mode,
             "original_action": decision_audit.action,
         }),
     );
@@ -573,6 +576,7 @@ where
             "reason": escalation_audit.reason,
             "capability": escalation_audit.capability,
             "sandbox_backend": escalation_audit.sandbox_backend,
+            "path_mode": escalation_audit.path_mode,
         },
         "live_applied": false,
     });
@@ -910,6 +914,7 @@ fn runtime_virtual_tool_audit(reason: &str) -> alan_agent_protocol::ToolDecision
         reason: Some(reason.to_string()),
         capability: "write".to_string(),
         sandbox_backend: crate::tools::active_backend_name().to_string(),
+        path_mode: Some(crate::tools::active_backend_path_mode().to_string()),
     }
 }
 
@@ -958,6 +963,7 @@ where
             "reason": policy_audit.reason,
             "capability": policy_audit.capability,
             "sandbox_backend": policy_audit.sandbox_backend,
+            "path_mode": policy_audit.path_mode,
         }),
     );
 

--- a/crates/agent-engine/src/tools/mod.rs
+++ b/crates/agent-engine/src/tools/mod.rs
@@ -23,6 +23,9 @@ pub use reified_namespace::{
 pub use sandbox::{ExecResult, NetworkPosture, Sandbox, SandboxSpec};
 pub use sandbox_backend::{
     LinuxReificationCapability, LinuxReificationCapabilityReport, LinuxReificationStatus,
-    SandboxBackendKind, active_backend_name, confines_network, detect_backend, os_backend_active,
-    preferred_linux_backend_with_reification, probe_linux_reification, seatbelt_profile,
+    LinuxReifiedNamespaceBackendReadiness, SandboxBackendKind, active_backend_name,
+    active_backend_path_mode, confines_network, detect_backend, detect_projection_backend,
+    linux_reified_namespace_backend_readiness, os_backend_active,
+    preferred_linux_backend_with_reification, preferred_linux_backend_with_reification_and_runner,
+    probe_linux_reification, seatbelt_profile,
 };

--- a/crates/agent-engine/src/tools/reified_namespace.rs
+++ b/crates/agent-engine/src/tools/reified_namespace.rs
@@ -5,10 +5,19 @@
 //! plan that can be tested on any host.
 
 #[cfg(target_os = "linux")]
+use std::io::Read;
+#[cfg(target_os = "linux")]
 use std::os::unix::fs::PermissionsExt;
+#[cfg(target_os = "linux")]
+use std::os::unix::process::CommandExt;
 use std::path::{Component, Path, PathBuf};
 #[cfg(target_os = "linux")]
-use std::process::Command;
+use std::process::{Command, Output, Stdio};
+#[cfg(target_os = "linux")]
+use std::thread::JoinHandle;
+use std::time::Duration;
+#[cfg(target_os = "linux")]
+use std::time::Instant;
 
 use thiserror::Error;
 
@@ -285,6 +294,7 @@ pub fn default_execution_substrate() -> Vec<ReifiedExecutionSubstrateMount> {
         ("/usr/lib64", "/usr/lib64"),
         ("/etc/ssl", "/etc/ssl"),
         ("/etc/hosts", "/etc/hosts"),
+        ("/etc/resolv.conf", "/etc/resolv.conf"),
     ]
     .into_iter()
     .map(|(namespace_path, host_path)| {
@@ -354,11 +364,20 @@ impl LinuxReifiedNamespaceRunner {
     pub const fn fallback_backend(&self) -> SandboxBackendKind {
         self.fallback_backend
     }
+
+    /// Run the command and terminate the Linux runner process group if the timeout expires.
+    pub fn run_with_timeout(
+        &self,
+        plan: &ReifiedNamespacePlan,
+        timeout: Option<Duration>,
+    ) -> Result<ExecResult, ReifiedNamespaceRunError> {
+        self.run_inner(plan, timeout)
+    }
 }
 
 impl ReifiedNamespaceRunner for LinuxReifiedNamespaceRunner {
     fn run(&self, plan: &ReifiedNamespacePlan) -> Result<ExecResult, ReifiedNamespaceRunError> {
-        self.run_inner(plan)
+        self.run_with_timeout(plan, None)
     }
 }
 
@@ -403,6 +422,92 @@ impl ReifiedNamespaceCommandSpec {
         command.env_clear();
         command.env("PATH", TRUSTED_LINUX_SETUP_PATH);
         command
+    }
+}
+
+/// Smoke-check the actual Linux reified namespace runner.
+#[cfg(target_os = "linux")]
+pub(crate) fn smoke_linux_reified_namespace_runner() -> LinuxReificationCapability {
+    match smoke_linux_reified_namespace_runner_inner() {
+        Ok(()) => LinuxReificationCapability::available(),
+        Err(reason) => LinuxReificationCapability::unavailable(reason),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn smoke_linux_reified_namespace_runner_inner() -> Result<(), String> {
+    let workspace = ReifiedSmokeWorkspace::create()
+        .map_err(|err| format!("create runner smoke workspace failed: {err}"))?;
+    let runner = LinuxReifiedNamespaceRunner::with_fallback_backend(SandboxBackendKind::Landlock);
+
+    let deny_plan = ReifiedNamespacePlan::workspace_seed(
+        workspace.root.as_path(),
+        workspace.root.as_path(),
+        vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "test -d /mnt/workspace && test ! -e /home".to_string(),
+        ],
+        NetworkPosture::Deny,
+    )
+    .map_err(|err| format!("build runner smoke plan failed: {err}"))?;
+    run_linux_reified_smoke_plan(&runner, &deny_plan, "network-denied")?;
+
+    let allow_script = if Path::new("/etc/resolv.conf").exists() {
+        "test -f /etc/resolv.conf"
+    } else {
+        "true"
+    };
+    let allow_plan = ReifiedNamespacePlan::workspace_seed(
+        workspace.root.as_path(),
+        workspace.root.as_path(),
+        vec!["sh".to_string(), "-c".to_string(), allow_script.to_string()],
+        NetworkPosture::Allow,
+    )
+    .map_err(|err| format!("build runner network-allow smoke plan failed: {err}"))?;
+    run_linux_reified_smoke_plan(&runner, &allow_plan, "network-allow")
+}
+
+#[cfg(target_os = "linux")]
+fn run_linux_reified_smoke_plan(
+    runner: &LinuxReifiedNamespaceRunner,
+    plan: &ReifiedNamespacePlan,
+    label: &str,
+) -> Result<(), String> {
+    match runner.run(plan) {
+        Ok(result) if result.exit_code == 0 => Ok(()),
+        Ok(result) => Err(format!(
+            "runner {label} smoke command failed: exit_code={} stderr={}",
+            result.exit_code,
+            result.stderr.trim()
+        )),
+        Err(err) => Err(format!("runner {label} smoke unavailable: {}", err.reason)),
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug)]
+struct ReifiedSmokeWorkspace {
+    root: PathBuf,
+}
+
+#[cfg(target_os = "linux")]
+impl ReifiedSmokeWorkspace {
+    fn create() -> std::io::Result<Self> {
+        let root = std::env::temp_dir().join(format!(
+            "alan-reified-smoke-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&root)?;
+        Ok(Self { root })
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for ReifiedSmokeWorkspace {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
     }
 }
 
@@ -457,6 +562,9 @@ while [ "$substrate_count" -gt 0 ]; do
 done
 
 "$mount_bin" --bind /dev/null "${root}/dev/null" || fail "bind /dev/null"
+"$mount_bin" --bind /proc/self/fd/0 "${root}/dev/stdin" || fail "bind /dev/stdin"
+"$mount_bin" --bind /proc/self/fd/1 "${root}/dev/stdout" || fail "bind /dev/stdout"
+"$mount_bin" --bind /proc/self/fd/2 "${root}/dev/stderr" || fail "bind /dev/stderr"
 
 scratch_tmp="$1"; shift
 scratch_destination="${root}${scratch_tmp}"
@@ -510,6 +618,7 @@ impl LinuxReifiedNamespaceRunner {
     fn run_inner(
         &self,
         _plan: &ReifiedNamespacePlan,
+        _timeout: Option<Duration>,
     ) -> Result<ExecResult, ReifiedNamespaceRunError> {
         Err(ReifiedNamespaceRunError::new(
             "linux reified namespace runner is only available on Linux",
@@ -532,6 +641,7 @@ impl LinuxReifiedNamespaceRunner {
     fn run_inner(
         &self,
         plan: &ReifiedNamespacePlan,
+        timeout: Option<Duration>,
     ) -> Result<ExecResult, ReifiedNamespaceRunError> {
         if plan.argv.is_empty() {
             return Err(self.error("argv must not be empty", Vec::new()));
@@ -562,10 +672,14 @@ impl LinuxReifiedNamespaceRunner {
             .map_err(|err| self.error(format!("create reified root failed: {err}"), Vec::new()))?;
         let command_spec = build_linux_reified_namespace_command(plan, &temp_root)
             .map_err(|err| self.error(err, Vec::new()))?;
-        let output = command_spec
-            .command()
-            .output()
-            .map_err(|err| self.error(format!("failed to start unshare: {err}"), Vec::new()))?;
+        let output = run_linux_reified_command(command_spec.command(), timeout).map_err(|err| {
+            let reason = if err.kind() == std::io::ErrorKind::TimedOut {
+                err.to_string()
+            } else {
+                format!("failed to run unshare: {err}")
+            };
+            self.error(reason, command_spec.audit_fields())
+        })?;
 
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
@@ -601,6 +715,86 @@ impl LinuxReifiedNamespaceRunner {
         ]);
         ReifiedNamespaceRunError::new(reason, self.fallback_backend, audit_fields)
     }
+}
+
+#[cfg(target_os = "linux")]
+fn run_linux_reified_command(
+    mut command: Command,
+    timeout: Option<Duration>,
+) -> std::io::Result<Output> {
+    let Some(limit) = timeout else {
+        return command.output();
+    };
+
+    run_linux_reified_command_with_timeout(command, limit)
+}
+
+#[cfg(target_os = "linux")]
+fn run_linux_reified_command_with_timeout(
+    mut command: Command,
+    timeout: Duration,
+) -> std::io::Result<Output> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    command.process_group(0);
+    let mut child = command.spawn()?;
+    let stdout_reader = child.stdout.take().map(read_child_pipe);
+    let stderr_reader = child.stderr.take().map(read_child_pipe);
+
+    let started = Instant::now();
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break status;
+        }
+        if started.elapsed() >= timeout {
+            let _ = kill_child_process_group(&mut child);
+            let _ = child.wait();
+            let _ = join_child_pipe(stdout_reader);
+            let _ = join_child_pipe(stderr_reader);
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!("Command execution timed out after {}s", timeout.as_secs()),
+            ));
+        }
+        let remaining = timeout.saturating_sub(started.elapsed());
+        std::thread::sleep(remaining.min(Duration::from_millis(20)));
+    };
+
+    Ok(Output {
+        status,
+        stdout: join_child_pipe(stdout_reader)?,
+        stderr: join_child_pipe(stderr_reader)?,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn read_child_pipe<R>(mut pipe: R) -> JoinHandle<std::io::Result<Vec<u8>>>
+where
+    R: Read + Send + 'static,
+{
+    std::thread::spawn(move || {
+        let mut output = Vec::new();
+        pipe.read_to_end(&mut output)?;
+        Ok(output)
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn join_child_pipe(
+    handle: Option<JoinHandle<std::io::Result<Vec<u8>>>>,
+) -> std::io::Result<Vec<u8>> {
+    let Some(handle) = handle else {
+        return Ok(Vec::new());
+    };
+    handle
+        .join()
+        .map_err(|_| std::io::Error::other("child output reader panicked"))?
+}
+
+#[cfg(target_os = "linux")]
+fn kill_child_process_group(child: &mut std::process::Child) -> std::io::Result<()> {
+    let pgid = -(child.id() as libc::pid_t);
+    let result = unsafe { libc::kill(pgid, libc::SIGKILL) };
+    if result == 0 { Ok(()) } else { child.kill() }
 }
 
 #[cfg(any(test, target_os = "linux"))]
@@ -855,7 +1049,7 @@ fn temp_parent_is_exposed_to_writable_mount(parent: &Path, mounts: &[ReifiedHost
 fn prepare_reified_root(plan: &ReifiedNamespacePlan, root: &Path) -> Result<(), String> {
     std::fs::create_dir_all(root).map_err(|err| format!("create root failed: {err}"))?;
 
-    prepare_dev_null_destination(root)?;
+    prepare_standard_device_destinations(root)?;
     for mount in &plan.declared_host_mounts {
         prepare_mount_destination(root, &mount.namespace_path, &mount.host_path, true)?;
     }
@@ -869,13 +1063,15 @@ fn prepare_reified_root(plan: &ReifiedNamespacePlan, root: &Path) -> Result<(), 
 }
 
 #[cfg(target_os = "linux")]
-fn prepare_dev_null_destination(root: &Path) -> Result<(), String> {
+fn prepare_standard_device_destinations(root: &Path) -> Result<(), String> {
     let dev_dir = root.join("dev");
     std::fs::create_dir_all(&dev_dir)
         .map_err(|err| format!("create /dev mountpoint parent failed: {err}"))?;
-    let dev_null = dev_dir.join("null");
-    std::fs::File::create(&dev_null)
-        .map_err(|err| format!("create /dev/null mountpoint failed: {err}"))?;
+    for name in ["null", "stdin", "stdout", "stderr"] {
+        let destination = dev_dir.join(name);
+        std::fs::File::create(&destination)
+            .map_err(|err| format!("create /dev/{name} mountpoint failed: {err}"))?;
+    }
     Ok(())
 }
 
@@ -1238,6 +1434,16 @@ mod tests {
             PathBuf::from("/run/alan-tmp")
         );
         assert_eq!(plan.network, NetworkPosture::Allow);
+    }
+
+    #[test]
+    fn default_execution_substrate_includes_dns_resolver_config() {
+        let substrate = default_execution_substrate();
+
+        assert!(substrate.iter().any(|mount| {
+            mount.namespace_path == Path::new("/etc/resolv.conf")
+                && mount.host_path == Path::new("/etc/resolv.conf")
+        }));
     }
 
     #[test]
@@ -1786,6 +1992,32 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
+    fn linux_runner_timeout_kills_child_process_group() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let marker = temp_dir.path().join("leaked-after-timeout");
+        let output = run_linux_reified_command(
+            ReifiedNamespaceCommandSpec {
+                program: "/bin/sh".to_string(),
+                args: vec![
+                    "-c".to_string(),
+                    format!("(sleep 2; printf leaked > {}) & wait", marker.display()),
+                ],
+            }
+            .command(),
+            Some(Duration::from_millis(50)),
+        );
+
+        let error = output.unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+        std::thread::sleep(Duration::from_millis(300));
+        assert!(
+            !marker.exists(),
+            "timeout should kill the shell and its sleeping child"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
     fn linux_runner_command_uses_unshare_mount_chroot_and_network_namespace() {
         let workspace = tempfile::tempdir().unwrap();
         let docs = tempfile::tempdir().unwrap();
@@ -1847,6 +2079,9 @@ mod tests {
         assert!(script.contains("\"$mount_bin\" --make-rprivate / || fail \"make root private\""));
         assert!(!script.contains("--make-rprivate / 2>/dev/null || true"));
         assert!(script.contains("\"$mount_bin\" --bind /dev/null \"${root}/dev/null\""));
+        assert!(script.contains("\"$mount_bin\" --bind /proc/self/fd/0 \"${root}/dev/stdin\""));
+        assert!(script.contains("\"$mount_bin\" --bind /proc/self/fd/1 \"${root}/dev/stdout\""));
+        assert!(script.contains("\"$mount_bin\" --bind /proc/self/fd/2 \"${root}/dev/stderr\""));
         assert!(script.contains("\"$mount_bin\" --bind \"$host_path\" \"$destination\""));
         assert!(script.contains("\"$chroot_bin\" \"$root\" \"$namespace_shell\""));
         assert!(!script.contains("chroot \"$root\""));
@@ -1862,6 +2097,9 @@ mod tests {
         assert!(command.args.contains(&"/usr/bin/mount".to_string()));
         assert!(command.args.contains(&"/usr/sbin/chroot".to_string()));
         assert!(command.args.contains(&"/usr/bin/setpriv".to_string()));
+        assert!(temp_root.root.join("dev/stdin").exists());
+        assert!(temp_root.root.join("dev/stdout").exists());
+        assert!(temp_root.root.join("dev/stderr").exists());
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/agent-engine/src/tools/reified_namespace.rs
+++ b/crates/agent-engine/src/tools/reified_namespace.rs
@@ -1015,6 +1015,7 @@ fn build_linux_reified_namespace_command_with_helpers(
         "--mount".to_string(),
         "--pid".to_string(),
         "--fork".to_string(),
+        "--kill-child=SIGKILL".to_string(),
     ];
     if matches!(plan.network, NetworkPosture::Deny) {
         args.push("--net".to_string());
@@ -2159,6 +2160,7 @@ mod tests {
         assert!(command.args.contains(&"--mount".to_string()));
         assert!(command.args.contains(&"--pid".to_string()));
         assert!(command.args.contains(&"--fork".to_string()));
+        assert!(command.args.contains(&"--kill-child=SIGKILL".to_string()));
         assert!(command.args.contains(&"--net".to_string()));
         assert!(
             command

--- a/crates/agent-engine/src/tools/reified_namespace.rs
+++ b/crates/agent-engine/src/tools/reified_namespace.rs
@@ -23,7 +23,9 @@ use thiserror::Error;
 
 use super::sandbox::{ExecResult, NetworkPosture};
 #[cfg(any(test, target_os = "linux"))]
-use super::sandbox_backend::{LinuxReificationCapability, LinuxReificationCapabilityReport};
+use super::sandbox_backend::{
+    LinuxReificationCapabilities, LinuxReificationCapability, LinuxReificationCapabilityReport,
+};
 use super::sandbox_backend::{SandboxBackendKind, detect_backend};
 #[cfg(target_os = "linux")]
 use super::sandbox_backend::{preferred_linux_backend_with_reification, probe_linux_reification};
@@ -365,7 +367,7 @@ impl LinuxReifiedNamespaceRunner {
         self.fallback_backend
     }
 
-    /// Run the command and terminate the Linux runner process group if the timeout expires.
+    /// Run the command and terminate the Linux runner PID namespace if the timeout expires.
     pub fn run_with_timeout(
         &self,
         plan: &ReifiedNamespacePlan,
@@ -871,6 +873,7 @@ fn linux_reification_report_supports_plan(
     report.linux_host.is_available()
         && report.user_namespace.is_available()
         && report.mount_namespace.is_available()
+        && report.pid_namespace.is_available()
         && report.bind_mount.is_available()
         && report.read_only_remount.is_available()
         && report.scratch_tmp_mount.is_available()
@@ -893,6 +896,11 @@ fn linux_reification_unavailable_reasons_for_plan(
         &mut reasons,
         "mount_namespace",
         &report.mount_namespace,
+    );
+    push_missing_linux_reification_requirement(
+        &mut reasons,
+        "pid_namespace",
+        &report.pid_namespace,
     );
     push_missing_linux_reification_requirement(&mut reasons, "bind_mount", &report.bind_mount);
     push_missing_linux_reification_requirement(
@@ -1005,6 +1013,8 @@ fn build_linux_reified_namespace_command_with_helpers(
         "--user".to_string(),
         "--map-root-user".to_string(),
         "--mount".to_string(),
+        "--pid".to_string(),
+        "--fork".to_string(),
     ];
     if matches!(plan.network, NetworkPosture::Deny) {
         args.push("--net".to_string());
@@ -2010,15 +2020,18 @@ mod tests {
 
     #[test]
     fn reification_report_selection_requires_network_only_for_denied_plans() {
-        let report = LinuxReificationCapabilityReport::new(
-            LinuxReificationCapability::available(),
-            LinuxReificationCapability::available(),
-            LinuxReificationCapability::available(),
-            LinuxReificationCapability::available(),
-            LinuxReificationCapability::available(),
-            LinuxReificationCapability::available(),
-            LinuxReificationCapability::unavailable("network namespaces disabled"),
-        );
+        let report = LinuxReificationCapabilityReport::new(LinuxReificationCapabilities {
+            linux_host: LinuxReificationCapability::available(),
+            user_namespace: LinuxReificationCapability::available(),
+            mount_namespace: LinuxReificationCapability::available(),
+            pid_namespace: LinuxReificationCapability::available(),
+            bind_mount: LinuxReificationCapability::available(),
+            read_only_remount: LinuxReificationCapability::available(),
+            scratch_tmp_mount: LinuxReificationCapability::available(),
+            network_confinement: LinuxReificationCapability::unavailable(
+                "network namespaces disabled",
+            ),
+        });
 
         assert!(linux_reification_report_supports_plan(
             &report,
@@ -2144,6 +2157,8 @@ mod tests {
         assert!(command.args.contains(&"--user".to_string()));
         assert!(command.args.contains(&"--map-root-user".to_string()));
         assert!(command.args.contains(&"--mount".to_string()));
+        assert!(command.args.contains(&"--pid".to_string()));
+        assert!(command.args.contains(&"--fork".to_string()));
         assert!(command.args.contains(&"--net".to_string()));
         assert!(
             command

--- a/crates/agent-engine/src/tools/reified_namespace.rs
+++ b/crates/agent-engine/src/tools/reified_namespace.rs
@@ -6,7 +6,7 @@
 
 #[cfg(target_os = "linux")]
 use std::io::Read;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", all(test, unix)))]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(target_os = "linux")]
 use std::os::unix::process::CommandExt;
@@ -289,11 +289,17 @@ impl ReifiedNamespacePlanInput {
 pub fn default_execution_substrate() -> Vec<ReifiedExecutionSubstrateMount> {
     [
         ("/bin", "/bin"),
+        ("/sbin", "/sbin"),
         ("/usr/bin", "/usr/bin"),
+        ("/usr/sbin", "/usr/sbin"),
+        ("/usr/local/bin", "/usr/local/bin"),
+        ("/usr/local/sbin", "/usr/local/sbin"),
         ("/lib", "/lib"),
         ("/lib64", "/lib64"),
         ("/usr/lib", "/usr/lib"),
         ("/usr/lib64", "/usr/lib64"),
+        ("/usr/local/lib", "/usr/local/lib"),
+        ("/usr/local/lib64", "/usr/local/lib64"),
         ("/etc/ssl", "/etc/ssl"),
         ("/etc/hosts", "/etc/hosts"),
         ("/etc/resolv.conf", "/etc/resolv.conf"),
@@ -436,6 +442,98 @@ pub(crate) fn smoke_linux_reified_namespace_runner() -> LinuxReificationCapabili
     }
 }
 
+/// Smoke-check that selecting reified mode will not hide user PATH toolchains.
+#[cfg(target_os = "linux")]
+pub(crate) fn smoke_linux_reified_namespace_user_path() -> LinuxReificationCapability {
+    match reified_namespace_user_path_unavailable_reason(std::env::var_os("PATH")) {
+        Some(reason) => LinuxReificationCapability::unavailable(reason),
+        None => LinuxReificationCapability::available(),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn reified_namespace_user_path_unavailable_reason(
+    path: Option<std::ffi::OsString>,
+) -> Option<String> {
+    let visible_roots = reified_command_path_roots();
+    reified_namespace_user_path_unavailable_reason_with_roots(path, &visible_roots)
+}
+
+#[cfg(target_os = "linux")]
+fn reified_command_path_roots() -> Vec<PathBuf> {
+    std::env::split_paths(LINUX_REIFIED_COMMAND_PATH)
+        .map(|path| canonicalize_existing_host_path(&path))
+        .collect()
+}
+
+#[cfg(any(target_os = "linux", all(test, unix)))]
+fn reified_namespace_user_path_unavailable_reason_with_roots(
+    path: Option<std::ffi::OsString>,
+    visible_roots: &[PathBuf],
+) -> Option<String> {
+    let path = path?;
+    let visible_roots = visible_roots
+        .iter()
+        .map(|root| canonicalize_existing_host_path(root))
+        .collect::<Vec<_>>();
+    let mut unsupported = Vec::new();
+
+    for entry in std::env::split_paths(&path) {
+        if entry.as_os_str().is_empty() {
+            continue;
+        }
+        if !entry.is_absolute() {
+            unsupported.push(format!("relative PATH entry {}", entry.display()));
+            continue;
+        }
+
+        let entry = canonicalize_existing_host_path(&entry);
+        if !path_directory_has_executables(&entry) {
+            continue;
+        }
+        if visible_roots
+            .iter()
+            .any(|root| entry == *root || entry.starts_with(root))
+        {
+            continue;
+        }
+
+        unsupported.push(entry.display().to_string());
+        if unsupported.len() >= 3 {
+            break;
+        }
+    }
+
+    if unsupported.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "current PATH has executable entries outside the reified execution substrate: {}; \
+             preserve user PATH/toolchain mounts before selecting linux_reified_namespace",
+            unsupported.join(", ")
+        ))
+    }
+}
+
+#[cfg(any(target_os = "linux", all(test, unix)))]
+fn path_directory_has_executables(path: &Path) -> bool {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_dir() {
+        return false;
+    }
+
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return true;
+    };
+    entries.filter_map(Result::ok).any(|entry| {
+        std::fs::metadata(entry.path())
+            .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    })
+}
+
 #[cfg(target_os = "linux")]
 fn smoke_linux_reified_namespace_runner_inner() -> Result<(), String> {
     let workspace = ReifiedSmokeWorkspace::create()
@@ -519,10 +617,17 @@ const SETUP_FAILURE_PREFIX: &str = "alan reified namespace setup failed:";
 #[cfg(target_os = "linux")]
 const TRUSTED_LINUX_SETUP_PATH: &str = "/usr/sbin:/usr/bin:/sbin:/bin";
 
+#[cfg(any(target_os = "linux", test))]
+const LINUX_REIFIED_COMMAND_PATH: &str =
+    "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
 #[cfg(target_os = "linux")]
-const LINUX_REIFIED_NAMESPACE_SCRIPT: &str = r#"
+const LINUX_REIFIED_NAMESPACE_SCRIPT: &str = concat!(
+    r#"
 set -u
-PATH='/usr/sbin:/usr/bin:/sbin:/bin'
+PATH='"#,
+    LINUX_REIFIED_COMMAND_PATH,
+    r#"'
 export PATH
 fail() {
   printf '%s %s\n' 'alan reified namespace setup failed:' "$*" >&2
@@ -574,7 +679,8 @@ scratch_destination="${root}${scratch_tmp}"
 
 cwd="$1"; shift
 "$chroot_bin" "$root" "$namespace_shell" -c 'cd "$1" || exit 126; shift; setpriv_bin="$1"; shift; shell_bin="$1"; shift; exec "$setpriv_bin" --no-new-privs --bounding-set=-all --inh-caps=-all --ambient-caps=-all "$shell_bin" -c '"'"'printf "%s\n" ok >&3 || exit 125; exec 3>&-; exec "$@"'"'"' alan-reified-command "$@"' alan-reified-command "$cwd" "$namespace_setpriv" "$namespace_shell" "$@" 3>"$setup_marker"
-"#;
+"#,
+);
 
 #[cfg(target_os = "linux")]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1524,6 +1630,57 @@ mod tests {
     }
 
     #[test]
+    fn default_execution_substrate_includes_trusted_path_directories() {
+        let substrate = default_execution_substrate();
+
+        for path in std::env::split_paths(LINUX_REIFIED_COMMAND_PATH) {
+            assert!(
+                substrate.iter().any(|mount| {
+                    mount.namespace_path == path.as_path() && mount.host_path == path.as_path()
+                }),
+                "missing trusted PATH substrate {}",
+                path.display()
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn user_path_smoke_allows_executable_dirs_under_visible_roots() {
+        let temp = tempfile::tempdir().unwrap();
+        let visible_root = temp.path().join("visible");
+        let visible_bin = visible_root.join("bin");
+        write_executable(&visible_bin.join("cargo"));
+        let path = std::env::join_paths([visible_bin.as_path()]).unwrap();
+
+        assert_eq!(
+            reified_namespace_user_path_unavailable_reason_with_roots(
+                Some(path),
+                std::slice::from_ref(&visible_root),
+            ),
+            None
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn user_path_smoke_rejects_executable_dirs_outside_visible_roots() {
+        let temp = tempfile::tempdir().unwrap();
+        let visible_root = temp.path().join("visible");
+        let user_bin = temp.path().join("home/alice/.cargo/bin");
+        write_executable(&visible_root.join("bin/sh"));
+        write_executable(&user_bin.join("cargo"));
+        let path = std::env::join_paths([visible_root.join("bin"), user_bin.clone()]).unwrap();
+
+        let reason =
+            reified_namespace_user_path_unavailable_reason_with_roots(Some(path), &[visible_root])
+                .expect("user-local executable PATH entry should block reified default selection");
+
+        assert!(reason.contains(user_bin.to_string_lossy().as_ref()));
+        assert!(reason.contains("preserve user PATH/toolchain mounts"));
+    }
+
+    #[test]
     fn virtual_mounts_are_excluded_from_native_plan() {
         let input = ReifiedNamespacePlanInput::new(
             vec![
@@ -2179,7 +2336,7 @@ mod tests {
             .iter()
             .find(|arg| arg.contains("alan reified namespace setup failed"))
             .unwrap();
-        assert!(script.contains("PATH='/usr/sbin:/usr/bin:/sbin:/bin'"));
+        assert!(script.contains(&format!("PATH='{LINUX_REIFIED_COMMAND_PATH}'")));
         assert!(script.contains("\"$mount_bin\" --make-rprivate / || fail \"make root private\""));
         assert!(!script.contains("--make-rprivate / 2>/dev/null || true"));
         assert!(script.contains("\"$mount_bin\" --bind /dev/null \"${root}/dev/null\""));
@@ -2270,5 +2427,16 @@ mod tests {
 
         std::fs::write(&marker, b"ok\n").unwrap();
         assert!(setup_marker_was_written(&marker));
+    }
+
+    #[cfg(unix)]
+    fn write_executable(path: &Path) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, b"#!/bin/sh\nexit 0\n").unwrap();
+        let mut permissions = std::fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).unwrap();
     }
 }

--- a/crates/agent-engine/src/tools/reified_namespace.rs
+++ b/crates/agent-engine/src/tools/reified_namespace.rs
@@ -476,7 +476,13 @@ fn reified_namespace_user_path_unavailable_reason_with_roots(
     visible_roots: &[PathBuf],
     reified_command_path: std::ffi::OsString,
 ) -> Option<String> {
-    let path = path?;
+    let Some(path) = path else {
+        return Some(
+            "current PATH is unset; preserve actual PATH/order before selecting \
+             linux_reified_namespace"
+                .to_string(),
+        );
+    };
     let visible_roots = visible_roots
         .iter()
         .map(|root| canonicalize_existing_host_path(root))
@@ -1713,6 +1719,25 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn user_path_smoke_rejects_unset_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let visible_bin = temp.path().join("bin");
+        write_executable(&visible_bin.join("sh"));
+        let reified_path = std::env::join_paths([visible_bin.as_path()]).unwrap();
+
+        let reason = reified_namespace_user_path_unavailable_reason_with_roots(
+            None,
+            &[temp.path().to_path_buf()],
+            reified_path,
+        )
+        .expect("unset PATH should block default selection");
+
+        assert!(reason.contains("current PATH is unset"));
+        assert!(reason.contains("preserve actual PATH/order"));
     }
 
     #[cfg(unix)]

--- a/crates/agent-engine/src/tools/reified_namespace.rs
+++ b/crates/agent-engine/src/tools/reified_namespace.rs
@@ -456,7 +456,11 @@ fn reified_namespace_user_path_unavailable_reason(
     path: Option<std::ffi::OsString>,
 ) -> Option<String> {
     let visible_roots = reified_command_path_roots();
-    reified_namespace_user_path_unavailable_reason_with_roots(path, &visible_roots)
+    reified_namespace_user_path_unavailable_reason_with_roots(
+        path,
+        &visible_roots,
+        std::ffi::OsString::from(LINUX_REIFIED_COMMAND_PATH),
+    )
 }
 
 #[cfg(target_os = "linux")]
@@ -470,6 +474,7 @@ fn reified_command_path_roots() -> Vec<PathBuf> {
 fn reified_namespace_user_path_unavailable_reason_with_roots(
     path: Option<std::ffi::OsString>,
     visible_roots: &[PathBuf],
+    reified_command_path: std::ffi::OsString,
 ) -> Option<String> {
     let path = path?;
     let visible_roots = visible_roots
@@ -477,6 +482,7 @@ fn reified_namespace_user_path_unavailable_reason_with_roots(
         .map(|root| canonicalize_existing_host_path(root))
         .collect::<Vec<_>>();
     let mut unsupported = Vec::new();
+    let mut current_executable_entries = Vec::new();
 
     for entry in std::env::split_paths(&path) {
         if entry.as_os_str().is_empty() {
@@ -495,6 +501,7 @@ fn reified_namespace_user_path_unavailable_reason_with_roots(
             .iter()
             .any(|root| entry == *root || entry.starts_with(root))
         {
+            push_unique_path(&mut current_executable_entries, entry);
             continue;
         }
 
@@ -504,15 +511,26 @@ fn reified_namespace_user_path_unavailable_reason_with_roots(
         }
     }
 
-    if unsupported.is_empty() {
-        None
-    } else {
-        Some(format!(
+    if !unsupported.is_empty() {
+        return Some(format!(
             "current PATH has executable entries outside the reified execution substrate: {}; \
              preserve user PATH/toolchain mounts before selecting linux_reified_namespace",
             unsupported.join(", ")
-        ))
+        ));
     }
+
+    let reified_executable_entries = executable_path_entries(&reified_command_path);
+    if current_executable_entries != reified_executable_entries {
+        return Some(format!(
+            "current PATH executable entry order differs from the reified command PATH: \
+             current=[{}], reified=[{}]; preserve actual PATH/order before selecting \
+             linux_reified_namespace",
+            format_path_entries(&current_executable_entries),
+            format_path_entries(&reified_executable_entries)
+        ));
+    }
+
+    None
 }
 
 #[cfg(any(target_os = "linux", all(test, unix)))]
@@ -532,6 +550,40 @@ fn path_directory_has_executables(path: &Path) -> bool {
             .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
             .unwrap_or(false)
     })
+}
+
+#[cfg(any(target_os = "linux", all(test, unix)))]
+fn executable_path_entries(path: &std::ffi::OsString) -> Vec<PathBuf> {
+    let mut entries = Vec::new();
+    for entry in std::env::split_paths(path) {
+        if entry.as_os_str().is_empty() || !entry.is_absolute() {
+            continue;
+        }
+        let entry = canonicalize_existing_host_path(&entry);
+        if path_directory_has_executables(&entry) {
+            push_unique_path(&mut entries, entry);
+        }
+    }
+    entries
+}
+
+#[cfg(any(target_os = "linux", all(test, unix)))]
+fn push_unique_path(entries: &mut Vec<PathBuf>, entry: PathBuf) {
+    if !entries.contains(&entry) {
+        entries.push(entry);
+    }
+}
+
+#[cfg(any(target_os = "linux", all(test, unix)))]
+fn format_path_entries(entries: &[PathBuf]) -> String {
+    if entries.is_empty() {
+        return "<none>".to_string();
+    }
+    entries
+        .iter()
+        .map(|entry| entry.display().to_string())
+        .collect::<Vec<_>>()
+        .join(":")
 }
 
 #[cfg(target_os = "linux")]
@@ -1655,8 +1707,9 @@ mod tests {
 
         assert_eq!(
             reified_namespace_user_path_unavailable_reason_with_roots(
-                Some(path),
+                Some(path.clone()),
                 std::slice::from_ref(&visible_root),
+                path,
             ),
             None
         );
@@ -1671,13 +1724,39 @@ mod tests {
         write_executable(&visible_root.join("bin/sh"));
         write_executable(&user_bin.join("cargo"));
         let path = std::env::join_paths([visible_root.join("bin"), user_bin.clone()]).unwrap();
+        let reified_path = std::env::join_paths([visible_root.join("bin")]).unwrap();
 
-        let reason =
-            reified_namespace_user_path_unavailable_reason_with_roots(Some(path), &[visible_root])
-                .expect("user-local executable PATH entry should block reified default selection");
+        let reason = reified_namespace_user_path_unavailable_reason_with_roots(
+            Some(path),
+            &[visible_root],
+            reified_path,
+        )
+        .expect("user-local executable PATH entry should block reified default selection");
 
         assert!(reason.contains(user_bin.to_string_lossy().as_ref()));
         assert!(reason.contains("preserve user PATH/toolchain mounts"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn user_path_smoke_rejects_reified_path_order_changes() {
+        let temp = tempfile::tempdir().unwrap();
+        let usr_bin = temp.path().join("usr/bin");
+        let local_bin = temp.path().join("usr/local/bin");
+        write_executable(&usr_bin.join("cargo"));
+        write_executable(&local_bin.join("cargo"));
+        let current_path = std::env::join_paths([usr_bin.as_path(), local_bin.as_path()]).unwrap();
+        let reified_path = std::env::join_paths([local_bin.as_path(), usr_bin.as_path()]).unwrap();
+
+        let reason = reified_namespace_user_path_unavailable_reason_with_roots(
+            Some(current_path),
+            &[temp.path().to_path_buf()],
+            reified_path,
+        )
+        .expect("reified PATH reordering should block default selection");
+
+        assert!(reason.contains("current PATH executable entry order differs"));
+        assert!(reason.contains("preserve actual PATH/order"));
     }
 
     #[test]

--- a/crates/agent-engine/src/tools/reified_namespace.rs
+++ b/crates/agent-engine/src/tools/reified_namespace.rs
@@ -492,7 +492,11 @@ fn reified_namespace_user_path_unavailable_reason_with_roots(
 
     for entry in std::env::split_paths(&path) {
         if entry.as_os_str().is_empty() {
-            continue;
+            return Some(
+                "current PATH contains an empty component for current-directory lookup; preserve \
+                 actual PATH/order before selecting linux_reified_namespace"
+                    .to_string(),
+            );
         }
         if !entry.is_absolute() {
             unsupported.push(format!("relative PATH entry {}", entry.display()));
@@ -1738,6 +1742,26 @@ mod tests {
 
         assert!(reason.contains("current PATH is unset"));
         assert!(reason.contains("preserve actual PATH/order"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn user_path_smoke_rejects_empty_path_entry() {
+        let temp = tempfile::tempdir().unwrap();
+        let visible_bin = temp.path().join("bin");
+        write_executable(&visible_bin.join("sh"));
+        let current_path = std::ffi::OsString::from(format!(":{}", visible_bin.display()));
+        let reified_path = std::env::join_paths([visible_bin.as_path()]).unwrap();
+
+        let reason = reified_namespace_user_path_unavailable_reason_with_roots(
+            Some(current_path),
+            &[temp.path().to_path_buf()],
+            reified_path,
+        )
+        .expect("empty PATH entries should block default selection");
+
+        assert!(reason.contains("empty component"));
+        assert!(reason.contains("current-directory lookup"));
     }
 
     #[cfg(unix)]

--- a/crates/agent-engine/src/tools/reified_namespace.rs
+++ b/crates/agent-engine/src/tools/reified_namespace.rs
@@ -12,7 +12,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::CommandExt;
 use std::path::{Component, Path, PathBuf};
 #[cfg(target_os = "linux")]
-use std::process::{Command, Output, Stdio};
+use std::process::{Child, Command, Output, Stdio};
 #[cfg(target_os = "linux")]
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -746,23 +746,28 @@ fn run_linux_reified_command_with_timeout(
             break status;
         }
         if started.elapsed() >= timeout {
-            let _ = kill_child_process_group(&mut child);
-            let _ = child.wait();
-            let _ = join_child_pipe(stdout_reader);
-            let _ = join_child_pipe(stderr_reader);
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                format!("Command execution timed out after {}s", timeout.as_secs()),
+            return Err(timeout_reified_command(
+                &mut child,
+                stdout_reader,
+                stderr_reader,
+                timeout,
             ));
         }
         let remaining = timeout.saturating_sub(started.elapsed());
         std::thread::sleep(remaining.min(Duration::from_millis(20)));
     };
+    let (stdout, stderr) = collect_child_pipes_before_deadline(
+        stdout_reader,
+        stderr_reader,
+        &mut child,
+        started,
+        timeout,
+    )?;
 
     Ok(Output {
         status,
-        stdout: join_child_pipe(stdout_reader)?,
-        stderr: join_child_pipe(stderr_reader)?,
+        stdout,
+        stderr,
     })
 }
 
@@ -788,6 +793,67 @@ fn join_child_pipe(
     handle
         .join()
         .map_err(|_| std::io::Error::other("child output reader panicked"))?
+}
+
+#[cfg(target_os = "linux")]
+fn collect_child_pipes_before_deadline(
+    stdout_reader: Option<JoinHandle<std::io::Result<Vec<u8>>>>,
+    stderr_reader: Option<JoinHandle<std::io::Result<Vec<u8>>>>,
+    child: &mut Child,
+    started: Instant,
+    timeout: Duration,
+) -> std::io::Result<(Vec<u8>, Vec<u8>)> {
+    let mut stdout_reader = stdout_reader;
+    let mut stderr_reader = stderr_reader;
+    loop {
+        let stdout_done = stdout_reader.as_ref().is_none_or(JoinHandle::is_finished);
+        let stderr_done = stderr_reader.as_ref().is_none_or(JoinHandle::is_finished);
+        if stdout_done && stderr_done {
+            return Ok((
+                join_child_pipe(stdout_reader.take())?,
+                join_child_pipe(stderr_reader.take())?,
+            ));
+        }
+
+        if started.elapsed() >= timeout {
+            return Err(timeout_reified_command(
+                child,
+                stdout_reader.take(),
+                stderr_reader.take(),
+                timeout,
+            ));
+        }
+
+        let remaining = timeout.saturating_sub(started.elapsed());
+        std::thread::sleep(remaining.min(Duration::from_millis(20)));
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn timeout_reified_command(
+    child: &mut Child,
+    stdout_reader: Option<JoinHandle<std::io::Result<Vec<u8>>>>,
+    stderr_reader: Option<JoinHandle<std::io::Result<Vec<u8>>>>,
+    timeout: Duration,
+) -> std::io::Error {
+    let _ = kill_child_process_group(child);
+    let _ = child.wait();
+    join_finished_child_pipe(stdout_reader);
+    join_finished_child_pipe(stderr_reader);
+    std::io::Error::new(
+        std::io::ErrorKind::TimedOut,
+        format!("Command execution timed out after {}s", timeout.as_secs()),
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn join_finished_child_pipe(handle: Option<JoinHandle<std::io::Result<Vec<u8>>>>) {
+    let Some(handle) = handle else {
+        return;
+    };
+    if handle.is_finished() {
+        let _ = join_child_pipe(Some(handle));
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -2013,6 +2079,27 @@ mod tests {
         assert!(
             !marker.exists(),
             "timeout should kill the shell and its sleeping child"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_runner_timeout_covers_output_drain_after_parent_exit() {
+        let started = Instant::now();
+        let output = run_linux_reified_command(
+            ReifiedNamespaceCommandSpec {
+                program: "/bin/sh".to_string(),
+                args: vec!["-c".to_string(), "sleep 2 &".to_string()],
+            }
+            .command(),
+            Some(Duration::from_millis(50)),
+        );
+
+        let error = output.unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "timeout should remain active while stdout/stderr readers wait for EOF"
         );
     }
 

--- a/crates/agent-engine/src/tools/sandbox.rs
+++ b/crates/agent-engine/src/tools/sandbox.rs
@@ -1051,26 +1051,207 @@ fn translate_reified_shell_token(
     token: &str,
     plan: &super::reified_namespace::ReifiedNamespacePlan,
 ) -> Option<String> {
-    for range in path_like_subtoken_ranges(token) {
+    if let Some(rewritten) = translate_reified_nested_shell_token(token, plan) {
+        return Some(shell_quote_token(&rewritten));
+    }
+
+    let mut replacements = Vec::new();
+    for range in reified_shell_token_path_candidate_ranges(token) {
+        if replacements
+            .iter()
+            .any(|(existing, _)| ranges_overlap(existing, &range))
+        {
+            continue;
+        }
+
         let candidate = &token[range.clone()];
         let candidate_path = Path::new(candidate);
         if !candidate_path.is_absolute() || is_allowed_absolute_command_path(candidate_path) {
             continue;
         }
 
-        let namespace_path = plan
-            .translate_projected_host_path(candidate_path)
-            .or_else(|| {
-                plan.translate_projected_host_path(&lexically_normalize_path(candidate_path))
-            })?;
-        let namespace_path = namespace_path.display().to_string();
-        let mut rewritten = String::with_capacity(token.len() + namespace_path.len());
-        rewritten.push_str(&token[..range.start]);
-        rewritten.push_str(&shell_quote_token(&namespace_path));
-        rewritten.push_str(&token[range.end..]);
-        return Some(rewritten);
+        let Some(namespace_path) =
+            plan.translate_projected_host_path(candidate_path)
+                .or_else(|| {
+                    plan.translate_projected_host_path(&lexically_normalize_path(candidate_path))
+                })
+        else {
+            continue;
+        };
+        replacements.push((range, namespace_path.display().to_string()));
+    }
+
+    if replacements.is_empty() {
+        return None;
+    }
+
+    replacements.sort_by_key(|(range, _)| range.start);
+    let replacement_len = replacements
+        .iter()
+        .map(|(_, replacement)| replacement.len())
+        .sum::<usize>();
+    let mut rewritten = String::with_capacity(token.len() + replacement_len);
+    let mut last = 0;
+    for (range, replacement) in replacements {
+        rewritten.push_str(&token[last..range.start]);
+        rewritten.push_str(&replacement);
+        last = range.end;
+    }
+    rewritten.push_str(&token[last..]);
+
+    Some(shell_quote_reified_token(&rewritten))
+}
+
+fn translate_reified_nested_shell_token(
+    token: &str,
+    plan: &super::reified_namespace::ReifiedNamespacePlan,
+) -> Option<String> {
+    let tokens = shell_word_tokens_with_spans(token).ok()?;
+    if !looks_like_nested_shell_script(&tokens) {
+        return None;
+    }
+
+    let mut translated = String::with_capacity(token.len());
+    let mut last = 0;
+    let mut changed = false;
+    for nested_token in tokens {
+        let Some(rewritten) = translate_reified_shell_token(&nested_token.decoded, plan) else {
+            continue;
+        };
+        translated.push_str(&token[last..nested_token.raw_start]);
+        translated.push_str(&rewritten);
+        last = nested_token.raw_end;
+        changed = true;
+    }
+    if !changed {
+        return None;
+    }
+
+    translated.push_str(&token[last..]);
+    Some(translated)
+}
+
+fn looks_like_nested_shell_script(tokens: &[ShellWordToken]) -> bool {
+    if tokens.len() < 2 {
+        return false;
+    }
+    let Some(command) = tokens
+        .iter()
+        .find(|token| !is_env_assignment(&token.decoded))
+    else {
+        return false;
+    };
+
+    !looks_like_path_token(&command.decoded)
+        && !looks_like_bare_protected_subpath_token(&command.decoded)
+}
+
+fn shell_quote_reified_token(token: &str) -> String {
+    if is_env_assignment(token) {
+        let (name, value) = token
+            .split_once('=')
+            .expect("is_env_assignment requires an equals sign");
+        return format!("{name}={}", shell_quote_token(value));
+    }
+    shell_quote_token(token)
+}
+
+fn ranges_overlap(left: &Range<usize>, right: &Range<usize>) -> bool {
+    left.start < right.end && right.start < left.end
+}
+
+fn reified_shell_token_path_candidate_ranges(token: &str) -> Vec<Range<usize>> {
+    let mut ranges = Vec::new();
+    for range in path_like_subtoken_ranges(token) {
+        push_unique_range(&mut ranges, range);
+    }
+    for range in embedded_absolute_path_literal_ranges(token) {
+        push_path_literal_candidate_ranges(token, range, &mut ranges);
+    }
+    ranges
+}
+
+fn push_path_literal_candidate_ranges(
+    token: &str,
+    range: Range<usize>,
+    ranges: &mut Vec<Range<usize>>,
+) {
+    if let Some(split_end) = first_later_absolute_path_split(token, &range) {
+        let first_operand = trim_trailing_whitespace_range(token, range.start..split_end);
+        if first_operand.start < first_operand.end {
+            if path_literal_range_contains_flag_segment(token, &first_operand) {
+                push_whitespace_prefix_ranges(token, first_operand.clone(), ranges);
+                push_unique_range(ranges, first_operand);
+            } else {
+                push_unique_range(ranges, first_operand.clone());
+                push_whitespace_prefix_ranges(token, first_operand, ranges);
+            }
+        }
+        return;
+    }
+
+    let trimmed = trim_trailing_whitespace_range(token, range.clone());
+    if trimmed.start < trimmed.end {
+        push_unique_range(ranges, trimmed);
+    }
+
+    let literal = &token[range.clone()];
+    for (offset, ch) in literal.char_indices() {
+        if ch.is_whitespace() && offset > 0 {
+            let prefix = range.start..range.start + offset;
+            push_unique_range(ranges, prefix);
+        }
+    }
+}
+
+fn push_whitespace_prefix_ranges(token: &str, range: Range<usize>, ranges: &mut Vec<Range<usize>>) {
+    let literal = &token[range.clone()];
+    for (offset, ch) in literal.char_indices() {
+        if ch.is_whitespace() && offset > 0 {
+            push_unique_range(ranges, range.start..range.start + offset);
+        }
+    }
+}
+
+fn path_literal_range_contains_flag_segment(token: &str, range: &Range<usize>) -> bool {
+    token[range.clone()]
+        .split_whitespace()
+        .skip(1)
+        .any(|segment| segment.starts_with('-'))
+}
+
+fn first_later_absolute_path_split(token: &str, range: &Range<usize>) -> Option<usize> {
+    let literal = &token[range.clone()];
+    let mut whitespace_start = None;
+    let mut in_whitespace = false;
+    for (offset, ch) in literal.char_indices().skip(1) {
+        if ch.is_whitespace() {
+            if !in_whitespace {
+                whitespace_start = Some(offset);
+                in_whitespace = true;
+            }
+            continue;
+        }
+
+        if ch == '/' && !absolute_path_match_has_path_prefix(literal, offset) {
+            return whitespace_start.map(|split| range.start + split);
+        }
+
+        whitespace_start = None;
+        in_whitespace = false;
     }
     None
+}
+
+fn trim_trailing_whitespace_range(token: &str, range: Range<usize>) -> Range<usize> {
+    let trimmed = token[range.clone()].trim_end_matches(char::is_whitespace);
+    range.start..range.start + trimmed.len()
+}
+
+fn push_unique_range(ranges: &mut Vec<Range<usize>>, range: Range<usize>) {
+    if !ranges.contains(&range) {
+        ranges.push(range);
+    }
 }
 
 fn path_like_subtoken_ranges(token: &str) -> Vec<Range<usize>> {

--- a/crates/agent-engine/src/tools/sandbox.rs
+++ b/crates/agent-engine/src/tools/sandbox.rs
@@ -1162,6 +1162,9 @@ fn ranges_overlap(left: &Range<usize>, right: &Range<usize>) -> bool {
 
 fn reified_shell_token_path_candidate_ranges(token: &str) -> Vec<Range<usize>> {
     let mut ranges = Vec::new();
+    for range in colon_separated_absolute_path_component_ranges(token) {
+        push_unique_range(&mut ranges, range);
+    }
     for range in path_like_subtoken_ranges(token) {
         push_unique_range(&mut ranges, range);
     }
@@ -1273,8 +1276,55 @@ fn path_like_subtoken_ranges(token: &str) -> Vec<Range<usize>> {
     ranges
 }
 
+fn colon_separated_absolute_path_component_ranges(token: &str) -> Vec<Range<usize>> {
+    let mut ranges = Vec::new();
+    if token.starts_with('/') {
+        push_colon_separated_absolute_path_components(token, 0..token.len(), &mut ranges);
+    }
+    if let Some(index) = token.rfind('=') {
+        let start = index + 1;
+        if start < token.len() {
+            push_colon_separated_absolute_path_components(token, start..token.len(), &mut ranges);
+        }
+    }
+    ranges
+}
+
+fn push_colon_separated_absolute_path_components(
+    token: &str,
+    range: Range<usize>,
+    ranges: &mut Vec<Range<usize>>,
+) {
+    let value = &token[range.clone()];
+    let mut component_start = range.start;
+    for (offset, ch) in value.char_indices() {
+        if ch != ':' {
+            continue;
+        }
+        push_absolute_path_component_range(token, component_start..range.start + offset, ranges);
+        component_start = range.start + offset + ch.len_utf8();
+    }
+    push_absolute_path_component_range(token, component_start..range.end, ranges);
+}
+
+fn push_absolute_path_component_range(
+    token: &str,
+    range: Range<usize>,
+    ranges: &mut Vec<Range<usize>>,
+) {
+    if range.start >= range.end {
+        return;
+    }
+    if token[range.clone()].starts_with('/') {
+        push_unique_range(ranges, range);
+    }
+}
+
 fn absolute_path_literal_candidates(token: &str) -> Vec<Vec<String>> {
     let mut literals = Vec::new();
+    for range in colon_separated_absolute_path_component_ranges(token) {
+        push_absolute_path_literal_candidates(token, range, &mut literals);
+    }
     for range in path_like_subtoken_ranges(token) {
         push_absolute_path_literal_candidates(token, range, &mut literals);
     }

--- a/crates/agent-engine/src/tools/sandbox.rs
+++ b/crates/agent-engine/src/tools/sandbox.rs
@@ -12,7 +12,6 @@
 //! recipes, or utility-specific script/DSL modes such as `sed -f`.
 
 use anyhow::{Result, anyhow};
-use regex::Regex;
 use std::ffi::OsString;
 use std::ops::Range;
 use std::path::{Component, Path, PathBuf};
@@ -638,6 +637,10 @@ impl Sandbox {
             Ok(tokens) => tokens,
             Err(err) => return if protected_only { Ok(()) } else { Err(err) },
         };
+        let span_tokens = match shell_word_tokens_with_spans(trimmed) {
+            Ok(tokens) => tokens,
+            Err(err) => return if protected_only { Ok(()) } else { Err(err) },
+        };
         let commands = match shell_commands(trimmed) {
             Ok(commands) => commands,
             Err(err) => return if protected_only { Ok(()) } else { Err(err) },
@@ -678,45 +681,7 @@ impl Sandbox {
             }
         }
 
-        let comment_free = strip_shell_comments(trimmed);
-        let regex = Regex::new(r"/[A-Za-z0-9._/-]+").expect("absolute-path regex is valid");
-        for matched in regex.find_iter(&comment_free) {
-            let start = matched.start();
-            if start > 0 {
-                let prev = comment_free.as_bytes()[start - 1];
-                if prev == b':'
-                    || prev == b'.'
-                    || prev == b'/'
-                    || prev == b'_'
-                    || prev == b'-'
-                    || prev == b'*'
-                    || prev == b'?'
-                    || prev == b']'
-                    || prev.is_ascii_alphanumeric()
-                {
-                    // Skip URL fragments and path segments within relative paths or identifiers.
-                    continue;
-                }
-            }
-            let literal = matched.as_str();
-            if is_allowed_absolute_command_path(Path::new(literal)) {
-                continue;
-            }
-            let literal_path = Path::new(literal);
-            let validation_path = self
-                .reified_namespace_path_to_host(literal_path)
-                .unwrap_or_else(|| literal_path.to_path_buf());
-            // Containment applies in every mode: the OS sandbox does not confine
-            // reads, so an out-of-workspace absolute path (e.g. a read of a secret)
-            // must still be rejected by the parser.
-            if !self.is_in_workspace(&validation_path) {
-                return Err(anyhow!(
-                    "Command contains absolute path outside workspace: {}",
-                    literal
-                ));
-            }
-            self.ensure_path_not_protected(&validation_path, "process path reference")?;
-        }
+        self.validate_absolute_path_literals(&span_tokens)?;
 
         Ok(())
     }
@@ -957,6 +922,53 @@ impl Sandbox {
         None
     }
 
+    fn validate_absolute_path_literals(&self, tokens: &[ShellWordToken]) -> Result<()> {
+        for token in tokens {
+            for candidates in absolute_path_literal_candidates(&token.decoded) {
+                let literal = candidates
+                    .iter()
+                    .find(|candidate| {
+                        self.absolute_path_literal_is_allowed_or_in_workspace(candidate)
+                    })
+                    .unwrap_or_else(|| &candidates[0]);
+                self.validate_absolute_path_literal(literal)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn absolute_path_literal_is_allowed_or_in_workspace(&self, literal: &str) -> bool {
+        let literal_path = Path::new(literal);
+        if is_allowed_absolute_command_path(literal_path) {
+            return true;
+        }
+        let validation_path = self
+            .reified_namespace_path_to_host(literal_path)
+            .unwrap_or_else(|| literal_path.to_path_buf());
+        self.is_in_workspace(&validation_path)
+    }
+
+    fn validate_absolute_path_literal(&self, literal: &str) -> Result<()> {
+        let literal_path = Path::new(literal);
+        if !literal_path.is_absolute() || is_allowed_absolute_command_path(literal_path) {
+            return Ok(());
+        }
+        let validation_path = self
+            .reified_namespace_path_to_host(literal_path)
+            .unwrap_or_else(|| literal_path.to_path_buf());
+        // Containment applies in every mode: the OS sandbox does not confine
+        // reads, so an out-of-workspace absolute path (e.g. a read of a secret)
+        // must still be rejected by the parser.
+        if !self.is_in_workspace(&validation_path) {
+            return Err(anyhow!(
+                "Command contains absolute path outside workspace: {}",
+                literal
+            ));
+        }
+        self.ensure_path_not_protected(&validation_path, "process path reference")?;
+        Ok(())
+    }
+
     fn translate_reified_command_host_paths(
         cmd: &str,
         plan: &super::reified_namespace::ReifiedNamespacePlan,
@@ -1078,6 +1090,86 @@ fn path_like_subtoken_ranges(token: &str) -> Vec<Range<usize>> {
         ranges.push(range);
     }
     ranges
+}
+
+fn absolute_path_literal_candidates(token: &str) -> Vec<Vec<String>> {
+    let mut literals = Vec::new();
+    for range in path_like_subtoken_ranges(token) {
+        push_absolute_path_literal_candidates(token, range, &mut literals);
+    }
+
+    for range in embedded_absolute_path_literal_ranges(token) {
+        push_absolute_path_literal_candidates(token, range, &mut literals);
+    }
+
+    literals
+}
+
+fn push_absolute_path_literal_candidates(
+    token: &str,
+    range: Range<usize>,
+    literals: &mut Vec<Vec<String>>,
+) {
+    let literal = &token[range.clone()];
+    if !Path::new(literal).is_absolute() {
+        return;
+    }
+
+    let mut candidates = vec![literal.to_string()];
+    for (offset, ch) in literal.char_indices() {
+        if ch.is_whitespace() && offset > 0 {
+            let prefix = literal[..offset].to_string();
+            if !candidates.contains(&prefix) {
+                candidates.push(prefix);
+            }
+        }
+    }
+    if !literals.iter().any(|existing| existing == &candidates) {
+        literals.push(candidates);
+    }
+}
+
+fn embedded_absolute_path_literal_ranges(token: &str) -> Vec<Range<usize>> {
+    let mut ranges = Vec::new();
+    let indices = token.char_indices().collect::<Vec<_>>();
+    for (position, &(start, ch)) in indices.iter().enumerate() {
+        if ch != '/' || absolute_path_match_has_path_prefix(token, start) {
+            continue;
+        }
+
+        let mut end = token.len();
+        for &(index, next) in &indices[position + 1..] {
+            if is_absolute_path_literal_terminator(next) {
+                end = index;
+                break;
+            }
+        }
+        ranges.push(start..end);
+    }
+    ranges
+}
+
+fn absolute_path_match_has_path_prefix(text: &str, start: usize) -> bool {
+    if start == 0 {
+        return false;
+    }
+    let prev = text.as_bytes()[start - 1];
+    prev == b':'
+        || prev == b'.'
+        || prev == b'/'
+        || prev == b'_'
+        || prev == b'-'
+        || prev == b'*'
+        || prev == b'?'
+        || prev == b']'
+        || prev.is_ascii_alphanumeric()
+}
+
+fn is_absolute_path_literal_terminator(ch: char) -> bool {
+    matches!(
+        ch,
+        '"' | '\'' | '`' | '(' | ')' | '[' | ']' | '{' | '}' | '<' | '>' | '|' | '&' | ';' | ','
+    )
 }
 
 fn shell_quote_token(token: &str) -> String {

--- a/crates/agent-engine/src/tools/sandbox.rs
+++ b/crates/agent-engine/src/tools/sandbox.rs
@@ -551,7 +551,7 @@ impl Sandbox {
         } else {
             NetworkPosture::Deny
         };
-        super::reified_namespace::ReifiedNamespacePlan::derive(
+        let mut plan = super::reified_namespace::ReifiedNamespacePlan::derive(
             super::reified_namespace::ReifiedNamespacePlanInput::new(
                 self.reified_mount_declarations(),
                 cwd,
@@ -564,7 +564,14 @@ impl Sandbox {
                 network,
             ),
         )
-        .map_err(|err| anyhow!("failed to build reified namespace plan: {err}"))
+        .map_err(|err| anyhow!("failed to build reified namespace plan: {err}"))?;
+        plan.argv = vec![
+            "sh".to_string(),
+            "-f".to_string(),
+            "-c".to_string(),
+            Self::translate_reified_command_host_paths(cmd, &plan),
+        ];
+        Ok(plan)
     }
 
     fn reified_mount_declarations(&self) -> Vec<super::reified_namespace::ReifiedMountDeclaration> {
@@ -948,6 +955,58 @@ impl Sandbox {
         }
         None
     }
+
+    fn translate_reified_command_host_paths(
+        cmd: &str,
+        plan: &super::reified_namespace::ReifiedNamespacePlan,
+    ) -> String {
+        let regex = Regex::new(r"/[A-Za-z0-9._/-]+").expect("absolute-path regex is valid");
+        let mut translated = String::with_capacity(cmd.len());
+        let mut last = 0;
+        for matched in regex.find_iter(cmd) {
+            let start = matched.start();
+            if absolute_path_match_has_path_prefix(cmd, start) {
+                continue;
+            }
+
+            let literal = matched.as_str();
+            let literal_path = Path::new(literal);
+            if is_allowed_absolute_command_path(literal_path) {
+                continue;
+            }
+
+            let namespace_path = plan
+                .translate_projected_host_path(literal_path)
+                .or_else(|| {
+                    plan.translate_projected_host_path(&lexically_normalize_path(literal_path))
+                });
+            let Some(namespace_path) = namespace_path else {
+                continue;
+            };
+
+            translated.push_str(&cmd[last..start]);
+            translated.push_str(&namespace_path.display().to_string());
+            last = matched.end();
+        }
+        translated.push_str(&cmd[last..]);
+        translated
+    }
+}
+
+fn absolute_path_match_has_path_prefix(text: &str, start: usize) -> bool {
+    if start == 0 {
+        return false;
+    }
+    let prev = text.as_bytes()[start - 1];
+    prev == b':'
+        || prev == b'.'
+        || prev == b'/'
+        || prev == b'_'
+        || prev == b'-'
+        || prev == b'*'
+        || prev == b'?'
+        || prev == b']'
+        || prev.is_ascii_alphanumeric()
 }
 
 fn validate_nested_command_evaluators(commands: &[Vec<String>], backend_name: &str) -> Result<()> {

--- a/crates/agent-engine/src/tools/sandbox.rs
+++ b/crates/agent-engine/src/tools/sandbox.rs
@@ -63,7 +63,7 @@ pub enum NetworkPosture {
 }
 
 impl NetworkPosture {
-    const fn allows_network(self) -> bool {
+    pub(crate) const fn allows_network(self) -> bool {
         matches!(self, Self::Allow)
     }
 }
@@ -416,7 +416,17 @@ impl Sandbox {
                 capability,
                 Some(alan_agent_protocol::ToolCapability::Network)
             );
-        let mut command = self.build_confined_command(cmd, allow_network)?;
+        let backend = self.active_backend();
+        if matches!(
+            backend,
+            super::sandbox_backend::SandboxBackendKind::LinuxReifiedNamespace
+        ) {
+            return self
+                .exec_reified_namespace(cmd, cwd, timeout, allow_network)
+                .await;
+        }
+
+        let mut command = self.build_confined_command(cmd, allow_network, backend)?;
         command.current_dir(cwd);
         let output = if let Some(limit) = timeout {
             match tokio::time::timeout(limit, command.output()).await {
@@ -450,9 +460,10 @@ impl Sandbox {
         &self,
         cmd: &str,
         allow_network: bool,
+        backend: super::sandbox_backend::SandboxBackendKind,
     ) -> Result<tokio::process::Command> {
         // Defense in depth: start the shell with pathname expansion disabled.
-        let command = match self.active_backend() {
+        let command = match backend {
             super::sandbox_backend::SandboxBackendKind::Seatbelt => {
                 let profile = super::sandbox_backend::seatbelt_profile(
                     &self.spec.writable_roots,
@@ -501,6 +512,79 @@ impl Sandbox {
             }
         };
         Ok(command)
+    }
+
+    async fn exec_reified_namespace(
+        &self,
+        cmd: &str,
+        cwd: &Path,
+        timeout: Option<Duration>,
+        allow_network: bool,
+    ) -> Result<ExecResult> {
+        let plan = self.reified_namespace_plan_for_command(cmd, cwd, allow_network)?;
+        let runner = super::reified_namespace::LinuxReifiedNamespaceRunner::with_fallback_backend(
+            super::sandbox_backend::detect_projection_backend(),
+        );
+        let run = move || {
+            runner
+                .run_with_timeout(&plan, timeout)
+                .map_err(anyhow::Error::from)
+        };
+        tokio::task::spawn_blocking(run)
+            .await
+            .map_err(|err| anyhow!("reified namespace runner task failed: {err}"))?
+    }
+
+    fn reified_namespace_plan_for_command(
+        &self,
+        cmd: &str,
+        cwd: &Path,
+        allow_network: bool,
+    ) -> Result<super::reified_namespace::ReifiedNamespacePlan> {
+        let cwd = if cwd.is_absolute() {
+            cwd.to_path_buf()
+        } else {
+            self.workspace_root().join(cwd)
+        };
+        let network = if allow_network {
+            NetworkPosture::Allow
+        } else {
+            NetworkPosture::Deny
+        };
+        super::reified_namespace::ReifiedNamespacePlan::derive(
+            super::reified_namespace::ReifiedNamespacePlanInput::new(
+                self.reified_mount_declarations(),
+                cwd,
+                vec![
+                    "sh".to_string(),
+                    "-f".to_string(),
+                    "-c".to_string(),
+                    cmd.to_string(),
+                ],
+                network,
+            ),
+        )
+        .map_err(|err| anyhow!("failed to build reified namespace plan: {err}"))
+    }
+
+    fn reified_mount_declarations(&self) -> Vec<super::reified_namespace::ReifiedMountDeclaration> {
+        self.spec
+            .writable_roots
+            .iter()
+            .enumerate()
+            .map(|(index, root)| {
+                let namespace_path = if index == 0 {
+                    super::reified_namespace::DEFAULT_WORKSPACE_NAMESPACE_PATH.to_string()
+                } else {
+                    format!("/mnt/writable-{index}")
+                };
+                super::reified_namespace::ReifiedMountDeclaration::host(
+                    namespace_path,
+                    root.clone(),
+                    super::reified_namespace::ReifiedMountAccess::ReadWrite,
+                )
+            })
+            .collect()
     }
 
     /// List directory contents
@@ -610,16 +694,20 @@ impl Sandbox {
             if is_allowed_absolute_command_path(Path::new(literal)) {
                 continue;
             }
+            let literal_path = Path::new(literal);
+            let validation_path = self
+                .reified_namespace_path_to_host(literal_path)
+                .unwrap_or_else(|| literal_path.to_path_buf());
             // Containment applies in every mode: the OS sandbox does not confine
             // reads, so an out-of-workspace absolute path (e.g. a read of a secret)
             // must still be rejected by the parser.
-            if !self.is_in_workspace(Path::new(literal)) {
+            if !self.is_in_workspace(&validation_path) {
                 return Err(anyhow!(
                     "Command contains absolute path outside workspace: {}",
                     literal
                 ));
             }
-            self.ensure_path_not_protected(Path::new(literal), "process path reference")?;
+            self.ensure_path_not_protected(&validation_path, "process path reference")?;
         }
 
         Ok(())
@@ -786,14 +874,17 @@ impl Sandbox {
             if candidate.is_absolute() && is_allowed_absolute_command_path(&candidate) {
                 return Ok(());
             }
-            if !self.is_in_workspace(&candidate) {
+            let validation_path = self
+                .reified_namespace_path_to_host(&candidate)
+                .unwrap_or(candidate);
+            if !self.is_in_workspace(&validation_path) {
                 return Err(anyhow!(
                     "Command references path outside workspace: {}",
                     token
                 ));
             }
-            self.ensure_path_not_protected(&candidate, "process path reference")?;
-            self.ensure_path_not_multiply_linked(&candidate, "process path reference")?;
+            self.ensure_path_not_protected(&validation_path, "process path reference")?;
+            self.ensure_path_not_multiply_linked(&validation_path, "process path reference")?;
         }
 
         Ok(())
@@ -819,15 +910,43 @@ impl Sandbox {
         if candidate.is_absolute() && is_allowed_absolute_command_path(&candidate) {
             return Ok(());
         }
-        if !self.is_in_workspace(&candidate) {
+        let validation_path = self
+            .reified_namespace_path_to_host(&candidate)
+            .unwrap_or(candidate);
+        if !self.is_in_workspace(&validation_path) {
             return Err(anyhow!(
                 "Command references path outside workspace: {}",
                 token
             ));
         }
-        self.ensure_path_not_protected(&candidate, "process path reference")?;
-        self.ensure_path_not_multiply_linked(&candidate, "process path reference")?;
+        self.ensure_path_not_protected(&validation_path, "process path reference")?;
+        self.ensure_path_not_multiply_linked(&validation_path, "process path reference")?;
         Ok(())
+    }
+
+    fn reified_namespace_path_to_host(&self, path: &Path) -> Option<PathBuf> {
+        if !matches!(
+            self.active_backend(),
+            super::sandbox_backend::SandboxBackendKind::LinuxReifiedNamespace
+        ) || !path.is_absolute()
+        {
+            return None;
+        }
+
+        for (index, root) in self.spec.writable_roots.iter().enumerate() {
+            let namespace_path = if index == 0 {
+                PathBuf::from(super::reified_namespace::DEFAULT_WORKSPACE_NAMESPACE_PATH)
+            } else {
+                PathBuf::from(format!("/mnt/writable-{index}"))
+            };
+            if path == namespace_path {
+                return Some(root.clone());
+            }
+            if let Ok(suffix) = path.strip_prefix(&namespace_path) {
+                return Some(root.join(suffix));
+            }
+        }
+        None
     }
 }
 

--- a/crates/agent-engine/src/tools/sandbox.rs
+++ b/crates/agent-engine/src/tools/sandbox.rs
@@ -14,6 +14,7 @@
 use anyhow::{Result, anyhow};
 use regex::Regex;
 use std::ffi::OsString;
+use std::ops::Range;
 use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
@@ -960,53 +961,22 @@ impl Sandbox {
         cmd: &str,
         plan: &super::reified_namespace::ReifiedNamespacePlan,
     ) -> String {
-        let regex = Regex::new(r"/[A-Za-z0-9._/-]+").expect("absolute-path regex is valid");
+        let Ok(tokens) = shell_word_tokens_with_spans(cmd) else {
+            return cmd.to_string();
+        };
         let mut translated = String::with_capacity(cmd.len());
         let mut last = 0;
-        for matched in regex.find_iter(cmd) {
-            let start = matched.start();
-            if absolute_path_match_has_path_prefix(cmd, start) {
-                continue;
-            }
-
-            let literal = matched.as_str();
-            let literal_path = Path::new(literal);
-            if is_allowed_absolute_command_path(literal_path) {
-                continue;
-            }
-
-            let namespace_path = plan
-                .translate_projected_host_path(literal_path)
-                .or_else(|| {
-                    plan.translate_projected_host_path(&lexically_normalize_path(literal_path))
-                });
-            let Some(namespace_path) = namespace_path else {
+        for token in tokens {
+            let Some(rewritten) = translate_reified_shell_token(&token.decoded, plan) else {
                 continue;
             };
-
-            translated.push_str(&cmd[last..start]);
-            translated.push_str(&namespace_path.display().to_string());
-            last = matched.end();
+            translated.push_str(&cmd[last..token.raw_start]);
+            translated.push_str(&rewritten);
+            last = token.raw_end;
         }
         translated.push_str(&cmd[last..]);
         translated
     }
-}
-
-fn absolute_path_match_has_path_prefix(text: &str, start: usize) -> bool {
-    if start == 0 {
-        return false;
-    }
-    let prev = text.as_bytes()[start - 1];
-    prev == b':'
-        || prev == b'.'
-        || prev == b'/'
-        || prev == b'_'
-        || prev == b'-'
-        || prev == b'*'
-        || prev == b'?'
-        || prev == b']'
-        || prev.is_ascii_alphanumeric()
 }
 
 fn validate_nested_command_evaluators(commands: &[Vec<String>], backend_name: &str) -> Result<()> {
@@ -1056,6 +1026,83 @@ fn validate_nested_command_evaluators(commands: &[Vec<String>], backend_name: &s
         }
     }
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ShellWordToken {
+    decoded: String,
+    raw_start: usize,
+    raw_end: usize,
+}
+
+fn translate_reified_shell_token(
+    token: &str,
+    plan: &super::reified_namespace::ReifiedNamespacePlan,
+) -> Option<String> {
+    for range in path_like_subtoken_ranges(token) {
+        let candidate = &token[range.clone()];
+        let candidate_path = Path::new(candidate);
+        if !candidate_path.is_absolute() || is_allowed_absolute_command_path(candidate_path) {
+            continue;
+        }
+
+        let namespace_path = plan
+            .translate_projected_host_path(candidate_path)
+            .or_else(|| {
+                plan.translate_projected_host_path(&lexically_normalize_path(candidate_path))
+            })?;
+        let namespace_path = namespace_path.display().to_string();
+        let mut rewritten = String::with_capacity(token.len() + namespace_path.len());
+        rewritten.push_str(&token[..range.start]);
+        rewritten.push_str(&shell_quote_token(&namespace_path));
+        rewritten.push_str(&token[range.end..]);
+        return Some(rewritten);
+    }
+    None
+}
+
+fn path_like_subtoken_ranges(token: &str) -> Vec<Range<usize>> {
+    let mut ranges = Vec::new();
+    if looks_like_path_token(token) || looks_like_bare_protected_subpath_token(token) {
+        ranges.push(0..token.len());
+    }
+    if let Some(index) = token.rfind('=') {
+        let start = index + 1;
+        if start < token.len() {
+            ranges.push(start..token.len());
+        }
+    }
+    if let Some(range) = short_option_attached_path_subtoken_range(token)
+        && !ranges.contains(&range)
+    {
+        ranges.push(range);
+    }
+    ranges
+}
+
+fn shell_quote_token(token: &str) -> String {
+    if !token.is_empty()
+        && token.chars().all(|ch| {
+            ch.is_ascii_alphanumeric()
+                || matches!(
+                    ch,
+                    '@' | '%' | '_' | '+' | '=' | ':' | ',' | '.' | '/' | '-'
+                )
+        })
+    {
+        return token.to_string();
+    }
+
+    let mut quoted = String::from("'");
+    for ch in token.chars() {
+        if ch == '\'' {
+            quoted.push_str("'\\''");
+        } else {
+            quoted.push(ch);
+        }
+    }
+    quoted.push('\'');
+    quoted
 }
 
 fn validate_bash_command_shape(cmd: &str) -> Result<()> {
@@ -1194,6 +1241,11 @@ fn path_like_subtokens(token: &str) -> Vec<&str> {
 }
 
 fn short_option_attached_path_subtoken(token: &str) -> Option<&str> {
+    let range = short_option_attached_path_subtoken_range(token)?;
+    Some(&token[range])
+}
+
+fn short_option_attached_path_subtoken_range(token: &str) -> Option<Range<usize>> {
     if token.starts_with("--") {
         return None;
     }
@@ -1202,14 +1254,17 @@ fn short_option_attached_path_subtoken(token: &str) -> Option<&str> {
         return None;
     }
 
-    rest.char_indices()
-        .skip(1)
-        .map(|(index, _)| &rest[index..])
-        .find(|candidate| {
-            candidate.starts_with('~')
-                || looks_like_path_token(candidate)
-                || looks_like_bare_protected_subpath_token(candidate)
-        })
+    rest.char_indices().skip(1).find_map(|(index, _)| {
+        let candidate = &rest[index..];
+        if candidate.starts_with('~')
+            || looks_like_path_token(candidate)
+            || looks_like_bare_protected_subpath_token(candidate)
+        {
+            Some((index + 1)..token.len())
+        } else {
+            None
+        }
+    })
 }
 
 fn is_file_redirection_operator(token: &str) -> bool {
@@ -1619,6 +1674,151 @@ where
         }
         _ => false,
     }
+}
+
+fn shell_word_tokens_with_spans(command: &str) -> Result<Vec<ShellWordToken>> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut chars = command.char_indices().peekable();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut in_comment = false;
+    let mut escaped = false;
+    let mut word_started = false;
+    let mut raw_start = None;
+
+    while let Some((index, ch)) = chars.next() {
+        if in_comment {
+            if matches!(ch, '\n' | '\r') {
+                in_comment = false;
+                word_started = false;
+            }
+            continue;
+        }
+
+        if escaped {
+            current.push(ch);
+            escaped = false;
+            word_started = true;
+            continue;
+        }
+
+        if in_single {
+            if ch == '\'' {
+                in_single = false;
+            } else {
+                current.push(ch);
+            }
+            word_started = true;
+            continue;
+        }
+
+        if in_double {
+            match ch {
+                '\\' => {
+                    if let Some((_, next)) = chars.next() {
+                        current.push(next);
+                        word_started = true;
+                    } else {
+                        return Err(anyhow!("Command ends with an incomplete escape sequence"));
+                    }
+                }
+                '"' => {
+                    in_double = false;
+                    word_started = true;
+                }
+                _ => {
+                    current.push(ch);
+                    word_started = true;
+                }
+            }
+            continue;
+        }
+
+        match ch {
+            '\\' => {
+                raw_start.get_or_insert(index);
+                if let Some((_, next)) = chars.next() {
+                    current.push(next);
+                    word_started = true;
+                } else {
+                    return Err(anyhow!("Command ends with an incomplete escape sequence"));
+                }
+            }
+            '\'' => {
+                raw_start.get_or_insert(index);
+                in_single = true;
+                word_started = true;
+            }
+            '"' => {
+                raw_start.get_or_insert(index);
+                in_double = true;
+                word_started = true;
+            }
+            '#' if !word_started => in_comment = true,
+            c if c.is_whitespace() => {
+                push_shell_word_token(&mut tokens, &mut current, &mut raw_start, index);
+                word_started = false;
+            }
+            ';' | '(' | ')' | '{' | '}' => {
+                push_shell_word_token(&mut tokens, &mut current, &mut raw_start, index);
+                word_started = false;
+            }
+            '&' | '|' => {
+                push_shell_word_token(&mut tokens, &mut current, &mut raw_start, index);
+
+                if matches!(chars.peek(), Some((_, next)) if *next == ch) {
+                    chars.next();
+                }
+                word_started = false;
+            }
+            '<' | '>' => {
+                push_shell_word_token(&mut tokens, &mut current, &mut raw_start, index);
+
+                match (ch, chars.peek().copied()) {
+                    ('<', Some((_, '<' | '>' | '&'))) | ('>', Some((_, '>' | '&' | '|'))) => {
+                        chars.next();
+                        if ch == '<' && matches!(chars.peek(), Some((_, '-'))) {
+                            chars.next();
+                        }
+                    }
+                    _ => {}
+                }
+                word_started = false;
+            }
+            _ => {
+                raw_start.get_or_insert(index);
+                current.push(ch);
+                word_started = true;
+            }
+        }
+    }
+
+    if escaped {
+        return Err(anyhow!("Command ends with an incomplete escape sequence"));
+    }
+    if in_single || in_double {
+        return Err(anyhow!("Command contains an unterminated quoted string"));
+    }
+    push_shell_word_token(&mut tokens, &mut current, &mut raw_start, command.len());
+
+    Ok(tokens)
+}
+
+fn push_shell_word_token(
+    tokens: &mut Vec<ShellWordToken>,
+    current: &mut String,
+    raw_start: &mut Option<usize>,
+    raw_end: usize,
+) {
+    let Some(start) = raw_start.take() else {
+        return;
+    };
+    tokens.push(ShellWordToken {
+        decoded: std::mem::take(current),
+        raw_start: start,
+        raw_end,
+    });
 }
 
 fn shell_word_tokens(command: &str) -> Result<Vec<String>> {

--- a/crates/agent-engine/src/tools/sandbox_backend.rs
+++ b/crates/agent-engine/src/tools/sandbox_backend.rs
@@ -201,6 +201,7 @@ pub struct LinuxReificationCapabilities {
 pub struct LinuxReifiedNamespaceBackendReadiness {
     pub capability_report: LinuxReificationCapabilityReport,
     pub runner_smoke: LinuxReificationCapability,
+    pub toolchain_smoke: LinuxReificationCapability,
     pub selected_backend: SandboxBackendKind,
 }
 
@@ -210,6 +211,7 @@ impl LinuxReifiedNamespaceBackendReadiness {
         let mut fields = self.capability_report.audit_fields();
         fields.extend([
             ("runner_smoke", self.runner_smoke.audit_value()),
+            ("toolchain_smoke", self.toolchain_smoke.audit_value()),
             ("selected_backend", self.selected_backend.name().to_string()),
             ("path_mode", self.selected_backend.path_mode().to_string()),
         ]);
@@ -348,7 +350,22 @@ pub fn preferred_linux_backend_with_reification_and_runner(
     runner_smoke: &LinuxReificationCapability,
     landlock_is_available: bool,
 ) -> SandboxBackendKind {
-    if report.is_selectable() && runner_smoke.is_available() {
+    let toolchain_smoke = LinuxReificationCapability::available();
+    preferred_linux_backend_with_reification_runner_and_toolchain(
+        report,
+        runner_smoke,
+        &toolchain_smoke,
+        landlock_is_available,
+    )
+}
+
+fn preferred_linux_backend_with_reification_runner_and_toolchain(
+    report: &LinuxReificationCapabilityReport,
+    runner_smoke: &LinuxReificationCapability,
+    toolchain_smoke: &LinuxReificationCapability,
+    landlock_is_available: bool,
+) -> SandboxBackendKind {
+    if report.is_selectable() && runner_smoke.is_available() && toolchain_smoke.is_available() {
         SandboxBackendKind::LinuxReifiedNamespace
     } else if landlock_is_available {
         SandboxBackendKind::Landlock
@@ -369,14 +386,17 @@ pub fn linux_reified_namespace_backend_readiness() -> LinuxReifiedNamespaceBacke
 fn probe_linux_reified_namespace_backend_readiness() -> LinuxReifiedNamespaceBackendReadiness {
     let capability_report = probe_linux_reification();
     let runner_smoke = LinuxReificationCapability::unavailable("not a linux host");
-    let selected_backend = preferred_linux_backend_with_reification_and_runner(
+    let toolchain_smoke = LinuxReificationCapability::unavailable("not a linux host");
+    let selected_backend = preferred_linux_backend_with_reification_runner_and_toolchain(
         &capability_report,
         &runner_smoke,
+        &toolchain_smoke,
         false,
     );
     LinuxReifiedNamespaceBackendReadiness {
         capability_report,
         runner_smoke,
+        toolchain_smoke,
         selected_backend,
     }
 }
@@ -389,14 +409,21 @@ fn probe_linux_reified_namespace_backend_readiness() -> LinuxReifiedNamespaceBac
     } else {
         LinuxReificationCapability::unavailable("capability probe did not select reification")
     };
-    let selected_backend = preferred_linux_backend_with_reification_and_runner(
+    let toolchain_smoke = if runner_smoke.is_available() {
+        super::reified_namespace::smoke_linux_reified_namespace_user_path()
+    } else {
+        LinuxReificationCapability::unavailable("runner smoke did not pass")
+    };
+    let selected_backend = preferred_linux_backend_with_reification_runner_and_toolchain(
         &capability_report,
         &runner_smoke,
+        &toolchain_smoke,
         landlock_available(),
     );
     LinuxReifiedNamespaceBackendReadiness {
         capability_report,
         runner_smoke,
+        toolchain_smoke,
         selected_backend,
     }
 }
@@ -1412,10 +1439,46 @@ mod tests {
     }
 
     #[test]
+    fn linux_reification_selection_requires_toolchain_smoke() {
+        let complete = complete_linux_reification_report();
+        let runner_smoke = available_capability();
+        let toolchain_smoke = unavailable_capability("current PATH cannot be preserved");
+
+        assert_eq!(
+            preferred_linux_backend_with_reification_runner_and_toolchain(
+                &complete,
+                &runner_smoke,
+                &toolchain_smoke,
+                true
+            ),
+            SandboxBackendKind::Landlock
+        );
+        assert_eq!(
+            preferred_linux_backend_with_reification_runner_and_toolchain(
+                &complete,
+                &runner_smoke,
+                &toolchain_smoke,
+                false
+            ),
+            SandboxBackendKind::WorkspacePathGuard
+        );
+        assert_eq!(
+            preferred_linux_backend_with_reification_runner_and_toolchain(
+                &complete,
+                &runner_smoke,
+                &available_capability(),
+                true
+            ),
+            SandboxBackendKind::LinuxReifiedNamespace
+        );
+    }
+
+    #[test]
     fn linux_reification_readiness_audit_names_selected_backend_and_path_mode() {
         let readiness = LinuxReifiedNamespaceBackendReadiness {
             capability_report: complete_linux_reification_report(),
             runner_smoke: unavailable_capability("runner smoke failed"),
+            toolchain_smoke: unavailable_capability("current PATH cannot be preserved"),
             selected_backend: SandboxBackendKind::Landlock,
         };
 
@@ -1424,6 +1487,10 @@ mod tests {
         assert!(fields.contains(&(
             "runner_smoke",
             "unavailable(runner smoke failed)".to_string()
+        )));
+        assert!(fields.contains(&(
+            "toolchain_smoke",
+            "unavailable(current PATH cannot be preserved)".to_string()
         )));
         assert!(fields.contains(&("selected_backend", "landlock".to_string())));
         assert!(fields.contains(&("path_mode", "projected_host_paths".to_string())));

--- a/crates/agent-engine/src/tools/sandbox_backend.rs
+++ b/crates/agent-engine/src/tools/sandbox_backend.rs
@@ -172,6 +172,8 @@ pub struct LinuxReificationCapabilityReport {
     pub user_namespace: LinuxReificationCapability,
     /// Mount namespace creation.
     pub mount_namespace: LinuxReificationCapability,
+    /// PID namespace creation for timeout cleanup of all descendants.
+    pub pid_namespace: LinuxReificationCapability,
     /// Bind-mount support inside the new namespace.
     pub bind_mount: LinuxReificationCapability,
     /// Read-only remount support for bound paths.
@@ -179,6 +181,19 @@ pub struct LinuxReificationCapabilityReport {
     /// Private scratch/tmp mount support.
     pub scratch_tmp_mount: LinuxReificationCapability,
     /// Network confinement support for network-denied commands.
+    pub network_confinement: LinuxReificationCapability,
+}
+
+/// Requirement states used to build a Linux reification capability report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinuxReificationCapabilities {
+    pub linux_host: LinuxReificationCapability,
+    pub user_namespace: LinuxReificationCapability,
+    pub mount_namespace: LinuxReificationCapability,
+    pub pid_namespace: LinuxReificationCapability,
+    pub bind_mount: LinuxReificationCapability,
+    pub read_only_remount: LinuxReificationCapability,
+    pub scratch_tmp_mount: LinuxReificationCapability,
     pub network_confinement: LinuxReificationCapability,
 }
 
@@ -205,23 +220,16 @@ impl LinuxReifiedNamespaceBackendReadiness {
 
 impl LinuxReificationCapabilityReport {
     /// Build a report from explicit requirement states.
-    pub fn new(
-        linux_host: LinuxReificationCapability,
-        user_namespace: LinuxReificationCapability,
-        mount_namespace: LinuxReificationCapability,
-        bind_mount: LinuxReificationCapability,
-        read_only_remount: LinuxReificationCapability,
-        scratch_tmp_mount: LinuxReificationCapability,
-        network_confinement: LinuxReificationCapability,
-    ) -> Self {
+    pub fn new(capabilities: LinuxReificationCapabilities) -> Self {
         Self {
-            linux_host,
-            user_namespace,
-            mount_namespace,
-            bind_mount,
-            read_only_remount,
-            scratch_tmp_mount,
-            network_confinement,
+            linux_host: capabilities.linux_host,
+            user_namespace: capabilities.user_namespace,
+            mount_namespace: capabilities.mount_namespace,
+            pid_namespace: capabilities.pid_namespace,
+            bind_mount: capabilities.bind_mount,
+            read_only_remount: capabilities.read_only_remount,
+            scratch_tmp_mount: capabilities.scratch_tmp_mount,
+            network_confinement: capabilities.network_confinement,
         }
     }
 
@@ -235,6 +243,7 @@ impl LinuxReificationCapabilityReport {
         let fs_requirements_available = self.linux_host.is_available()
             && self.user_namespace.is_available()
             && self.mount_namespace.is_available()
+            && self.pid_namespace.is_available()
             && self.bind_mount.is_available()
             && self.read_only_remount.is_available()
             && self.scratch_tmp_mount.is_available();
@@ -279,11 +288,12 @@ impl LinuxReificationCapabilityReport {
         fields
     }
 
-    fn capabilities(&self) -> [(&'static str, &LinuxReificationCapability); 7] {
+    fn capabilities(&self) -> [(&'static str, &LinuxReificationCapability); 8] {
         [
             ("linux_host", &self.linux_host),
             ("user_namespace", &self.user_namespace),
             ("mount_namespace", &self.mount_namespace),
+            ("pid_namespace", &self.pid_namespace),
             ("bind_mount", &self.bind_mount),
             ("read_only_remount", &self.read_only_remount),
             ("scratch_tmp_mount", &self.scratch_tmp_mount),
@@ -395,15 +405,16 @@ fn probe_linux_reified_namespace_backend_readiness() -> LinuxReifiedNamespaceBac
 #[cfg(not(target_os = "linux"))]
 fn probe_linux_reification_for_host() -> LinuxReificationCapabilityReport {
     let reason = "not a linux host";
-    LinuxReificationCapabilityReport::new(
-        LinuxReificationCapability::unavailable(reason),
-        LinuxReificationCapability::unavailable(reason),
-        LinuxReificationCapability::unavailable(reason),
-        LinuxReificationCapability::unavailable(reason),
-        LinuxReificationCapability::unavailable(reason),
-        LinuxReificationCapability::unavailable(reason),
-        LinuxReificationCapability::unavailable(reason),
-    )
+    LinuxReificationCapabilityReport::new(LinuxReificationCapabilities {
+        linux_host: LinuxReificationCapability::unavailable(reason),
+        user_namespace: LinuxReificationCapability::unavailable(reason),
+        mount_namespace: LinuxReificationCapability::unavailable(reason),
+        pid_namespace: LinuxReificationCapability::unavailable(reason),
+        bind_mount: LinuxReificationCapability::unavailable(reason),
+        read_only_remount: LinuxReificationCapability::unavailable(reason),
+        scratch_tmp_mount: LinuxReificationCapability::unavailable(reason),
+        network_confinement: LinuxReificationCapability::unavailable(reason),
+    })
 }
 
 #[cfg(target_os = "linux")]
@@ -420,6 +431,15 @@ fn probe_linux_reification_for_host() -> LinuxReificationCapabilityReport {
         run_linux_probe_command(
             "mount namespace",
             linux_unshare_command(&["--user", "--map-root-user", "--mount"]),
+        )
+    } else {
+        LinuxReificationCapability::unavailable("requires available user namespace")
+    };
+
+    let pid_namespace = if user_namespace.is_available() {
+        run_linux_probe_command(
+            "pid namespace",
+            linux_unshare_command(&["--user", "--map-root-user", "--pid", "--fork"]),
         )
     } else {
         LinuxReificationCapability::unavailable("requires available user namespace")
@@ -463,15 +483,16 @@ fn probe_linux_reification_for_host() -> LinuxReificationCapabilityReport {
         LinuxReificationCapability::unavailable("requires available mount namespace")
     };
 
-    LinuxReificationCapabilityReport::new(
+    LinuxReificationCapabilityReport::new(LinuxReificationCapabilities {
         linux_host,
         user_namespace,
         mount_namespace,
+        pid_namespace,
         bind_mount,
         read_only_remount,
         scratch_tmp_mount,
         network_confinement,
-    )
+    })
 }
 
 #[cfg(target_os = "linux")]
@@ -1232,15 +1253,16 @@ mod tests {
 
     #[test]
     fn linux_reification_report_formats_audit_fields() {
-        let report = LinuxReificationCapabilityReport::new(
-            available_capability(),
-            available_capability(),
-            available_capability(),
-            available_capability(),
-            available_capability(),
-            available_capability(),
-            unavailable_capability("network namespace unavailable"),
-        );
+        let report = LinuxReificationCapabilityReport::new(LinuxReificationCapabilities {
+            linux_host: available_capability(),
+            user_namespace: available_capability(),
+            mount_namespace: available_capability(),
+            pid_namespace: available_capability(),
+            bind_mount: available_capability(),
+            read_only_remount: available_capability(),
+            scratch_tmp_mount: available_capability(),
+            network_confinement: unavailable_capability("network namespace unavailable"),
+        });
 
         assert_eq!(report.backend_name(), "linux_reified_namespace");
         assert_eq!(report.status(), LinuxReificationStatus::Degraded);
@@ -1252,6 +1274,7 @@ mod tests {
                 ("linux_host", "available".to_string()),
                 ("user_namespace", "available".to_string()),
                 ("mount_namespace", "available".to_string()),
+                ("pid_namespace", "available".to_string()),
                 ("bind_mount", "available".to_string()),
                 ("read_only_remount", "available".to_string()),
                 ("scratch_tmp_mount", "available".to_string()),
@@ -1264,23 +1287,24 @@ mod tests {
         assert_eq!(
             report.to_string(),
             "linux_reified_namespace: degraded (linux_host=available, \
-             user_namespace=available, mount_namespace=available, bind_mount=available, \
-             read_only_remount=available, scratch_tmp_mount=available, \
+             user_namespace=available, mount_namespace=available, pid_namespace=available, \
+             bind_mount=available, read_only_remount=available, scratch_tmp_mount=available, \
              network_confinement=unavailable(network namespace unavailable))"
         );
     }
 
     #[test]
     fn linux_reification_report_lists_unavailable_reasons() {
-        let report = LinuxReificationCapabilityReport::new(
-            unavailable_capability("not a linux host"),
-            unavailable_capability("not a linux host"),
-            unavailable_capability("requires available user namespace"),
-            unavailable_capability("requires available mount namespace"),
-            available_capability(),
-            available_capability(),
-            unavailable_capability("network namespace unavailable"),
-        );
+        let report = LinuxReificationCapabilityReport::new(LinuxReificationCapabilities {
+            linux_host: unavailable_capability("not a linux host"),
+            user_namespace: unavailable_capability("not a linux host"),
+            mount_namespace: unavailable_capability("requires available user namespace"),
+            pid_namespace: unavailable_capability("requires available user namespace"),
+            bind_mount: unavailable_capability("requires available mount namespace"),
+            read_only_remount: available_capability(),
+            scratch_tmp_mount: available_capability(),
+            network_confinement: unavailable_capability("network namespace unavailable"),
+        });
 
         assert_eq!(
             report.unavailable_reasons(),
@@ -1288,6 +1312,7 @@ mod tests {
                 "linux_host: not a linux host".to_string(),
                 "user_namespace: not a linux host".to_string(),
                 "mount_namespace: requires available user namespace".to_string(),
+                "pid_namespace: requires available user namespace".to_string(),
                 "bind_mount: requires available mount namespace".to_string(),
                 "network_confinement: network namespace unavailable".to_string(),
             ]
@@ -1306,6 +1331,7 @@ mod tests {
                 "linux_host: not a linux host".to_string(),
                 "user_namespace: not a linux host".to_string(),
                 "mount_namespace: not a linux host".to_string(),
+                "pid_namespace: not a linux host".to_string(),
                 "bind_mount: not a linux host".to_string(),
                 "read_only_remount: not a linux host".to_string(),
                 "scratch_tmp_mount: not a linux host".to_string(),
@@ -1322,15 +1348,16 @@ mod tests {
             SandboxBackendKind::LinuxReifiedNamespace
         );
 
-        let incomplete = LinuxReificationCapabilityReport::new(
-            available_capability(),
-            unavailable_capability("user namespaces disabled"),
-            available_capability(),
-            available_capability(),
-            available_capability(),
-            available_capability(),
-            available_capability(),
-        );
+        let incomplete = LinuxReificationCapabilityReport::new(LinuxReificationCapabilities {
+            linux_host: available_capability(),
+            user_namespace: unavailable_capability("user namespaces disabled"),
+            mount_namespace: available_capability(),
+            pid_namespace: available_capability(),
+            bind_mount: available_capability(),
+            read_only_remount: available_capability(),
+            scratch_tmp_mount: available_capability(),
+            network_confinement: available_capability(),
+        });
         assert_eq!(
             preferred_linux_backend_with_reification(&incomplete, true),
             SandboxBackendKind::Landlock
@@ -1340,15 +1367,16 @@ mod tests {
             SandboxBackendKind::WorkspacePathGuard
         );
 
-        let degraded = LinuxReificationCapabilityReport::new(
-            available_capability(),
-            available_capability(),
-            available_capability(),
-            available_capability(),
-            available_capability(),
-            available_capability(),
-            unavailable_capability("network confinement unavailable"),
-        );
+        let degraded = LinuxReificationCapabilityReport::new(LinuxReificationCapabilities {
+            linux_host: available_capability(),
+            user_namespace: available_capability(),
+            mount_namespace: available_capability(),
+            pid_namespace: available_capability(),
+            bind_mount: available_capability(),
+            read_only_remount: available_capability(),
+            scratch_tmp_mount: available_capability(),
+            network_confinement: unavailable_capability("network confinement unavailable"),
+        });
         assert_eq!(
             preferred_linux_backend_with_reification(&degraded, true),
             SandboxBackendKind::Landlock
@@ -1440,14 +1468,15 @@ mod tests {
     }
 
     fn complete_linux_reification_report() -> LinuxReificationCapabilityReport {
-        LinuxReificationCapabilityReport::new(
-            available_capability(),
-            available_capability(),
-            available_capability(),
-            available_capability(),
-            available_capability(),
-            available_capability(),
-            available_capability(),
-        )
+        LinuxReificationCapabilityReport::new(LinuxReificationCapabilities {
+            linux_host: available_capability(),
+            user_namespace: available_capability(),
+            mount_namespace: available_capability(),
+            pid_namespace: available_capability(),
+            bind_mount: available_capability(),
+            read_only_remount: available_capability(),
+            scratch_tmp_mount: available_capability(),
+            network_confinement: available_capability(),
+        })
     }
 }

--- a/crates/agent-engine/src/tools/sandbox_backend.rs
+++ b/crates/agent-engine/src/tools/sandbox_backend.rs
@@ -20,6 +20,7 @@ use std::fmt;
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
+use std::sync::OnceLock;
 
 /// Available sandbox enforcement backends, in order of strength.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -42,6 +43,16 @@ impl SandboxBackendKind {
             SandboxBackendKind::LinuxReifiedNamespace => "linux_reified_namespace",
             SandboxBackendKind::Landlock => "landlock",
             SandboxBackendKind::WorkspacePathGuard => "workspace_path_guard",
+        }
+    }
+
+    /// Whether native subprocess paths are host-projected or namespace-reified.
+    pub const fn path_mode(self) -> &'static str {
+        match self {
+            SandboxBackendKind::LinuxReifiedNamespace => "reified_namespace_paths",
+            SandboxBackendKind::Seatbelt
+            | SandboxBackendKind::Landlock
+            | SandboxBackendKind::WorkspacePathGuard => "projected_host_paths",
         }
     }
 
@@ -171,6 +182,27 @@ pub struct LinuxReificationCapabilityReport {
     pub network_confinement: LinuxReificationCapability,
 }
 
+/// Selection readiness for the Linux reified namespace backend.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinuxReifiedNamespaceBackendReadiness {
+    pub capability_report: LinuxReificationCapabilityReport,
+    pub runner_smoke: LinuxReificationCapability,
+    pub selected_backend: SandboxBackendKind,
+}
+
+impl LinuxReifiedNamespaceBackendReadiness {
+    /// Stable fields for startup/debug audits.
+    pub fn audit_fields(&self) -> Vec<(&'static str, String)> {
+        let mut fields = self.capability_report.audit_fields();
+        fields.extend([
+            ("runner_smoke", self.runner_smoke.audit_value()),
+            ("selected_backend", self.selected_backend.name().to_string()),
+            ("path_mode", self.selected_backend.path_mode().to_string()),
+        ]);
+        fields
+    }
+}
+
 impl LinuxReificationCapabilityReport {
     /// Build a report from explicit requirement states.
     pub fn new(
@@ -294,12 +326,69 @@ pub fn preferred_linux_backend_with_reification(
     report: &LinuxReificationCapabilityReport,
     landlock_is_available: bool,
 ) -> SandboxBackendKind {
-    if report.is_selectable() {
+    preferred_linux_backend_with_reification_and_runner(
+        report,
+        &LinuxReificationCapability::available(),
+        landlock_is_available,
+    )
+}
+
+/// Choose a Linux backend from capability and runner-smoke evidence.
+pub fn preferred_linux_backend_with_reification_and_runner(
+    report: &LinuxReificationCapabilityReport,
+    runner_smoke: &LinuxReificationCapability,
+    landlock_is_available: bool,
+) -> SandboxBackendKind {
+    if report.is_selectable() && runner_smoke.is_available() {
         SandboxBackendKind::LinuxReifiedNamespace
     } else if landlock_is_available {
         SandboxBackendKind::Landlock
     } else {
         SandboxBackendKind::WorkspacePathGuard
+    }
+}
+
+/// Cached readiness for selecting the Linux reified namespace backend.
+pub fn linux_reified_namespace_backend_readiness() -> LinuxReifiedNamespaceBackendReadiness {
+    static READINESS: OnceLock<LinuxReifiedNamespaceBackendReadiness> = OnceLock::new();
+    READINESS
+        .get_or_init(probe_linux_reified_namespace_backend_readiness)
+        .clone()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn probe_linux_reified_namespace_backend_readiness() -> LinuxReifiedNamespaceBackendReadiness {
+    let capability_report = probe_linux_reification();
+    let runner_smoke = LinuxReificationCapability::unavailable("not a linux host");
+    let selected_backend = preferred_linux_backend_with_reification_and_runner(
+        &capability_report,
+        &runner_smoke,
+        false,
+    );
+    LinuxReifiedNamespaceBackendReadiness {
+        capability_report,
+        runner_smoke,
+        selected_backend,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn probe_linux_reified_namespace_backend_readiness() -> LinuxReifiedNamespaceBackendReadiness {
+    let capability_report = probe_linux_reification();
+    let runner_smoke = if capability_report.is_selectable() {
+        super::reified_namespace::smoke_linux_reified_namespace_runner()
+    } else {
+        LinuxReificationCapability::unavailable("capability probe did not select reification")
+    };
+    let selected_backend = preferred_linux_backend_with_reification_and_runner(
+        &capability_report,
+        &runner_smoke,
+        landlock_available(),
+    );
+    LinuxReifiedNamespaceBackendReadiness {
+        capability_report,
+        runner_smoke,
+        selected_backend,
     }
 }
 
@@ -569,6 +658,22 @@ pub fn active_backend_name() -> &'static str {
     detect_backend().name()
 }
 
+/// Path semantics for the active execution backend.
+pub fn active_backend_path_mode() -> &'static str {
+    detect_backend().path_mode()
+}
+
+/// Detect the strongest projection backend, ignoring Linux reification.
+pub fn detect_projection_backend() -> SandboxBackendKind {
+    if cfg!(target_os = "macos") && seatbelt_available() {
+        SandboxBackendKind::Seatbelt
+    } else if cfg!(target_os = "linux") && landlock_available() {
+        SandboxBackendKind::Landlock
+    } else {
+        SandboxBackendKind::WorkspacePathGuard
+    }
+}
+
 /// Detect the strongest available backend for the host.
 ///
 /// Conservative by design: returns an OS backend only when its tooling is
@@ -576,8 +681,8 @@ pub fn active_backend_name() -> &'static str {
 pub fn detect_backend() -> SandboxBackendKind {
     if cfg!(target_os = "macos") && seatbelt_available() {
         SandboxBackendKind::Seatbelt
-    } else if cfg!(target_os = "linux") && landlock_available() {
-        SandboxBackendKind::Landlock
+    } else if cfg!(target_os = "linux") {
+        linux_reified_namespace_backend_readiness().selected_backend
     } else {
         SandboxBackendKind::WorkspacePathGuard
     }
@@ -879,6 +984,26 @@ mod tests {
     }
 
     #[test]
+    fn backend_path_modes_are_stable() {
+        assert_eq!(
+            SandboxBackendKind::Seatbelt.path_mode(),
+            "projected_host_paths"
+        );
+        assert_eq!(
+            SandboxBackendKind::Landlock.path_mode(),
+            "projected_host_paths"
+        );
+        assert_eq!(
+            SandboxBackendKind::WorkspacePathGuard.path_mode(),
+            "projected_host_paths"
+        );
+        assert_eq!(
+            SandboxBackendKind::LinuxReifiedNamespace.path_mode(),
+            "reified_namespace_paths"
+        );
+    }
+
+    #[test]
     fn seatbelt_profile_confines_writes_and_denies_network() {
         let writable_roots = vec![PathBuf::from("/work/space")];
         let profile = seatbelt_profile(&writable_roots, &[], false);
@@ -1084,14 +1209,25 @@ mod tests {
         assert!(matches!(
             kind,
             SandboxBackendKind::Seatbelt
+                | SandboxBackendKind::LinuxReifiedNamespace
                 | SandboxBackendKind::Landlock
                 | SandboxBackendKind::WorkspacePathGuard
         ));
     }
 
+    #[cfg(not(target_os = "linux"))]
     #[test]
-    fn detect_backend_does_not_select_linux_reified_namespace_yet() {
+    fn detect_backend_does_not_select_linux_reified_namespace_on_non_linux() {
         assert_ne!(detect_backend(), SandboxBackendKind::LinuxReifiedNamespace);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn detect_backend_matches_linux_reified_namespace_readiness() {
+        assert_eq!(
+            detect_backend(),
+            linux_reified_namespace_backend_readiness().selected_backend
+        );
     }
 
     #[test]
@@ -1217,6 +1353,47 @@ mod tests {
             preferred_linux_backend_with_reification(&degraded, true),
             SandboxBackendKind::Landlock
         );
+    }
+
+    #[test]
+    fn linux_reification_selection_requires_runner_smoke() {
+        let complete = complete_linux_reification_report();
+        let runner_smoke = unavailable_capability("runner smoke failed");
+
+        assert_eq!(
+            preferred_linux_backend_with_reification_and_runner(&complete, &runner_smoke, true),
+            SandboxBackendKind::Landlock
+        );
+        assert_eq!(
+            preferred_linux_backend_with_reification_and_runner(&complete, &runner_smoke, false),
+            SandboxBackendKind::WorkspacePathGuard
+        );
+        assert_eq!(
+            preferred_linux_backend_with_reification_and_runner(
+                &complete,
+                &available_capability(),
+                true
+            ),
+            SandboxBackendKind::LinuxReifiedNamespace
+        );
+    }
+
+    #[test]
+    fn linux_reification_readiness_audit_names_selected_backend_and_path_mode() {
+        let readiness = LinuxReifiedNamespaceBackendReadiness {
+            capability_report: complete_linux_reification_report(),
+            runner_smoke: unavailable_capability("runner smoke failed"),
+            selected_backend: SandboxBackendKind::Landlock,
+        };
+
+        let fields = readiness.audit_fields();
+
+        assert!(fields.contains(&(
+            "runner_smoke",
+            "unavailable(runner smoke failed)".to_string()
+        )));
+        assert!(fields.contains(&("selected_backend", "landlock".to_string())));
+        assert!(fields.contains(&("path_mode", "projected_host_paths".to_string())));
     }
 
     fn pre_refactor_single_workspace_profile(workspace_root: &Path, allow_network: bool) -> String {

--- a/crates/agent-engine/src/tools/sandbox_backend.rs
+++ b/crates/agent-engine/src/tools/sandbox_backend.rs
@@ -439,7 +439,13 @@ fn probe_linux_reification_for_host() -> LinuxReificationCapabilityReport {
     let pid_namespace = if user_namespace.is_available() {
         run_linux_probe_command(
             "pid namespace",
-            linux_unshare_command(&["--user", "--map-root-user", "--pid", "--fork"]),
+            linux_unshare_command(&[
+                "--user",
+                "--map-root-user",
+                "--pid",
+                "--fork",
+                "--kill-child=SIGKILL",
+            ]),
         )
     } else {
         LinuxReificationCapability::unavailable("requires available user namespace")

--- a/crates/agent-engine/src/tools/sandbox_backend.rs
+++ b/crates/agent-engine/src/tools/sandbox_backend.rs
@@ -75,9 +75,11 @@ impl SandboxBackendKind {
 
     /// Whether the backend confines bash strongly enough to run shell wrappers
     /// and reviewer-route escalated bash: the workspace filesystem boundary AND
-    /// network are kernel-enforced (Seatbelt). Landlock does not qualify — it
-    /// cannot guarantee network confinement on older kernels — so it keeps the
-    /// full shape parser and routes escalated bash to a human.
+    /// network are kernel-enforced (Seatbelt). Landlock does not qualify because
+    /// network confinement is kernel-conditional, and Linux reified namespace
+    /// does not qualify until protected subpaths are carved out of the writable
+    /// workspace mount. Conservative backends keep the full shape parser and
+    /// route escalated bash to a human.
     ///
     /// NOTE: protected subpaths (`.git`/`.alan`/`.agents`) are NOT kernel-confined
     /// (denying `.git` breaks git itself). Their integrity rests on the path-guard
@@ -85,10 +87,7 @@ impl SandboxBackendKind {
     /// writes by approved code (git porcelain, a reviewer-approved test runner)
     /// are trusted — see the residual-gap audit.
     pub const fn permits_autonomous_bash(self) -> bool {
-        matches!(
-            self,
-            SandboxBackendKind::Seatbelt | SandboxBackendKind::LinuxReifiedNamespace
-        )
+        matches!(self, SandboxBackendKind::Seatbelt)
     }
 }
 

--- a/crates/agent-engine/src/tools/sandbox_tests.rs
+++ b/crates/agent-engine/src/tools/sandbox_tests.rs
@@ -2509,6 +2509,35 @@ async fn test_reified_backend_translates_namespace_paths_for_protected_checks() 
     );
 }
 
+#[test]
+fn test_reified_backend_translates_host_workspace_paths_in_command_argv() {
+    let temp = TempDir::new().unwrap();
+    let host_manifest = temp.path().join("Cargo.toml");
+    std::fs::write(&host_manifest, "[package]\n").unwrap();
+    let sandbox = Sandbox::with_backend(
+        temp.path().to_path_buf(),
+        crate::tools::SandboxBackendKind::LinuxReifiedNamespace,
+    );
+
+    let plan = sandbox
+        .reified_namespace_plan_for_command(
+            &format!("cat {} > /dev/null", host_manifest.display()),
+            temp.path(),
+            false,
+        )
+        .unwrap();
+
+    assert_eq!(
+        plan.argv,
+        vec![
+            "sh".to_string(),
+            "-f".to_string(),
+            "-c".to_string(),
+            "cat /mnt/workspace/Cargo.toml > /dev/null".to_string()
+        ]
+    );
+}
+
 #[tokio::test]
 async fn test_os_backend_still_blocks_out_of_workspace_reads() {
     // Seatbelt denies writes/network but permits reads, so the parser must still

--- a/crates/agent-engine/src/tools/sandbox_tests.rs
+++ b/crates/agent-engine/src/tools/sandbox_tests.rs
@@ -2539,6 +2539,159 @@ fn test_reified_backend_translates_host_workspace_paths_in_command_argv() {
 }
 
 #[test]
+fn test_reified_backend_translates_embedded_host_paths_in_wrapper_script() {
+    let temp = TempDir::new().unwrap();
+    let host_manifest = temp.path().join("Cargo.toml");
+    let host_copy = temp.path().join("copy.toml");
+    std::fs::write(&host_manifest, "[package]\n").unwrap();
+    let sandbox = Sandbox::with_backend(
+        temp.path().to_path_buf(),
+        crate::tools::SandboxBackendKind::LinuxReifiedNamespace,
+    );
+
+    let plan = sandbox
+        .reified_namespace_plan_for_command(
+            &format!(
+                "bash -lc 'cp {} {}'",
+                host_manifest.display(),
+                host_copy.display()
+            ),
+            temp.path(),
+            false,
+        )
+        .unwrap();
+
+    assert_eq!(
+        plan.argv,
+        vec![
+            "sh".to_string(),
+            "-f".to_string(),
+            "-c".to_string(),
+            "bash -lc 'cp /mnt/workspace/Cargo.toml /mnt/workspace/copy.toml'".to_string()
+        ]
+    );
+}
+
+#[test]
+fn test_reified_backend_translates_embedded_host_paths_with_intervening_flag() {
+    let temp = TempDir::new().unwrap();
+    let host_manifest = temp.path().join("Cargo.toml");
+    let host_output_dir = temp.path().join("out");
+    std::fs::write(&host_manifest, "[package]\n").unwrap();
+    std::fs::create_dir_all(&host_output_dir).unwrap();
+    let sandbox = Sandbox::with_backend(
+        temp.path().to_path_buf(),
+        crate::tools::SandboxBackendKind::LinuxReifiedNamespace,
+    );
+
+    let plan = sandbox
+        .reified_namespace_plan_for_command(
+            &format!(
+                "bash -lc 'cp {} -t {}'",
+                host_manifest.display(),
+                host_output_dir.display()
+            ),
+            temp.path(),
+            false,
+        )
+        .unwrap();
+
+    assert_eq!(
+        plan.argv,
+        vec![
+            "sh".to_string(),
+            "-f".to_string(),
+            "-c".to_string(),
+            "bash -lc 'cp /mnt/workspace/Cargo.toml -t /mnt/workspace/out'".to_string()
+        ]
+    );
+}
+
+#[test]
+fn test_reified_backend_translates_quoted_spaced_wrapper_operand_before_second_path() {
+    let temp = TempDir::new().unwrap();
+    let docs_dir = temp.path().join("My Project");
+    let host_doc = docs_dir.join("Project Notes.txt");
+    let host_output_dir = temp.path().join("out");
+    std::fs::create_dir_all(&docs_dir).unwrap();
+    std::fs::create_dir_all(&host_output_dir).unwrap();
+    std::fs::write(&host_doc, "notes\n").unwrap();
+    let sandbox = Sandbox::with_backend(
+        temp.path().to_path_buf(),
+        crate::tools::SandboxBackendKind::LinuxReifiedNamespace,
+    );
+
+    let plan = sandbox
+        .reified_namespace_plan_for_command(
+            &format!(
+                "bash -lc \"cp '{}' {}\"",
+                host_doc.display(),
+                host_output_dir.display()
+            ),
+            temp.path(),
+            false,
+        )
+        .unwrap();
+
+    let command = &plan.argv[3];
+    assert!(
+        command.contains("/mnt/workspace/My Project/Project Notes.txt"),
+        "spaced source path was not translated: {command}"
+    );
+    assert!(
+        command.contains("/mnt/workspace/out"),
+        "second host path was not translated: {command}"
+    );
+    assert!(
+        !command.contains(&host_doc.display().to_string()),
+        "host source path leaked into namespace command: {command}"
+    );
+    assert!(
+        !command.contains(&host_output_dir.display().to_string()),
+        "host output path leaked into namespace command: {command}"
+    );
+}
+
+#[test]
+fn test_reified_backend_preserves_assignment_words_for_quoted_spaced_paths() {
+    let temp = TempDir::new().unwrap();
+    let docs_dir = temp.path().join("My Project");
+    let host_doc = docs_dir.join("Project Notes.txt");
+    std::fs::create_dir_all(&docs_dir).unwrap();
+    std::fs::write(&host_doc, "notes\n").unwrap();
+    let sandbox = Sandbox::with_backend(
+        temp.path().to_path_buf(),
+        crate::tools::SandboxBackendKind::LinuxReifiedNamespace,
+    );
+
+    let plan = sandbox
+        .reified_namespace_plan_for_command(
+            &format!("bash -lc \"FOO='{}' env\"", host_doc.display()),
+            temp.path(),
+            false,
+        )
+        .unwrap();
+
+    let command = &plan.argv[3];
+    assert!(
+        command.contains("FOO="),
+        "translated assignment no longer has assignment syntax: {command}"
+    );
+    assert!(
+        command.contains("/mnt/workspace/My Project/Project Notes.txt"),
+        "assignment value path was not translated: {command}"
+    );
+    assert!(
+        !command.contains("'FOO=/mnt/workspace"),
+        "entire assignment word was quoted instead of only its value: {command}"
+    );
+    assert!(
+        !command.contains(&host_doc.display().to_string()),
+        "host assignment value leaked into namespace command: {command}"
+    );
+}
+
+#[test]
 fn test_reified_backend_translates_quoted_host_workspace_paths_with_spaces() {
     let temp = TempDir::new().unwrap();
     let workspace = temp.path().join("My Project");

--- a/crates/agent-engine/src/tools/sandbox_tests.rs
+++ b/crates/agent-engine/src/tools/sandbox_tests.rs
@@ -2718,6 +2718,42 @@ fn test_reified_backend_preserves_assignment_words_for_quoted_spaced_paths() {
 }
 
 #[test]
+fn test_reified_backend_translates_colon_separated_assignment_paths() {
+    let temp = TempDir::new().unwrap();
+    let pkg_dir = temp.path().join("pkg");
+    let tests_dir = temp.path().join("tests");
+    std::fs::create_dir_all(&pkg_dir).unwrap();
+    std::fs::create_dir_all(&tests_dir).unwrap();
+    let sandbox = Sandbox::with_backend(
+        temp.path().to_path_buf(),
+        crate::tools::SandboxBackendKind::LinuxReifiedNamespace,
+    );
+
+    let host_path_list = format!("{}:{}", pkg_dir.display(), tests_dir.display());
+    let plan = sandbox
+        .reified_namespace_plan_for_command(
+            &format!("bash -lc 'PYTHONPATH={host_path_list} python -c \"import sys\"'"),
+            temp.path(),
+            false,
+        )
+        .unwrap();
+
+    let command = &plan.argv[3];
+    assert!(
+        command.contains("PYTHONPATH=/mnt/workspace/pkg:/mnt/workspace/tests"),
+        "colon-separated assignment paths were not fully translated: {command}"
+    );
+    assert!(
+        !command.contains(&pkg_dir.display().to_string()),
+        "host pkg path leaked into namespace command: {command}"
+    );
+    assert!(
+        !command.contains(&tests_dir.display().to_string()),
+        "host tests path leaked into namespace command: {command}"
+    );
+}
+
+#[test]
 fn test_reified_backend_translates_quoted_host_workspace_paths_with_spaces() {
     let temp = TempDir::new().unwrap();
     let workspace = temp.path().join("My Project");

--- a/crates/agent-engine/src/tools/sandbox_tests.rs
+++ b/crates/agent-engine/src/tools/sandbox_tests.rs
@@ -2388,9 +2388,11 @@ fn only_seatbelt_permits_autonomous_bash() {
     // Seatbelt is a complete bash boundary (workspace fs + network), so wrappers
     // run and escalated bash is reviewer-eligible.
     assert!(SandboxBackendKind::Seatbelt.permits_autonomous_bash());
-    // Landlock (network confinement is kernel-conditional) and the path-guard
-    // fallback are treated conservatively: full shape parser, escalated bash to a
-    // human.
+    // Landlock (network confinement is kernel-conditional), Linux reified
+    // namespace (protected subpaths are not carved out of the writable workspace
+    // mount), and the path-guard fallback are treated conservatively: full shape
+    // parser, escalated bash to a human.
+    assert!(!SandboxBackendKind::LinuxReifiedNamespace.permits_autonomous_bash());
     assert!(!SandboxBackendKind::Landlock.permits_autonomous_bash());
     assert!(!SandboxBackendKind::WorkspacePathGuard.permits_autonomous_bash());
 }
@@ -2414,6 +2416,30 @@ async fn test_landlock_keeps_shape_parser_for_opaque_writers() {
         )
         .await;
     assert!(result.is_err(), "opaque writer not rejected under Landlock");
+}
+
+#[tokio::test]
+async fn test_reified_backend_keeps_shape_parser_for_opaque_writers() {
+    // Linux reified namespace still bind-mounts the writable workspace as a whole,
+    // so protected subpath integrity depends on the full parser until those
+    // subpaths are carved out of the namespace.
+    let temp = TempDir::new().unwrap();
+    let sandbox = Sandbox::with_backend(
+        temp.path().to_path_buf(),
+        crate::tools::SandboxBackendKind::LinuxReifiedNamespace,
+    );
+    let result = sandbox
+        .exec_with_timeout_and_capability(
+            "python -c 'open(\".git/config\",\"w\").write(\"x\")'",
+            temp.path(),
+            None,
+            Some(alan_agent_protocol::ToolCapability::Write),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "opaque writer not rejected under Linux reified namespace"
+    );
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/crates/agent-engine/src/tools/sandbox_tests.rs
+++ b/crates/agent-engine/src/tools/sandbox_tests.rs
@@ -2538,6 +2538,38 @@ fn test_reified_backend_translates_host_workspace_paths_in_command_argv() {
     );
 }
 
+#[test]
+fn test_reified_backend_translates_quoted_host_workspace_paths_with_spaces() {
+    let temp = TempDir::new().unwrap();
+    let workspace = temp.path().join("My Project");
+    let docs_dir = workspace.join("docs");
+    std::fs::create_dir_all(&docs_dir).unwrap();
+    let host_doc = docs_dir.join("Project Notes.txt");
+    std::fs::write(&host_doc, "notes\n").unwrap();
+    let sandbox = Sandbox::with_backend(
+        workspace.clone(),
+        crate::tools::SandboxBackendKind::LinuxReifiedNamespace,
+    );
+
+    let plan = sandbox
+        .reified_namespace_plan_for_command(
+            &format!("cat '{}' > /dev/null", host_doc.display()),
+            &workspace,
+            false,
+        )
+        .unwrap();
+
+    assert_eq!(
+        plan.argv,
+        vec![
+            "sh".to_string(),
+            "-f".to_string(),
+            "-c".to_string(),
+            "cat '/mnt/workspace/docs/Project Notes.txt' > /dev/null".to_string()
+        ]
+    );
+}
+
 #[tokio::test]
 async fn test_os_backend_still_blocks_out_of_workspace_reads() {
     // Seatbelt denies writes/network but permits reads, so the parser must still

--- a/crates/agent-engine/src/tools/sandbox_tests.rs
+++ b/crates/agent-engine/src/tools/sandbox_tests.rs
@@ -2571,6 +2571,37 @@ fn test_reified_backend_translates_quoted_host_workspace_paths_with_spaces() {
 }
 
 #[tokio::test]
+async fn test_reified_backend_exec_validates_quoted_host_workspace_paths_with_spaces() {
+    let temp = TempDir::new().unwrap();
+    let workspace = temp.path().join("My Project");
+    let docs_dir = workspace.join("docs");
+    tokio::fs::create_dir_all(&docs_dir).await.unwrap();
+    let host_doc = docs_dir.join("Project Notes.txt");
+    tokio::fs::write(&host_doc, "notes\n").await.unwrap();
+    let sandbox = Sandbox::with_backend(
+        workspace.clone(),
+        crate::tools::SandboxBackendKind::LinuxReifiedNamespace,
+    );
+
+    let result = sandbox
+        .exec_with_timeout_and_capability(
+            &format!("cat '{}' > /dev/null", host_doc.display()),
+            &workspace,
+            Some(std::time::Duration::from_millis(50)),
+            Some(alan_agent_protocol::ToolCapability::Read),
+        )
+        .await;
+
+    if let Err(err) = result {
+        let message = err.to_string();
+        assert!(
+            !message.contains("outside workspace"),
+            "quoted host workspace path with spaces should not be truncated during validation: {message}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_os_backend_still_blocks_out_of_workspace_reads() {
     // Seatbelt denies writes/network but permits reads, so the parser must still
     // contain reads: an auto-approved `cat ~/.ssh/id_rsa` / `cat /etc/passwd` must

--- a/crates/agent-engine/src/tools/sandbox_tests.rs
+++ b/crates/agent-engine/src/tools/sandbox_tests.rs
@@ -2416,6 +2416,99 @@ async fn test_landlock_keeps_shape_parser_for_opaque_writers() {
     assert!(result.is_err(), "opaque writer not rejected under Landlock");
 }
 
+#[cfg(not(target_os = "linux"))]
+#[tokio::test]
+async fn test_reified_backend_fails_closed_without_non_linux_runner() {
+    let temp = TempDir::new().unwrap();
+    let sandbox = Sandbox::with_backend(
+        temp.path().to_path_buf(),
+        crate::tools::SandboxBackendKind::LinuxReifiedNamespace,
+    );
+
+    let result = sandbox
+        .exec_with_timeout_and_capability(
+            "touch created-by-ambient-shell.txt",
+            temp.path(),
+            None,
+            Some(alan_agent_protocol::ToolCapability::Write),
+        )
+        .await;
+
+    assert!(result.is_err(), "reified backend should fail closed");
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("only available on Linux")
+    );
+    assert!(!temp.path().join("created-by-ambient-shell.txt").exists());
+}
+
+#[tokio::test]
+async fn test_reified_backend_accepts_namespace_workspace_paths_for_validation() {
+    let temp = TempDir::new().unwrap();
+    tokio::fs::write(temp.path().join("Cargo.toml"), "[package]\n")
+        .await
+        .unwrap();
+    let sandbox = Sandbox::with_backend(
+        temp.path().to_path_buf(),
+        crate::tools::SandboxBackendKind::LinuxReifiedNamespace,
+    );
+
+    let result = sandbox
+        .exec_with_timeout_and_capability(
+            "cat /mnt/workspace/Cargo.toml > /dev/null",
+            temp.path(),
+            Some(std::time::Duration::from_millis(50)),
+            Some(alan_agent_protocol::ToolCapability::Read),
+        )
+        .await;
+
+    if let Err(err) = result {
+        let message = err.to_string();
+        assert!(
+            !message.contains("outside workspace"),
+            "reified namespace path was not translated for validation: {message}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_reified_backend_translates_namespace_paths_for_protected_checks() {
+    let temp = TempDir::new().unwrap();
+    tokio::fs::create_dir_all(temp.path().join(".git"))
+        .await
+        .unwrap();
+    tokio::fs::write(temp.path().join(".git/config"), "[core]\n")
+        .await
+        .unwrap();
+    let sandbox = Sandbox::with_backend(
+        temp.path().to_path_buf(),
+        crate::tools::SandboxBackendKind::LinuxReifiedNamespace,
+    );
+
+    let result = sandbox
+        .exec_with_timeout_and_capability(
+            "cat /mnt/workspace/.git/config",
+            temp.path(),
+            None,
+            Some(alan_agent_protocol::ToolCapability::Read),
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "protected namespace path should be blocked"
+    );
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("protected subpath"),
+        "reified namespace path should be translated before protected checks"
+    );
+}
+
 #[tokio::test]
 async fn test_os_backend_still_blocks_out_of_workspace_reads() {
     // Seatbelt denies writes/network but permits reads, so the parser must still

--- a/crates/agent-protocol/src/event.rs
+++ b/crates/agent-protocol/src/event.rs
@@ -164,6 +164,9 @@ pub struct ToolDecisionAudit {
     ///
     /// Field name is kept for compatibility with existing event consumers.
     pub sandbox_backend: String,
+    /// Native subprocess path semantics for this backend.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_mode: Option<String>,
 }
 
 /// Presentation-form tool result, decoupled from tool identity. Built-in tools

--- a/openspec/changes/define-linux-namespace-reification/tasks.md
+++ b/openspec/changes/define-linux-namespace-reification/tasks.md
@@ -33,12 +33,12 @@
 
 ## 4. Enforcement And Policy Integration
 
-- [ ] 4.1 Wire backend selection to prefer `linux_reified_namespace` only when the
+- [x] 4.1 Wire backend selection to prefer `linux_reified_namespace` only when the
   probe and runner smoke checks pass.
-- [ ] 4.2 Ensure network-denied commands remain denied under the reified backend,
+- [x] 4.2 Ensure network-denied commands remain denied under the reified backend,
   route to a human, or fall back to a network-confined backend when degraded;
   never allow autonomous reviewer approval without network confinement.
-- [ ] 4.3 Update bash/tool policy audits to distinguish reified namespace paths
+- [x] 4.3 Update bash/tool policy audits to distinguish reified namespace paths
   from projected host paths.
 
 ## 5. Verification And PRs


### PR DESCRIPTION
## Summary
- prefer `linux_reified_namespace` only after the capability probe and runner smoke check both pass
- route active reified sandbox execution through `LinuxReifiedNamespaceRunner` with a plan derived from `SandboxSpec`
- keep network-denied commands denied under reified execution and fall back to projection backends when degraded
- add `ToolDecisionAudit.path_mode` so audits distinguish `projected_host_paths` from `reified_namespace_paths`
- mark OpenSpec tasks 4.1-4.3 complete for `define-linux-namespace-reification`

## Validation
- `cargo fmt --all`
- `cargo test -p alan-agent-engine sandbox_backend::tests -- --nocapture`
- `cargo test -p alan-agent-engine reified_namespace -- --nocapture`
- `cargo test -p alan-agent-engine test_tool_policy_audit_reports_active_path_mode -- --nocapture`
- `cargo test -p alan-agent-engine test_reified_backend_fails_closed_without_non_linux_runner -- --nocapture`
- `cargo test -p alan-agent-protocol`
- `cargo test -p alan-agent-engine tool_policy -- --nocapture`
- `cargo clippy -p alan-agent-protocol -p alan-agent-engine --all-targets --all-features -- -D warnings`
- `openspec validate define-linux-namespace-reification --strict`
- `openspec validate define-namespace-driven-sandbox --strict`
- `git diff --check`

Note: the Linux-only runner smoke path is cfg-gated and wired here; the dedicated Linux host smoke remains OpenSpec task 5.1.