### PR TITLE
North Star 22/22: verify reified namespace smoke coverage

### DIFF
--- a/crates/agent-engine/src/tools/reified_namespace.rs
+++ b/crates/agent-engine/src/tools/reified_namespace.rs
@@ -2405,13 +2405,15 @@ mod tests {
     #[cfg(target_os = "linux")]
     fn linux_reified_runner_ready_for_smoke() -> bool {
         let readiness = crate::tools::linux_reified_namespace_backend_readiness();
-        if readiness.selected_backend == SandboxBackendKind::LinuxReifiedNamespace {
+        // These smoke plans use explicit executables, so they validate runner
+        // capability even when the default backend selection rejects the current
+        // user PATH/toolchain shape.
+        if readiness.capability_report.is_selectable() && readiness.runner_smoke.is_available() {
             return true;
         }
 
         eprintln!(
-            "skipping linux reified namespace smoke: selected_backend={} audit={:?}",
-            readiness.selected_backend.name(),
+            "skipping linux reified namespace smoke: audit={:?}",
             readiness.audit_fields()
         );
         false

--- a/crates/agent-engine/src/tools/reified_namespace.rs
+++ b/crates/agent-engine/src/tools/reified_namespace.rs
@@ -2403,6 +2403,182 @@ mod tests {
     }
 
     #[cfg(target_os = "linux")]
+    fn linux_reified_runner_ready_for_smoke() -> bool {
+        let readiness = crate::tools::linux_reified_namespace_backend_readiness();
+        if readiness.selected_backend == SandboxBackendKind::LinuxReifiedNamespace {
+            return true;
+        }
+
+        eprintln!(
+            "skipping linux reified namespace smoke: selected_backend={} audit={:?}",
+            readiness.selected_backend.name(),
+            readiness.audit_fields()
+        );
+        false
+    }
+
+    #[cfg(target_os = "linux")]
+    fn run_linux_reified_smoke(plan: &ReifiedNamespacePlan) -> ExecResult {
+        let runner =
+            LinuxReifiedNamespaceRunner::with_fallback_backend(SandboxBackendKind::Landlock);
+        runner.run(plan).unwrap_or_else(|err| {
+            panic!(
+                "linux reified namespace smoke failed to start: {err}; audit={:?}",
+                err.audit_fields
+            )
+        })
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_runner_smoke_enforces_mount_visibility_and_access() {
+        if !linux_reified_runner_ready_for_smoke() {
+            return;
+        }
+
+        let workspace = tempfile::tempdir().unwrap();
+        let readonly = tempfile::tempdir().unwrap();
+        let secret_home = tempfile::tempdir().unwrap();
+        std::fs::write(workspace.path().join("visible.txt"), "visible").unwrap();
+        std::fs::write(readonly.path().join("readonly.txt"), "readonly").unwrap();
+
+        let script = r#"
+set -eu
+secret_home="$1"
+test -f /mnt/project/visible.txt
+test "$(cat /mnt/project/visible.txt)" = visible
+printf changed > /mnt/project/writable.txt
+test "$(cat /mnt/project/writable.txt)" = changed
+test -f /mnt/docs/readonly.txt
+test "$(cat /mnt/docs/readonly.txt)" = readonly
+if sh -c 'printf blocked > /mnt/docs/blocked.txt'; then
+  exit 42
+fi
+test ! -e "$secret_home"
+"#;
+        let plan = ReifiedNamespacePlan::derive(ReifiedNamespacePlanInput::new(
+            vec![
+                ReifiedMountDeclaration::host(
+                    "/mnt/project",
+                    workspace.path(),
+                    ReifiedMountAccess::ReadWrite,
+                ),
+                ReifiedMountDeclaration::host(
+                    "/mnt/docs",
+                    readonly.path(),
+                    ReifiedMountAccess::ReadOnly,
+                ),
+            ],
+            workspace.path(),
+            vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                script.to_string(),
+                "alan-reified-fs-smoke".to_string(),
+                secret_home.path().display().to_string(),
+            ],
+            NetworkPosture::Deny,
+        ))
+        .unwrap();
+
+        let result = run_linux_reified_smoke(&plan);
+
+        assert_eq!(
+            result.exit_code, 0,
+            "stdout={} stderr={}",
+            result.stdout, result.stderr
+        );
+        assert_eq!(
+            std::fs::read_to_string(workspace.path().join("writable.txt")).unwrap(),
+            "changed"
+        );
+        assert!(
+            !readonly.path().join("blocked.txt").exists(),
+            "read-only mount accepted a write"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_runner_smoke_denies_network_connections() {
+        if !linux_reified_runner_ready_for_smoke() {
+            return;
+        }
+
+        let workspace = tempfile::tempdir().unwrap();
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let accepted = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop_listener = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let accepted_by_thread = std::sync::Arc::clone(&accepted);
+        let stop_listener_by_thread = std::sync::Arc::clone(&stop_listener);
+        let listener_thread = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(4);
+            while std::time::Instant::now() < deadline
+                && !stop_listener_by_thread.load(std::sync::atomic::Ordering::SeqCst)
+            {
+                match listener.accept() {
+                    Ok((_stream, _addr)) => {
+                        accepted_by_thread.store(true, std::sync::atomic::Ordering::SeqCst);
+                        return;
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(25));
+                    }
+                    Err(_) => return,
+                }
+            }
+        });
+
+        let script = r#"
+set -u
+port="$1"
+if ! command -v bash >/tmp/bash-path; then
+  exit 77
+fi
+if ! command -v timeout >/tmp/timeout-path; then
+  exit 77
+fi
+if timeout 2 bash -c "cat < /dev/tcp/127.0.0.1/${port}" >/tmp/network-out 2>/tmp/network-err; then
+  exit 42
+fi
+exit 0
+"#;
+        let plan = ReifiedNamespacePlan::workspace_seed(
+            workspace.path(),
+            workspace.path(),
+            vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                script.to_string(),
+                "alan-reified-network-smoke".to_string(),
+                port.to_string(),
+            ],
+            NetworkPosture::Deny,
+        )
+        .unwrap();
+
+        let result = run_linux_reified_smoke(&plan);
+        stop_listener.store(true, std::sync::atomic::Ordering::SeqCst);
+        listener_thread.join().unwrap();
+
+        assert!(
+            !accepted.load(std::sync::atomic::Ordering::SeqCst),
+            "network-denied reified command connected to the host listener"
+        );
+        if result.exit_code == 77 {
+            eprintln!("skipping denied-network smoke assertion: bash or timeout unavailable");
+            return;
+        }
+        assert_eq!(
+            result.exit_code, 0,
+            "stdout={} stderr={}",
+            result.stdout, result.stderr
+        );
+    }
+
+    #[cfg(target_os = "linux")]
     #[test]
     fn linux_runner_command_uses_unshare_mount_chroot_and_network_namespace() {
         let workspace = tempfile::tempdir().unwrap();

--- a/openspec/changes/define-linux-namespace-reification/tasks.md
+++ b/openspec/changes/define-linux-namespace-reification/tasks.md
@@ -64,5 +64,9 @@
   `openspec validate define-linux-namespace-reification --strict`,
   `openspec validate define-namespace-driven-sandbox --strict`, and
   `git diff --check` passed.
-- [ ] 5.4 Update parent namespace-driven sandbox task state and open stacked PRs
+- [x] 5.4 Update parent namespace-driven sandbox task state and open stacked PRs
   for each landed implementation slice.
+  Done 2026-07-03: updated the parent `define-namespace-driven-sandbox` task
+  ledger and opened ready stacked PRs for the Linux reification slices: #603
+  (probe), #604 (plan), #605 (runner), #606 (backend integration), and #607
+  (verification smoke coverage).

--- a/openspec/changes/define-linux-namespace-reification/tasks.md
+++ b/openspec/changes/define-linux-namespace-reification/tasks.md
@@ -43,12 +43,26 @@
 
 ## 5. Verification And PRs
 
-- [ ] 5.1 Add Linux-only smoke tests gated by capability detection for visible
+- [x] 5.1 Add Linux-only smoke tests gated by capability detection for visible
   `/mnt/<name>` mounts, absent undeclared home paths, read-only mount mutation
   rejection, writable mount mutation, and network denial.
-- [ ] 5.2 Run focused Rust tests for the probe, plan model, path translation, and
+  Done 2026-07-03: added Linux cfg runner smoke tests gated by
+  `linux_reified_namespace_backend_readiness()` for declared mount visibility,
+  absent undeclared host paths, read-only/write access enforcement, writable
+  mutation, and denied loopback connections. The Linux smoke tests were not run
+  locally because this host is macOS and has no Linux Rust target installed.
+- [x] 5.2 Run focused Rust tests for the probe, plan model, path translation, and
   fallback behavior; run Linux smoke tests when host capabilities are available.
-- [ ] 5.3 Run clippy for touched crates, OpenSpec strict validate, and diff
+  Done 2026-07-03: `cargo test -p alan-agent-engine reified_namespace -- --nocapture`,
+  `cargo test -p alan-agent-engine sandbox_backend::tests -- --nocapture`, and
+  `cargo test -p alan-agent-engine test_reified_backend_fails_closed_without_non_linux_runner -- --nocapture`
+  passed on macOS. Linux smoke tests are cfg-gated and require a capable Linux
+  host.
+- [x] 5.3 Run clippy for touched crates, OpenSpec strict validate, and diff
   checks.
+  Done 2026-07-03: `cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings`,
+  `openspec validate define-linux-namespace-reification --strict`,
+  `openspec validate define-namespace-driven-sandbox --strict`, and
+  `git diff --check` passed.
 - [ ] 5.4 Update parent namespace-driven sandbox task state and open stacked PRs
   for each landed implementation slice.

--- a/openspec/changes/define-namespace-driven-sandbox/tasks.md
+++ b/openspec/changes/define-namespace-driven-sandbox/tasks.md
@@ -43,3 +43,7 @@ proposals out as their own OpenSpec changes. No application code lands here.
 
 - [ ] 3.1 Archive this framing change once P1 and P2 are proposed and the
   relationship it fixes is captured in their design docs.
+  Updated 2026-07-03: downstream Linux reification is now represented by ready
+  stacked PRs #603-#607. Keep this unchecked until the downstream stack merges,
+  then archive this framing change as the parent ledger for the completed
+  namespace-driven sandbox sequence.


### PR DESCRIPTION
## Summary
- add Linux-only reified namespace runner smoke tests gated by backend readiness
- cover declared `/mnt/<name>` visibility, absent undeclared host paths, writable mutation, read-only mutation rejection, and denied loopback connections
- record OpenSpec verification progress for `define-linux-namespace-reification` tasks 5.1-5.4
- update the parent `define-namespace-driven-sandbox` ledger to keep archive pending until the downstream stack merges

## Validation
- `cargo fmt --all`
- `cargo test -p alan-agent-engine reified_namespace -- --nocapture`
- `cargo test -p alan-agent-engine sandbox_backend::tests -- --nocapture`
- `cargo test -p alan-agent-engine test_reified_backend_fails_closed_without_non_linux_runner -- --nocapture`
- `cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings`
- `openspec validate define-linux-namespace-reification --strict`
- `openspec validate define-namespace-driven-sandbox --strict`
- `git diff --check`

Note: Linux-only smoke tests are cfg-gated and require a capable Linux host. This local validation ran on macOS, where the Linux Rust target is not installed.