### PR TITLE
fix(kernel): release the namespace lock across a forwarded walk (CI flake)

### DIFF
--- a/crates/agent-engine/src/agent_root.rs
+++ b/crates/agent-engine/src/agent_root.rs
@@ -123,13 +123,8 @@ impl AgentRootLayout {
     }
 
     pub fn normalize_named_agent_name<'a>(&self, agent_name: Option<&'a str>) -> Option<&'a str> {
-        self.normalize_agent_name(agent_name).and_then(|name| {
-            if name == DEFAULT_AGENT_NAME {
-                None
-            } else {
-                Some(name)
-            }
-        })
+        self.normalize_agent_name(agent_name)
+            .filter(|&name| name != DEFAULT_AGENT_NAME)
     }
 
     pub fn is_single_path_component(&self, name: &str) -> bool {

--- a/crates/kernel/src/mountfs.rs
+++ b/crates/kernel/src/mountfs.rs
@@ -291,29 +291,39 @@ impl MountFs {
 #[async_trait]
 impl FileServer for MountFs {
     async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
-        let mut state = self.state.lock().await;
-        if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
-            return Err(ErrorCode::BadRequest);
-        }
-        let base = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
-        if base.reserved {
-            return Err(ErrorCode::BadRequest);
-        }
-        // A non-empty walk descends into a child, so the base must be a directory.
-        // A backing *file* base is rejected here rather than re-resolving the
-        // absolute path (which could otherwise traverse a non-directory into a
-        // mounted descendant, e.g. a `/` file `mnt` walking into a `/mnt/llm` mount).
-        if !names.is_empty()
-            && let Some(b) = &base.backing
-            && !b.is_dir
-        {
-            return Err(ErrorCode::NotDirectory);
-        }
-        let mut path = base.path.clone();
-        path.extend(names.iter().cloned());
+        // Resolve the target path under the lock, then RELEASE it before
+        // forwarding the walk to the backing tree(s): a backing walk can block
+        // (it may itself resolve through another server that is mid-operation),
+        // and holding the namespace lock across it would freeze every other
+        // operation — the same discipline `target()`/`read`/`open`/`write` use.
+        let path = {
+            let state = self.state.lock().await;
+            if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
+                return Err(ErrorCode::BadRequest);
+            }
+            let base = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+            if base.reserved {
+                return Err(ErrorCode::BadRequest);
+            }
+            // A non-empty walk descends into a child, so the base must be a
+            // directory. A backing *file* base is rejected here rather than
+            // re-resolving the absolute path (which could otherwise traverse a
+            // non-directory into a mounted descendant, e.g. a `/` file `mnt`
+            // walking into a `/mnt/llm` mount).
+            if !names.is_empty()
+                && let Some(b) = &base.backing
+                && !b.is_dir
+            {
+                return Err(ErrorCode::NotDirectory);
+            }
+            let mut path = base.path.clone();
+            path.extend(names.iter().cloned());
+            path
+        };
 
         // At or below a mount: forward the walk to the backing tree(s), trying each
         // union contributor (longest-prefix, most-recent-first) until one resolves.
+        // The namespace lock is not held across these forwarded calls.
         let candidates = self.ns.resolve_candidates(&join_path(&path));
         for resolved in candidates {
             let backing_fid = Fid(NEXT_BACKING.fetch_add(1, Ordering::Relaxed));
@@ -325,6 +335,14 @@ impl FileServer for MountFs {
                 })
                 .await;
             if let Ok(Response::Walk { qid }) = walked {
+                let mut state = self.state.lock().await;
+                // A concurrent walk may have claimed `newfid` while the lock was
+                // released; discard our backing fid and reject rather than leak.
+                if state.fids.contains_key(&newfid) {
+                    drop(state);
+                    let _ = resolved.call(Request::Clunk { fid: backing_fid }).await;
+                    return Err(ErrorCode::BadRequest);
+                }
                 state.fids.insert(
                     newfid,
                     Entry {
@@ -348,6 +366,10 @@ impl FileServer for MountFs {
         // the deeper mount.
         if path.is_empty() || self.is_synthetic_dir(&path) {
             let qid = synthetic_qid(&path, self.ns.generation());
+            let mut state = self.state.lock().await;
+            if state.fids.contains_key(&newfid) {
+                return Err(ErrorCode::BadRequest);
+            }
             state.fids.insert(
                 newfid,
                 Entry {

--- a/crates/kernel/tests/mountfs.rs
+++ b/crates/kernel/tests/mountfs.rs
@@ -1015,3 +1015,93 @@ async fn a_clunked_fid_is_released() {
         .await
         .unwrap();
 }
+
+/// A backing server whose `walk` blocks until `gate` is notified. Every other
+/// method is trivial. Used to prove `MountFs::walk` does not hold the namespace
+/// lock across the forwarded backing walk.
+struct GatedFs {
+    gate: Arc<Notify>,
+}
+
+#[async_trait::async_trait]
+impl FileServer for GatedFs {
+    async fn walk(&self, _fid: Fid, _newfid: Fid, _names: &[String]) -> Result<Qid, ErrorCode> {
+        // Block inside the forwarded walk until the test releases the gate.
+        self.gate.notified().await;
+        Ok(Qid {
+            kind: FileKind::Dir,
+            version: 0,
+            path: 0,
+        })
+    }
+    async fn open(&self, _: Fid, _: OpenMode) -> Result<Qid, ErrorCode> {
+        Ok(Qid {
+            kind: FileKind::Dir,
+            version: 0,
+            path: 0,
+        })
+    }
+    async fn read(&self, _: Fid, _: Offset, _: u32) -> Result<Vec<u8>, ErrorCode> {
+        Ok(Vec::new())
+    }
+    async fn write(&self, _: Fid, _: Offset, _: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::NoAccess)
+    }
+    async fn stat(&self, _: Fid) -> Result<Stat, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn create(&self, _: Fid, _: Fid, _: &str, _: FileKind) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn remove(&self, _: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn clunk(&self, _: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
+/// Regression: a walk whose backing tree blocks must NOT hold the namespace
+/// lock, so a concurrent MountFs operation can still make progress. On the old
+/// code (walk held the state lock across the forwarded call) the concurrent
+/// walk deadlocked on the lock and this test timed out.
+#[tokio::test]
+async fn walk_does_not_hold_the_namespace_lock_across_the_backing_walk() {
+    let gate = Arc::new(Notify::new());
+    let mut ns = Namespace::new();
+    ns.mount(
+        "/gated",
+        InProcessTransport::new(Arc::new(GatedFs { gate: gate.clone() })),
+        Access::ReadWrite,
+    );
+    ns.mount("/data", memfs(), Access::ReadWrite);
+    let fs = Arc::new(MountFs::new(ns));
+
+    // Task 1 walks into the gated tree; its forwarded backing walk blocks.
+    let gated = {
+        let fs = fs.clone();
+        tokio::spawn(async move { fs.walk(Fid::ROOT, Fid(1), &["gated".into()]).await })
+    };
+    // Give task 1 a chance to enter the forwarded (blocked) backing walk.
+    tokio::task::yield_now().await;
+
+    // A concurrent MountFs walk needs the namespace lock. If task 1 held it
+    // across the blocked backing walk, this would deadlock. It must complete;
+    // then we release the gate so task 1 finishes too.
+    let concurrent = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        fs.walk(Fid::ROOT, Fid(2), &["data".into()]),
+    )
+    .await
+    .expect("concurrent walk must not be blocked by the gated walk")
+    .expect("walk /data");
+    assert_eq!(concurrent.kind, FileKind::Dir);
+
+    gate.notify_one();
+    let gated = tokio::time::timeout(std::time::Duration::from_secs(5), gated)
+        .await
+        .expect("gated walk should finish after the gate is released")
+        .expect("join gated task")
+        .expect("gated walk");
+    assert_eq!(gated.kind, FileKind::Dir);
+}

--- a/crates/tui/src/file_backed.rs
+++ b/crates/tui/src/file_backed.rs
@@ -1702,13 +1702,9 @@ impl FileBackedApp {
     }
 
     fn shift_pending_remote_turn_start(&mut self, removed_prefix_len: usize) {
-        self.pending_remote_turn_start = self.pending_remote_turn_start.map(|index| {
-            if index < removed_prefix_len {
-                0
-            } else {
-                index - removed_prefix_len
-            }
-        });
+        self.pending_remote_turn_start = self
+            .pending_remote_turn_start
+            .map(|index| index.saturating_sub(removed_prefix_len));
     }
 
     fn seed_reconciler_from_tape_history(&mut self, raw: &str) {

--- a/crates/tui/src/reconcile.rs
+++ b/crates/tui/src/reconcile.rs
@@ -165,7 +165,7 @@ impl StreamReconciler {
     }
 
     /// A `machine/tape` user record arrived: a turn boundary. Call
-    /// [`take_flushed_stream`] afterwards to render any buffered next-turn
+    /// [`Self::take_flushed_stream`] afterwards to render any buffered next-turn
     /// bytes that were waiting for this boundary.
     pub(crate) fn on_user_record(&mut self, content: &str) -> UserDecision {
         self.awaiting_boundary = false;
@@ -230,10 +230,10 @@ impl StreamReconciler {
             self.held = format!("{remainder}{}", std::mem::take(&mut self.held));
             return AssistantDecision::ReplacePreview(content);
         }
-        if content.starts_with(preview) {
+        if let Some(remainder) = content.strip_prefix(preview) {
             // Record won the channel race mid-stream: finish the cell and
             // consume the queued remainder exactly.
-            self.suppress.push_str(&content[preview.len()..]);
+            self.suppress.push_str(remainder);
             return AssistantDecision::ReplacePreview(content);
         }
         if content.ends_with(preview) {


### PR DESCRIPTION
## Summary

Fixes the intermittent CI hang that has been failing `Test Suite` across recent PRs — `smoke_tool_call_flow` and `smoke_cross_session_persona_memory_is_reinjected` timing out after `ToolCallStarted`, at 0% CPU (a deadlock, not a slow test).

**Root cause:** `MountFs::walk` held the namespace `state` lock across the forwarded `resolved.call(Walk).await`. It was the *only* MountFs method that did — `read`/`open`/`write`/`stat`/`clunk` all resolve the target under the lock and release it before forwarding, with an explicit comment that "a tail parked on a stream's live edge must not freeze every other operation." `walk` violated that discipline.

On the single-threaded runtime the smoke tests (and CI runners) use, a walk into a layered backing (`MountFs → AgentRootFs → AgentFs`) held the namespace lock across the whole forwarded chain while an inner step awaited, and a concurrent namespace operation that needed the lock stalled behind it. The victim was the tool-action-record write's walk — which is why the turn hung right after the tool call started, even though the tool itself had already completed.

**Fix:** `walk` now resolves the path under the lock, releases it, forwards the backing walk unlocked, then re-acquires only to insert the new fid (re-checking that a concurrent walk hasn't claimed it, clunking the backing fid if so).

## How it was found

Reproduced locally (not just CI): ~10–17% hang rate under parallel contention with a tight loop. Instrumented the layers to trace the stall from the tool spawn → second generation → action write → the walk parked in a forwarded call holding the MountFs lock, with 0% CPU and no lock actually held downstream (a lost-wakeup-shaped stall from holding a lock across a forwarded/blocking call).

## Testing

- **Regression test** `walk_does_not_hold_the_namespace_lock_across_the_backing_walk`: a gated backing server blocks inside the forwarded walk while a concurrent MountFs walk must still complete. **Times out on the old code, passes on the new** (verified both directions).
- Deterministic loop: **0 / 216** contended runs hang after the fix (pre-fix ≈ 17%).
- `alan-kernel` + `alan-agentfs` suites green; full `smoke_test` suite green ×3; fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)