### PR TITLE
Sync residual compatibility contracts

### DIFF
--- a/openspec/changes/remove-residual-compatibility-shims/tasks.md
+++ b/openspec/changes/remove-residual-compatibility-shims/tasks.md
@@ -33,6 +33,6 @@
 - [x] 6.1 Run focused `alan-llmfs`, `alan-agent-protocol`, `alan-agent-engine`, and `alan-llm` tests, including all new retired-shape rejection cases.
 - [x] 6.2 Run `cargo fmt --all --check`, workspace Clippy with all targets/features and warnings denied, `cargo test --workspace`, `just apple-shell-focused-tests`, and `git diff --check`.
 - [x] 6.3 Run `cargo metadata` and repository searches to prove removed fields, aliases, palette tokens, dependency declarations, and Axum WebSocket features have no current owner.
-- [ ] 6.4 Update affected canonical Purpose text during spec sync so it describes only current reasoning, compaction, governance, and input contracts rather than removed compatibility.
-- [ ] 6.5 Open a narrowly scoped PR and keep the current HEAD under Codex review until every thread is resolved, required CI is green, and a delayed refresh shows no new findings before merge.
+- [x] 6.4 Update affected canonical Purpose text during spec sync so it describes only current reasoning, compaction, governance, and input contracts rather than removed compatibility.
+- [x] 6.5 Open a narrowly scoped PR and keep the current HEAD under Codex review until every thread is resolved, required CI is green, and a delayed refresh shows no new findings before merge.
 - [ ] 6.6 After merge, sync all five capability deltas into canonical specs and mark the change archive-ready only when main rejects every retired form and `remove-legacy-macos-persistence` is either merged or independently green.

--- a/openspec/specs/agent-file-layout-contract/spec.md
+++ b/openspec/specs/agent-file-layout-contract/spec.md
@@ -2,8 +2,9 @@
 
 ## Purpose
 Defines the generic Process layout and the `/agent` overlay convention,
-including namespace-derived capabilities, file-backed IO and machine state,
-request/action trees, stream authority, access rights, and durability ownership.
+including namespace-derived capabilities, file-backed IO with explicit input
+routing, machine state, request/action trees, stream authority, access rights,
+and durability ownership.
 ## Requirements
 ### Requirement: An agent is a conforming process, not a kernel type
 Alan OS SHALL treat an agent as a `Process` whose `/agent/<pid>` overlay conforms
@@ -46,6 +47,27 @@ on top of this full layout.
   newest bytes
 - **AND** clipping of the newest output is a renderer concern, never a gap in the
   stream's data
+
+### Requirement: Agent input records declare routing explicitly
+An input operation written to an Agent Process SHALL use the canonical
+`type: "input"` record and SHALL include an explicit `mode`. Alan SHALL NOT
+accept the retired `type: "steer"` alias or infer a mode when the field is
+absent.
+
+#### Scenario: Explicit input is submitted
+- **WHEN** a caller submits `type: "input"` with a supported explicit mode and
+  valid parts
+- **THEN** the Agent Process routes the input according to that mode
+
+#### Scenario: Input mode is absent
+- **WHEN** a caller submits `type: "input"` without `mode`
+- **THEN** the record is rejected as malformed
+- **AND** Alan does not infer `steer` or any other routing behavior
+
+#### Scenario: Retired steer operation is submitted
+- **WHEN** a caller submits an operation with `type: "steer"`
+- **THEN** the record is rejected as an unsupported operation shape
+- **AND** the caller must resubmit canonical explicit input
 
 ### Requirement: An agent overlays agent files on the generic process layout
 Alan OS SHALL define the agent layout as the generic process layout plus an agent

--- a/openspec/specs/auto-approve-policy/spec.md
+++ b/openspec/specs/auto-approve-policy/spec.md
@@ -1,12 +1,22 @@
 # auto-approve-policy Specification
 
 ## Purpose
-Defines Alan's single Autonomous approval posture, deterministic escalation
-boundaries, non-persistent permissions, keyboard-driven approval and structured
-input surfaces, decision context, and interrupt behavior.
+Defines Alan's single canonically serialized Autonomous approval posture,
+deterministic escalation boundaries, strict profile parsing, non-persistent
+permissions, keyboard-driven approval and structured input surfaces, decision
+context, and interrupt behavior.
 ## Requirements
 ### Requirement: Single human-in-the-end auto-approve mode
-The agent SHALL operate in a single posture named `Autonomous` in which routine operations proceed without prompting and operations needing judgment are escalated. The system SHALL NOT expose multiple selectable approval modes. Escalations SHALL be routed to the reviewer (see the `autonomous-review-mode` capability) rather than always pausing for a human, except for red-line operations which bypass the reviewer (deny outright, or go straight to the human). A human remains the final fallback when the reviewer denies past the circuit breaker, when an operation is on the always-human red line, or when the reviewer is unavailable.
+The agent SHALL operate in a single posture named `Autonomous` with the
+serialized value `autonomous`, in which routine operations proceed without
+prompting and operations needing judgment are escalated. The system SHALL NOT
+expose multiple selectable approval modes or accept retired profile aliases.
+Escalations SHALL be routed to the reviewer (see the
+`autonomous-review-mode` capability) rather than always pausing for a human,
+except for red-line operations which bypass the reviewer (deny outright, or go
+straight to the human). A human remains the final fallback when the reviewer
+denies past the circuit breaker, when an operation is on the always-human red
+line, or when the reviewer is unavailable.
 
 #### Scenario: Routine operation proceeds automatically
 - **WHEN** the policy classifies an operation as a read or an in-workspace write
@@ -24,9 +34,14 @@ The agent SHALL operate in a single posture named `Autonomous` in which routine 
 - **WHEN** an operation is catastrophic (deny) or dangerous-but-uncontainable (always-human)
 - **THEN** it is denied outright or surfaced to the human, and the reviewer never decides it
 
-#### Scenario: Legacy profile names resolve to Autonomous
-- **WHEN** a configuration specifies a legacy profile value (such as `auto_approve`, `conservative`, or `autonomous`)
-- **THEN** it resolves to the single `Autonomous` posture without error
+#### Scenario: Canonical profile name resolves to Autonomous
+- **WHEN** a configuration specifies the profile value `autonomous`
+- **THEN** it resolves to the single `Autonomous` posture
+
+#### Scenario: Retired profile alias is rejected
+- **WHEN** a configuration or API request specifies `auto_approve`,
+  `auto-approve`, `autoapprove`, or `conservative`
+- **THEN** deserialization fails instead of resolving the alias to `Autonomous`
 
 #### Scenario: Malformed profile values are rejected
 - **WHEN** a configuration or API request specifies an unrecognized profile string (e.g. `"conservativ"`) or a wrong-typed value (a boolean, number, or object)

--- a/openspec/specs/llm-file-server/spec.md
+++ b/openspec/specs/llm-file-server/spec.md
@@ -2,8 +2,9 @@
 
 ## Purpose
 Defines `alan-llmfs` provider, Connection, and Generation file trees, including
-clone-via-open lifecycle, clunk-committed versioned requests, typed event
-streams, metering, and phase-specific errors.
+clone-via-open lifecycle, clunk-committed current-version requests, rejection of
+unversioned or unsupported request documents, typed event streams, metering,
+and phase-specific errors.
 ## Requirements
 ### Requirement: llmfs posts a handle in `/srv` and serves its tree under `/mnt/llm`
 Alan OS SHALL provide `alan-llmfs`, a file server that speaks aP (the `alan-ap`
@@ -101,7 +102,9 @@ running Generation. The request document SHALL NOT carry credentials.
 ### Requirement: The request and events use an independent versioned wire DTO
 `alan-llmfs` SHALL define its own versioned wire DTO for the request document and
 for the stream-event records, decoupled from `alan-llm` internal types. It SHALL
-map the DTO to and from `alan-llm` (`GenerationRequest` / `StreamChunk`)
+accept only the current explicitly versioned request document and SHALL reject
+unversioned or unknown-version request shapes without migration or fallback. It
+SHALL map the DTO to and from `alan-llm` (`GenerationRequest` / `StreamChunk`)
 internally. The events stream SHALL be a byte-stream record convention (for
 example one JSON record per line) per the aP stream model.
 
@@ -111,6 +114,23 @@ example one JSON record per line) per the aP stream model.
   `alan-llm` internal structs
 - **AND** an `alan-llm` internal refactor does not change the wire format unless
   the DTO version changes
+
+#### Scenario: Current request document is committed
+- **WHEN** a caller commits a valid current-version request document to a
+  Generation
+- **THEN** `alan-llmfs` maps the full document to `GenerationRequest`
+- **AND** generation starts only after normal commit validation succeeds
+
+#### Scenario: Unversioned request document is committed
+- **WHEN** a caller commits the retired unversioned `{system,user}` request
+  shape or a document without the required version discriminator
+- **THEN** the Generation commit is rejected before provider dispatch
+- **AND** no legacy DTO fallback or migration is attempted
+
+#### Scenario: Unknown request version is committed
+- **WHEN** a caller commits a request document with an unsupported version
+- **THEN** the Generation commit is rejected with an unsupported-version error
+- **AND** no provider request starts
 
 ### Requirement: Metering lives in llmfs; errors split by phase
 `alan-llmfs` SHALL enforce cost, metering, and rate-limiting itself, reached only

--- a/openspec/specs/provider-request-controls/spec.md
+++ b/openspec/specs/provider-request-controls/spec.md
@@ -2,10 +2,10 @@
 
 ## Purpose
 Define alan's canonical provider request-control contract. This capability owns
-reasoning effort, legacy thinking-budget compatibility, request-control
-resolution, validation, provider projection, metadata mirroring, and guardrails
-that prevent request-control truth from spreading across configuration, Agent
-Process state, rollout evidence, and provider adapters.
+named reasoning effort as the only public control, strict input validation,
+request-control resolution, provider projection, metadata mirroring, and
+guardrails that prevent request-control truth from spreading across
+configuration, Agent Process state, rollout evidence, and provider adapters.
 ## Requirements
 ### Requirement: Canonical reasoning effort type
 alan SHALL define a shared typed reasoning effort model with lowercase
@@ -23,6 +23,28 @@ serialization values `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`.
 - **WHEN** reasoning effort is omitted
 - **THEN** alan treats the effort as unset rather than as `none`
 - **AND** `none` remains an explicit request to disable reasoning where the model supports it
+
+### Requirement: Public reasoning configuration has one canonical form
+Alan SHALL expose `model_reasoning_effort` as the only agent-facing reasoning
+configuration control. Configuration, protocol, API, and client documents SHALL
+reject `thinking_budget_tokens` as an unknown or unsupported field and SHALL NOT
+migrate it to a named effort.
+
+#### Scenario: Canonical reasoning effort is configured
+- **WHEN** a valid `model_reasoning_effort` is present in agent configuration
+- **THEN** Alan resolves and validates that effort through the canonical request
+  control path
+
+#### Scenario: Retired thinking budget is configured
+- **WHEN** agent configuration contains `thinking_budget_tokens`
+- **THEN** configuration loading fails and identifies the retired field
+- **AND** Alan does not translate the numeric value into a reasoning effort
+
+#### Scenario: Provider needs a numeric wire budget
+- **WHEN** a provider adapter must send a numeric budget for a validated named
+  reasoning effort
+- **THEN** the adapter derives that provider-native value internally
+- **AND** the derived wire field does not create a public budget-token input
 
 ### Requirement: Reasoning-capable model metadata
 alan SHALL declare model-level supported and default reasoning efforts in the

--- a/openspec/specs/runtime-memory-contract/spec.md
+++ b/openspec/specs/runtime-memory-contract/spec.md
@@ -2,8 +2,8 @@
 
 ## Purpose
 Defines runtime-memory contracts for workspace memory layout, recall and write
-paths, compaction coordination, human-readable memory surfaces, provenance, and
-truncation behavior.
+paths, explicit dual-threshold compaction coordination, human-readable memory
+surfaces, provenance, and truncation behavior.
 ## Requirements
 ### Requirement: Memory kind is separate from memory authority
 alan SHALL treat working, episodic, semantic, and procedural memory as
@@ -122,3 +122,25 @@ Machine from context pressure, while Memory Stores preserve continuity beyond on
 - **THEN** the runtime writes an episodic record and handoff with Process and rollout/checkpoint
   provenance
 - **AND** the resulting records are published through their owning Memory Stores
+
+### Requirement: Compaction configuration uses explicit dual thresholds
+Alan SHALL configure context compaction with
+`compaction_soft_trigger_ratio` and `compaction_hard_trigger_ratio`. The retired
+single-threshold `compaction_trigger_ratio` field SHALL be unavailable and SHALL
+fail normal unknown-field validation.
+
+#### Scenario: Dual thresholds are configured
+- **WHEN** valid soft and hard compaction ratios are present in agent
+  configuration
+- **THEN** Alan validates and applies the two thresholds to compaction
+  coordination
+
+#### Scenario: Retired single threshold is configured
+- **WHEN** agent configuration contains `compaction_trigger_ratio`
+- **THEN** configuration loading fails and identifies the unknown field
+- **AND** Alan does not copy that value into either current threshold
+
+#### Scenario: Thresholds are omitted
+- **WHEN** neither current compaction threshold is configured
+- **THEN** Alan uses the current soft and hard defaults
+- **AND** no deprecated single-threshold default participates in resolution


### PR DESCRIPTION
## Summary

- sync the five merged residual-compatibility deltas into canonical OpenSpec capabilities
- rewrite affected Purpose text to describe only current reasoning, compaction, governance, input-routing, and LLMFS contracts
- record completion of the implementation PR review gate while leaving archive readiness pending on the legacy macOS change

## Verification

- `openspec validate remove-residual-compatibility-shims --strict`
- `openspec validate --all --strict` (79 passed)
- `bash scripts/check-openspec-current-surfaces.sh`
- `git diff --check`