### PR TITLE
docs(openspec): sync Alan OS Host extraction

### DIFF
--- a/openspec/changes/extract-system-level-alan-os-host/specs/local-alan-os-attachment/spec.md
+++ b/openspec/changes/extract-system-level-alan-os-host/specs/local-alan-os-attachment/spec.md
@@ -3,7 +3,8 @@
 ### Requirement: Local attachment uses native aP wire
 The Alan OS Host SHALL export its ready namespace through the existing aP wire
 protocol on a channel-specific Unix domain socket in a platform runtime
-directory. It MUST NOT expose HTTP, WebSocket, Session, or relay protocols.
+directory. This SHALL remain the sole local attachment transport; Alan MUST NOT
+introduce a separate management transport beside aP.
 
 #### Scenario: Authorized local client attaches
 - **WHEN** a same-user client connects to the matching channel endpoint

--- a/openspec/changes/extract-system-level-alan-os-host/tasks.md
+++ b/openspec/changes/extract-system-level-alan-os-host/tasks.md
@@ -38,6 +38,6 @@
 ## 6. Review and archive readiness
 
 - [x] 6.1 Submit one Host extraction PR after `remove-workspace-runtime-model` is merged and archived
-- [ ] 6.2 Complete current-HEAD Codex review, zero unresolved threads, green CI, and delayed recheck before merge
-- [ ] 6.3 Sync Host and attachment deltas into canonical specs after implementation merge
+- [x] 6.2 Merge implementation PR #646 after current-HEAD Codex review, zero unresolved threads, green CI, and delayed recheck
+- [ ] 6.3 Merge this canonical-spec sync PR after syncing every Host and attachment delta and completing the same review gate
 - [ ] 6.4 Archive only after canonical sync is merged and `implement-minimal-service-manager` can consume the Host seam

--- a/openspec/specs/agent-namespace-runtime/spec.md
+++ b/openspec/specs/agent-namespace-runtime/spec.md
@@ -196,3 +196,14 @@ workspace identity, workspace root, or Host `.alan` directory.
 - **WHEN** an Agent Process begins a transition
 - **THEN** every contextual resource is read from a mounted path or descriptor
 - **AND** no Host-directory overlay scan occurs
+
+### Requirement: System composition belongs to Alan OS Host
+Agent Execution Engine SHALL execute Agent Process transitions behind AgentFS
+and MUST NOT create the system Kernel, `/srv`, system Root Agent role, Host
+endpoint, or System Store root. During this change only, Alan OS Host MAY use a
+fixed internal boot composition that the Service Manager change MUST delete.
+
+#### Scenario: Engine is started for an Agent Process
+- **WHEN** the Host composition starts Agent execution
+- **THEN** the engine receives an assembled Process namespace and descriptors
+- **AND** it does not construct a competing system root

--- a/openspec/specs/alan-os-host-lifecycle/spec.md
+++ b/openspec/specs/alan-os-host-lifecycle/spec.md
@@ -1,0 +1,42 @@
+# alan-os-host-lifecycle Specification
+
+## Purpose
+Defines singleton Alan OS Host ownership, file-proven readiness, per-boot
+identity, and test-only ephemeral hosting.
+
+## Requirements
+
+### Requirement: One system Host owns each channel
+Alan SHALL run at most one Alan OS Host per user, device, and install channel.
+The dedicated Host SHALL own Kernel and whole-system lifetime; renderer hosts
+MUST attach and MUST NOT boot competing product instances.
+
+#### Scenario: CLI and macOS use stable
+- **WHEN** both stable clients start for the same user
+- **THEN** both target the same stable Alan OS Host
+- **AND** neither creates an app-private Kernel
+
+### Requirement: Host readiness is file-proven
+The Host SHALL accept product attachments only after the Standard Namespace,
+required fixed services, and `/agent/root` are readable. Required failure SHALL
+fail boot rather than expose a partial system as ready.
+
+#### Scenario: Root Agent fails to start
+- **WHEN** `/agent/root` cannot be read during boot
+- **THEN** the Host reports boot failure and rejects normal attachments
+
+### Requirement: Host restart creates a new boot identity
+Every Host boot SHALL publish a fresh boot identity and create a new Process
+table and Root Agent Process. It MUST NOT deserialize live Process state.
+
+#### Scenario: Stored Process Reference predates restart
+- **WHEN** a client presents a reference with the previous boot identity
+- **THEN** Alan rejects it even if the PID has been reused
+
+### Requirement: Ephemeral Host is test-only
+An in-process or ephemeral Host SHALL require explicit development/test
+selection and MUST NOT be a product fallback when the dedicated Host is absent.
+
+#### Scenario: Product Host fails
+- **WHEN** a normal client cannot start or attach the dedicated Host
+- **THEN** it reports the failure instead of silently booting an embedded system

--- a/openspec/specs/alan-shell/spec.md
+++ b/openspec/specs/alan-shell/spec.md
@@ -82,3 +82,13 @@ read-eval-print loop. Rich terminal rendering SHALL remain the responsibility of
 - **THEN** a user can list, read, write, tail, and spawn over the namespace
 - **AND** Ratatui rendering is provided later by `alan-terminal-ui`, not by this
   change
+
+### Requirement: Alan enters the system Shell
+Running `alan` SHALL start or attach the matching dedicated Alan OS Host and
+enter Alan Shell. It MUST NOT privately boot an Agent runtime or select an Agent
+Definition as Host startup behavior.
+
+#### Scenario: User runs alan with no subcommand
+- **WHEN** the system Host is ready
+- **THEN** the client attaches and presents Alan Shell
+- **AND** Agent Processes are spawned or attached from inside the Shell

--- a/openspec/specs/ap-wire-transport/spec.md
+++ b/openspec/specs/ap-wire-transport/spec.md
@@ -68,3 +68,13 @@ SHALL NOT depend on transport-specific crates or call transport-specific APIs.
 - **THEN** `alan-kernel` still depends only on `alan-ap` among Alan crates
 - **AND** remote import/export is represented to the kernel as ordinary mounted
   file-server handles
+
+### Requirement: Local system root is exportable over aP
+The generic aP export/import implementation SHALL carry the Alan OS mounted
+root across a Unix socket while preserving fid, typed failure, blocking stream,
+and commit-on-clunk semantics.
+
+#### Scenario: Client tails Agent output remotely in-process boundary
+- **WHEN** an imported client reads a live AgentFS stream at its current offset
+- **THEN** the read blocks and later returns appended bytes exactly as the
+  in-process transport would

--- a/openspec/specs/local-alan-os-attachment/spec.md
+++ b/openspec/specs/local-alan-os-attachment/spec.md
@@ -10,7 +10,8 @@ reattachment semantics.
 ### Requirement: Local attachment uses native aP wire
 The Alan OS Host SHALL export its ready namespace through the existing aP wire
 protocol on a channel-specific Unix domain socket in a platform runtime
-directory. It MUST NOT expose HTTP, WebSocket, Session, or relay protocols.
+directory. This SHALL remain the sole local attachment transport; Alan MUST NOT
+introduce a separate management transport beside aP.
 
 #### Scenario: Authorized local client attaches
 - **WHEN** a same-user client connects to the matching channel endpoint

--- a/openspec/specs/local-alan-os-attachment/spec.md
+++ b/openspec/specs/local-alan-os-attachment/spec.md
@@ -1,0 +1,36 @@
+# local-alan-os-attachment Specification
+
+## Purpose
+Defines channel-scoped same-user local Alan OS attachment over native aP Unix
+sockets, including peer authorization, fid ownership, disconnect, and
+reattachment semantics.
+
+## Requirements
+
+### Requirement: Local attachment uses native aP wire
+The Alan OS Host SHALL export its ready namespace through the existing aP wire
+protocol on a channel-specific Unix domain socket in a platform runtime
+directory. It MUST NOT expose HTTP, WebSocket, Session, or relay protocols.
+
+#### Scenario: Authorized local client attaches
+- **WHEN** a same-user client connects to the matching channel endpoint
+- **THEN** it imports the exported tree as an ordinary aP FileServer
+
+### Requirement: Host OS peer identity ends at authorization
+The Host SHALL restrict the endpoint to the current Host OS user and validate
+peer identity. It MUST NOT project Host UID, home, cwd, or login identity into
+Alan OS credentials or namespace.
+
+#### Scenario: Different Host OS user connects
+- **WHEN** a peer with a different UID connects
+- **THEN** the Host rejects it before namespace access
+
+### Requirement: Connections own fids, not execution identity
+Each attachment connection SHALL own independent fid lifecycle. Disconnect
+SHALL clunk those fids and MUST NOT terminate Alan OS Processes; reconnect SHALL
+walk stable paths and resume streams from caller-held offsets.
+
+#### Scenario: Renderer disconnects during Agent work
+- **WHEN** its Unix socket closes
+- **THEN** the Agent Process continues according to `/proc`
+- **AND** a later client can attach without recreating execution

--- a/openspec/specs/macos-app-instance-lifecycle/spec.md
+++ b/openspec/specs/macos-app-instance-lifecycle/spec.md
@@ -210,3 +210,13 @@ enough channel identity to distinguish stable Alan from Alan Dev.
 - **WHEN** a capture or debugging helper targets an Alan channel
 - **THEN** it can target the stable bundle identifier or the dev bundle identifier explicitly
 - **AND** the default stable capture behavior remains compatible with `app.alanworks.macos`
+
+### Requirement: App channel and Alan OS Host channel are paired
+Alan for macOS stable and dev SHALL discover only the matching Alan OS Host
+endpoint and System Store identity. App singleton lifetime SHALL remain
+separate from Alan OS Host singleton lifetime.
+
+#### Scenario: Stable app exits
+- **WHEN** the stable app terminates
+- **THEN** the stable Alan OS Host remains running
+- **AND** the dev channel is unaffected


### PR DESCRIPTION
## Summary

- sync all six extract-system-level-alan-os-host deltas into canonical OpenSpec
- add canonical Alan OS Host lifecycle and local attachment specifications
- record implementation PR #646 gate completion while keeping archive readiness open

## Validation

- openspec validate extract-system-level-alan-os-host --strict
- openspec validate --all --strict: 84 passed, 0 failed