### PR TITLE
docs(openspec): sync minimal Service Manager

### DIFF
--- a/openspec/changes/implement-minimal-service-manager/tasks.md
+++ b/openspec/changes/implement-minimal-service-manager/tasks.md
@@ -54,6 +54,6 @@
 ## 8. Review and archive readiness
 
 - [x] 8.1 Submit after `extract-system-level-alan-os-host` is merged and archived
-- [ ] 8.2 Complete current-HEAD Codex review, zero unresolved threads, green CI, and delayed recheck before merge
-- [ ] 8.3 Sync all service deltas into canonical specs and verify package-management rewrite prerequisites
+- [x] 8.2 Complete current-HEAD Codex review, zero unresolved threads, green CI, and delayed recheck before merge
+- [x] 8.3 Sync all service deltas into canonical specs and verify package-management rewrite prerequisites
 - [ ] 8.4 Archive only after implementation and canonical sync are merged

--- a/openspec/specs/agent-root-layout-contract/spec.md
+++ b/openspec/specs/agent-root-layout-contract/spec.md
@@ -14,3 +14,14 @@ global, workspace, default, or named Host-directory root chains.
 - **WHEN** an Agent Process receives an Agent Definition descriptor
 - **THEN** its assets resolve within that tree
 - **AND** no other definition tree is overlaid implicitly
+
+### Requirement: Root Agent is a supervised role
+Service Manager SHALL start Root Agent from a Boot Unit with a system-owned
+Agent Definition descriptor and SHALL publish the current Process at
+`/agent/root`. Host arguments and Host directories MUST NOT change the Root
+Agent Definition.
+
+#### Scenario: Root Agent restarts
+- **WHEN** its Process exits and restart succeeds
+- **THEN** `/agent/root` resolves to the replacement Process
+- **AND** the old PID remains terminal rather than being reused as continuity

--- a/openspec/specs/alan-shell/spec.md
+++ b/openspec/specs/alan-shell/spec.md
@@ -92,3 +92,13 @@ Definition as Host startup behavior.
 - **WHEN** the system Host is ready
 - **THEN** the client attaches and presents Alan Shell
 - **AND** Agent Processes are spawned or attached from inside the Shell
+
+### Requirement: Interactive Alan Shell is an ordinary Process
+Each interactive Alan Shell SHALL run as a Shell Process with PID, parent,
+Alan OS credentials, namespace, descriptors, and namespace cwd. Renderer hosts
+SHALL attach input/output and MUST NOT invoke Kernel spawning as an out-of-band
+execution manager.
+
+#### Scenario: Shell spawns an Agent
+- **WHEN** the user executes an Agent Executable with a definition descriptor
+- **THEN** `/proc` records the Agent Process as a child of the Shell Process

--- a/openspec/specs/connection-service/spec.md
+++ b/openspec/specs/connection-service/spec.md
@@ -1,0 +1,37 @@
+# connection-service Specification
+
+## Purpose
+Defines Connection Service ownership of profile metadata, callable LLM trees,
+and bounded native credential requests without exposing Host secrets.
+
+## Requirements
+
+### Requirement: Connection Service owns profile metadata
+Connection Service SHALL own provider/model settings, profile identity,
+defaults, Process selection, validation status, and publication of callable LLM
+connection trees. Metadata SHALL be channel-scoped in System Store.
+
+#### Scenario: Agent selects a profile
+- **WHEN** its launch context passes an installed Connection reference
+- **THEN** the Agent Process receives the corresponding callable LLM tree
+- **AND** no Host config file is read
+
+### Requirement: Host adapters own credential secrets
+Browser/device login and secret storage SHALL remain in platform adapters.
+Connection Service SHALL receive only opaque credential references and MUST NOT
+expose secret bytes through its namespace.
+
+#### Scenario: Browser login completes
+- **WHEN** a Host adapter stores credentials successfully
+- **THEN** it returns an opaque reference to Connection Service
+- **AND** profile files reveal no credential material
+
+### Requirement: Native actions are request files
+Connection Service SHALL expose pending native login/credential operations and
+their bounded responses as files; a renderer adapter MUST NOT become profile
+authority.
+
+#### Scenario: No renderer can answer login
+- **WHEN** a native request remains unanswered
+- **THEN** the profile reports pending/unavailable status
+- **AND** no hidden Host-side profile is created

--- a/openspec/specs/host-directory-mounts/spec.md
+++ b/openspec/specs/host-directory-mounts/spec.md
@@ -72,3 +72,14 @@ Alan OS mount path and MUST NOT expose the raw Host path.
 - **WHEN** the CLI is launched with that directory as Host cwd
 - **THEN** the directory remains absent until the Host explicitly grants and
   mounts it
+
+### Requirement: Host Mount projection is service-mediated
+Alan OS SHALL route all runtime Host directory authorization, hostfs export,
+live namespace projection, revocation, and sandbox derivation through Host Mount
+Service. Host renderers MAY answer native authorization requests but MUST NOT
+maintain a second grant registry.
+
+#### Scenario: CLI authorizes a path
+- **WHEN** CLI Host Command Plane approves a Host directory
+- **THEN** its adapter returns the export to Host Mount Service
+- **AND** only the service publishes Alan OS-visible grant state

--- a/openspec/specs/host-mount-service/spec.md
+++ b/openspec/specs/host-mount-service/spec.md
@@ -1,0 +1,36 @@
+# host-mount-service Specification
+
+## Purpose
+Defines Host Mount Service as the sole grant, projection, revocation, and audit
+authority for Host-backed file trees.
+
+## Requirements
+
+### Requirement: Host Mount Service is the grant authority
+Host Mount Service SHALL own request, user grant, hostfs export, namespace
+projection, revocation, audit, and status. Alan OS-visible records SHALL expose
+grant identity, label, access, provenance, and `/mnt` path but MUST NOT expose
+the raw Host OS path.
+
+#### Scenario: User approves a writable directory
+- **WHEN** a Host adapter returns an approved hostfs export
+- **THEN** Host Mount Service records the grant and mounts it into the requesting
+  Process live namespace at the approved Alan OS path
+
+### Requirement: Grant authority is capability-passed
+Knowing a grant ID SHALL confer no access. A Process SHALL gain access only when
+the grant handle or mount is explicitly projected into its namespace, and
+native sandbox rights SHALL derive from that same grant.
+
+#### Scenario: Child does not receive parent grant
+- **WHEN** a parent launches a child without passing a Host Mount
+- **THEN** the child cannot use the grant or its Host backing
+
+### Requirement: Revocation invalidates projections
+Revoking a Host Mount grant SHALL make every associated mount unavailable and
+record the actor, time, and affected Process references.
+
+#### Scenario: Active grant is revoked
+- **WHEN** the user revokes it through a Host adapter
+- **THEN** subsequent aP access fails
+- **AND** no stale sandbox authorization remains valid for new Tool Processes

--- a/openspec/specs/local-entry-service/spec.md
+++ b/openspec/specs/local-entry-service/spec.md
@@ -1,0 +1,26 @@
+# local-entry-service Specification
+
+## Purpose
+Defines Local Entry Service as the bounded creator and handoff owner for local
+Alan Shell Processes.
+
+## Requirements
+
+### Requirement: Local entry creates a Shell Process
+Local Entry Service SHALL create `/bin/alan-shell` as an ordinary Process with
+Alan OS credentials, Login Namespace Template, descriptors, cwd, PID, and
+parentage, then hand its namespace to an authorized local renderer.
+
+#### Scenario: macOS requests local entry
+- **WHEN** Host transport has authorized the peer
+- **THEN** Local Entry Service creates a Shell Process
+- **AND** commands launched by the Shell become child Processes
+
+### Requirement: Entry state is not a Session
+Local Entry Service SHALL retain only bounded Process-creation/handoff state. It
+MUST NOT own Agent Processes, conversations, workspaces, or renderer continuity.
+
+#### Scenario: Local socket disconnects
+- **WHEN** the renderer loses its connection
+- **THEN** its Shell Process may drain and exit
+- **AND** independent Agent Processes continue according to `/proc`

--- a/openspec/specs/plan9-kernel-substrate/spec.md
+++ b/openspec/specs/plan9-kernel-substrate/spec.md
@@ -363,3 +363,13 @@ The `alan-kernel` crate SHALL depend only on `alan-ap`, the aP protocol contract
 - **WHEN** `alan-kernel` dependencies are reviewed
 - **THEN** they include `alan-ap` and exclude Agent Execution Engine, AgentFS service, provider, Memory Store, sandbox backend, renderer, and transport implementation crates
 - **AND** agents, providers, memory, and Tools appear to Alan Kernel only through Processes, descriptors, namespaces, mounts, and file-server trees
+
+### Requirement: Kernel boot creates the Service Manager Process
+Kernel bootstrap SHALL provide the Process and namespace primitives needed for
+Alan OS Host to create Service Manager as the first system Process. Kernel MUST
+remain ignorant of Boot Unit, service policy, and renderer transport details.
+
+#### Scenario: Host starts Service Manager
+- **WHEN** a fresh Kernel has no committed Processes
+- **THEN** Host creates Service Manager through normal Process creation
+- **AND** later services appear as ordinary Process table entries

--- a/openspec/specs/provider-connection-contract/spec.md
+++ b/openspec/specs/provider-connection-contract/spec.md
@@ -336,3 +336,13 @@ metadata.
 - **WHEN** the operator edits it to use a new valid credential id
 - **THEN** matching credential metadata is registered before the profile is saved
 - **AND** setting the secret and testing the edited profile succeed
+
+### Requirement: Connection authority is file-service owned
+Connection Service SHALL be the only owner of profile metadata, defaults,
+selection, validation status, and callable connection publication. Host
+adapters SHALL own only native login and secret storage.
+
+#### Scenario: Host adapter restarts
+- **WHEN** Connection Service remains running
+- **THEN** profile identity and non-secret settings remain authoritative
+- **AND** the adapter can reconnect without reconstructing profiles

--- a/openspec/specs/service-manager/spec.md
+++ b/openspec/specs/service-manager/spec.md
@@ -1,0 +1,49 @@
+# service-manager Specification
+
+## Purpose
+Defines Service Manager as the first system Process and sole owner of bounded
+Alan OS service and Root Agent lifecycle.
+
+## Requirements
+
+### Requirement: Service Manager is the first system Process
+Alan OS Host SHALL create Kernel and start one Service Manager Process. Service
+Manager SHALL be the sole owner of later system service and Root Agent Process
+lifecycle; Host MUST NOT retain fallback boot or supervision.
+
+#### Scenario: System boot begins
+- **WHEN** Kernel is ready
+- **THEN** Host starts Service Manager
+- **AND** all other required system Processes are started by Service Manager
+
+### Requirement: Boot Units use a bounded schema
+Service Manager SHALL read system-package-owned units from `/lib/boot`. A unit
+SHALL contain executable, descriptors/mounts, ordering, required flag, timeout,
+restart enum, and published handles; arbitrary shell, environment templating,
+user units, and dynamic reload MUST be rejected.
+
+#### Scenario: Unit contains shell script
+- **WHEN** a unit requests arbitrary shell execution
+- **THEN** Service Manager rejects the unit before launch
+
+### Requirement: Service readiness uses proc and srv
+A File-Server Service SHALL be ready only while its Process is running in
+`/proc` and all unit-declared handles are published in `/srv`. Service Manager
+SHALL expose unit PID, attempts, status, errors, degraded state, and retry in
+its own tree.
+
+#### Scenario: Service exits after publication
+- **WHEN** a ready service Process exits
+- **THEN** its handles are invalidated
+- **AND** Service Manager applies its restart policy
+
+### Requirement: Restart policy is bounded
+Service Manager SHALL support only `never`, `on-failure`, and `always`, with
+bounded exponential backoff, restart budget, and stable reset window. Required
+budget exhaustion before ready SHALL fail boot; afterward it SHALL mark the
+system degraded and await explicit retry.
+
+#### Scenario: Root Agent crash loops
+- **WHEN** the `always` Root Agent unit exhausts its restart budget
+- **THEN** the system becomes degraded
+- **AND** Service Manager does not restart it without bound


### PR DESCRIPTION
## Summary
- promote all nine Service Manager deltas into canonical OpenSpec capabilities
- add canonical Connection, Host Mount, Local Entry, and Service Manager specifications
- record implementation review and canonical sync tasks as complete

## Verification
- `openspec validate --all --strict` (87 passed)
- `git diff --check`

This is a mechanical canonical-spec sync after #649; no implementation code changes.