### PR TITLE
feat(runtime): align delegation with namespaces

### DIFF
--- a/crates/agent-engine/skills/repo-coding/SKILL.md
+++ b/crates/agent-engine/skills/repo-coding/SKILL.md
@@ -33,6 +33,26 @@ work.
    package delivery contract JSON even when the user-facing parent response
    should be concise prose.
 
+## Namespace Requirement And Recovery Contract
+
+Before spawn, alan classifies the delegated task in namespace terms and checks
+the assembled child namespace. Keep the task honest about what the child needs:
+workspace read/write scope, `/bin` shell or external-service bindings, an LLM
+Connection, and material side effects.
+
+- If the child namespace satisfies the task, alan launches it unchanged.
+- If alan narrows the task, the child receives an explicit narrowed-scope block
+  naming withheld capabilities; the parent remains responsible for that work.
+- If the parent can satisfy a missing binding, alan declines the original child
+  launch and records `parent_path` recovery instead of pretending the child did it.
+- Otherwise alan asks for missing input or returns an explicit limitation. Never
+  substitute unrelated local context for unavailable GitHub, network, browser,
+  or workspace evidence.
+
+The decision is recorded in the parent's delegated tool result/tape. A launched
+child also carries the bounded requirement and namespace summary in its launch
+record; the live authority remains `/proc/<pid>/namespace`.
+
 ## Working Principles
 
 1. Treat this package as alan's general repo-local coding mode, not as a

--- a/crates/agent-engine/skills/skill-creator/assets/templates/basic-delegate/SKILL.md
+++ b/crates/agent-engine/skills/skill-creator/assets/templates/basic-delegate/SKILL.md
@@ -10,3 +10,10 @@ metadata:
 
 Describe the parent-side contract here and delegate detailed execution to the
 package-local child agent.
+
+State the workspace, `/bin` tool, LLM Connection, and side-effect requirements
+the child materially needs. alan checks the assembled namespace before spawn.
+Narrowed tasks must name withheld capabilities and leave that work with the
+parent; otherwise recover through the parent, ask for input, or state the
+limitation. The decision is recorded on the parent tape and launched-child
+metadata; `/proc/<pid>/namespace` remains the live authority.

--- a/crates/agent-engine/skills/workspace-inspect/SKILL.md
+++ b/crates/agent-engine/skills/workspace-inspect/SKILL.md
@@ -28,6 +28,21 @@ different local workspace.
 4. Keep the delegated task bounded to read-only inspection, search, synthesis, or comparison.
 5. Return a concise summary and any important residual uncertainty to the parent.
 
+## Namespace Requirement And Recovery Contract
+
+alan checks the requested inspection against the assembled child namespace
+before spawn. A normal workspace-reader launch requires the target workspace
+read projection and an LLM Connection. GitHub, network, browser, shell, write,
+or side-effect work requires corresponding mounts or `/bin` bindings and is not
+implied by this read-only package.
+
+When a capability is unavailable, alan either records `parent_path` recovery,
+passes an explicitly narrowed local-only task, asks for the missing input, or
+returns a limitation. Do not silently treat unrelated local files as remote
+evidence. Decisions are visible in the parent's delegated result/tape; launched
+children also retain bounded requirements and a namespace summary in launch
+metadata, with `/proc/<pid>/namespace` as the live source of truth.
+
 ## Workspace-Reader Expectations
 
 The workspace reader should:

--- a/crates/agent-engine/src/runtime/child_agents.rs
+++ b/crates/agent-engine/src/runtime/child_agents.rs
@@ -3,6 +3,9 @@ use super::child_runs::{
     ChildRunRecord, ChildRunStatus, ChildRunTerminationMode, ChildRunTerminationRequest,
     global_child_run_registry,
 };
+use super::delegation_capabilities::{
+    DelegatedSpawnRejected, evaluate_delegated_namespace, namespace_summary_from_bindings,
+};
 use super::engine::{
     AgentConfig, RuntimeController, RuntimeEventEnvelope, RuntimeLivenessEnvelope,
     RuntimeStartupMetadata, WorkspaceRuntimeConfig, spawn_with_namespace_environment,
@@ -11,7 +14,8 @@ use crate::llm::LlmClient;
 use crate::tape::{ContentPart, Message};
 use crate::tools::ToolRegistry;
 use alan_agent_protocol::{
-    GovernanceConfig, Op, SpawnHandle, SpawnSpec, SpawnTarget, Submission, YieldKind,
+    DelegatedCapabilityDecision, DelegatedCapabilityRecovery, GovernanceConfig, Op, SpawnHandle,
+    SpawnSpec, SpawnTarget, Submission, YieldKind,
 };
 use alan_ap::{Fid, FileServer, InProcessTransport, OpenMode};
 use alan_kernel::{ExecNamespaceAccess, ExecNamespaceManifest, ExecNamespaceMount, ExecSpec};
@@ -279,7 +283,7 @@ where
 
 async fn spawn_child_runtime_with_client_factory_and_cancel<F>(
     parent: &RuntimeLoopState,
-    spec: SpawnSpec,
+    mut spec: SpawnSpec,
     llm_client_factory: F,
     cancel: Option<&CancellationToken>,
 ) -> Result<ChildRuntimeController>
@@ -351,6 +355,8 @@ where
     let child_namespace_plan =
         build_child_namespace_assembly_plan(parent, &spec, &effective_child_core_config)
             .context("Failed to assemble child-agent namespace plan")?;
+    let delegation_capability_decision =
+        evaluate_delegated_launch_capabilities(parent, &mut spec, &child_namespace_plan)?;
     let child_tools = build_child_tool_registry_from_namespace_plan(
         parent,
         &spec,
@@ -399,7 +405,7 @@ where
     .context("Failed to spawn child-agent namespace runtime")?;
     let (runtime, startup_metadata) = wait_for_child_runtime_startup(runtime, cancel).await?;
     let child_run_id = uuid::Uuid::new_v4().to_string();
-    let child_run_record = ChildRunRecord::new(
+    let mut child_run_record = ChildRunRecord::new(
         child_run_id.clone(),
         parent.session.id.clone(),
         startup_metadata.session_id.clone(),
@@ -413,6 +419,9 @@ where
             .map(|path| path.display().to_string()),
         Some(format!("{:?}", spec.target)),
     );
+    if let Some(decision) = delegation_capability_decision {
+        child_run_record = child_run_record.with_delegation_capability_decision(decision);
+    }
     global_child_run_registry().register(child_run_record);
     let event_rx = runtime.handle.event_sender.subscribe();
     let liveness_rx = runtime.handle.liveness_sender.subscribe();
@@ -443,6 +452,82 @@ where
         child_run_id,
         timeout: spec.launch.timeout_secs.map(Duration::from_secs),
     })
+}
+
+fn evaluate_delegated_launch_capabilities(
+    parent: &RuntimeLoopState,
+    spec: &mut SpawnSpec,
+    plan: &ChildNamespaceAssemblyPlan,
+) -> Result<Option<DelegatedCapabilityDecision>> {
+    let Some(context) = spec.delegated.as_ref() else {
+        return Ok(None);
+    };
+    let requirements = context.requirements.clone();
+    let child_namespace = namespace_summary_from_child_plan(plan);
+    let parent_namespace = namespace_summary_from_parent(parent);
+    let decision = evaluate_delegated_namespace(
+        &spec.launch.task,
+        &requirements,
+        child_namespace,
+        &parent_namespace,
+    );
+
+    match decision.recovery {
+        DelegatedCapabilityRecovery::Satisfied => Ok(Some(decision)),
+        DelegatedCapabilityRecovery::Narrowed => {
+            if let Some(narrowed_task) = decision.narrowed_task.clone() {
+                spec.launch.task = narrowed_task;
+            }
+            Ok(Some(decision))
+        }
+        DelegatedCapabilityRecovery::ParentPath
+        | DelegatedCapabilityRecovery::AskUser
+        | DelegatedCapabilityRecovery::Limitation => {
+            Err(DelegatedSpawnRejected { decision }.into())
+        }
+    }
+}
+
+fn namespace_summary_from_child_plan(
+    plan: &ChildNamespaceAssemblyPlan,
+) -> alan_agent_protocol::DelegatedNamespaceSummary {
+    namespace_summary_from_bindings(
+        vec![
+            plan.agent_mount.clone(),
+            plan.llm_mount.clone(),
+            plan.srv_mount.clone(),
+            plan.route_mount.clone(),
+        ],
+        plan.bin_tool_mounts.clone(),
+        plan.workspace_root.clone(),
+        Some(plan.llm_connection_name.clone()),
+    )
+}
+
+fn namespace_summary_from_parent(
+    parent: &RuntimeLoopState,
+) -> alan_agent_protocol::DelegatedNamespaceSummary {
+    namespace_summary_from_bindings(
+        vec![
+            "/agent".to_string(),
+            "/mnt/llm".to_string(),
+            "/srv".to_string(),
+            alan_routefs::MOUNT_PATH.to_string(),
+        ],
+        parent
+            .static_tool_names()
+            .into_iter()
+            .map(|tool| format!("/bin/{tool}"))
+            .collect(),
+        bound_workspace_root(parent),
+        Some(
+            parent
+                .core_config
+                .connection_profile
+                .clone()
+                .unwrap_or_else(|| "default".to_string()),
+        ),
+    )
 }
 
 async fn wait_for_child_runtime_startup(
@@ -2428,7 +2513,127 @@ mod tests {
             },
             handles: Vec::new(),
             runtime_overrides: alan_agent_protocol::SpawnRuntimeOverrides::default(),
+            delegated: None,
         }
+    }
+
+    fn capability_plan(
+        workspace_root: Option<PathBuf>,
+        tools: &[&str],
+    ) -> ChildNamespaceAssemblyPlan {
+        ChildNamespaceAssemblyPlan {
+            agent_mount: "/agent".to_string(),
+            llm_mount: "/mnt/llm".to_string(),
+            llm_connection_name: "default".to_string(),
+            srv_mount: "/srv".to_string(),
+            route_mount: alan_routefs::MOUNT_PATH.to_string(),
+            bin_tool_mounts: tools.iter().map(|tool| format!("/bin/{tool}")).collect(),
+            cwd: workspace_root.clone(),
+            workspace_root,
+        }
+    }
+
+    #[test]
+    fn delegated_spawn_boundary_passes_satisfied_task_unchanged() {
+        let temp = TempDir::new().unwrap();
+        let parent = make_parent_state(
+            &temp,
+            RecordedRequests::default(),
+            completed_response("unused"),
+        );
+        let workspace_root = PathBuf::from("/tmp/repo");
+        let mut spec = launch_spec(temp.path().join("agent"));
+        spec.launch.task = "Inspect local files".to_string();
+        spec.delegated = Some(alan_agent_protocol::DelegatedSpawnContext {
+            requirements: vec![
+                alan_agent_protocol::DelegatedCapabilityRequirement::WorkspaceRead {
+                    path: Some(workspace_root.clone()),
+                },
+                alan_agent_protocol::DelegatedCapabilityRequirement::LlmConnection,
+            ],
+        });
+
+        let decision = evaluate_delegated_launch_capabilities(
+            &parent,
+            &mut spec,
+            &capability_plan(Some(workspace_root), &["read_file"]),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            decision.recovery,
+            alan_agent_protocol::DelegatedCapabilityRecovery::Satisfied
+        );
+        assert_eq!(spec.launch.task, "Inspect local files");
+    }
+
+    #[test]
+    fn delegated_spawn_boundary_rewrites_narrowed_task_explicitly() {
+        let temp = TempDir::new().unwrap();
+        let parent = make_parent_state(
+            &temp,
+            RecordedRequests::default(),
+            completed_response("unused"),
+        );
+        let workspace_root = PathBuf::from("/tmp/repo");
+        let mut spec = launch_spec(temp.path().join("agent"));
+        spec.launch.task = "Review GitHub issue against local code".to_string();
+        spec.delegated = Some(alan_agent_protocol::DelegatedSpawnContext {
+            requirements: vec![
+                alan_agent_protocol::DelegatedCapabilityRequirement::WorkspaceRead {
+                    path: Some(workspace_root.clone()),
+                },
+                alan_agent_protocol::DelegatedCapabilityRequirement::Github,
+            ],
+        });
+
+        let decision = evaluate_delegated_launch_capabilities(
+            &parent,
+            &mut spec,
+            &capability_plan(Some(workspace_root), &["read_file"]),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            decision.recovery,
+            alan_agent_protocol::DelegatedCapabilityRecovery::Narrowed
+        );
+        assert!(spec.launch.task.contains("NARROWED DELEGATION SCOPE"));
+        assert!(spec.launch.task.contains("Withheld capabilities: github"));
+    }
+
+    #[test]
+    fn delegated_spawn_boundary_declines_unsatisfied_workspace() {
+        let temp = TempDir::new().unwrap();
+        let parent = make_parent_state(
+            &temp,
+            RecordedRequests::default(),
+            completed_response("unused"),
+        );
+        let mut spec = launch_spec(temp.path().join("agent"));
+        spec.delegated = Some(alan_agent_protocol::DelegatedSpawnContext {
+            requirements: vec![
+                alan_agent_protocol::DelegatedCapabilityRequirement::WorkspaceRead {
+                    path: Some(PathBuf::from("/outside/repo")),
+                },
+            ],
+        });
+
+        let error = evaluate_delegated_launch_capabilities(
+            &parent,
+            &mut spec,
+            &capability_plan(None, &["read_file"]),
+        )
+        .unwrap_err();
+        let rejection = error.downcast_ref::<DelegatedSpawnRejected>().unwrap();
+
+        assert_eq!(
+            rejection.decision.recovery,
+            alan_agent_protocol::DelegatedCapabilityRecovery::AskUser
+        );
+        assert_eq!(rejection.decision.unsatisfied.len(), 1);
     }
 
     fn completed_response(text: &str) -> GenerationResponse {
@@ -4353,6 +4558,7 @@ model_reasoning_effort = "high"
             },
             handles: vec![SpawnHandle::Workspace],
             runtime_overrides: alan_agent_protocol::SpawnRuntimeOverrides::default(),
+            delegated: None,
         };
 
         let child = spawn_child_runtime_with_client_factory(&parent, spec, |_| {
@@ -4422,6 +4628,7 @@ Body
             },
             handles: vec![SpawnHandle::Workspace],
             runtime_overrides: alan_agent_protocol::SpawnRuntimeOverrides::default(),
+            delegated: None,
         };
 
         let child = spawn_child_runtime_with_client_factory(&parent, spec, |_| {

--- a/crates/agent-engine/src/runtime/child_runs.rs
+++ b/crates/agent-engine/src/runtime/child_runs.rs
@@ -81,6 +81,8 @@ pub struct ChildRunRecord {
     pub error_message: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub termination: Option<ChildRunTerminationRequest>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delegation_capability_decision: Option<alan_agent_protocol::DelegatedCapabilityDecision>,
 }
 
 impl ChildRunRecord {
@@ -110,7 +112,18 @@ impl ChildRunRecord {
             warnings: Vec::new(),
             error_message: None,
             termination: None,
+            delegation_capability_decision: None,
         }
+    }
+
+    /// Attach bounded delegation requirements and the derived namespace
+    /// summary to this historical launch record.
+    pub fn with_delegation_capability_decision(
+        mut self,
+        decision: alan_agent_protocol::DelegatedCapabilityDecision,
+    ) -> Self {
+        self.delegation_capability_decision = Some(decision);
+        self
     }
 }
 
@@ -387,6 +400,33 @@ mod tests {
             Some("/tmp/workspace/.alan/runtime/stable/sessions/child.jsonl".to_string()),
             Some("repo-coding".to_string()),
         )
+    }
+
+    #[test]
+    fn child_run_launch_record_retains_requirements_and_namespace_summary() {
+        let decision = alan_agent_protocol::DelegatedCapabilityDecision {
+            requirements: vec![
+                alan_agent_protocol::DelegatedCapabilityRequirement::WorkspaceRead {
+                    path: Some(std::path::PathBuf::from("/tmp/workspace")),
+                },
+            ],
+            namespace: alan_agent_protocol::DelegatedNamespaceSummary {
+                mounts: vec!["/agent".to_string(), "/mnt/llm".to_string()],
+                bin_bindings: vec!["/bin/read_file".to_string()],
+                workspace_root: Some(std::path::PathBuf::from("/tmp/workspace")),
+                workspace_access: Some(alan_agent_protocol::DelegatedWorkspaceAccess::ReadOnly),
+                workspace_projection: Some("host_tool_binding_compatibility".to_string()),
+                llm_connection: Some("default".to_string()),
+            },
+            unsatisfied: Vec::new(),
+            recovery: alan_agent_protocol::DelegatedCapabilityRecovery::Satisfied,
+            narrowed_task: None,
+        };
+
+        let record = test_record("run-audit", "parent-audit")
+            .with_delegation_capability_decision(decision.clone());
+
+        assert_eq!(record.delegation_capability_decision, Some(decision));
     }
 
     #[test]

--- a/crates/agent-engine/src/runtime/delegation_capabilities.rs
+++ b/crates/agent-engine/src/runtime/delegation_capabilities.rs
@@ -15,8 +15,16 @@ use std::path::{Path, PathBuf};
 const READ_TOOL_BINDINGS: &[&str] = &["read_file", "grep", "glob", "list_dir", "bash"];
 const WRITE_TOOL_BINDINGS: &[&str] = &["write_file", "edit_file", "bash"];
 const SHELL_TOOL_BINDINGS: &[&str] = &["bash", "shell", "exec_command"];
-const NETWORK_TOOL_BINDINGS: &[&str] = &["gh", "github", "curl", "browser", "agent-browser", "web"];
-const GITHUB_TOOL_BINDINGS: &[&str] = &["gh", "github"];
+const NETWORK_TOOL_BINDINGS: &[&str] = &[
+    "bash",
+    "gh",
+    "github",
+    "curl",
+    "browser",
+    "agent-browser",
+    "web",
+];
+const GITHUB_TOOL_BINDINGS: &[&str] = &["bash", "gh", "github"];
 const BROWSER_TOOL_BINDINGS: &[&str] = &["browser", "agent-browser", "web"];
 
 /// Error returned before `/proc/clone` when the original delegated task cannot
@@ -421,6 +429,25 @@ mod tests {
 
         assert_eq!(decision.recovery, DelegatedCapabilityRecovery::ParentPath);
         assert_eq!(decision.unsatisfied, requirements);
+    }
+
+    #[test]
+    fn builtin_bash_binding_satisfies_network_and_github_requirements() {
+        let child = summary(&["read_file", "bash"], true);
+        let requirements = vec![
+            DelegatedCapabilityRequirement::Network,
+            DelegatedCapabilityRequirement::Github,
+        ];
+
+        let decision = evaluate_delegated_namespace(
+            "Review GitHub issue",
+            &requirements,
+            child,
+            &DelegatedNamespaceSummary::default(),
+        );
+
+        assert_eq!(decision.recovery, DelegatedCapabilityRecovery::Satisfied);
+        assert!(decision.unsatisfied.is_empty());
     }
 
     #[test]

--- a/crates/agent-engine/src/runtime/delegation_capabilities.rs
+++ b/crates/agent-engine/src/runtime/delegation_capabilities.rs
@@ -1,0 +1,466 @@
+//! Delegated-task requirement classification and namespace eligibility checks.
+//!
+//! Requirements use namespace vocabulary. Decisions are derived from the
+//! assembled namespace summary and are persisted only as bounded audit data;
+//! they are not an authority registry.
+
+use alan_agent_protocol::{
+    DelegatedCapabilityDecision, DelegatedCapabilityRecovery, DelegatedCapabilityRequirement,
+    DelegatedNamespaceSummary, DelegatedWorkspaceAccess,
+};
+use std::collections::BTreeSet;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+const READ_TOOL_BINDINGS: &[&str] = &["read_file", "grep", "glob", "list_dir", "bash"];
+const WRITE_TOOL_BINDINGS: &[&str] = &["write_file", "edit_file", "bash"];
+const SHELL_TOOL_BINDINGS: &[&str] = &["bash", "shell", "exec_command"];
+const NETWORK_TOOL_BINDINGS: &[&str] = &["gh", "github", "curl", "browser", "agent-browser", "web"];
+const GITHUB_TOOL_BINDINGS: &[&str] = &["gh", "github"];
+const BROWSER_TOOL_BINDINGS: &[&str] = &["browser", "agent-browser", "web"];
+
+/// Error returned before `/proc/clone` when the original delegated task cannot
+/// run in the assembled namespace and no explicit narrowing was selected.
+#[derive(Debug, Clone)]
+pub(crate) struct DelegatedSpawnRejected {
+    pub decision: DelegatedCapabilityDecision,
+}
+
+impl fmt::Display for DelegatedSpawnRejected {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let missing = self
+            .decision
+            .unsatisfied
+            .iter()
+            .map(DelegatedCapabilityRequirement::label)
+            .collect::<Vec<_>>()
+            .join(", ");
+        write!(
+            formatter,
+            "delegated namespace cannot satisfy the original task; missing: {missing}; recovery: {:?}",
+            self.decision.recovery
+        )
+    }
+}
+
+impl std::error::Error for DelegatedSpawnRejected {}
+
+/// Mechanically classify the first bounded requirement vocabulary.
+pub(crate) fn classify_delegated_task_requirements(
+    task: &str,
+    workspace_root: Option<&Path>,
+) -> Vec<DelegatedCapabilityRequirement> {
+    let normalized = task.to_ascii_lowercase();
+    let words = normalized
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .filter(|word| !word.is_empty())
+        .collect::<BTreeSet<_>>();
+    let workspace_path = workspace_root.map(Path::to_path_buf);
+    let mut requirements = BTreeSet::from([
+        DelegatedCapabilityRequirement::WorkspaceRead {
+            path: workspace_path.clone(),
+        },
+        DelegatedCapabilityRequirement::LlmConnection,
+    ]);
+
+    let github = contains_any_phrase(
+        &normalized,
+        &["github", "pull request", "merge request", "github issue"],
+    ) || words.contains("pr")
+        || words.contains("gh");
+    let browser = contains_any_phrase(
+        &normalized,
+        &["browser", "web page", "webpage", "website", "open url"],
+    ) || normalized.contains("http://")
+        || normalized.contains("https://");
+    let network = github
+        || browser
+        || contains_any_word(&words, &["network", "online", "remote", "curl", "download"]);
+    let workspace_write = contains_any_word(
+        &words,
+        &[
+            "edit",
+            "modify",
+            "implement",
+            "fix",
+            "write",
+            "create",
+            "delete",
+            "rename",
+            "format",
+            "commit",
+            "apply",
+        ],
+    );
+    let shell = workspace_write
+        || contains_any_word(
+            &words,
+            &[
+                "shell", "command", "build", "test", "lint", "cargo", "just", "bash",
+            ],
+        );
+
+    if workspace_write {
+        requirements.insert(DelegatedCapabilityRequirement::WorkspaceWrite {
+            path: workspace_path,
+        });
+        requirements.insert(DelegatedCapabilityRequirement::SideEffects);
+    }
+    if shell {
+        requirements.insert(DelegatedCapabilityRequirement::Shell);
+    }
+    if network {
+        requirements.insert(DelegatedCapabilityRequirement::Network);
+    }
+    if github {
+        requirements.insert(DelegatedCapabilityRequirement::Github);
+    }
+    if browser {
+        requirements.insert(DelegatedCapabilityRequirement::Browser);
+    }
+
+    requirements.into_iter().collect()
+}
+
+/// Compare requirements with the assembled child namespace and choose a
+/// visible recovery path without silently substituting unrelated context.
+pub(crate) fn evaluate_delegated_namespace(
+    original_task: &str,
+    requirements: &[DelegatedCapabilityRequirement],
+    child_namespace: DelegatedNamespaceSummary,
+    parent_namespace: &DelegatedNamespaceSummary,
+) -> DelegatedCapabilityDecision {
+    let unsatisfied = unsatisfied_requirements(requirements, &child_namespace);
+    if unsatisfied.is_empty() {
+        return DelegatedCapabilityDecision {
+            requirements: requirements.to_vec(),
+            namespace: child_namespace,
+            unsatisfied,
+            recovery: DelegatedCapabilityRecovery::Satisfied,
+            narrowed_task: None,
+        };
+    }
+
+    if unsatisfied_requirements(&unsatisfied, parent_namespace).is_empty() {
+        return DelegatedCapabilityDecision {
+            requirements: requirements.to_vec(),
+            namespace: child_namespace,
+            unsatisfied,
+            recovery: DelegatedCapabilityRecovery::ParentPath,
+            narrowed_task: None,
+        };
+    }
+
+    if can_narrow_to_local_inspection(&unsatisfied, &child_namespace) {
+        let withheld = unsatisfied
+            .iter()
+            .map(DelegatedCapabilityRequirement::label)
+            .collect::<Vec<_>>()
+            .join(", ");
+        let narrowed_task = format!(
+            "[NARROWED DELEGATION SCOPE]\n\
+             Work only from the mounted local workspace and return inspection or guidance; do not perform withheld operations.\n\
+             Withheld capabilities: {withheld}.\n\
+             Do not infer or substitute unrelated local context for missing external input. The parent remains responsible for the withheld part.\n\
+             Original task: {original_task}"
+        );
+        return DelegatedCapabilityDecision {
+            requirements: requirements.to_vec(),
+            namespace: child_namespace,
+            unsatisfied,
+            recovery: DelegatedCapabilityRecovery::Narrowed,
+            narrowed_task: Some(narrowed_task),
+        };
+    }
+
+    let recovery = if unsatisfied
+        .iter()
+        .any(|requirement| matches!(requirement, DelegatedCapabilityRequirement::LlmConnection))
+    {
+        DelegatedCapabilityRecovery::Limitation
+    } else {
+        DelegatedCapabilityRecovery::AskUser
+    };
+    DelegatedCapabilityDecision {
+        requirements: requirements.to_vec(),
+        namespace: child_namespace,
+        unsatisfied,
+        recovery,
+        narrowed_task: None,
+    }
+}
+
+pub(crate) fn namespace_summary_from_bindings(
+    mounts: Vec<String>,
+    bin_bindings: Vec<String>,
+    workspace_root: Option<PathBuf>,
+    llm_connection: Option<String>,
+) -> DelegatedNamespaceSummary {
+    let tool_names = bin_bindings
+        .iter()
+        .map(|binding| binding.strip_prefix("/bin/").unwrap_or(binding))
+        .collect::<BTreeSet<_>>();
+    let workspace_access = if workspace_root.is_none() {
+        None
+    } else if WRITE_TOOL_BINDINGS
+        .iter()
+        .any(|name| tool_names.contains(name))
+    {
+        Some(DelegatedWorkspaceAccess::ReadWrite)
+    } else if READ_TOOL_BINDINGS
+        .iter()
+        .any(|name| tool_names.contains(name))
+    {
+        Some(DelegatedWorkspaceAccess::ReadOnly)
+    } else {
+        None
+    };
+
+    DelegatedNamespaceSummary {
+        mounts,
+        bin_bindings,
+        workspace_root,
+        workspace_access,
+        workspace_projection: workspace_access
+            .map(|_| "host_tool_binding_compatibility".to_string()),
+        llm_connection,
+    }
+}
+
+fn unsatisfied_requirements(
+    requirements: &[DelegatedCapabilityRequirement],
+    namespace: &DelegatedNamespaceSummary,
+) -> Vec<DelegatedCapabilityRequirement> {
+    requirements
+        .iter()
+        .filter(|requirement| !namespace_satisfies(requirement, namespace))
+        .cloned()
+        .collect()
+}
+
+fn namespace_satisfies(
+    requirement: &DelegatedCapabilityRequirement,
+    namespace: &DelegatedNamespaceSummary,
+) -> bool {
+    let tool_names = namespace
+        .bin_bindings
+        .iter()
+        .map(|binding| binding.strip_prefix("/bin/").unwrap_or(binding))
+        .collect::<BTreeSet<_>>();
+    match requirement {
+        DelegatedCapabilityRequirement::WorkspaceRead { path } => {
+            workspace_path_is_covered(path.as_deref(), namespace.workspace_root.as_deref())
+                && namespace.workspace_access.is_some()
+        }
+        DelegatedCapabilityRequirement::WorkspaceWrite { path } => {
+            workspace_path_is_covered(path.as_deref(), namespace.workspace_root.as_deref())
+                && matches!(
+                    namespace.workspace_access,
+                    Some(DelegatedWorkspaceAccess::ReadWrite)
+                )
+        }
+        DelegatedCapabilityRequirement::Shell => contains_binding(&tool_names, SHELL_TOOL_BINDINGS),
+        DelegatedCapabilityRequirement::Network => {
+            contains_binding(&tool_names, NETWORK_TOOL_BINDINGS)
+        }
+        DelegatedCapabilityRequirement::Github => {
+            contains_binding(&tool_names, GITHUB_TOOL_BINDINGS)
+        }
+        DelegatedCapabilityRequirement::Browser => {
+            contains_binding(&tool_names, BROWSER_TOOL_BINDINGS)
+        }
+        DelegatedCapabilityRequirement::LlmConnection => namespace.llm_connection.is_some(),
+        DelegatedCapabilityRequirement::SideEffects => {
+            matches!(
+                namespace.workspace_access,
+                Some(DelegatedWorkspaceAccess::ReadWrite)
+            ) || contains_binding(&tool_names, NETWORK_TOOL_BINDINGS)
+        }
+    }
+}
+
+fn workspace_path_is_covered(required: Option<&Path>, mounted: Option<&Path>) -> bool {
+    match (required, mounted) {
+        (_, None) => false,
+        (None, Some(_)) => true,
+        (Some(required), Some(mounted)) => required.starts_with(mounted),
+    }
+}
+
+fn contains_binding(bindings: &BTreeSet<&str>, candidates: &[&str]) -> bool {
+    candidates
+        .iter()
+        .any(|candidate| bindings.contains(candidate))
+}
+
+fn can_narrow_to_local_inspection(
+    unsatisfied: &[DelegatedCapabilityRequirement],
+    namespace: &DelegatedNamespaceSummary,
+) -> bool {
+    namespace_satisfies(
+        &DelegatedCapabilityRequirement::WorkspaceRead { path: None },
+        namespace,
+    ) && namespace_satisfies(&DelegatedCapabilityRequirement::LlmConnection, namespace)
+        && unsatisfied.iter().all(|requirement| {
+            matches!(
+                requirement,
+                DelegatedCapabilityRequirement::WorkspaceWrite { .. }
+                    | DelegatedCapabilityRequirement::Shell
+                    | DelegatedCapabilityRequirement::Network
+                    | DelegatedCapabilityRequirement::Github
+                    | DelegatedCapabilityRequirement::Browser
+                    | DelegatedCapabilityRequirement::SideEffects
+            )
+        })
+}
+
+fn contains_any_phrase(text: &str, phrases: &[&str]) -> bool {
+    phrases.iter().any(|phrase| text.contains(phrase))
+}
+
+fn contains_any_word(words: &BTreeSet<&str>, candidates: &[&str]) -> bool {
+    candidates.iter().any(|candidate| words.contains(candidate))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary(tools: &[&str], access_root: bool) -> DelegatedNamespaceSummary {
+        namespace_summary_from_bindings(
+            vec!["/agent".to_string(), "/mnt/llm".to_string()],
+            tools.iter().map(|tool| format!("/bin/{tool}")).collect(),
+            access_root.then(|| PathBuf::from("/tmp/repo")),
+            Some("default".to_string()),
+        )
+    }
+
+    #[test]
+    fn classifies_github_review_in_namespace_vocabulary() {
+        let requirements = classify_delegated_task_requirements(
+            "Review GitHub issue #42 and the target repository",
+            Some(Path::new("/tmp/repo")),
+        );
+
+        assert!(
+            requirements.contains(&DelegatedCapabilityRequirement::WorkspaceRead {
+                path: Some(PathBuf::from("/tmp/repo")),
+            })
+        );
+        assert!(requirements.contains(&DelegatedCapabilityRequirement::Github));
+        assert!(requirements.contains(&DelegatedCapabilityRequirement::Network));
+    }
+
+    #[test]
+    fn classifies_local_inspection_without_network_or_write() {
+        let requirements = classify_delegated_task_requirements(
+            "Inspect the local architecture and report findings",
+            Some(Path::new("/tmp/repo")),
+        );
+
+        assert!(
+            requirements.contains(&DelegatedCapabilityRequirement::WorkspaceRead {
+                path: Some(PathBuf::from("/tmp/repo")),
+            })
+        );
+        assert!(requirements.contains(&DelegatedCapabilityRequirement::LlmConnection));
+        assert!(!requirements.contains(&DelegatedCapabilityRequirement::Network));
+        assert!(!requirements.iter().any(|requirement| matches!(
+            requirement,
+            DelegatedCapabilityRequirement::WorkspaceWrite { .. }
+        )));
+    }
+
+    #[test]
+    fn classifies_mixed_remote_edit_task() {
+        let requirements = classify_delegated_task_requirements(
+            "Inspect GitHub PR 7, implement the fix, and run tests",
+            Some(Path::new("/tmp/repo")),
+        );
+
+        assert!(requirements.contains(&DelegatedCapabilityRequirement::Github));
+        assert!(requirements.contains(&DelegatedCapabilityRequirement::Network));
+        assert!(requirements.contains(&DelegatedCapabilityRequirement::Shell));
+        assert!(
+            requirements.contains(&DelegatedCapabilityRequirement::WorkspaceWrite {
+                path: Some(PathBuf::from("/tmp/repo")),
+            })
+        );
+        assert!(requirements.contains(&DelegatedCapabilityRequirement::SideEffects));
+    }
+
+    #[test]
+    fn satisfied_spawn_passes_without_rewriting_task() {
+        let child = summary(&["read_file"], true);
+        let requirements = vec![
+            DelegatedCapabilityRequirement::WorkspaceRead {
+                path: Some(PathBuf::from("/tmp/repo")),
+            },
+            DelegatedCapabilityRequirement::LlmConnection,
+        ];
+
+        let decision = evaluate_delegated_namespace(
+            "Inspect local files",
+            &requirements,
+            child,
+            &DelegatedNamespaceSummary::default(),
+        );
+
+        assert_eq!(decision.recovery, DelegatedCapabilityRecovery::Satisfied);
+        assert!(decision.narrowed_task.is_none());
+    }
+
+    #[test]
+    fn parent_path_recovery_is_explicit() {
+        let child = summary(&["read_file"], true);
+        let parent = summary(&["read_file", "gh"], true);
+        let requirements = vec![DelegatedCapabilityRequirement::Github];
+
+        let decision =
+            evaluate_delegated_namespace("Review GitHub issue", &requirements, child, &parent);
+
+        assert_eq!(decision.recovery, DelegatedCapabilityRecovery::ParentPath);
+        assert_eq!(decision.unsatisfied, requirements);
+    }
+
+    #[test]
+    fn narrowed_spawn_names_scope_and_withheld_capability() {
+        let child = summary(&["read_file"], true);
+        let requirements = vec![
+            DelegatedCapabilityRequirement::WorkspaceRead {
+                path: Some(PathBuf::from("/tmp/repo")),
+            },
+            DelegatedCapabilityRequirement::Github,
+        ];
+
+        let decision = evaluate_delegated_namespace(
+            "Review GitHub issue against local code",
+            &requirements,
+            child,
+            &DelegatedNamespaceSummary::default(),
+        );
+
+        assert_eq!(decision.recovery, DelegatedCapabilityRecovery::Narrowed);
+        let task = decision.narrowed_task.unwrap();
+        assert!(task.contains("NARROWED DELEGATION SCOPE"));
+        assert!(task.contains("Withheld capabilities: github"));
+        assert!(task.contains("parent remains responsible"));
+    }
+
+    #[test]
+    fn missing_workspace_declines_with_ask_user_recovery() {
+        let requirements = vec![DelegatedCapabilityRequirement::WorkspaceRead {
+            path: Some(PathBuf::from("/tmp/repo")),
+        }];
+
+        let decision = evaluate_delegated_namespace(
+            "Inspect local files",
+            &requirements,
+            summary(&["read_file"], false),
+            &DelegatedNamespaceSummary::default(),
+        );
+
+        assert_eq!(decision.recovery, DelegatedCapabilityRecovery::AskUser);
+        assert_eq!(decision.unsatisfied, requirements);
+    }
+}

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -6,6 +6,7 @@ mod agent_loop;
 mod child_agents;
 mod child_runs;
 mod compaction;
+mod delegation_capabilities;
 mod engine;
 mod guardian;
 mod loop_guard;

--- a/crates/agent-engine/src/runtime/virtual_tools.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools.rs
@@ -1,7 +1,8 @@
 use alan_agent_protocol::{
-    AdaptivePresentationHint, ConfirmationYieldPayload, Event, SpawnHandle, SpawnLaunchInputs,
-    SpawnRuntimeOverrides, SpawnSpec, SpawnToolProfileOverride, StructuredInputKind,
-    StructuredInputOption, StructuredInputQuestion, StructuredInputYieldPayload, YieldKind,
+    AdaptivePresentationHint, ConfirmationYieldPayload, DelegatedSpawnContext, Event, SpawnHandle,
+    SpawnLaunchInputs, SpawnRuntimeOverrides, SpawnSpec, SpawnToolProfileOverride,
+    StructuredInputKind, StructuredInputOption, StructuredInputQuestion,
+    StructuredInputYieldPayload, YieldKind,
 };
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -27,6 +28,9 @@ use super::child_agents::{
 };
 use super::child_runs::{
     ChildRunRegistryError, ChildRunTerminationMode, global_child_run_registry,
+};
+use super::delegation_capabilities::{
+    DelegatedSpawnRejected, classify_delegated_task_requirements,
 };
 use super::tool_policy::{ToolPolicyDecision, evaluate_tool_policy};
 use super::turn_support::{check_turn_cancelled, tool_result_preview};
@@ -1198,19 +1202,24 @@ where
                             return Ok(VirtualToolOutcome::EndTurn);
                         }
 
-                        (
-                            persisted_request,
-                            DelegatedSkillResult::failed(
-                                format!(
-                                    "Failed to launch delegated runtime for skill '{}': {err}",
-                                    request.skill_id
-                                ),
-                                Some(json!({
-                                    "error_kind": "child_launch_failed"
-                                })),
+                        let capability_decision = err
+                            .downcast_ref::<DelegatedSpawnRejected>()
+                            .map(|rejection| rejection.decision.clone());
+                        let error_kind = if capability_decision.is_some() {
+                            "delegated_capability_mismatch"
+                        } else {
+                            "child_launch_failed"
+                        };
+                        let mut result = DelegatedSkillResult::failed(
+                            format!(
+                                "Failed to launch delegated runtime for skill '{}': {err}",
+                                request.skill_id
                             ),
-                            None,
-                        )
+                            Some(json!({ "error_kind": error_kind })),
+                        );
+                        result.error_kind = Some(error_kind.to_string());
+                        result.capability_decision = capability_decision;
+                        (persisted_request, result, None)
                     }
                 }
             }
@@ -1394,6 +1403,8 @@ fn build_delegated_spawn_spec(
         request.workspace_root.is_some(),
         parent_default_cwd.as_deref(),
     )?;
+    let requirements =
+        classify_delegated_task_requirements(&request.task, workspace_root.as_deref());
     Ok(SpawnSpec {
         target,
         launch: SpawnLaunchInputs {
@@ -1409,6 +1420,7 @@ fn build_delegated_spawn_spec(
         },
         handles: vec![SpawnHandle::Workspace, SpawnHandle::ApprovalScope],
         runtime_overrides: delegated_runtime_overrides(request.skill_id.as_str()),
+        delegated: Some(DelegatedSpawnContext { requirements }),
     })
 }
 
@@ -1510,7 +1522,7 @@ fn delegated_tool_profile(skill_id: &str) -> Option<SpawnToolProfileOverride> {
 }
 
 fn delegated_result_from_child_result(result: &ChildRuntimeResult) -> DelegatedSkillResult {
-    match result.status {
+    let mut delegated = match result.status {
         ChildRuntimeStatus::Completed => delegated_result_from_completed_child(result),
         ChildRuntimeStatus::Failed => child_failure_result(
             format!(
@@ -1570,7 +1582,12 @@ fn delegated_result_from_child_result(result: &ChildRuntimeResult) -> DelegatedS
             delegated.warnings = result.warnings.clone();
             delegated
         }
-    }
+    };
+    delegated.capability_decision = result
+        .child_run
+        .as_ref()
+        .and_then(|record| record.delegation_capability_decision.clone());
+    delegated
 }
 
 fn delegated_result_from_completed_child(result: &ChildRuntimeResult) -> DelegatedSkillResult {

--- a/crates/agent-engine/src/runtime/virtual_tools_tests.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools_tests.rs
@@ -2411,6 +2411,19 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill() {
         spec.launch.timeout_secs,
         Some(DEFAULT_DELEGATED_TIMEOUT_SECS)
     );
+    let requirements = &spec
+        .delegated
+        .as_ref()
+        .expect("delegated launch should carry classified requirements")
+        .requirements;
+    assert!(requirements.contains(
+        &alan_agent_protocol::DelegatedCapabilityRequirement::WorkspaceRead {
+            path: Some(PathBuf::from("/tmp/alan-delegated-parent")),
+        }
+    ));
+    assert!(
+        requirements.contains(&alan_agent_protocol::DelegatedCapabilityRequirement::LlmConnection)
+    );
 
     let prompt_view = state.session.tape.prompt_view();
     let tool_result = prompt_view
@@ -2429,6 +2442,54 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill() {
     assert!(tool_result.contains("Delegated review completed."));
     assert!(tool_result.contains("child_run"));
     assert!(tool_result.contains("child-session"));
+}
+
+#[tokio::test]
+async fn test_delegated_capability_rejection_is_recorded_on_parent_tape() {
+    let mut state = create_test_agent_loop_state();
+    state.core_config.memory.workspace_dir =
+        Some(PathBuf::from("/tmp/alan-delegated-parent/.alan/memory"));
+    activate_test_delegated_skill(&mut state, "repo-review", "reviewer");
+    let tool_call = NormalizedToolCall {
+        id: "call_capability_mismatch".to_string(),
+        name: "invoke_delegated_skill".to_string(),
+        arguments: serde_json::json!({
+            "skill_id": "repo-review",
+            "target": "reviewer",
+            "task": "Review GitHub issue 42"
+        }),
+    };
+    let decision = alan_agent_protocol::DelegatedCapabilityDecision {
+        requirements: vec![alan_agent_protocol::DelegatedCapabilityRequirement::Github],
+        namespace: alan_agent_protocol::DelegatedNamespaceSummary::default(),
+        unsatisfied: vec![alan_agent_protocol::DelegatedCapabilityRequirement::Github],
+        recovery: alan_agent_protocol::DelegatedCapabilityRecovery::ParentPath,
+        narrowed_task: None,
+    };
+    let expected_decision = decision.clone();
+    let cancel = CancellationToken::new();
+    let mut emit = |_event: Event| async {};
+
+    handle_invoke_delegated_skill(
+        &mut state,
+        &tool_call,
+        &tool_call.arguments,
+        &cancel,
+        &mut emit,
+        move |_state, _spec, _cancel| {
+            Box::pin(async move { Err(anyhow::Error::new(DelegatedSpawnRejected { decision })) })
+        },
+    )
+    .await
+    .unwrap();
+
+    let tool_result = tool_result_text_for_call(&state, "call_capability_mismatch");
+    let record: DelegatedSkillInvocationRecord = serde_json::from_str(&tool_result).unwrap();
+    assert_eq!(
+        record.result.error_kind.as_deref(),
+        Some("delegated_capability_mismatch")
+    );
+    assert_eq!(record.result.capability_decision, Some(expected_decision));
 }
 
 #[tokio::test]

--- a/crates/agent-engine/src/skills/types.rs
+++ b/crates/agent-engine/src/skills/types.rs
@@ -1197,6 +1197,8 @@ pub struct DelegatedSkillResult {
     pub error_kind: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capability_decision: Option<alan_agent_protocol::DelegatedCapabilityDecision>,
 }
 
 /// Inspectable reference for omitted delegated child output.
@@ -1251,6 +1253,7 @@ impl DelegatedSkillResult {
             warnings: Vec::new(),
             error_kind: None,
             error_message: None,
+            capability_decision: None,
         }
     }
 
@@ -1271,6 +1274,7 @@ impl DelegatedSkillResult {
             warnings: Vec::new(),
             error_kind: None,
             error_message: None,
+            capability_decision: None,
         }
     }
 }

--- a/crates/agent-protocol/src/lib.rs
+++ b/crates/agent-protocol/src/lib.rs
@@ -40,8 +40,9 @@ pub use op::{
 };
 pub use reasoning::{ReasoningControls, ReasoningEffort};
 pub use spawn::{
-    SpawnHandle, SpawnLaunchInputs, SpawnRuntimeOverrides, SpawnSpec, SpawnTarget,
-    SpawnToolProfileOverride,
+    DelegatedCapabilityDecision, DelegatedCapabilityRecovery, DelegatedCapabilityRequirement,
+    DelegatedNamespaceSummary, DelegatedSpawnContext, DelegatedWorkspaceAccess, SpawnHandle,
+    SpawnLaunchInputs, SpawnRuntimeOverrides, SpawnSpec, SpawnTarget, SpawnToolProfileOverride,
 };
 pub use ui_surface::{
     UI_SURFACE_VERSION, UiActivitySnapshot, UiActivityState, UiEvent, UiNoticeKind,

--- a/crates/agent-protocol/src/spawn.rs
+++ b/crates/agent-protocol/src/spawn.rs
@@ -2,6 +2,103 @@ use crate::ReasoningEffort;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+/// Material capability required by a delegated task, expressed in the same
+/// mount-and-binding vocabulary used to assemble the child namespace.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum DelegatedCapabilityRequirement {
+    WorkspaceRead {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        path: Option<PathBuf>,
+    },
+    WorkspaceWrite {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        path: Option<PathBuf>,
+    },
+    Shell,
+    Network,
+    Github,
+    Browser,
+    LlmConnection,
+    SideEffects,
+}
+
+impl DelegatedCapabilityRequirement {
+    /// Stable human-readable label used in launch and mismatch records.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::WorkspaceRead { .. } => "workspace_read",
+            Self::WorkspaceWrite { .. } => "workspace_write",
+            Self::Shell => "shell",
+            Self::Network => "network",
+            Self::Github => "github",
+            Self::Browser => "browser",
+            Self::LlmConnection => "llm_connection",
+            Self::SideEffects => "side_effects",
+        }
+    }
+}
+
+/// Access projected from the assembled namespace into the delegated child.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DelegatedWorkspaceAccess {
+    ReadOnly,
+    ReadWrite,
+}
+
+/// Bounded historical summary derived from the actual child namespace plan.
+///
+/// This is audit metadata, not a second authority registry. While a child is
+/// alive, `/proc/<pid>/namespace` remains the source of truth.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct DelegatedNamespaceSummary {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mounts: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub bin_bindings: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_root: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_access: Option<DelegatedWorkspaceAccess>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_projection: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub llm_connection: Option<String>,
+}
+
+/// Visible recovery selected when a delegated namespace cannot satisfy the
+/// original task requirements.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DelegatedCapabilityRecovery {
+    Satisfied,
+    ParentPath,
+    Narrowed,
+    AskUser,
+    Limitation,
+}
+
+/// Auditable outcome of comparing classified task requirements with the
+/// assembled child namespace.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DelegatedCapabilityDecision {
+    pub requirements: Vec<DelegatedCapabilityRequirement>,
+    pub namespace: DelegatedNamespaceSummary,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unsatisfied: Vec<DelegatedCapabilityRequirement>,
+    pub recovery: DelegatedCapabilityRecovery,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub narrowed_task: Option<String>,
+}
+
+/// Requirement input attached to a delegated spawn before namespace assembly.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct DelegatedSpawnContext {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requirements: Vec<DelegatedCapabilityRequirement>,
+}
+
 /// Explicit launch target for a child agent instance.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
@@ -96,6 +193,8 @@ pub struct SpawnSpec {
     pub handles: Vec<SpawnHandle>,
     #[serde(default, skip_serializing_if = "SpawnRuntimeOverrides::is_empty")]
     pub runtime_overrides: SpawnRuntimeOverrides,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delegated: Option<DelegatedSpawnContext>,
 }
 
 impl SpawnSpec {
@@ -134,6 +233,14 @@ mod tests {
                     allowed_tools: vec!["read_file".to_string(), "grep".to_string()],
                 }),
             },
+            delegated: Some(DelegatedSpawnContext {
+                requirements: vec![
+                    DelegatedCapabilityRequirement::WorkspaceRead {
+                        path: Some(PathBuf::from("/tmp/workspace")),
+                    },
+                    DelegatedCapabilityRequirement::LlmConnection,
+                ],
+            }),
         };
 
         let value = serde_json::to_value(&spec).unwrap();
@@ -141,6 +248,10 @@ mod tests {
         assert_eq!(value["handles"][0], "workspace");
         assert_eq!(value["runtime_overrides"]["model"], "gpt-5.4");
         assert_eq!(value["runtime_overrides"]["model_reasoning_effort"], "high");
+        assert_eq!(
+            value["delegated"]["requirements"][0]["kind"],
+            "workspace_read"
+        );
 
         let parsed: SpawnSpec = serde_json::from_value(value).unwrap();
         assert!(parsed.has_handle(SpawnHandle::Workspace));
@@ -164,6 +275,7 @@ mod tests {
             },
             handles: vec![SpawnHandle::Workspace],
             runtime_overrides: SpawnRuntimeOverrides::default(),
+            delegated: None,
         };
 
         let value = serde_json::to_value(&spec).unwrap();

--- a/crates/alan/skill_templates/basic-delegate/SKILL.md
+++ b/crates/alan/skill_templates/basic-delegate/SKILL.md
@@ -18,3 +18,13 @@ Use this skill when:
 2. Hand long-running or specialized work to the delegated child agent.
 3. Return a bounded result to the parent runtime.
 4. Move detailed material into `references/` and deterministic helpers into `scripts/`.
+
+## Namespace Requirement Contract
+
+Describe the mounts and `/bin` bindings the delegated task materially needs.
+alan checks those requirements against the assembled child namespace before
+spawn. If the task is narrowed, the child task names the withheld capability
+and the parent retains responsibility; otherwise the parent uses its own path,
+asks for missing input, or states the limitation. Never silently substitute
+unrelated local context. The parent tape records the decision and a launched
+child retains bounded requirement plus namespace-summary launch metadata.

--- a/openspec/changes/align-delegation-capability-with-namespace/.openspec.yaml
+++ b/openspec/changes/align-delegation-capability-with-namespace/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/align-delegation-capability-with-namespace/design.md
+++ b/openspec/changes/align-delegation-capability-with-namespace/design.md
@@ -1,0 +1,103 @@
+## Context
+
+The superseded `harden-agent-operating-system-contracts` change (2026-05-14)
+observed real failures: delegation launched children that could not reach
+GitHub, the network, or the target workspace, and the failure surfaced as an
+opaque bad answer instead of a routing decision. Its remedy — a capability
+descriptor per delegated target plus a runtime matching engine — predates the
+namespace-native substrate. Today:
+
+- An agent's capability set is exactly what its spawner mounted
+  (`agent-namespace-runtime`: "anything not present in that namespace is
+  unreachable").
+- `/proc/<pid>/namespace` already renders a spawned process's world; there is
+  no need for a second capability record for launched children.
+- `delegate` is designated an Agent Executable spawn target
+  (`agent-file-layout-contract`), while the shipping code still routes
+  delegation through the `invoke_delegated_skill` virtual tool.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Requirement classification and eligibility checking at the child-spawn
+  boundary, expressed in mount/binding vocabulary.
+- Visible, recorded recovery when requirements cannot be satisfied.
+- Zero new registries: launched-child observability rides `/proc`, declined
+  launches ride the parent's action/tape records.
+
+**Non-Goals:**
+
+- Migrating `invoke_delegated_skill` to the `delegate` Agent Executable (a
+  separate change; this contract is written to survive it).
+- Hard security isolation claims (ADR-0024 R1 boundary still applies:
+  convention-enforced until the kernel amplification check lands).
+- A general planner that infers requirements from arbitrary prose; the first
+  vocabulary is small and mechanical.
+- Cleaning up the legacy child-run registry vs `children/` duplication (tracked
+  separately; this change only adds launch metadata to whichever record exists).
+
+## Decisions
+
+### 1. Capability vocabulary = namespace vocabulary
+
+A requirement is named by the mount or binding that would satisfy it (e.g.
+"workspace write mount for path X", "`gh`/GitHub-capable tool in `/bin`",
+"network-capable shell", "LLM connection"). Satisfaction is a lookup against
+the exec spec's namespace assembly, not a comparison of two hand-maintained
+descriptor lists.
+
+Alternative considered: per-target capability descriptors (the superseded
+design). Rejected: descriptors drift from actual mounts; the namespace is
+already the authoritative record and cannot drift from itself.
+
+### 2. The check lives at the spawn boundary
+
+The eligibility check runs where the exec spec is assembled, immediately before
+`/proc/clone`. That single seam covers the current virtual tool (which
+ultimately spawns a child runtime) and the future `delegate` executable (which
+assembles a namespace by construction). Nothing upstream of the spawn boundary
+needs to know the vocabulary.
+
+Alternative considered: checking inside the delegated skill's prompt guidance.
+Rejected by the superseded change already: the failure mode is a routing error,
+so the model that made the error cannot be its only guard.
+
+### 3. Mismatch produces a decision record on existing surfaces
+
+Declined or narrowed launches append a bounded decision record to the parent's
+action record (or tape, pre-migration): required capabilities, what was
+missing, and the chosen recovery path. Launched children need no extra record
+beyond a bounded namespace summary in child-run launch metadata, because
+`/proc/<pid>/namespace` is live truth while the child exists and the launch
+metadata preserves it after exit.
+
+Alternative considered: a dedicated capability-decision log. Rejected: second
+source of truth, violates the no-parallel-registries principle.
+
+### 4. Narrowing rewrites the task, not just the mounts
+
+When the parent narrows a task to fit an available namespace (e.g. "local
+inspection only, GitHub content will be supplied by the parent"), the child's
+task description states the narrowed scope explicitly, and the parent remains
+responsible for the withheld part. A child must never discover mid-run that its
+task assumed a capability its world lacks.
+
+## Risks / Trade-offs
+
+- [Risk] Requirement classification under-detects (task needs network, classifier
+  misses it) → the child fails as today, but the decision record shows the
+  classifier's view, making the gap diagnosable; vocabulary grows incrementally.
+- [Risk] Over-detection blocks legitimate delegation → recovery paths include
+  proceeding with an explicitly narrowed task; the check narrows rather than
+  hard-fails wherever a narrowed task is coherent.
+- [Risk] Dual delegation paths (virtual tool now, `delegate` executable later)
+  drift → the check is a single function at the spawn boundary both paths share;
+  tests pin both entry points.
+
+## Open Questions
+
+- Exact first vocabulary: is browser access modeled as a `/bin` tool binding or
+  a dedicated mount at first cut?
+- Should the user-facing mismatch surface be a `requests/` entry (ask for the
+  missing input) by default, or only when no narrowing is possible?

--- a/openspec/changes/align-delegation-capability-with-namespace/proposal.md
+++ b/openspec/changes/align-delegation-capability-with-namespace/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+Delegation can still launch a child whose world cannot satisfy the task (the
+capability-mismatch failure mode observed in the superseded
+`harden-agent-operating-system-contracts` change, archived 2026-07-10). Since
+the namespace-native refactor, an agent's capability set IS its spawner-assembled
+namespace (`agent-namespace-runtime`), so eligibility must be expressed as
+spawn-time namespace alignment — not the descriptor-matching engine the
+superseded change proposed.
+
+## What Changes
+
+- Classify the material capabilities a delegated task requires (workspace
+  read/write scope, shell, network/GitHub, browser, model access, side effects)
+  before spawning the child, in a vocabulary that maps directly onto namespace
+  mounts and `/bin` bindings.
+- Check the namespace the spawner is about to assemble against those
+  requirements; a requirement is satisfied if and only if the corresponding
+  mount/binding will be present in the child's namespace.
+- On mismatch, take a visible recovery path: narrow the task to what the
+  namespace supports (stated in the child's task description), satisfy the
+  requirement through the parent's own namespace, ask the user for the missing
+  input, or return a limitation-focused answer — never silently substitute
+  unrelated local context.
+- Make decisions auditable through existing namespace surfaces: a launched
+  child's capability record is its `/proc/<pid>/namespace`; declined or
+  narrowed launches are recorded on the parent's own surfaces (action record /
+  tape), not in a parallel decision store.
+- Design the check on the spawn model (`delegate` is an Agent Executable spawn
+  target per `agent-file-layout-contract`); the current `invoke_delegated_skill`
+  virtual tool receives the check at its child-spawn boundary so the contract
+  survives the delegation-to-spawn migration.
+
+## Capabilities
+
+### New Capabilities
+
+- `delegation-capability-alignment`: Owns task-requirement classification, the
+  spawn-time requirement-vs-namespace check, mismatch recovery paths, and
+  decision observability for delegated launches.
+
+### Modified Capabilities
+
+- `child-run-lifecycle`: Child-run launch metadata gains a bounded summary of
+  the capability-bearing mounts the child was spawned with, so a mismatch
+  investigation does not require the child process to still be alive.
+
+## Impact
+
+- Affected runtime modules: delegated child spawn path
+  (`crates/agent-engine/src/runtime/virtual_tools.rs` and the future `delegate`
+  Agent Executable), exec-spec/namespace assembly, child-run registration.
+- Affected specs: interacts with `agent-namespace-runtime` (spawner-assembled
+  namespace) and `agent-file-layout-contract` (Agent Executables, `children/`);
+  neither is modified — this change consumes their guarantees.
+- Affected skills: delegated-skill instructions describe requirement narrowing
+  and recovery semantics once the runtime check exists.
+- Affected tests: mismatch decline, narrowed-task delegation, parent-path
+  recovery, and namespace-metadata presence on child-run records.

--- a/openspec/changes/align-delegation-capability-with-namespace/specs/child-run-lifecycle/spec.md
+++ b/openspec/changes/align-delegation-capability-with-namespace/specs/child-run-lifecycle/spec.md
@@ -1,0 +1,13 @@
+## MODIFIED Requirements
+
+### Requirement: Child Run Registration
+The system SHALL create a child-run record before submitting the first operation to a delegated child runtime.
+
+#### Scenario: Delegated child is launched
+- **WHEN** a parent runtime launches a delegated child runtime
+- **THEN** the child-run registry contains a record with parent session id, child session id, workspace metadata, rollout path when available, launch metadata, created time, and `starting` or `running` status before the child receives its initial turn
+- **AND** the launch metadata includes a bounded summary of the capability-bearing mounts and `/bin` bindings the child was spawned with, so capability investigations do not require the child process to still be alive
+
+#### Scenario: Child launch fails after runtime startup
+- **WHEN** child launch fails after a child session id or rollout path is known
+- **THEN** the child-run record is updated to `failed` with terminal metadata instead of disappearing from the registry

--- a/openspec/changes/align-delegation-capability-with-namespace/specs/delegation-capability-alignment/spec.md
+++ b/openspec/changes/align-delegation-capability-with-namespace/specs/delegation-capability-alignment/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Task Requirements Are Classified In Namespace Vocabulary
+The runtime SHALL classify the material capabilities a delegated task requires
+before spawning the child, using a vocabulary whose terms map directly onto
+namespace mounts and `/bin` bindings (workspace read/write scope, shell,
+network/GitHub-capable tools, browser, LLM connection, side effects).
+
+#### Scenario: GitHub issue review requires GitHub-capable bindings
+- **WHEN** a user asks alan to inspect and review a GitHub issue in another
+  repository via delegated work
+- **THEN** the classified requirements include target-workspace read access and
+  a GitHub- or network-capable tool binding, before any child is spawned
+
+#### Scenario: Local inspection classifies as workspace-read only
+- **WHEN** a delegated task only inspects local files in another workspace
+- **THEN** the classified requirements name a read-scoped workspace mount and no
+  network capability
+
+### Requirement: Delegated Spawn Requires Namespace Satisfaction
+The runtime SHALL spawn a delegated child only when the namespace its exec spec
+assembles satisfies the classified task requirements, or when the task has been
+explicitly narrowed to what that namespace supports. A requirement SHALL be
+considered satisfied only by a corresponding mount or binding in the child's
+namespace, not by a separately maintained capability descriptor.
+
+#### Scenario: Child namespace lacks a required capability
+- **WHEN** the assembled child namespace would contain no binding satisfying a
+  classified requirement (for example, no GitHub-capable tool in `/bin`)
+- **THEN** the runtime does not spawn the child for the original task and records
+  a capability-mismatch decision naming the unsatisfied requirements
+
+#### Scenario: Narrowed task is spawned with explicit scope
+- **WHEN** the parent narrows the task to fit the available namespace
+- **THEN** the child's task description states the narrowed scope and the
+  withheld capability, and the parent remains responsible for the withheld part
+
+### Requirement: Capability Mismatch Has Visible Recovery
+The runtime SHALL take a visible recovery path when no assemblable child
+namespace satisfies the task: satisfy the requirement through the parent's own
+namespace, narrow the task, ask the user for the missing input, or return a
+limitation-focused answer. The runtime SHALL NOT silently substitute unrelated
+local context for the unsatisfiable part of the task.
+
+#### Scenario: Parent namespace can satisfy the missing capability
+- **WHEN** the parent's own namespace contains a binding that satisfies the
+  requirement the child world lacks
+- **THEN** alan may perform that part through the parent path and records that
+  the parent recovered from a delegated capability mismatch
+
+#### Scenario: No available namespace can satisfy the task
+- **WHEN** neither the parent namespace nor any assemblable child namespace
+  satisfies a required capability
+- **THEN** alan asks for the missing input or answers with the limitation stated,
+  instead of substituting unrelated local context
+
+### Requirement: Capability Decisions Are Observable On Existing Surfaces
+The runtime SHALL make capability decisions auditable through existing
+namespace surfaces: a launched child's capability record is its
+`/proc/<pid>/namespace` plus bounded launch metadata, and declined or narrowed
+launches are recorded on the parent's action record or tape. The runtime SHALL
+NOT introduce a parallel capability-decision registry.
+
+#### Scenario: Launched child is audited
+- **WHEN** an auditor inspects a delegated launch decision for a running child
+- **THEN** `/proc/<pid>/namespace` shows the child's actual capability set and
+  the launch record carries the classified requirements
+
+#### Scenario: Declined launch is audited
+- **WHEN** an auditor inspects a delegation that was declined or narrowed
+- **THEN** the parent's action record or tape contains the classified
+  requirements, the unsatisfied capabilities, and the chosen recovery path

--- a/openspec/changes/align-delegation-capability-with-namespace/tasks.md
+++ b/openspec/changes/align-delegation-capability-with-namespace/tasks.md
@@ -1,0 +1,28 @@
+## 1. Requirement Vocabulary And Classification
+
+- [x] 1.1 Define the first capability vocabulary as namespace terms (workspace read/write mounts, shell, network/GitHub tool bindings, browser, LLM connection, side effects) with in-repo docs.
+- [x] 1.2 Implement task-requirement classification for delegated launches, producing a bounded requirement record.
+- [x] 1.3 Add unit tests for classification of GitHub-review, local-inspection, and mixed tasks.
+
+## 2. Spawn-Boundary Eligibility Check
+
+- [x] 2.1 Implement the requirement-vs-namespace satisfaction check at the child spawn boundary (single seam shared by `invoke_delegated_skill` today and the `delegate` Agent Executable later).
+- [x] 2.2 Decline or narrow launches whose assembled namespace does not satisfy requirements; narrowed tasks state the narrowed scope and withheld capability in the child task description.
+- [x] 2.3 Add tests: mismatch decline, narrowed spawn with explicit scope, satisfied spawn passes unchanged.
+
+## 3. Recovery And Observability
+
+- [x] 3.1 Implement recovery selection (parent-path satisfaction, narrowing, ask-user, limitation answer) with the no-silent-substitution guarantee.
+- [x] 3.2 Record declined/narrowed decisions on the parent action record or tape; include classified requirements in child-run launch metadata with the namespace summary.
+- [x] 3.3 Add tests: parent-path recovery is recorded, declined launch is auditable, launched child's record carries requirements and namespace summary.
+
+## 4. Skill Guidance
+
+- [x] 4.1 Update delegated-skill instructions to describe requirement narrowing, recovery semantics, and where decisions are recorded.
+
+## 5. Verification And Archive Readiness
+
+- [x] 5.1 Run `just verify` and fix fallout.
+- [x] 5.2 Run `openspec validate align-delegation-capability-with-namespace --strict`.
+- [ ] 5.3 Open PR, address review, merge.
+- [ ] 5.4 After merge, sync delta specs into `openspec/specs/` and confirm archive readiness.


### PR DESCRIPTION
## Summary

- classify delegated task requirements in namespace and `/bin` binding vocabulary
- enforce requirement satisfaction at the child spawn boundary with explicit narrowing/recovery
- persist bounded capability decisions in existing child-run and parent tape surfaces
- document the contract in OpenSpec and delegated-skill guidance

## Verification

- `cargo test -p alan-agent-protocol` (57 passed)
- `cargo test -p alan-agent-engine` (1288 passed, 1 ignored)
- `openspec validate align-delegation-capability-with-namespace --strict`
- `git diff --check`

## Sequencing

This is the base Alan OS contract PR. Evidence projection and child-run lifecycle reconciliation follow after this lands.
