### PR TITLE
docs(openspec): define alan programmable client surface

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -291,6 +291,13 @@ It is stored under `/lib/exec/<name>/manifest` and complements the Tool's
 `--help` output and manual page.
 _Avoid_: hidden registry entry, agent-only schema, permission source
 
+**WASM Component**:
+A portable compiled Alan extension with a WIT boundary and explicitly granted
+Descriptors and Access Rights. It is projected into Alan OS as a Tool or a
+File-Server Service rather than becoming a separate client API.
+_Avoid_: ambient host plugin, replacement for aP, user-facing scripting language,
+unclassified extension
+
 **Skill**:
 A manual-like knowledge package installed under `/lib/skill/<name>` and
 documented under `/man/skill/<name>`. Skills are read by Agent Processes through
@@ -589,6 +596,22 @@ surface for using the Namespace, files, processes, Agent Processes, Tools,
 Skills, Memory Stores, and system services. It may be rendered by the current
 Ratatui path in `crates/tui` and by Alan for macOS.
 _Avoid_: Alan TUI as product name, daemon client, terminal product naming, chat UI
+
+**Programmable Client Surface**:
+The Alan Shell interaction contract that lets humans and agents compose mounted
+Files, Streams, and executable Processes through editable text and file
+operations. It is part of Alan Shell, not a separate component, service, app, or
+product.
+_Avoid_: ClientSurface object, client service, UI framework, app runtime,
+separate programmable environment
+
+**Alan Shell Evaluator Process**:
+An ordinary Process spawned by an Alan Shell client to execute one explicit
+editable-text selection under the caller's bounded Namespace. Its `/proc` path
+is the execution identity; it is created through the `run` Tool, and `editfs`
+never owns a separate execution registry.
+_Avoid_: buffer-local execution object, hidden evaluator task, editfs command
+runner, opaque execution id
 
 **Primary Shell Window**:
 The single main Alan shell window used by the macOS app. Short-term product

--- a/openspec/changes/define-alan-programmable-client-surface/.openspec.yaml
+++ b/openspec/changes/define-alan-programmable-client-surface/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/define-alan-programmable-client-surface/design.md
+++ b/openspec/changes/define-alan-programmable-client-surface/design.md
@@ -1,0 +1,248 @@
+## Context
+
+ADR-0026 adopts the Acme interaction idea: editable text is programmable and
+the interaction surface is itself a file server. ADR-0027 places that work in
+Ring 4 and states the stronger Alan claim that one namespace is the runtime, UI,
+and extension boundary. The repository now has the relevant pieces, but not the
+loop between them:
+
+- `alan-shell` is an aP-only namespace client with generic `ls`, `cat`, `tail`,
+  `write`, `echo`, and `spawn` builtins. Its command parser and dispatcher are
+  private to `StdioDriver`.
+- `alan-editfs` exposes one buffer at `/mnt/edit` with
+  `body`/`tag`/`addr`/`ctl`/`event`, but its `ExecutionPolicy` only records an
+  accept/deny decision and cannot execute under the caller's namespace.
+- `/proc` already supplies the correct execution identity, lifecycle, IO, and
+  control files. The current `ProcessRunner` returns one terminal
+  `ProcessOutcome`, so the user-space runner bridge needs an incremental output
+  sink for a live `tail` process.
+- renderer hosts are already required to read files and write `ctl`, while the
+  current TUI completion model still receives renderer-assembled command,
+  Skill, and host-file candidate lists.
+
+The design was sharpened through a domain-modeling/grilling session. The
+resolved terms live in `CONTEXT.md`: Programmable Client Surface belongs to
+Alan Shell; an Alan Shell Evaluator Process is an ordinary Process created by
+the `run` Tool; a WASM Component is a future portable Tool or File-Server
+Service implementation, not a new Alan OS client API.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Connect Alan Shell, editfs, `/proc`, and renderer-host contracts into one
+  text-first programmable client loop.
+- Make every selected-text execution a real Process spawned under the caller's
+  bounded Namespace.
+- Reuse one explicit Alan Shell grammar for stdio and editable-buffer execution.
+- Keep selection validation, Process execution, result materialization, and
+  live observation visible as ordinary file operations.
+- Prove the loop with a native-Rust, headless end-to-end harness over the
+  existing single `/mnt/edit` buffer.
+- Preserve Rust to WASM Component as the promotion direction without coupling
+  this slice to a WASM host.
+
+**Non-Goals:**
+
+- No new Alan Kernel primitive, ClientSurface object, execution registry,
+  opaque execution id, `/client` root, or `/mnt/client` service.
+- No complete `rc`-like language, variables, pipelines, conditions, loops,
+  functions, or new surface-only grammar.
+- No multi-buffer allocator, buffer manager, clone file, or cross-buffer
+  navigation.
+- No generic widget/form/view schema and no generated dashboard framework.
+- No Ratatui or Alan for macOS implementation in the first slice.
+- No WASM host, WIT package contract, component build/sign/install pipeline, or
+  runtime projection implementation.
+- No claim that the in-process v1 namespace is a hardware-enforced security
+  boundary; native execution still requires OS sandbox projection.
+
+## Decisions
+
+### 1. Programmable Client Surface is an Alan Shell contract, not a component
+
+The surface is the composition of a caller's mounted Namespace, generic Alan
+Shell operations, an editable interaction buffer, and a renderer projection.
+No new durable system object represents that composition. Domain truth remains
+in its owning service tree, editable interaction state remains in editfs,
+execution truth remains in `/proc`, and cursor/viewport/hover state remains in
+the renderer.
+
+Alternative considered: add a ClientSurface type, manager, id, and service
+tree. Rejected because it would duplicate existing owners and contradict the
+namespace-as-runtime/UI thesis.
+
+### 2. One shared explicit grammar drives stdio and selected-text execution
+
+Extract the current `LineCommand` parsing and dispatch from `StdioDriver` into
+a reusable headless Alan Shell command layer. The first grammar remains exactly
+the bounded set already implemented: `ls`, `cat`, `tail`, `write`, `echo`,
+`spawn`, plus empty/exit handling where appropriate. Unknown text fails
+explicitly. The surface never guesses that arbitrary prose is a path or Tool.
+
+Alternative considered: design a complete `rc` dialect now. Rejected because
+it would lock language semantics before dogfood establishes the needed
+composition forms. Alternative considered: create an editfs-specific parser.
+Rejected because two grammars would immediately drift.
+
+### 3. `run` is a Tool and every execution is an ordinary Process
+
+Install a first-party Tool at `/bin/run`, with its machine-readable manifest at
+`/lib/exec/run/manifest` and manual at `/man/1/run`. A client reads the current
+`addr` snapshot and spawns `run`, passing the `/mnt/edit` path or bounded buffer
+descriptors plus the expected body/address revisions and range. The resulting
+Alan Shell Evaluator Process is visible at `/proc/<pid>`; that path is the sole
+execution identity.
+
+The target `alan-binfs` crate does not yet exist. The first slice therefore
+uses a named compatibility projection in the namespace-native bootstrap to
+bind the executable and its package files. That projection has one deletion
+gate: replace it with the normal binfs/package mount when `alan-binfs` lands.
+It must not make `run` available only as an Agent Execution Engine-private JSON
+Tool, because humans and non-agent clients must be able to spawn the same
+command file.
+
+The `run` Tool uses its `ProcessInvocation` pid and inherited Namespace to read
+the selected bytes and submit a complete-document `ctl exec` containing the
+process path and revision snapshot. Editfs atomically verifies that the
+captured bytes still describe the active selection before the Tool dispatches
+the shared command executor. A stale or invalid selection makes the Tool exit
+without executing the command.
+
+Alternative considered: a renderer-local helper. Rejected because humans,
+agents, tests, and other clients would not share one executable. Alternative
+considered: an editfs-owned execution registry with correlation ids. Rejected
+because `/proc` already owns execution identity, status, output, cancellation,
+and exit state.
+
+### 4. Editfs validates interaction state but never supplies execution authority
+
+Remove `ExecutionPolicy::{AcceptAll,DenyAll}` as the execution boundary. A
+successful `ctl exec` means only that the body/address snapshot is current and
+the caller had write access to `ctl`. Whether `/bin/run` is visible, may be
+spawned, may access a mount, or may perform a side effect is decided by the
+spawner's Namespace, descriptors, Tool governance, credentials, and sandbox
+projection.
+
+The order is deliberately spawn then validate: a denied spawn produces no
+Process and is audited by the Tool/governance path; a successful Process
+submits its real `/proc/<pid>` path while validating immediately before command
+dispatch. Editfs never runs a Tool on behalf of a client and therefore cannot
+become an arbitrary-command confused deputy.
+
+Alternative considered: let editfs invoke a callback under service authority.
+Rejected because a client could acquire the service's ambient mounts and Tool
+rights.
+
+### 5. Process IO is canonical; bounded finite text is also materialized
+
+All command output is appended to `/proc/<pid>/io/output`, including output
+produced before Process exit. The user-space ProcessRunner bridge will accept an
+incremental output sink backed by the existing ProcFS stream; this changes no
+Kernel ontology.
+
+For a finite command whose complete output is bounded UTF-8, `run` also opens
+`/mnt/edit/body` read-write, appends the bytes at the observed end, and clunks
+to commit only if the body revision still matches. A conflict never overwrites
+another client's edit: `run` reopens the latest revision and retries a bounded
+number of safe end-appends. The editfs event stream records the resulting body
+range, body revision, and `/proc/<pid>` path, so the raw body stays plain text
+while the execution boundary remains inspectable. If materialization fails,
+the command may still succeed; its complete result remains in Process output
+and status distinguishes command failure from materialization failure.
+
+Alternative considered: renderer-owned copy-on-exit. Rejected because headless,
+TUI, macOS, and agent clients would behave differently. Alternative considered:
+store output only in editfs events. Rejected because events are audit metadata,
+not an unbounded result store.
+
+### 6. Live `tail` remains descriptor-backed until explicitly captured
+
+For `tail`, the evaluator Process remains running and holds the source Stream
+Descriptor. Bytes flow incrementally to its own `io/output` and are rendered as
+a transient projection; they are not continually copied into `body`. Interrupt
+or cancel uses `/proc/<pid>/ctl`. Reconnect reads the Process output stream from
+a saved offset. A client that wants editable text stops or snapshots the live
+operation and explicitly runs `cat /proc/<pid>/io/output`; that finite command
+uses the normal materialization path.
+
+Alternative considered: append every live byte to `body`. Rejected because it
+creates unbounded editable state, revision churn, and a hidden retention policy.
+
+### 7. Discovery is namespace-derived and text-first
+
+Generic discovery walks the mounted Namespace and reads `/bin`, Tool Manifests,
+`/man`, `/lib/skill`, file kinds, and access rights. A renderer may project that
+information into completion or a selector, but its candidate list is a cache,
+not the authority. Capability-specific rich renderers may interpret the same
+service tree; services are not required to publish a generic widget/form schema.
+
+Alternative considered: require UI schemas from every service. Rejected because
+it recreates the retired universal View/Command/Query framework and makes files
+a veneer over an RPC-shaped UI protocol.
+
+### 8. Host actions and namespace actions remain separate
+
+Space/Tab/Pane/window operations remain in `alan-shell-core` and platform
+action routing. Reads, writes, tails, `ctl` commands, and executable spawn
+remain namespace operations. Renderers may present both planes together but do
+not merge them into one universal action registry.
+
+### 9. Rust to WASM is an explicit promotion target, not this slice's runtime
+
+Scratch text does not become an extension by being saved. Reusable behavior is
+promoted deliberately and classified as either a Tool or a File-Server Service.
+The preferred portable direction is Rust compiled to a WASM Component with a
+WIT boundary and explicit descriptors/access rights. WIT is an internal
+component-host ABI; the Alan OS surface remains `/bin` or an aP file tree.
+
+The first `run` Tool is native Rust because no WASM Component host exists in the
+current tree. A later change owns hosting, WASI policy, WIT packages, build,
+signing, installation, and Service Manager/binfs projection.
+
+## Risks / Trade-offs
+
+- [The current ProcessRunner buffers output until exit] → Add an incremental
+  user-space output sink backed by the existing `/proc/<pid>/io/output` Stream
+  and cover running-process reads before implementing live `tail` in `run`.
+- [A process path written in editfs ctl is caller-asserted in the in-process v1]
+  → Accept only the first-party `run` protocol in this slice, treat the path as
+  correlation rather than authority, and leave authenticated request provenance
+  to the broader aP credential/isolation track.
+- [A command side effect can succeed before result materialization conflicts]
+  → Keep Process status/output canonical, retry only safe end-appends, and report
+  materialization failure separately without replaying the command.
+- [A single `/mnt/edit` cannot serve a future multi-buffer UI] → Use it only for
+  the first headless proof; define allocation after real renderer lifecycle
+  requirements exist.
+- [The small grammar may feel less programmable than `rc`] → Preserve a clean
+  reusable command boundary and add language features only from dogfood evidence.
+- [Native subprocesses cannot inspect Alan namespaces] → Continue projecting
+  allowed mounts into the OS sandbox and do not claim mount visibility alone is
+  security enforcement.
+
+## Migration Plan
+
+1. Land the modified contracts and glossary terms without changing Kernel
+   primitives or renderer products.
+2. Extract the Alan Shell command parser/executor while keeping stdio behavior
+   byte-for-byte compatible.
+3. Evolve the ProcessRunner/ProcFS bridge for incremental output and verify
+   running Process observation and cancellation.
+4. Replace editfs `ExecutionPolicy` with revision validation, Process-linked
+   events, and revision-safe result append semantics.
+5. Add the native `run` Tool and its manifest/manual projection in the
+   namespace-native bootstrap used by the harness; name the temporary package
+   projection and its binfs deletion gate.
+6. Prove stale-selection rejection, caller authority, finite materialization,
+   live tail, explicit capture, concurrency, and headless human/agent symmetry
+   end to end.
+7. Keep the existing stdio driver and direct `io/` + `ctl` agent paths working;
+   rollback removes the `run` binding and restores the prior editfs adapter
+   without changing stored domain data.
+
+## Open Questions
+
+None for the first slice. Multi-buffer allocation, a full `rc` language, native
+renderers, generic promotion tooling, and the WASM Component host are explicit
+follow-up changes rather than unresolved requirements here.

--- a/openspec/changes/define-alan-programmable-client-surface/design.md
+++ b/openspec/changes/define-alan-programmable-client-surface/design.md
@@ -141,17 +141,19 @@ produced before Process exit. The user-space ProcessRunner bridge will accept an
 incremental output sink backed by the existing ProcFS stream; this changes no
 Kernel ontology.
 
-For a finite command whose complete output is bounded UTF-8, `run` also opens
-`/mnt/edit/body` read-write, appends the bytes at the observed end, and clunks
-to commit only if the body revision still matches. A conflict never overwrites
-another client's edit: `run` reopens the latest revision and retries a bounded
-number of safe end-appends. A committed append returns an editfs-issued commit
-token naming the committed range and revision; the materialization record must
-present that token, so a Process/result link can only name bytes this evaluator
-actually appended — range existence in a revision is not enough. The editfs
-event stream records the resulting body range, body revision, and `/proc/<pid>`
-path, so the raw body stays plain text while the execution boundary remains
-inspectable. If materialization fails,
+For a finite command whose complete output is bounded UTF-8, `run` submits one
+complete-document `materialize` control write carrying its `/proc/<pid>` path,
+the expected body revision and append position, and the result bytes; editfs
+commits on clunk, atomically appending the bytes as an ordinary body edit and
+emitting the Process-linked materialization event in the same commit. A
+conflict never overwrites another client's edit: a stale revision fails the
+commit without side effects and `run` retries a bounded number of safe
+end-appends against the newly read end. Because bytes and attribution commit
+together, a Process/result link can only name bytes this evaluator actually
+appended — no post-hoc range claim exists, and no aP clunk payload or protocol
+change is needed. The editfs event stream records the resulting body range,
+body revision, and `/proc/<pid>` path, so the raw body stays plain text while
+the execution boundary remains inspectable. If materialization fails,
 the command may still succeed; its complete result remains in Process output
 and status distinguishes command failure from materialization failure.
 

--- a/openspec/changes/define-alan-programmable-client-surface/design.md
+++ b/openspec/changes/define-alan-programmable-client-surface/design.md
@@ -145,9 +145,13 @@ For a finite command whose complete output is bounded UTF-8, `run` also opens
 `/mnt/edit/body` read-write, appends the bytes at the observed end, and clunks
 to commit only if the body revision still matches. A conflict never overwrites
 another client's edit: `run` reopens the latest revision and retries a bounded
-number of safe end-appends. The editfs event stream records the resulting body
-range, body revision, and `/proc/<pid>` path, so the raw body stays plain text
-while the execution boundary remains inspectable. If materialization fails,
+number of safe end-appends. A committed append returns an editfs-issued commit
+token naming the committed range and revision; the materialization record must
+present that token, so a Process/result link can only name bytes this evaluator
+actually appended — range existence in a revision is not enough. The editfs
+event stream records the resulting body range, body revision, and `/proc/<pid>`
+path, so the raw body stays plain text while the execution boundary remains
+inspectable. If materialization fails,
 the command may still succeed; its complete result remains in Process output
 and status distinguishes command failure from materialization failure.
 

--- a/openspec/changes/define-alan-programmable-client-surface/proposal.md
+++ b/openspec/changes/define-alan-programmable-client-surface/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+Alan already has a namespace-native shell, a headless editable-buffer file
+server, and file-backed renderer contracts, but they do not yet form one
+programmable interaction loop. Without a shared contract, selected-text
+execution, result capture, completion, and future renderer work can drift into
+renderer-local commands, hidden editfs authority, or another generic UI/action
+framework.
+
+## What Changes
+
+- Define the Programmable Client Surface as part of Alan Shell: a text-first
+  interaction contract over the caller's mounted Namespace, not a new service,
+  app, UI framework, registry, or top-level namespace root.
+- Reuse Alan Shell's existing explicit `ls`, `cat`, `tail`, `write`, `echo`, and
+  `spawn` grammar through a shared headless parser/executor; do not introduce a
+  second surface-only parser or a full `rc`-like language in this slice.
+- Add the short, discoverable `run` Tool. Each selected-text execution spawns an
+  ordinary Alan Shell Evaluator Process whose `/proc/<pid>` tree is the sole
+  execution identity and lifecycle surface.
+- Make the evaluator validate the selected `body`/`addr` revisions through
+  `editfs`, execute under its inherited caller Namespace, stream output through
+  its Process files, and materialize bounded UTF-8 results back into the buffer
+  without overwriting concurrent edits.
+- Keep live `tail` output descriptor-backed and transient; only an explicit
+  bounded capture becomes editable buffer text.
+- Remove `editfs` execution policy as an authority boundary. `editfs` owns
+  selection consistency and interaction events; Process spawn, Namespace,
+  access rights, Tool governance, and sandbox projection own execution
+  authority.
+- Derive text-first discovery from the mounted Namespace, `/bin`, Tool
+  Manifests, `/man`, `/lib/skill`, file kinds, and access rights; do not define a
+  generic UI/form schema.
+- Record Rust to WASM Component as the explicit promotion direction for mature
+  reusable behavior while deferring WASM hosting, WIT package design, build,
+  signing, installation, and projection to a later change.
+- Deliver a headless end-to-end harness over the existing single buffer at
+  `/mnt/edit`; defer multi-buffer allocation and TUI/macOS surface work.
+
+## Capabilities
+
+### New Capabilities
+
+None. Programmable Client Surface is part of the existing `alan-shell`
+capability, not an independent durable subsystem.
+
+### Modified Capabilities
+
+- `alan-shell`: Define the programmable interaction contract, shared command
+  execution layer, namespace-derived discovery, and Process-backed `run` Tool.
+- `editable-buffer-interaction`: Replace service-side execution with
+  caller-spawned evaluator Processes, define result materialization and live
+  stream behavior, and keep interaction events linked to `/proc` truth.
+- `editable-buffer-file-server`: Replace the headless accept/deny execution
+  policy with revision validation and evaluator-originated execution events.
+- `alan-renderer-host-contract`: Require renderers to project programmable
+  buffers and evaluator Process files without becoming execution or domain
+  authority.
+
+## Impact
+
+- Refactors `crates/shell` so its current private line parser/executor can be
+  reused by stdio and the `run` Tool.
+- Evolves `crates/editfs` control and event semantics and removes
+  `ExecutionPolicy::{AcceptAll,DenyAll}` as the execution boundary.
+- Adds a first-party `run` executable, Tool Manifest, manual surface, Process
+  lifecycle tests, and a headless Shell + editfs + Kernel integration harness.
+- Updates the Alan product glossary with Programmable Client Surface, Alan Shell
+  Evaluator Process, and WASM Component terminology.
+- Does not change Alan Kernel primitives, add a new namespace root, implement a
+  WASM host, or modify Ratatui and Alan for macOS in the first slice.

--- a/openspec/changes/define-alan-programmable-client-surface/specs/alan-renderer-host-contract/spec.md
+++ b/openspec/changes/define-alan-programmable-client-surface/specs/alan-renderer-host-contract/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Renderer hosts project Programmable Client Surface files
+An Alan renderer host SHALL render a Programmable Client Surface by reading the
+mounted editable-buffer files and evaluator Process files and by translating
+user intent into ordinary file operations and `run` Tool spawn. Renderer-local
+cursor, viewport, hover, selection highlight, completion cache, and layout state
+MAY optimize presentation but SHALL NOT become editable text, execution, or
+domain authority.
+
+#### Scenario: Renderer attaches to a programmable buffer
+- **WHEN** a renderer receives a Namespace containing `/mnt/edit`, `/bin/run`,
+  and `/proc`
+- **THEN** it can render `body` and `tag`, project `addr`, observe `event`, and
+  follow evaluator Process output without a daemon session or semantic view
+  snapshot
+- **AND** another file client can perform the same authoritative operations
+
+### Requirement: Renderer discovery is a Namespace projection
+Renderer hosts SHALL derive completion and selection surfaces for Paths, Tools,
+Skills, commands, and writable or observable files from the mounted Namespace and
+its package metadata. The renderer SHALL treat its candidate model as a
+replaceable cache and SHALL NOT require a generic service UI schema.
+
+#### Scenario: Namespace availability changes
+- **WHEN** a Tool, Skill, service tree, or Path becomes absent from the
+  renderer's Namespace
+- **THEN** the corresponding generic candidate disappears when the projection
+  refreshes
+- **AND** the renderer does not preserve it as an independently authoritative
+  action
+
+### Requirement: Renderer hosts keep host and Namespace action planes distinct
+Renderer hosts SHALL keep Space, Tab, Pane, window, and other host-presentation
+actions separate from namespace operations such as read, write, tail, `ctl`,
+and executable spawn. A renderer MAY present both action planes in one visual
+surface but SHALL NOT merge their authority into a universal action registry.
+
+#### Scenario: User executes selected buffer text
+- **WHEN** a user invokes execution for the current editable range
+- **THEN** the renderer spawns `/bin/run` with the bounded buffer snapshot
+- **AND** it does not dispatch the selected text through a host layout action
+  registry or renderer-private callback
+
+### Requirement: Renderer hosts treat live output as a transient projection
+A renderer host SHALL read a running evaluator's `/proc/<pid>/io/output` from a
+Stream Offset and SHALL NOT automatically copy live `tail` bytes into editable
+`body`. Explicit finite capture SHALL use ordinary Alan Shell commands and the
+same result-materialization contract as a headless client.
+
+#### Scenario: Renderer reconnects to a live evaluator
+- **WHEN** a renderer reattaches while a `tail` evaluator Process remains live
+- **THEN** it resumes the Process output Stream from its saved offset
+- **AND** it does not reconstruct execution from renderer history or duplicate
+  the live bytes into editfs

--- a/openspec/changes/define-alan-programmable-client-surface/specs/alan-shell/spec.md
+++ b/openspec/changes/define-alan-programmable-client-surface/specs/alan-shell/spec.md
@@ -1,0 +1,109 @@
+## ADDED Requirements
+
+### Requirement: Programmable Client Surface belongs to Alan Shell
+Alan Shell SHALL provide the Programmable Client Surface as its text-first
+interaction contract over the caller's mounted Namespace. The surface SHALL
+compose Files, Streams, editable buffers, and executable Processes without
+creating a separate client service, app runtime, authority store, generic UI
+framework, or top-level namespace root.
+
+#### Scenario: Surface ownership is reviewed
+- **WHEN** a programmable client interaction is implemented or rendered
+- **THEN** its domain truth remains in the owning mounted service tree, its
+  editable interaction state remains in editfs, and its execution truth remains
+  in `/proc`
+- **AND** no ClientSurface object, client manager, opaque surface id, `/client`,
+  or `/mnt/client` authority is introduced
+
+### Requirement: Alan Shell reuses one explicit command grammar
+Alan Shell SHALL expose one reusable headless parser and executor for its
+existing `ls`, `cat`, `tail`, `write`, `echo`, and `spawn` grammar. The stdio
+driver and editable-text execution SHALL use that same parser and executor.
+Unknown text SHALL fail explicitly and SHALL NOT be inferred as a Path, Tool,
+script language expression, or side-effecting action.
+
+#### Scenario: Stdio and editable text run the same command
+- **WHEN** the same valid command text is submitted through `StdioDriver` and
+  through an editable buffer selection
+- **THEN** both paths resolve the same Alan Shell command and aP operations
+- **AND** neither path uses a renderer-local or editfs-local parser
+
+#### Scenario: Arbitrary prose is selected
+- **WHEN** selected text does not match the bounded Alan Shell grammar
+- **THEN** execution fails without reading, writing, tailing, or spawning based
+  on a heuristic interpretation of the prose
+
+### Requirement: The run Tool creates Alan Shell Evaluator Processes
+Alan Shell SHALL provide a first-party Tool named `run`, bound at `/bin/run`,
+with a Tool Manifest under `/lib/exec/run/manifest` and a manual under
+`/man/1/run`. Each selected-text execution SHALL spawn one ordinary Alan Shell
+Evaluator Process; `/proc/<pid>` SHALL be its execution identity, status,
+output, cancellation, and exit surface. Tool governance and policy escalation
+SHALL apply to every command the evaluator dispatches — including `spawn` of
+another Tool — identically to the same operation invoked directly by the
+caller; `run` SHALL NOT bypass, launder, or pre-approve a policy decision that
+direct invocation would raise.
+
+#### Scenario: Selected text is executed
+- **WHEN** a client invokes `run` with an editable-buffer Path or bounded
+  descriptors and an expected body/address revision snapshot
+- **THEN** it spawns a Process under the caller's delegated Namespace and the
+  Process validates that snapshot before dispatching the shared command
+  executor
+- **AND** editfs does not create an execution object or run the command under
+  service authority
+
+#### Scenario: Selection validation fails
+- **WHEN** the body revision, address revision, or selected range no longer
+  matches when the evaluator Process validates it
+- **THEN** the Process exits failed without executing the selected command
+- **AND** its failure is inspectable through `/proc/<pid>`
+
+#### Scenario: Inner spawn keeps governance parity
+- **WHEN** the evaluator executes `spawn` for a Tool whose direct invocation
+  would raise a policy escalation or approval requirement
+- **THEN** the identical governance decision applies to the evaluator-initiated
+  spawn, and any escalation surfaces through the normal request path before the
+  Tool runs
+- **AND** the policy audit records the inner Tool identity, so executing it
+  through `run` is indistinguishable from direct spawn to governance
+
+### Requirement: Programmable discovery derives from the Namespace
+Alan Shell SHALL derive generic programmable-client discovery from resources
+visible in the caller's Namespace, including directory entries, file kinds,
+access rights, `/bin`, Tool Manifests, `/man`, and `/lib/skill`. Renderer
+completion or selector models SHALL remain projections of those files and SHALL
+NOT become private capability registries. Alan Shell SHALL NOT require services
+to publish a generic widget, form, card, view, command, or query schema.
+
+#### Scenario: A renderer offers completion
+- **WHEN** a renderer presents Paths, Tools, Skills, or commands for completion
+- **THEN** the candidates are derived from the mounted Namespace and its package
+  metadata
+- **AND** withholding a mount or executable removes the corresponding candidate
+  without a second renderer-specific deny list
+
+#### Scenario: A service has no rich renderer schema
+- **WHEN** a conforming mounted service exposes only its documented file layout
+- **THEN** the Programmable Client Surface can still inspect, observe, and invoke
+  allowed behavior through text-first file operations
+- **AND** the service is not required to describe a generated UI
+
+### Requirement: Mature surface behavior promotes explicitly to classified extensions
+Alan Shell SHALL treat scratch editable text as interaction state, not as an
+installed extension. Reusable behavior SHALL be promoted explicitly and
+classified as either a Tool or a File-Server Service. Rust to WASM Component
+with a WIT boundary and explicit descriptors/access rights SHALL remain the
+portable extension direction, while `/bin` executables and aP file trees remain
+the Alan OS surfaces.
+
+#### Scenario: Scratch text is saved
+- **WHEN** a user saves or retains editable buffer text
+- **THEN** Alan does not automatically install it as a Tool, Skill, WASM
+  Component, or service
+
+#### Scenario: Reusable behavior is promoted later
+- **WHEN** a later workflow compiles Rust behavior into a WASM Component
+- **THEN** it classifies the component as a Tool or File-Server Service and
+  grants only explicit descriptors and access rights
+- **AND** WIT does not replace aP as the client-facing Alan OS contract

--- a/openspec/changes/define-alan-programmable-client-surface/specs/editable-buffer-file-server/spec.md
+++ b/openspec/changes/define-alan-programmable-client-surface/specs/editable-buffer-file-server/spec.md
@@ -1,3 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Address ranges are revision-bound
+
+Alan SHALL store the active body range in `addr` using `rev:<body-revision>
+<start>..<end>` write syntax. Reads SHALL return the selected body revision,
+address revision, and range as `rev:<body-revision> addr:<addr-revision>
+<start>..<end>`. The only `exec` form `ctl` accepts SHALL be the evaluator
+`ctl exec` document carrying the `/proc/<pid>` Path and the expected
+body/address revision snapshot; the legacy path-less
+`exec rev:<body-revision> addr:<addr-revision> <start>..<end>` syntax SHALL be
+rejected rather than validated.
+
+#### Scenario: Address range is selected
+
+- **WHEN** a client writes a valid current-revision range to `addr` and clunks
+  the fid
+- **THEN** subsequent reads of `addr` return that range
+- **AND** an address event is appended to `event`
+
+#### Scenario: Stale address fails at execution
+
+- **WHEN** the body revision changes after an address range is selected
+- **AND** an evaluator Process clunks a complete `ctl exec` document carrying
+  its `/proc/<pid>` Path and the stale body/address revision snapshot
+- **THEN** the clunk fails with a typed aP error
+- **AND** no command text from the stale range is executed
+
+#### Scenario: Legacy path-less exec is rejected
+
+- **WHEN** a client writes the legacy `exec rev:<body-revision>
+  addr:<addr-revision> <start>..<end>` form to `ctl` without an evaluator
+  `/proc/<pid>` Path and clunks the fid
+- **THEN** the clunk fails with a typed aP error and no execution event is
+  recorded
+- **AND** stale-selection validation cannot be satisfied through the legacy
+  syntax
+
 ## REMOVED Requirements
 
 ### Requirement: Explicit exec records accepted and denied outcomes

--- a/openspec/changes/define-alan-programmable-client-surface/specs/editable-buffer-file-server/spec.md
+++ b/openspec/changes/define-alan-programmable-client-surface/specs/editable-buffer-file-server/spec.md
@@ -40,13 +40,17 @@ Editfs SHALL allow an evaluator Process to append bounded UTF-8 result bytes to
 the current end of `body` through a read-write fid bound to the body revision
 observed at open. Clunk SHALL commit the append only if that revision and append
 position are still current. A successful result append SHALL advance the body
-revision and remain an ordinary body edit.
+revision and remain an ordinary body edit, and editfs SHALL return an append
+commit token to the committing fid identifying that commit, its resulting body
+revision, and the committed range.
 
 #### Scenario: Result append commits
 - **WHEN** an evaluator opens `body` read-write, writes bounded UTF-8 bytes at the
   observed end, and clunks before another body edit
 - **THEN** editfs appends the bytes, advances the body revision, and emits an edit
   event
+- **AND** the committing evaluator receives an append commit token naming the
+  committed range and new body revision
 
 #### Scenario: Concurrent edit rejects result append
 - **WHEN** another client changes `body` after the evaluator opens its
@@ -55,21 +59,30 @@ revision and remain an ordinary body edit.
 
 ### Requirement: editfs links materialized ranges to Process truth
 After a successful result append, editfs SHALL accept a complete-document
-materialization record from the evaluator that names `/proc/<pid>`, the committed
-body revision, and result range. It SHALL validate that the named range exists
-in that revision and append a Process-linked materialization event. Editfs
-SHALL NOT copy Process status, exit state, or complete output into a parallel
-execution record.
+materialization record from the evaluator that names `/proc/<pid>` and presents
+the append commit token editfs issued for that result append. Editfs SHALL bind
+the materialization event to the specific append commit the token identifies —
+its committed range and body revision — and SHALL NOT accept range existence in
+a revision as a substitute for the token; a record naming bytes committed by a
+different writer or a different commit SHALL be rejected. Editfs SHALL NOT copy
+Process status, exit state, or complete output into a parallel execution record.
 
 #### Scenario: Materialization is recorded
-- **WHEN** a `run` Process reports the body revision and range committed for its
-  finite result
-- **THEN** editfs appends an event linking that range to `/proc/<pid>`
+- **WHEN** a `run` Process presents the append commit token for its finite
+  result together with its `/proc/<pid>` Path
+- **THEN** editfs appends an event linking that commit's range and revision to
+  `/proc/<pid>`
 - **AND** clients continue to read execution status and complete output from the
   Process files
 
 #### Scenario: Materialization record is inconsistent
-- **WHEN** the reported body revision or range does not describe the committed
-  result bytes
+- **WHEN** the record's token does not match an append commit editfs performed,
+  or names a commit other than the one that wrote the result bytes
 - **THEN** editfs rejects the record and does not publish a false Process/result
   association
+
+#### Scenario: Record names another writer's bytes
+- **WHEN** an evaluator reports a range that exists in the named revision but was
+  committed by a different writer or commit
+- **THEN** editfs rejects the record because the presented token does not
+  identify that commit

--- a/openspec/changes/define-alan-programmable-client-surface/specs/editable-buffer-file-server/spec.md
+++ b/openspec/changes/define-alan-programmable-client-surface/specs/editable-buffer-file-server/spec.md
@@ -81,8 +81,12 @@ atomically validate the expected revision and append position, append the bytes
 at the current end of `body` as an ordinary body edit that advances the body
 revision, and emit the edit event plus a Process-linked materialization event
 naming the committed range, the new body revision, and the supplied
-`/proc/<pid>` Path. A stale revision or append position SHALL fail the commit
-with a typed aP error and no side effects. Because the result bytes and their
+`/proc/<pid>` Path. As with `ctl exec`, the supplied `/proc/<pid>` Path SHALL be
+recorded as caller-asserted correlation metadata, not verified identity, until
+aP request provenance provides authentication: the atomic commit binds the
+bytes to this commit, not the pid to the writer, so consumers MUST NOT treat
+the Process link as verified provenance. A stale revision or append position
+SHALL fail the commit with a typed aP error and no side effects. Because the result bytes and their
 Process link commit together, a materialization event SHALL never attribute
 bytes committed by another writer, and editfs SHALL NOT accept a post-hoc
 record that links an existing `body` range to a Process. This uses only
@@ -96,7 +100,8 @@ complete output into a parallel execution record.
 - **THEN** `body` gains the appended bytes as an ordinary edit with an advanced
   revision and an edit event
 - **AND** the same commit emits a materialization event linking exactly that
-  committed range and revision to the supplied `/proc/<pid>` Path
+  committed range and revision to the supplied `/proc/<pid>` Path, recorded as
+  caller-asserted correlation
 
 #### Scenario: Concurrent edit rejects materialization
 - **WHEN** another client changes `body` after the evaluator captures the append

--- a/openspec/changes/define-alan-programmable-client-surface/specs/editable-buffer-file-server/spec.md
+++ b/openspec/changes/define-alan-programmable-client-surface/specs/editable-buffer-file-server/spec.md
@@ -35,54 +35,40 @@ identity, until aP request provenance provides authentication.
   the current buffer at clunk
 - **THEN** editfs returns a typed aP error and appends no execution-started event
 
-### Requirement: body supports revision-safe result append
-Editfs SHALL allow an evaluator Process to append bounded UTF-8 result bytes to
-the current end of `body` through a read-write fid bound to the body revision
-observed at open. Clunk SHALL commit the append only if that revision and append
-position are still current. A successful result append SHALL advance the body
-revision and remain an ordinary body edit, and editfs SHALL return an append
-commit token to the committing fid identifying that commit, its resulting body
-revision, and the committed range.
+### Requirement: Result materialization is one atomic append-and-link commit
+Editfs SHALL accept an evaluator's complete-document `materialize` control write
+carrying the evaluator's `/proc/<pid>` Path, the expected body revision and
+append position, and the bounded UTF-8 result bytes. On clunk, editfs SHALL
+atomically validate the expected revision and append position, append the bytes
+at the current end of `body` as an ordinary body edit that advances the body
+revision, and emit the edit event plus a Process-linked materialization event
+naming the committed range, the new body revision, and the supplied
+`/proc/<pid>` Path. A stale revision or append position SHALL fail the commit
+with a typed aP error and no side effects. Because the result bytes and their
+Process link commit together, a materialization event SHALL never attribute
+bytes committed by another writer, and editfs SHALL NOT accept a post-hoc
+record that links an existing `body` range to a Process. This uses only
+ordinary aP writes and commit-on-clunk; no clunk response payload or protocol
+change is required. Editfs SHALL NOT copy Process status, exit state, or
+complete output into a parallel execution record.
 
-#### Scenario: Result append commits
-- **WHEN** an evaluator opens `body` read-write, writes bounded UTF-8 bytes at the
-  observed end, and clunks before another body edit
-- **THEN** editfs appends the bytes, advances the body revision, and emits an edit
-  event
-- **AND** the committing evaluator receives an append commit token naming the
-  committed range and new body revision
+#### Scenario: Materialization commits atomically
+- **WHEN** an evaluator clunks a complete `materialize` document whose expected
+  revision and append position match the current buffer
+- **THEN** `body` gains the appended bytes as an ordinary edit with an advanced
+  revision and an edit event
+- **AND** the same commit emits a materialization event linking exactly that
+  committed range and revision to the supplied `/proc/<pid>` Path
 
-#### Scenario: Concurrent edit rejects result append
-- **WHEN** another client changes `body` after the evaluator opens its
-  read-write fid but before clunk
-- **THEN** editfs rejects the stale append and preserves the concurrent edit
+#### Scenario: Concurrent edit rejects materialization
+- **WHEN** another client changes `body` after the evaluator captures the append
+  position but before its `materialize` document is clunked
+- **THEN** editfs fails the commit with a typed aP error, appends no bytes,
+  emits no events, and preserves the concurrent edit
+- **AND** the evaluator may retry a safe append against the newly read body end
 
-### Requirement: editfs links materialized ranges to Process truth
-After a successful result append, editfs SHALL accept a complete-document
-materialization record from the evaluator that names `/proc/<pid>` and presents
-the append commit token editfs issued for that result append. Editfs SHALL bind
-the materialization event to the specific append commit the token identifies —
-its committed range and body revision — and SHALL NOT accept range existence in
-a revision as a substitute for the token; a record naming bytes committed by a
-different writer or a different commit SHALL be rejected. Editfs SHALL NOT copy
-Process status, exit state, or complete output into a parallel execution record.
-
-#### Scenario: Materialization is recorded
-- **WHEN** a `run` Process presents the append commit token for its finite
-  result together with its `/proc/<pid>` Path
-- **THEN** editfs appends an event linking that commit's range and revision to
-  `/proc/<pid>`
-- **AND** clients continue to read execution status and complete output from the
-  Process files
-
-#### Scenario: Materialization record is inconsistent
-- **WHEN** the record's token does not match an append commit editfs performed,
-  or names a commit other than the one that wrote the result bytes
-- **THEN** editfs rejects the record and does not publish a false Process/result
-  association
-
-#### Scenario: Record names another writer's bytes
-- **WHEN** an evaluator reports a range that exists in the named revision but was
-  committed by a different writer or commit
-- **THEN** editfs rejects the record because the presented token does not
-  identify that commit
+#### Scenario: Post-hoc range attribution is rejected
+- **WHEN** a client submits a record that names an existing `body` range and a
+  `/proc/<pid>` Path without carrying the result bytes in a `materialize` commit
+- **THEN** editfs rejects it, because Process/result links exist only as
+  products of atomic materialize commits

--- a/openspec/changes/define-alan-programmable-client-surface/specs/editable-buffer-file-server/spec.md
+++ b/openspec/changes/define-alan-programmable-client-surface/specs/editable-buffer-file-server/spec.md
@@ -1,0 +1,75 @@
+## REMOVED Requirements
+
+### Requirement: Explicit exec records accepted and denied outcomes
+
+**Reason**: The headless `ExecutionPolicy::{AcceptAll,DenyAll}` decision can
+neither grant nor enforce execution authority once selected text runs as a
+caller-spawned Process. Keeping it would misrepresent editfs as a Tool-policy
+boundary and invite a confused-deputy implementation.
+
+**Migration**: Replace accept/deny policy with atomic selection validation for
+the caller-spawned `run` Process. Spawn, Namespace access, Tool governance, and
+sandbox projection own execution authority; editfs records Process-linked
+interaction events.
+
+## ADDED Requirements
+
+### Requirement: editfs validates evaluator Process selections
+Editfs SHALL accept a complete-document `ctl exec` from a caller-spawned `run`
+Process containing the evaluator's `/proc/<pid>` Path, expected body revision,
+expected address revision, and selected range. On clunk, editfs SHALL atomically
+validate the snapshot and append an execution-started event only when it still
+matches. Editfs SHALL NOT spawn the evaluator, execute the selected text, or
+apply an editfs-owned side-effect policy. The evaluator-supplied `/proc/<pid>`
+Path SHALL be recorded as caller-asserted correlation metadata, not verified
+identity, until aP request provenance provides authentication.
+
+#### Scenario: Evaluator selection is current
+- **WHEN** a `run` Process clunks a complete `ctl exec` document whose body and
+  address snapshot matches the current buffer
+- **THEN** editfs commits validation and appends an event containing the selected
+  command text and `/proc/<pid>` Path
+
+#### Scenario: Evaluator selection is stale
+- **WHEN** the expected body revision, address revision, or range does not match
+  the current buffer at clunk
+- **THEN** editfs returns a typed aP error and appends no execution-started event
+
+### Requirement: body supports revision-safe result append
+Editfs SHALL allow an evaluator Process to append bounded UTF-8 result bytes to
+the current end of `body` through a read-write fid bound to the body revision
+observed at open. Clunk SHALL commit the append only if that revision and append
+position are still current. A successful result append SHALL advance the body
+revision and remain an ordinary body edit.
+
+#### Scenario: Result append commits
+- **WHEN** an evaluator opens `body` read-write, writes bounded UTF-8 bytes at the
+  observed end, and clunks before another body edit
+- **THEN** editfs appends the bytes, advances the body revision, and emits an edit
+  event
+
+#### Scenario: Concurrent edit rejects result append
+- **WHEN** another client changes `body` after the evaluator opens its
+  read-write fid but before clunk
+- **THEN** editfs rejects the stale append and preserves the concurrent edit
+
+### Requirement: editfs links materialized ranges to Process truth
+After a successful result append, editfs SHALL accept a complete-document
+materialization record from the evaluator that names `/proc/<pid>`, the committed
+body revision, and result range. It SHALL validate that the named range exists
+in that revision and append a Process-linked materialization event. Editfs
+SHALL NOT copy Process status, exit state, or complete output into a parallel
+execution record.
+
+#### Scenario: Materialization is recorded
+- **WHEN** a `run` Process reports the body revision and range committed for its
+  finite result
+- **THEN** editfs appends an event linking that range to `/proc/<pid>`
+- **AND** clients continue to read execution status and complete output from the
+  Process files
+
+#### Scenario: Materialization record is inconsistent
+- **WHEN** the reported body revision or range does not describe the committed
+  result bytes
+- **THEN** editfs rejects the record and does not publish a false Process/result
+  association

--- a/openspec/changes/define-alan-programmable-client-surface/specs/editable-buffer-interaction/spec.md
+++ b/openspec/changes/define-alan-programmable-client-surface/specs/editable-buffer-interaction/spec.md
@@ -58,6 +58,36 @@ projection remains a permanent second enforcement mechanism for them.
   layer instead of assuming the subprocess can inspect or enforce the Alan
   Namespace directly
 
+### Requirement: Buffer activity is observable as events
+
+Alan OS SHALL expose edits, address changes, validated execution starts, and
+result materializations through the buffer `event` stream using blocking-read
+semantics. Execution outcome, exit state, and output SHALL be read from the
+evaluator's `/proc/<pid>` files; buffer events link to that Process truth and
+SHALL NOT record a parallel accepted, denied, yielded, or failed execution
+status.
+
+#### Scenario: Edit event is observed
+
+- **WHEN** a client writes new content to `body`
+- **THEN** another client reading `event` at the live edge blocks until an edit
+  event is appended and then receives that event
+
+#### Scenario: Execution-start event is observed
+
+- **WHEN** an evaluator Process commits a valid `ctl exec` snapshot
+- **THEN** a client reading `event` at the live edge receives an
+  execution-started event carrying the source range, command text, and the
+  evaluator's `/proc/<pid>` Path
+- **AND** execution status and outcome are read from the Process files, not from
+  a buffer-event status field
+
+#### Scenario: Materialization event is observed
+
+- **WHEN** an evaluator's finite result append commits to `body`
+- **THEN** the `event` stream records the result range, committed body revision,
+  and the evaluator's `/proc/<pid>` Path
+
 ## ADDED Requirements
 
 ### Requirement: Process IO is the execution output authority

--- a/openspec/changes/define-alan-programmable-client-surface/specs/editable-buffer-interaction/spec.md
+++ b/openspec/changes/define-alan-programmable-client-surface/specs/editable-buffer-interaction/spec.md
@@ -1,0 +1,125 @@
+## MODIFIED Requirements
+
+### Requirement: Executable text uses explicit control operations
+
+Alan OS SHALL execute text from an editable buffer only through an explicit
+caller-spawned `run` Tool Process. The evaluator Process SHALL read the selected
+bytes and submit a complete-document `ctl exec` carrying its `/proc/<pid>` Path,
+the expected `addr` range, source `body` revision, and address revision; editfs
+SHALL act only when that document is clunked and SHALL atomically validate the
+snapshot before the Process dispatches the shared Alan Shell command executor.
+Editfs SHALL NOT spawn the Process, execute the text, or lend service authority.
+Until the ADR-0024 R1 amplification check lands, the mount set is an
+architectural discipline rather than a security property; native subprocesses
+such as shell commands cannot see the Alan namespace directly, so OS sandbox
+projection remains a permanent second enforcement mechanism for them.
+
+#### Scenario: Selected text is executed
+
+- **WHEN** a client spawns `/bin/run` with a buffer Path or bounded descriptors
+  and the evaluator commits a matching process/body/address snapshot to `ctl`
+- **THEN** editfs records an execution-started event referencing `/proc/<pid>`
+- **AND** the evaluator executes the captured text through the shared Alan Shell
+  command path under its inherited Namespace
+
+#### Scenario: Partial control writes do not validate execution
+
+- **WHEN** the evaluator writes only part of an `exec` control document to `ctl`
+- **THEN** editfs does not validate or record the execution until the evaluator
+  completes the document and clunks `ctl`
+
+#### Scenario: Concurrent selection changes do not retarget execution
+
+- **WHEN** a client captures an `addr` range, source `body` revision, and address
+  revision, another client changes `addr`, and the evaluator commits the old
+  snapshot
+- **THEN** the operation fails with a typed aP error and the evaluator exits
+  without executing text from the other client's range
+
+#### Scenario: Concurrent body edits do not retarget execution
+
+- **WHEN** a client captures selected bytes and another client edits `body`
+  before the evaluator commits the expected body/address snapshot
+- **THEN** the operation fails with a typed aP error and the evaluator exits
+  without executing the mutated range
+
+#### Scenario: Execution does not bypass authority
+
+- **WHEN** selected text would require an executable, mount, descriptor, or
+  action not available to the evaluator Process
+- **THEN** execution is denied or fails through normal Namespace, access-right,
+  Tool-governance, or policy behavior
+- **AND** editfs validation does not grant the missing authority
+
+#### Scenario: Native process execution keeps the OS sandbox boundary
+
+- **WHEN** selected text resolves to a native subprocess such as a shell command
+- **THEN** Alan projects the evaluator's allowed authority into the OS sandbox
+  layer instead of assuming the subprocess can inspect or enforce the Alan
+  Namespace directly
+
+## ADDED Requirements
+
+### Requirement: Process IO is the execution output authority
+An Alan Shell Evaluator Process SHALL publish output incrementally through its
+ordinary `/proc/<pid>/io/output` Stream while running. Process status, exit
+state, cancellation, and output SHALL remain authoritative in `/proc`; editfs
+events and editable result text SHALL be linked projections rather than a
+second execution state machine.
+
+#### Scenario: Output arrives before Process exit
+- **WHEN** an evaluator command produces output while it is still running
+- **THEN** a client reading `/proc/<pid>/io/output` at the live edge receives the
+  bytes before Process exit
+- **AND** it does not wait for a terminal ProcessOutcome buffer
+
+#### Scenario: A Process is cancelled
+- **WHEN** a client writes interrupt or cancel to `/proc/<pid>/ctl`
+- **THEN** the evaluator lifecycle and final state are reflected through the
+  ordinary Process files
+- **AND** editfs does not own a separate cancellation mechanism
+
+### Requirement: Bounded finite UTF-8 results materialize into body
+After a finite command completes successfully, the evaluator Process SHALL
+retain its complete output in `/proc/<pid>/io/output` and SHALL attempt to append
+bounded UTF-8 output to `body` through revision-safe file operations. A
+materialization conflict SHALL NOT overwrite concurrent edits or replay the
+command. The buffer event stream SHALL link the materialized body range and
+revision to `/proc/<pid>`.
+
+#### Scenario: Finite result materializes
+- **WHEN** a finite evaluator command succeeds with bounded UTF-8 output and the
+  body append commits
+- **THEN** subsequent reads of `body` contain the appended result
+- **AND** `event` identifies the result range, new body revision, and evaluator
+  Process Path
+
+#### Scenario: Body changes during materialization
+- **WHEN** another client changes `body` before the evaluator's append commits
+- **THEN** editfs rejects the stale commit and the evaluator may retry only a
+  safe append against a newly read body end
+- **AND** it never overwrites the concurrent edit or reruns the command
+
+#### Scenario: Materialization ultimately fails
+- **WHEN** a command succeeds but bounded retries cannot commit its result
+- **THEN** the complete result remains readable from `/proc/<pid>/io/output`
+- **AND** Process diagnostics distinguish materialization failure from command
+  failure
+
+### Requirement: Live stream output stays transient until explicit capture
+A long-running `tail` command SHALL keep its source Stream Descriptor in the
+evaluator Process and project new bytes through `/proc/<pid>/io/output`. It
+SHALL NOT continually append live bytes into editable `body`. A client SHALL
+materialize a finite snapshot explicitly, for example by stopping or
+snapshotting the evaluator and running `cat` on its retained Process output.
+
+#### Scenario: Tail remains live
+- **WHEN** `/bin/run` executes `tail <path>` and the source Stream appends bytes
+- **THEN** the evaluator remains running and publishes those bytes through its
+  Process output Stream
+- **AND** `body` does not change merely because live bytes arrived
+
+#### Scenario: Live output is explicitly captured
+- **WHEN** a client executes a finite `cat` of retained evaluator output
+- **THEN** the resulting bounded UTF-8 snapshot follows the normal finite
+  materialization path into `body`

--- a/openspec/changes/define-alan-programmable-client-surface/tasks.md
+++ b/openspec/changes/define-alan-programmable-client-surface/tasks.md
@@ -36,11 +36,12 @@
   start and result materialization while keeping Process status, output,
   cancellation, and exit truth exclusively under `/proc`.
 - [ ] 3.3 Add revision-bound read-write body fids that can append bounded UTF-8
-  bytes at the observed end and reject clunk after any concurrent body revision
-  or append-position change.
-- [ ] 3.4 Add complete-document materialization reporting that validates the
-  committed body revision/range before linking it to `/proc/<pid>` and rejects
-  inconsistent associations.
+  bytes at the observed end, reject clunk after any concurrent body revision
+  or append-position change, and return an append commit token naming the
+  committed range and resulting revision.
+- [ ] 3.4 Add complete-document materialization reporting that binds the record
+  to the presented append commit token before linking it to `/proc/<pid>`,
+  rejecting tokenless range claims and ranges committed by another writer.
 - [ ] 3.5 Replace the existing editfs policy tests with focused tests for current
   and stale evaluator snapshots, partial ctl writes, concurrent selection/body
   changes, safe result append, materialization records, and blocking event reads.

--- a/openspec/changes/define-alan-programmable-client-surface/tasks.md
+++ b/openspec/changes/define-alan-programmable-client-surface/tasks.md
@@ -36,7 +36,9 @@
   rejected rather than validated.
 - [ ] 3.2 Define and implement Process-linked editfs event records for execution
   start and result materialization while keeping Process status, output,
-  cancellation, and exit truth exclusively under `/proc`.
+  cancellation, and exit truth exclusively under `/proc`; both event kinds
+  record the supplied `/proc/<pid>` path as caller-asserted correlation, not
+  verified identity.
 - [ ] 3.3 Add the complete-document `materialize` control write: expected
   revision and append position plus bounded UTF-8 result bytes and the
   evaluator's `/proc/<pid>` path, committing atomically on clunk as an ordinary

--- a/openspec/changes/define-alan-programmable-client-surface/tasks.md
+++ b/openspec/changes/define-alan-programmable-client-surface/tasks.md
@@ -1,0 +1,117 @@
+## 1. Shared Alan Shell Command Layer
+
+- [ ] 1.1 Extract the current private `LineCommand` parser from `StdioDriver`
+  into a reusable headless Alan Shell command module without adding grammar,
+  heuristic path/Tool inference, or agent-specific commands.
+- [ ] 1.2 Introduce a reusable command executor and output-sink contract for
+  finite and live command output; keep the `alan-shell` crate dependent only on
+  `alan-ap`.
+- [ ] 1.3 Rewire `StdioDriver` to the shared parser/executor and preserve its
+  current `ls`, `cat`, `tail`, `write`, `echo`, `spawn`, concurrent-input, error,
+  and tail-cleanup behavior with focused tests.
+- [ ] 1.4 Add namespace-derived discovery helpers/tests for Paths, file kinds,
+  access visibility, `/bin`, Tool Manifests, `/man`, and `/lib/skill`, with no
+  generic UI schema or renderer-private authority.
+
+## 2. Streaming Process Output Foundation
+
+- [ ] 2.1 Evolve the user-space `ProcessRunner` bridge so a running Process can
+  append output incrementally to the existing `/proc/<pid>/io/output` Stream
+  before returning its terminal exit outcome, without adding a Kernel concept.
+- [ ] 2.2 Preserve compatibility for existing agent/tool runners while migrating
+  them to the streaming output sink, and keep executable resolution constrained
+  to the Process invocation Namespace.
+- [ ] 2.3 Add ProcFS tests proving pre-exit output reads, ordered stream offsets,
+  final exit state, runner failure, interrupt/cancel, and output-stream closure.
+- [ ] 2.4 Re-run dependency-boundary tests proving `alan-kernel` still depends
+  only on `alan-ap` and the streaming runner bridge does not leak shell, editfs,
+  Tool, or renderer semantics into Kernel.
+
+## 3. Editfs Validation And Materialization
+
+- [ ] 3.1 Remove `ExecutionPolicy::{AcceptAll,DenyAll}` and refactor `ctl exec`
+  into atomic validation of evaluator Process Path, body revision, address
+  revision, and selected range; editfs must never spawn or execute the command.
+- [ ] 3.2 Define and implement Process-linked editfs event records for execution
+  start and result materialization while keeping Process status, output,
+  cancellation, and exit truth exclusively under `/proc`.
+- [ ] 3.3 Add revision-bound read-write body fids that can append bounded UTF-8
+  bytes at the observed end and reject clunk after any concurrent body revision
+  or append-position change.
+- [ ] 3.4 Add complete-document materialization reporting that validates the
+  committed body revision/range before linking it to `/proc/<pid>` and rejects
+  inconsistent associations.
+- [ ] 3.5 Replace the existing editfs policy tests with focused tests for current
+  and stale evaluator snapshots, partial ctl writes, concurrent selection/body
+  changes, safe result append, materialization records, and blocking event reads.
+
+## 4. Native run Tool And Package Projection
+
+- [ ] 4.1 Implement the native Rust `run` Tool as an ordinary executable Process
+  that receives a buffer Path or bounded descriptors plus the expected body and
+  address snapshot, reads the captured command, and validates through editfs
+  before dispatch.
+- [ ] 4.2 Dispatch the shared Alan Shell command executor inside `run` under the
+  inherited Process Namespace and credentials; ensure missing executables,
+  mounts, descriptors, or policy approval cannot be supplied by editfs.
+- [ ] 4.3 Stream every command result to `/proc/<pid>/io/output`; for finite
+  bounded UTF-8 output, implement safe end-append materialization with bounded
+  conflict retries and distinct command-vs-materialization status diagnostics.
+- [ ] 4.4 Keep `tail` running with its source Stream Descriptor, publish live
+  bytes only through Process output, close descriptors on exit/cancel, and prove
+  explicit finite capture by running `cat` on retained Process output.
+- [ ] 4.5 Add `/bin/run`, `/lib/exec/run/manifest`, and `/man/1/run` through a
+  named namespace-bootstrap compatibility projection; document its deletion
+  gate when `alan-binfs`/normal package mounts land and do not expose `run` only
+  through the Agent Execution Engine-private Tool registry.
+- [ ] 4.6 Add Tool/process tests for manifest/manual discovery, successful and
+  stale selection, unknown command, finite output, non-UTF-8/oversized output,
+  spawn denial, side-effect failure, materialization conflict, live tail,
+  cancellation, and Process exit state.
+- [ ] 4.7 Add governance-parity tests: a Tool whose direct spawn requires policy
+  escalation or approval raises the identical escalation, approval, and audit
+  records when spawned by the evaluator through `run`; `run` itself carries no
+  pre-approved authority and the audit names the inner Tool identity.
+
+## 5. Headless Programmable Client Harness
+
+- [ ] 5.1 Assemble a headless Namespace with `/proc`, `/srv/edit`, the single
+  `/mnt/edit` buffer, `/bin/run`, package metadata, and representative readable,
+  writable, and Stream files without adding a buffer manager or new root.
+- [ ] 5.2 Prove the complete loop: discover namespace files, edit/select a Shell
+  command, spawn `run`, observe `/proc/<pid>`, validate through editfs, stream
+  output, materialize a finite result, and inspect Process-linked buffer events.
+- [ ] 5.3 Run the same harness operations through human-shaped and agent-shaped
+  aP clients and prove neither path needs renderer-specific domain code,
+  daemon/session transport, or editfs-owned authority.
+- [ ] 5.4 Add concurrency and recovery coverage for stale selections, concurrent
+  edits, safe materialization retry, live output offsets, renderer/client
+  detach, reconnect from offsets, cancel, and explicit capture.
+
+## 6. Documentation And Boundary Review
+
+- [ ] 6.1 Update Alan Shell/editfs architecture documentation and public Rust API
+  docs to use Programmable Client Surface, Alan Shell Evaluator Process, and
+  `run` consistently with `CONTEXT.md` and AGENTS.md component names.
+- [ ] 6.2 Document that Rust to WASM Component is the explicit promotion target
+  for mature Tool/File-Server behavior while WASM hosting, WIT packages, build,
+  signing, installation, and projection remain a separate future change.
+- [ ] 6.3 Audit the diff for forbidden ClientSurface objects/ids/managers,
+  execution registries, editfs command authority, generic UI schemas,
+  surface-only parsers, new top-level roots, and hidden renderer actions.
+
+## 7. Verification, Review, And Archive Readiness
+
+- [ ] 7.1 Run `cargo fmt --all` and focused tests for `alan-shell`, `alan-editfs`,
+  `alan-kernel`, the native runtime bootstrap/runner owner, and the new headless
+  harness.
+- [ ] 7.2 Run focused Clippy with warnings denied for every materially changed
+  Rust crate, then run the proportional workspace test/check gate required by
+  the final implementation diff.
+- [ ] 7.3 Run `openspec validate define-alan-programmable-client-surface
+  --strict`, `openspec validate --all --strict`, and `git diff --check`.
+- [ ] 7.4 Review the final diff against ADR-0024 through ADR-0027, the Rust test
+  placement contract, namespace amplification caveats, Process/file ownership,
+  and the named binfs compatibility-projection deletion gate.
+- [ ] 7.5 After implementation review and merge, sync the four delta specs into
+  `openspec/specs/`, verify the merged behavior, and archive the change.

--- a/openspec/changes/define-alan-programmable-client-surface/tasks.md
+++ b/openspec/changes/define-alan-programmable-client-surface/tasks.md
@@ -35,13 +35,14 @@
 - [ ] 3.2 Define and implement Process-linked editfs event records for execution
   start and result materialization while keeping Process status, output,
   cancellation, and exit truth exclusively under `/proc`.
-- [ ] 3.3 Add revision-bound read-write body fids that can append bounded UTF-8
-  bytes at the observed end, reject clunk after any concurrent body revision
-  or append-position change, and return an append commit token naming the
-  committed range and resulting revision.
-- [ ] 3.4 Add complete-document materialization reporting that binds the record
-  to the presented append commit token before linking it to `/proc/<pid>`,
-  rejecting tokenless range claims and ranges committed by another writer.
+- [ ] 3.3 Add the complete-document `materialize` control write: expected
+  revision and append position plus bounded UTF-8 result bytes and the
+  evaluator's `/proc/<pid>` path, committing atomically on clunk as an ordinary
+  body edit plus a Process-linked materialization event, failing stale commits
+  with no side effects.
+- [ ] 3.4 Reject post-hoc Process/range association records that do not carry
+  their bytes in a `materialize` commit, and add concurrency tests proving a
+  materialization event can never name another writer's bytes.
 - [ ] 3.5 Replace the existing editfs policy tests with focused tests for current
   and stale evaluator snapshots, partial ctl writes, concurrent selection/body
   changes, safe result append, materialization records, and blocking event reads.

--- a/openspec/changes/define-alan-programmable-client-surface/tasks.md
+++ b/openspec/changes/define-alan-programmable-client-surface/tasks.md
@@ -31,7 +31,9 @@
 
 - [ ] 3.1 Remove `ExecutionPolicy::{AcceptAll,DenyAll}` and refactor `ctl exec`
   into atomic validation of evaluator Process Path, body revision, address
-  revision, and selected range; editfs must never spawn or execute the command.
+  revision, and selected range; editfs must never spawn or execute the command,
+  and the legacy path-less `exec rev:... addr:... <start>..<end>` syntax is
+  rejected rather than validated.
 - [ ] 3.2 Define and implement Process-linked editfs event records for execution
   start and result materialization while keeping Process status, output,
   cancellation, and exit truth exclusively under `/proc`.
@@ -44,8 +46,9 @@
   their bytes in a `materialize` commit, and add concurrency tests proving a
   materialization event can never name another writer's bytes.
 - [ ] 3.5 Replace the existing editfs policy tests with focused tests for current
-  and stale evaluator snapshots, partial ctl writes, concurrent selection/body
-  changes, safe result append, materialization records, and blocking event reads.
+  and stale evaluator snapshots, legacy path-less exec rejection, partial ctl
+  writes, concurrent selection/body changes, safe result append, materialization
+  records, and blocking event reads.
 
 ## 4. Native run Tool And Package Projection
 


### PR DESCRIPTION
## Summary

Proposal for the **Programmable Client Surface** — the Acme-style programmable interaction loop over the existing namespace-native pieces (Alan Shell, editfs, `/proc`, renderer-host contracts). Docs only; no code in this PR.

### Core contract

- The surface **is part of Alan Shell**: a text-first contract over the caller's mounted Namespace — no ClientSurface object, client service, UI framework, or new namespace root.
- **One shared explicit grammar** (`ls`, `cat`, `tail`, `write`, `echo`, `spawn`) reused by stdio and selected-text execution; unknown text fails explicitly, prose is never heuristically executed.
- **`run` is a first-party Tool** (`/bin/run` + manifest + manual). Every selected-text execution spawns an ordinary **Alan Shell Evaluator Process**; `/proc/<pid>` is the sole execution identity — no editfs execution registry.
- **editfs loses execution authority**: `ExecutionPolicy::{AcceptAll,DenyAll}` is removed; editfs atomically validates body/address revision snapshots and records Process-linked events. Spawn, Namespace, Tool governance, and sandbox projection own execution authority.
- **Result semantics**: finite bounded UTF-8 output materializes into `body` via revision-safe append (never overwriting concurrent edits); live `tail` output stays transient in Process output until explicit capture.
- **Discovery is namespace-derived** (`/bin`, manifests, `/man`, `/lib/skill`, access rights); renderer candidates are a cache, not authority.
- **WASM Component** recorded as the explicit promotion direction for mature behavior; hosting deferred to a later change.

### Governance hardening (from review)

- Inner `spawn` through `run` raises the **identical escalation/approval/audit** as direct spawn — `run` cannot launder policy decisions (spec scenario + dedicated test task 4.7).
- The evaluator-supplied `/proc/<pid>` path is **caller-asserted correlation, not verified identity**, until aP request provenance lands.

### Files

- Modified capabilities (no new capability): `alan-shell`, `editable-buffer-interaction`, `editable-buffer-file-server`, `alan-renderer-host-contract`.
- `CONTEXT.md`: adds the WASM Component, Programmable Client Surface, and Alan Shell Evaluator Process glossary terms the design references.

## Verification

- `openspec validate --all --strict`: 79 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)