### PR TITLE
feat: attach Alan for macOS to Alan OS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "tracing",
  "uuid",
 ]
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ early development and currently contains three usable layers:
 - local hosts: a file-backed Rust terminal UI, direct management commands, and
   the native Alan for macOS terminal workspace.
 
-The complete Service Manager boot path and the final Alan for macOS-to-Alan OS
-attachment are not implemented yet. The attachment decision is deliberately
-deferred by [ADR-0029](docs/adr/0029-remove-daemon-era-surfaces-before-replacement-design.md).
+The dedicated system Host boots the Service Manager and Root Agent Process.
+Alan for macOS attaches to the matching stable/dev Host over its protected aP
+endpoint; it renders Agent Processes by boot ID and PID without owning their
+lifecycle or embedding Alan OS.
 
 ## Execution model
 

--- a/clients/apple/README.md
+++ b/clients/apple/README.md
@@ -227,10 +227,11 @@ terminal content.
   bounded socket requests, diagnostic surfacing, and truthful `terminal.send_text`
   delivery results
 
-Alan for macOS currently owns renderer, input, windowing, terminal runtime, and
-local shell-control integration. Attachment to Alan OS Agent Processes is a
-separate design change and is intentionally not represented by a compatibility
-network client in this target.
+Alan for macOS owns renderer, input, windowing, terminal runtime, and local
+shell-control integration. It also attaches to the matching stable/dev Alan OS
+Host over aP and renders Agent Processes from Process References and caller-held
+stream offsets. The app does not embed Alan Kernel, the Agent Execution Engine,
+or Process lifecycle authority.
 
 ## Command-Line Build
 

--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		000000000000000000000040 /* Services/Terminal/TerminalContentProjectionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000140 /* Services/Terminal/TerminalContentProjectionAdapter.swift */; };
 		000000000000000000000041 /* Services/Terminal/TerminalContentLifecycleAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000141 /* Services/Terminal/TerminalContentLifecycleAdapter.swift */; };
 		000000000000000000000042 /* Services/Shell/ShellContentRenderingRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000142 /* Services/Shell/ShellContentRenderingRegistry.swift */; };
+		00000000000000000000007A /* Services/AlanOS/AlanOSAttachmentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000017A /* Services/AlanOS/AlanOSAttachmentService.swift */; };
 		000000000000000000000043 /* Models/Shell/ShellAutomationCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000143 /* Models/Shell/ShellAutomationCommand.swift */; };
 		000000000000000000000044 /* Models/Shell/ShellAutomationEntities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000144 /* Models/Shell/ShellAutomationEntities.swift */; };
 		000000000000000000000045 /* Models/Shell/ShellAutomationIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000145 /* Models/Shell/ShellAutomationIntents.swift */; };
@@ -181,6 +182,7 @@
 		000000000000000000000140 /* Services/Terminal/TerminalContentProjectionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalContentProjectionAdapter.swift; sourceTree = "<group>"; };
 		000000000000000000000141 /* Services/Terminal/TerminalContentLifecycleAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalContentLifecycleAdapter.swift; sourceTree = "<group>"; };
 		000000000000000000000142 /* Services/Shell/ShellContentRenderingRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellContentRenderingRegistry.swift; sourceTree = "<group>"; };
+		00000000000000000000017A /* Services/AlanOS/AlanOSAttachmentService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/AlanOS/AlanOSAttachmentService.swift; sourceTree = "<group>"; };
 		000000000000000000000143 /* Models/Shell/ShellAutomationCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellAutomationCommand.swift; sourceTree = "<group>"; };
 		000000000000000000000144 /* Models/Shell/ShellAutomationEntities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellAutomationEntities.swift; sourceTree = "<group>"; };
 		000000000000000000000145 /* Models/Shell/ShellAutomationIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellAutomationIntents.swift; sourceTree = "<group>"; };
@@ -269,6 +271,7 @@
 				00000000000000000000030F /* Controllers/Shell */,
 				000000000000000000000306 /* Views/Shell */,
 				00000000000000000000030B /* Models/Shell */,
+				00000000000000000000030E /* Services/AlanOS */,
 				00000000000000000000030C /* Services/Shell */,
 				00000000000000000000030D /* Services/Terminal */,
 				000000000000000000000101 /* AlanApp.swift */,
@@ -406,6 +409,14 @@
 				00000000000000000000013A /* Services/Shell/ShellWorkspaceManifestStore.swift */,
 			);
 			name = Services/Shell;
+			sourceTree = "<group>";
+		};
+		00000000000000000000030E /* Services/AlanOS */ = {
+			isa = PBXGroup;
+			children = (
+				00000000000000000000017A /* Services/AlanOS/AlanOSAttachmentService.swift */,
+			);
+			name = Services/AlanOS;
 			sourceTree = "<group>";
 		};
 		00000000000000000000030D /* Services/Terminal */ = {
@@ -663,6 +674,7 @@
 				00000000000000000000002F /* Services/Shell/ShellDiagnostics.swift in Sources */,
 				000000000000000000000030 /* Services/Shell/ShellClipboardWriter.swift in Sources */,
 				000000000000000000000042 /* Services/Shell/ShellContentRenderingRegistry.swift in Sources */,
+				00000000000000000000007A /* Services/AlanOS/AlanOSAttachmentService.swift in Sources */,
 				000000000000000000000041 /* Services/Terminal/TerminalContentLifecycleAdapter.swift in Sources */,
 				000000000000000000000040 /* Services/Terminal/TerminalContentProjectionAdapter.swift in Sources */,
 				000000000000000000000031 /* Services/Terminal/TerminalNativeScrollViewAdapter.swift in Sources */,

--- a/clients/apple/alan-macos/App/AlanMacAppStartup.swift
+++ b/clients/apple/alan-macos/App/AlanMacAppStartup.swift
@@ -9,6 +9,8 @@ enum AlanMacAppStartup {
         "--alan-dev-privileged-helper-restart-and-exit"
     private static let devHelperSmokeAndExitArgument =
         "--alan-dev-privileged-helper-smoke-and-exit"
+    private static let devAlanOSAttachmentSmokeAndExitArgument =
+        "--alan-dev-os-attachment-smoke-and-exit"
 
     static func handleDevPrivilegedHelperCommandIfRequested() {
         let arguments = ProcessInfo.processInfo.arguments
@@ -21,6 +23,35 @@ enum AlanMacAppStartup {
         if arguments.contains(devHelperSmokeAndExitArgument) {
             smokeDevPrivilegedHelperAndExit()
         }
+        if arguments.contains(devAlanOSAttachmentSmokeAndExitArgument) {
+            smokeDevAlanOSAttachmentAndExit()
+        }
+    }
+
+    private static func smokeDevAlanOSAttachmentAndExit() -> Never {
+        guard AlanInstallChannel.current() == .dev else {
+            fputs("Alan OS attachment smoke command is dev-channel only.\n", stderr)
+            Darwin.exit(2)
+        }
+        Task {
+            do {
+                let session = try await AlanOSAttachmentSession.attach(channel: .dev)
+                let bootID = session.status.bootID
+                let processes = try await session.list("/proc")
+                let agents = try await session.list("/agent")
+                print("channel=dev")
+                print("bootID=\(bootID)")
+                print("processCount=\(processes.filter { UInt64($0) != nil }.count)")
+                print("agentCount=\(agents.filter { UInt64($0) != nil }.count)")
+                print("attachment smoke passed")
+                await session.detach()
+                Darwin.exit(0)
+            } catch {
+                fputs("Alan OS attachment smoke failed: \(error.localizedDescription)\n", stderr)
+                Darwin.exit(1)
+            }
+        }
+        dispatchMain()
     }
 
     private static func installDevPrivilegedHelperAndExit() -> Never {

--- a/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
+++ b/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
@@ -6,6 +6,8 @@ import SwiftUI
 @MainActor
 final class AlanMacPrimaryShellOwner: ObservableObject {
     let host: ShellHostController
+    let alanOSAttachment: AlanOSAttachmentController
+    let alanOSNativeCapabilities: AlanOSNativeCapabilityAdapter
 
     init(fileManager: FileManager = .default) {
         let windowContext = ShellWindowContext.make(
@@ -16,6 +18,10 @@ final class AlanMacPrimaryShellOwner: ObservableObject {
             fileManager: fileManager,
             windowContext: windowContext
         )
+        let resolvedAttachment = AlanOSAttachmentController.shared
+        resolvedAttachment.attach()
+        let nativeCapabilities = AlanOSNativeCapabilityAdapter.shared
+        nativeCapabilities.start(attachment: resolvedAttachment)
         #if canImport(AppIntents)
         ShellAutomationEntityStore.install(snapshotProvider: { [weak resolvedHost] in
             resolvedHost?.shellState
@@ -25,12 +31,16 @@ final class AlanMacPrimaryShellOwner: ObservableObject {
         )
         #endif
         host = resolvedHost
+        alanOSAttachment = resolvedAttachment
+        alanOSNativeCapabilities = nativeCapabilities
     }
 
     deinit {
         let host = host
         Task { @MainActor in
             host.shutdownTerminalRuntimes()
+            AlanOSAttachmentController.shared.detach()
+            AlanOSNativeCapabilityAdapter.shared.stop()
         }
     }
 }

--- a/clients/apple/alan-macos/App/AlanMacShellCommands.swift
+++ b/clients/apple/alan-macos/App/AlanMacShellCommands.swift
@@ -77,6 +77,14 @@ struct AlanMacShellCommands: Commands {
                 openSettingsTab()
             }
 
+            Button("Open Root Agent") {
+                openRootAgent()
+            }
+
+            Button("Attach Agent Process…") {
+                attachAgentProcess()
+            }
+
             Button("Find") {
                 host.openTerminalSearch(source: .menuBar)
             }
@@ -247,6 +255,65 @@ struct AlanMacShellCommands: Commands {
         openWindow(id: "main")
         _ = host.openSettingsTab()
         AlanMacPrimaryWindowPresenter.focusExistingWindowSoon()
+    }
+
+    private func attachAgentProcess() {
+        guard let session = AlanOSAttachmentController.shared.session else {
+            let alert = NSAlert()
+            alert.messageText = "Alan OS is unavailable"
+            alert.informativeText = "Wait for Alan for macOS to attach to the matching system Host."
+            alert.runModal()
+            return
+        }
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
+        field.placeholderString = "Process ID"
+        let alert = NSAlert()
+        alert.messageText = "Attach Agent Process"
+        alert.informativeText = "Enter an Alan OS PID. Closing the resulting view will only detach it."
+        alert.accessoryView = field
+        alert.addButton(withTitle: "Attach")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn,
+              let pid = UInt64(field.stringValue),
+              pid > 0
+        else { return }
+
+        let reference = AlanOSProcessReference(bootID: session.status.bootID, pid: pid)
+        Task { @MainActor in
+            do {
+                _ = try await session.validate(reference)
+                let attachment = AlanAgentAttachment(
+                    process: reference,
+                    offsets: .zero,
+                    presentation: .default
+                )
+                _ = host.openAgentTab(attachment: attachment)
+            } catch {
+                let failure = NSAlert(error: error)
+                failure.messageText = "Agent Process is unavailable"
+                failure.runModal()
+            }
+        }
+    }
+
+    private func openRootAgent() {
+        guard let session = AlanOSAttachmentController.shared.session else {
+            let alert = NSAlert()
+            alert.messageText = "Alan OS is unavailable"
+            alert.informativeText = "Wait for Alan for macOS to attach to the matching system Host."
+            alert.runModal()
+            return
+        }
+        Task { @MainActor in
+            do {
+                let attachment = try await session.rootAgentAttachment()
+                _ = host.openAgentTab(attachment: attachment, title: "Root Agent")
+            } catch {
+                let failure = NSAlert(error: error)
+                failure.messageText = "Root Agent is unavailable"
+                failure.runModal()
+            }
+        }
     }
 
     private func summonPrimaryShellWindow() {

--- a/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
@@ -131,12 +131,14 @@ enum ShellContentKind: String, Codable, CaseIterable {
     case terminal
     case markdown
     case settings
+    case agent
 }
 
 enum ShellContentIntent {
     case terminal(launchTarget: ShellLaunchTarget, title: String?, workingDirectory: String?)
     case markdown(fileURL: URL, title: String?)
     case settings(title: String?)
+    case agent(attachment: AlanAgentAttachment, title: String?)
 }
 
 enum ShellContentCapability: String, Codable, CaseIterable {
@@ -146,6 +148,10 @@ enum ShellContentCapability: String, Codable, CaseIterable {
     case terminalRuntimeMetadata = "terminal_runtime_metadata"
     case markdownReadOnlyViewer = "markdown_read_only_viewer"
     case settingsSurface = "settings_surface"
+    case agentInput = "agent_input"
+    case agentRequestResponse = "agent_request_response"
+    case agentMachineControl = "agent_machine_control"
+    case agentStopProcess = "agent_stop_process"
 }
 
 enum ShellContentLifecycleState: String, Codable, CaseIterable {
@@ -522,27 +528,69 @@ struct ShellSettingsContentPayload: Codable, Equatable {
     }
 }
 
+struct AlanOSProcessReference: Codable, Equatable, Hashable {
+    let bootID: String
+    let pid: UInt64
+
+    private enum CodingKeys: String, CodingKey {
+        case bootID = "boot_id"
+        case pid
+    }
+}
+
+struct AlanAgentStreamOffsets: Codable, Equatable {
+    var output: UInt64
+    var requests: UInt64
+    var actions: UInt64
+    var ui: UInt64
+
+    static let zero = AlanAgentStreamOffsets(output: 0, requests: 0, actions: 0, ui: 0)
+}
+
+struct AlanAgentContentPresentation: Codable, Equatable {
+    var followsOutput: Bool
+
+    static let `default` = AlanAgentContentPresentation(followsOutput: true)
+
+    private enum CodingKeys: String, CodingKey {
+        case followsOutput = "follows_output"
+    }
+}
+
+/// The only Agent state shell persistence may own.
+struct AlanAgentAttachment: Codable, Equatable {
+    let process: AlanOSProcessReference
+    var offsets: AlanAgentStreamOffsets
+    var presentation: AlanAgentContentPresentation
+}
+
 struct ShellContentPayload: Codable, Equatable {
     let terminal: ShellTerminalContentPayload?
     let markdown: ShellMarkdownContentPayload?
     let settings: ShellSettingsContentPayload?
+    let agent: AlanAgentAttachment?
 
     private enum CodingKeys: String, CodingKey {
         case terminal
         case markdown
         case settings
+        case agent
     }
 
     static func terminal(_ payload: ShellTerminalContentPayload) -> ShellContentPayload {
-        ShellContentPayload(terminal: payload, markdown: nil, settings: nil)
+        ShellContentPayload(terminal: payload, markdown: nil, settings: nil, agent: nil)
     }
 
     static func markdown(_ payload: ShellMarkdownContentPayload) -> ShellContentPayload {
-        ShellContentPayload(terminal: nil, markdown: payload, settings: nil)
+        ShellContentPayload(terminal: nil, markdown: payload, settings: nil, agent: nil)
     }
 
     static func settings(_ payload: ShellSettingsContentPayload) -> ShellContentPayload {
-        ShellContentPayload(terminal: nil, markdown: nil, settings: payload)
+        ShellContentPayload(terminal: nil, markdown: nil, settings: payload, agent: nil)
+    }
+
+    static func agent(_ attachment: AlanAgentAttachment) -> ShellContentPayload {
+        ShellContentPayload(terminal: nil, markdown: nil, settings: nil, agent: attachment)
     }
 }
 
@@ -602,6 +650,8 @@ struct ShellContentInstance: Identifiable, Codable, Equatable {
             return [.markdownReadOnlyViewer]
         case .settings:
             return [.settingsSurface]
+        case .agent:
+            return [.agentInput, .agentRequestResponse, .agentMachineControl, .agentStopProcess]
         }
     }
 }
@@ -2017,6 +2067,8 @@ private extension ShellPane {
             return "markdown viewer ready"
         case .settings:
             return "settings surface ready"
+        case .agent:
+            return "Agent attachment ready"
         }
     }
 }

--- a/clients/apple/alan-macos/Services/AlanOS/AlanOSAttachmentService.swift
+++ b/clients/apple/alan-macos/Services/AlanOS/AlanOSAttachmentService.swift
@@ -1,0 +1,1077 @@
+#if os(macOS)
+import Darwin
+import AppKit
+import Combine
+import Foundation
+import Security
+
+enum AlanOSAttachmentError: LocalizedError, Equatable {
+    case invalidStatus(String)
+    case hostUnavailable(String)
+    case transport(String)
+    case protocolFailure(String)
+    case processUnavailable(String)
+    case priorBoot
+    case retentionGap(stream: String, requested: UInt64, available: UInt64)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidStatus(let detail), .hostUnavailable(let detail), .transport(let detail),
+             .protocolFailure(let detail), .processUnavailable(let detail):
+            return detail
+        case .priorBoot:
+            return "This Agent Process belongs to an earlier Alan OS boot."
+        case .retentionGap(let stream, let requested, let available):
+            return "\(stream) cannot resume at offset \(requested); its current available length is \(available)."
+        }
+    }
+}
+
+struct AlanOSHostStatus: Codable, Equatable {
+    let version: UInt16
+    let channelID: String
+    let bootID: String
+    let pid: UInt32
+    let readiness: String
+    let socket: String
+
+    private enum CodingKeys: String, CodingKey {
+        case version
+        case channelID = "channel_id"
+        case bootID = "boot_id"
+        case pid
+        case readiness
+        case socket
+    }
+}
+
+struct AlanAPQID: Codable, Equatable {
+    let kind: String
+    let version: UInt32
+    let path: UInt64
+}
+
+struct AlanAPStat: Codable, Equatable {
+    let name: String
+    let qid: AlanAPQID
+    let length: UInt64
+    let writable: Bool
+}
+
+struct AlanOSValidatedProcess: Equatable {
+    let reference: AlanOSProcessReference
+    let procQID: AlanAPQID
+    let status: String
+}
+
+struct AlanAgentStreamChunk: Equatable {
+    let stream: String
+    let requestedOffset: UInt64
+    let nextOffset: UInt64
+    let data: Data
+}
+
+struct AlanAgentPendingRequest: Equatable {
+    let id: String
+    let kind: String
+    let prompt: String
+    let options: String
+}
+
+/// Deduplicates intentional overlap reads while keeping the caller-owned next offset explicit.
+struct AlanAgentStreamAccumulator: Equatable {
+    private(set) var nextOffset: UInt64
+
+    init(nextOffset: UInt64) {
+        self.nextOffset = nextOffset
+    }
+
+    mutating func accept(_ chunk: AlanAgentStreamChunk) throws -> Data {
+        guard chunk.requestedOffset <= nextOffset else {
+            throw AlanOSAttachmentError.retentionGap(
+                stream: chunk.stream,
+                requested: nextOffset,
+                available: chunk.requestedOffset
+            )
+        }
+        let overlap = nextOffset - chunk.requestedOffset
+        guard overlap <= UInt64(chunk.data.count) else {
+            return Data()
+        }
+        let fresh = chunk.data.dropFirst(Int(overlap))
+        nextOffset = max(nextOffset, chunk.nextOffset)
+        return Data(fresh)
+    }
+
+    mutating func recover(at availableOffset: UInt64) {
+        nextOffset = availableOffset
+    }
+}
+
+private struct AlanAPWireFailure: Error {
+    let code: String
+}
+
+/// One app-level Shell Process attachment. Every fid and offset remains caller-owned.
+actor AlanOSAttachmentSession {
+    nonisolated let status: AlanOSHostStatus
+
+    private var descriptor: Int32
+    private var nextFid: UInt64 = 1
+    private var nextTag: UInt64 = 1
+    private var receiveBuffer = Data()
+
+    private init(status: AlanOSHostStatus, descriptor: Int32) {
+        self.status = status
+        self.descriptor = descriptor
+    }
+
+    deinit {
+        if descriptor >= 0 {
+            Darwin.close(descriptor)
+        }
+    }
+
+    static func attach(
+        channel: AlanInstallChannel = .current(),
+        fileManager: FileManager = .default
+    ) async throws -> AlanOSAttachmentSession {
+        let paths = AlanOSHostEndpointPaths(channel: channel, fileManager: fileManager)
+        var status = try? paths.readStatus()
+        if status?.readiness != "ready" {
+            try paths.requestPlatformHostStart()
+            status = try await paths.waitUntilReady()
+        }
+        guard let status else {
+            throw AlanOSAttachmentError.hostUnavailable("Alan OS Host did not publish readiness.")
+        }
+        return try await connect(status: status, channel: channel)
+    }
+
+    static func connect(
+        status: AlanOSHostStatus,
+        channel: AlanInstallChannel
+    ) async throws -> AlanOSAttachmentSession {
+        let descriptor = try connectUnixSocket(path: status.socket)
+        do {
+            try sendAttachRequest(descriptor: descriptor)
+            let session = AlanOSAttachmentSession(status: status, descriptor: descriptor)
+            try await session.validateNamespace(channel: channel)
+            return session
+        } catch {
+            Darwin.close(descriptor)
+            throw error
+        }
+    }
+
+    func detach() {
+        guard descriptor >= 0 else { return }
+        Darwin.shutdown(descriptor, SHUT_RDWR)
+        Darwin.close(descriptor)
+        descriptor = -1
+        receiveBuffer.removeAll(keepingCapacity: false)
+    }
+
+    func cat(_ path: String) throws -> Data {
+        try read(path, offset: 0, count: 1 << 20)
+    }
+
+    func list(_ path: String) throws -> [String] {
+        let data = try cat(path)
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw AlanOSAttachmentError.protocolFailure("Alan OS returned non-UTF-8 directory data for \(path).")
+        }
+        return text.split(whereSeparator: \.isNewline).map(String.init)
+    }
+
+    func stat(_ path: String) throws -> AlanAPStat {
+        let fid = try walk(path)
+        defer { try? clunk(fid) }
+        let response = try call(op: "stat", fields: ["fid": fid])
+        guard response["op"] as? String == "stat",
+              let raw = response["stat"] as? [String: Any]
+        else {
+            throw AlanOSAttachmentError.protocolFailure("Invalid aP stat response for \(path).")
+        }
+        let data = try JSONSerialization.data(withJSONObject: raw)
+        return try JSONDecoder().decode(AlanAPStat.self, from: data)
+    }
+
+    func validate(_ reference: AlanOSProcessReference) throws -> AlanOSValidatedProcess {
+        guard reference.bootID == status.bootID else {
+            throw AlanOSAttachmentError.priorBoot
+        }
+        let procPath = "/proc/\(reference.pid)"
+        do {
+            let procStat = try stat(procPath)
+            let stateData = try cat("\(procPath)/status")
+            let state = String(decoding: stateData, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return AlanOSValidatedProcess(reference: reference, procQID: procStat.qid, status: state)
+        } catch let failure as AlanAPWireFailure where failure.code == "not_found" {
+            throw AlanOSAttachmentError.processUnavailable("Alan OS Process \(reference.pid) is unavailable.")
+        }
+    }
+
+    func readAgentStream(
+        reference: AlanOSProcessReference,
+        relativePath: String,
+        offset: UInt64,
+        overlap: UInt64 = 0,
+        count: UInt32 = 64 * 1024
+    ) throws -> AlanAgentStreamChunk {
+        _ = try validate(reference)
+        let path = "/agent/\(reference.pid)/\(relativePath)"
+        let metadata = try stat(path)
+        guard offset <= metadata.length else {
+            throw AlanOSAttachmentError.retentionGap(
+                stream: relativePath,
+                requested: offset,
+                available: metadata.length
+            )
+        }
+        if offset == metadata.length {
+            return AlanAgentStreamChunk(
+                stream: relativePath,
+                requestedOffset: offset,
+                nextOffset: offset,
+                data: Data()
+            )
+        }
+        let requestedOffset = offset > overlap ? offset - overlap : 0
+        let data = try read(path, offset: requestedOffset, count: count)
+        return AlanAgentStreamChunk(
+            stream: relativePath,
+            requestedOffset: requestedOffset,
+            nextOffset: requestedOffset + UInt64(data.count),
+            data: data
+        )
+    }
+
+    /// Rehydrates a bounded window ending at a caller-owned offset without moving that offset.
+    func readAgentStreamWindow(
+        reference: AlanOSProcessReference,
+        relativePath: String,
+        endingAt offset: UInt64,
+        count: UInt32 = 64 * 1024
+    ) throws -> Data {
+        _ = try validate(reference)
+        let path = "/agent/\(reference.pid)/\(relativePath)"
+        let metadata = try stat(path)
+        guard offset <= metadata.length else {
+            throw AlanOSAttachmentError.retentionGap(
+                stream: relativePath,
+                requested: offset,
+                available: metadata.length
+            )
+        }
+        let start = offset > UInt64(count) ? offset - UInt64(count) : 0
+        guard start < offset else { return Data() }
+        return try read(path, offset: start, count: UInt32(offset - start))
+    }
+
+    func latestPendingRequest(
+        reference: AlanOSProcessReference
+    ) throws -> AlanAgentPendingRequest? {
+        _ = try validate(reference)
+        let base = "/agent/\(reference.pid)/requests"
+        let requestIDs = try list(base)
+            .filter { $0 != "clone" && $0 != "events" }
+            .sorted(by: alanAgentFileIDPrecedes)
+            .reversed()
+        for requestID in requestIDs {
+            let requestPath = "\(base)/\(requestID)"
+            guard try readText("\(requestPath)/status") == "pending" else { continue }
+            return AlanAgentPendingRequest(
+                id: requestID,
+                kind: try readText("\(requestPath)/kind"),
+                prompt: try readText("\(requestPath)/prompt"),
+                options: (try? readText("\(requestPath)/options")) ?? ""
+            )
+        }
+        return nil
+    }
+
+    func rootAgentAttachment() throws -> AlanAgentAttachment {
+        let text = try readText("/mnt/service-manager/units/root-agent/pid")
+        guard let pid = UInt64(text), pid > 0 else {
+            throw AlanOSAttachmentError.protocolFailure("Root Agent Process has no valid PID.")
+        }
+        let reference = AlanOSProcessReference(bootID: status.bootID, pid: pid)
+        _ = try validate(reference)
+        return AlanAgentAttachment(
+            process: reference,
+            offsets: .zero,
+            presentation: .default
+        )
+    }
+
+    func writeAgentInput(reference: AlanOSProcessReference, data: Data) throws {
+        _ = try validate(reference)
+        try writeDocument("/agent/\(reference.pid)/io/input", data: data)
+    }
+
+    func writeFile(_ path: String, data: Data) throws {
+        try writeDocument(path, data: data)
+    }
+
+    func respond(reference: AlanOSProcessReference, requestID: String, data: Data) throws {
+        _ = try validate(reference)
+        try writeDocument("/agent/\(reference.pid)/requests/\(requestID)/response", data: data)
+    }
+
+    func controlMachine(reference: AlanOSProcessReference, command: String) throws {
+        _ = try validate(reference)
+        try writeDocument("/agent/\(reference.pid)/machine/ctl", data: Data(command.utf8))
+    }
+
+    func interrupt(reference: AlanOSProcessReference) throws {
+        _ = try validate(reference)
+        try writeDocument("/agent/\(reference.pid)/machine/ctl", data: Data("interrupt".utf8))
+    }
+
+    func stop(reference: AlanOSProcessReference) throws {
+        _ = try validate(reference)
+        try writeDocument("/proc/\(reference.pid)/ctl", data: Data("cancel".utf8))
+    }
+
+    private func validateNamespace(channel: AlanInstallChannel) throws {
+        guard status.version == 1,
+              status.channelID == channel.installChannelID,
+              status.readiness == "ready"
+        else {
+            throw AlanOSAttachmentError.invalidStatus("Alan OS Host status does not match this app channel.")
+        }
+        let publishedBootID = String(decoding: try cat("/proc/host/boot_id"), as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard publishedBootID == status.bootID else {
+            throw AlanOSAttachmentError.invalidStatus("Alan OS Host status and namespace boot identity differ.")
+        }
+        guard try cat("/proc/host/state") == Data("ready\n".utf8) else {
+            throw AlanOSAttachmentError.hostUnavailable("Alan OS namespace is not ready.")
+        }
+        _ = try list("/agent/root")
+    }
+
+    private func read(_ path: String, offset: UInt64, count: UInt32) throws -> Data {
+        let fid = try walk(path)
+        defer { try? clunk(fid) }
+        _ = try call(op: "open", fields: ["fid": fid, "mode": "read"])
+        let response = try call(op: "read", fields: ["fid": fid, "offset": offset, "count": count])
+        guard response["op"] as? String == "read",
+              let bytes = response["data"] as? [UInt8]
+        else {
+            throw AlanOSAttachmentError.protocolFailure("Invalid aP read response for \(path).")
+        }
+        return Data(bytes)
+    }
+
+    private func readText(_ path: String) throws -> String {
+        String(decoding: try cat(path), as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func writeDocument(_ path: String, data: Data) throws {
+        let fid = try walk(path)
+        var shouldClunk = true
+        defer {
+            if shouldClunk { try? clunk(fid) }
+        }
+        _ = try call(op: "open", fields: ["fid": fid, "mode": "write"])
+        _ = try call(op: "write", fields: ["fid": fid, "offset": UInt64(0), "data": [UInt8](data)])
+        try clunk(fid)
+        shouldClunk = false
+    }
+
+    private func walk(_ path: String) throws -> UInt64 {
+        let names = path.split(separator: "/").map(String.init)
+        let fid = nextFid
+        nextFid += 1
+        _ = try call(op: "walk", fields: ["fid": UInt64(0), "newfid": fid, "names": names])
+        return fid
+    }
+
+    private func clunk(_ fid: UInt64) throws {
+        _ = try call(op: "clunk", fields: ["fid": fid])
+    }
+
+    private func call(op: String, fields: [String: Any]) throws -> [String: Any] {
+        guard descriptor >= 0 else {
+            throw AlanOSAttachmentError.transport("Alan OS attachment is detached.")
+        }
+        let tag = nextTag
+        nextTag += 1
+        var request = fields
+        request["op"] = op
+        let frame: [String: Any] = ["tag": tag, "request": request]
+        var data = try JSONSerialization.data(withJSONObject: frame)
+        data.append(0x0A)
+        try sendAll(descriptor: descriptor, data: data)
+        let responseData = try readLine()
+        guard let envelope = try JSONSerialization.jsonObject(with: responseData) as? [String: Any],
+              (envelope["tag"] as? NSNumber)?.uint64Value == tag,
+              let status = envelope["status"] as? String
+        else {
+            throw AlanOSAttachmentError.protocolFailure("Malformed or mismatched aP response.")
+        }
+        if status == "error" {
+            throw AlanAPWireFailure(code: envelope["code"] as? String ?? "io")
+        }
+        guard status == "ok", let response = envelope["response"] as? [String: Any] else {
+            throw AlanOSAttachmentError.protocolFailure("Malformed successful aP response.")
+        }
+        return response
+    }
+
+    private func readLine() throws -> Data {
+        while true {
+            if let newline = receiveBuffer.firstIndex(of: 0x0A) {
+                let line = receiveBuffer.prefix(upTo: newline)
+                receiveBuffer.removeSubrange(receiveBuffer.startIndex...newline)
+                return Data(line)
+            }
+            var bytes = [UInt8](repeating: 0, count: 8192)
+            let count = Darwin.read(descriptor, &bytes, bytes.count)
+            guard count > 0 else {
+                throw AlanOSAttachmentError.transport("Alan OS closed the aP connection.")
+            }
+            receiveBuffer.append(contentsOf: bytes.prefix(count))
+            guard receiveBuffer.count <= 1 << 20 else {
+                throw AlanOSAttachmentError.protocolFailure("aP response exceeded the wire limit.")
+            }
+        }
+    }
+}
+
+@MainActor
+final class AlanOSAttachmentController: ObservableObject {
+    enum State: Equatable {
+        case detached
+        case attaching
+        case ready(bootID: String)
+        case unavailable(String)
+    }
+
+    static let shared = AlanOSAttachmentController()
+
+    @Published private(set) var state: State = .detached
+    private(set) var session: AlanOSAttachmentSession?
+    private var attachTask: Task<Void, Never>?
+
+    func attach() {
+        guard attachTask == nil, session == nil else { return }
+        state = .attaching
+        attachTask = Task { [weak self] in
+            do {
+                let session = try await AlanOSAttachmentSession.attach()
+                guard !Task.isCancelled else {
+                    await session.detach()
+                    return
+                }
+                self?.session = session
+                self?.state = .ready(bootID: session.status.bootID)
+            } catch {
+                self?.state = .unavailable(error.localizedDescription)
+            }
+            self?.attachTask = nil
+        }
+    }
+
+    func detach() {
+        attachTask?.cancel()
+        attachTask = nil
+        let active = session
+        session = nil
+        state = .detached
+        Task { await active?.detach() }
+    }
+}
+
+struct AlanOSHostEndpointPaths {
+    let channel: AlanInstallChannel
+    let runtimeRoot: URL
+    let productRoot: URL
+    let root: URL
+    let socket: URL
+    let status: URL
+
+    init(
+        channel: AlanInstallChannel,
+        fileManager: FileManager,
+        runtimeRoot override: URL? = nil
+    ) {
+        self.channel = channel
+        runtimeRoot = override ?? fileManager.temporaryDirectory
+            .appendingPathComponent("alan-os-\(getuid())", isDirectory: true)
+        productRoot = runtimeRoot
+            .appendingPathComponent("Alan OS", isDirectory: true)
+        root = productRoot.appendingPathComponent(channel.installChannelID, isDirectory: true)
+        socket = root.appendingPathComponent("namespace.ap.sock", isDirectory: false)
+        status = root.appendingPathComponent("host.json", isDirectory: false)
+    }
+
+    func readStatus() throws -> AlanOSHostStatus {
+        try validatePrivateDirectory(runtimeRoot)
+        try validatePrivateDirectory(productRoot)
+        try validatePrivateDirectory(root)
+        let value = try JSONDecoder().decode(
+            AlanOSHostStatus.self,
+            from: try readOwnedPrivateFile(status)
+        )
+        guard value.channelID == channel.installChannelID,
+              value.version == 1,
+              value.pid > 0,
+              UUID(uuidString: value.bootID) != nil,
+              value.readiness == "ready" || value.readiness == "stopping",
+              URL(fileURLWithPath: value.socket).standardizedFileURL == socket.standardizedFileURL
+        else {
+            throw AlanOSAttachmentError.invalidStatus("Alan OS Host endpoint does not match this app channel.")
+        }
+        try validateOwnedPrivateSocket(socket)
+        return value
+    }
+
+    func waitUntilReady() async throws -> AlanOSHostStatus {
+        let deadline = ContinuousClock.now + .seconds(10)
+        var lastError = "Host status is unavailable."
+        while ContinuousClock.now < deadline {
+            do {
+                let value = try readStatus()
+                if value.readiness == "ready" { return value }
+            } catch {
+                lastError = error.localizedDescription
+            }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        throw AlanOSAttachmentError.hostUnavailable("Alan OS Host did not become ready: \(lastError)")
+    }
+
+    func requestPlatformHostStart(
+        bundle: Bundle = .main,
+        process: Process = Process()
+    ) throws {
+        let name = channel == .dev ? "alan-os-host-dev" : "alan-os-host"
+        guard let executable = bundle.resourceURL?
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent(name),
+              FileManager.default.isExecutableFile(atPath: executable.path)
+        else {
+            throw AlanOSAttachmentError.hostUnavailable("The signed app does not contain \(name).")
+        }
+        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        process.arguments = [
+            "submit", "-l", "\(channel.bundleIdentifier).os-host",
+            "-p", executable.path, "-o", "/dev/null", "-e", "/dev/null", "--",
+            executable.path,
+        ]
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw AlanOSAttachmentError.hostUnavailable("launchd rejected the Alan OS Host start request.")
+        }
+    }
+}
+
+private func validatePrivateDirectory(_ url: URL) throws {
+    var metadata = Darwin.stat()
+    guard lstat(url.path, &metadata) == 0,
+          metadata.st_uid == getuid(),
+          (metadata.st_mode & S_IFMT) == S_IFDIR,
+          metadata.st_mode & 0o077 == 0
+    else {
+        throw AlanOSAttachmentError.invalidStatus(
+            "Alan OS runtime directory is missing, redirected, foreign-owned, or not private."
+        )
+    }
+}
+
+private func validateOwnedPrivateSocket(_ url: URL) throws {
+    var metadata = Darwin.stat()
+    guard lstat(url.path, &metadata) == 0,
+          metadata.st_uid == getuid(),
+          (metadata.st_mode & S_IFMT) == S_IFSOCK,
+          metadata.st_mode & 0o077 == 0
+    else {
+        throw AlanOSAttachmentError.invalidStatus(
+            "Alan OS attachment socket is missing, redirected, foreign-owned, or not private."
+        )
+    }
+}
+
+private func readOwnedPrivateFile(_ url: URL) throws -> Data {
+    let descriptor = Darwin.open(url.path, O_RDONLY | O_NOFOLLOW)
+    guard descriptor >= 0 else {
+        throw AlanOSAttachmentError.invalidStatus("Alan OS Host status is unavailable or redirected.")
+    }
+    defer { Darwin.close(descriptor) }
+    var metadata = Darwin.stat()
+    guard fstat(descriptor, &metadata) == 0,
+          metadata.st_uid == getuid(),
+          (metadata.st_mode & S_IFMT) == S_IFREG,
+          metadata.st_mode & 0o077 == 0
+    else {
+        throw AlanOSAttachmentError.invalidStatus(
+            "Alan OS Host status is foreign-owned or not private."
+        )
+    }
+    let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: false)
+    return try handle.readToEnd() ?? Data()
+}
+
+private func connectUnixSocket(path: String) throws -> Int32 {
+    let descriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+    guard descriptor >= 0 else {
+        throw AlanOSAttachmentError.transport("Could not create the Alan OS Unix socket.")
+    }
+    var address = sockaddr_un()
+    address.sun_family = sa_family_t(AF_UNIX)
+    let capacity = MemoryLayout.size(ofValue: address.sun_path)
+    guard path.utf8.count < capacity else {
+        Darwin.close(descriptor)
+        throw AlanOSAttachmentError.transport("Alan OS Unix socket path is too long.")
+    }
+    withUnsafeMutablePointer(to: &address.sun_path) { pointer in
+        pointer.withMemoryRebound(to: CChar.self, capacity: capacity) { destination in
+            path.withCString { source in
+                _ = strncpy(destination, source, capacity - 1)
+            }
+        }
+    }
+    let result = withUnsafePointer(to: &address) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+            Darwin.connect(descriptor, socketAddress, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    guard result == 0 else {
+        let message = String(cString: strerror(errno))
+        Darwin.close(descriptor)
+        throw AlanOSAttachmentError.transport("Could not connect to Alan OS Host: \(message)")
+    }
+    var peerUID: uid_t = 0
+    var peerGID: gid_t = 0
+    guard getpeereid(descriptor, &peerUID, &peerGID) == 0, peerUID == getuid() else {
+        Darwin.close(descriptor)
+        throw AlanOSAttachmentError.transport("Alan OS Host peer identity did not match this user.")
+    }
+    return descriptor
+}
+
+private func alanAgentFileIDPrecedes(_ lhs: String, _ rhs: String) -> Bool {
+    let leftNumber = UInt64(lhs.drop(while: { !$0.isNumber }))
+    let rightNumber = UInt64(rhs.drop(while: { !$0.isNumber }))
+    if let leftNumber, let rightNumber, leftNumber != rightNumber {
+        return leftNumber < rightNumber
+    }
+    return lhs < rhs
+}
+
+private func sendAttachRequest(descriptor: Int32) throws {
+    let payload = Data(#"{"op":"attach"}"#.utf8)
+    var length = UInt32(payload.count).bigEndian
+    var frame = Data(bytes: &length, count: MemoryLayout<UInt32>.size)
+    frame.append(payload)
+    try sendAll(descriptor: descriptor, data: frame)
+}
+
+private func sendAll(descriptor: Int32, data: Data) throws {
+    try data.withUnsafeBytes { raw in
+        guard let base = raw.baseAddress else { return }
+        var sent = 0
+        while sent < raw.count {
+            let count = Darwin.write(descriptor, base.advanced(by: sent), raw.count - sent)
+            guard count > 0 else {
+                throw AlanOSAttachmentError.transport("Alan OS aP write failed.")
+            }
+            sent += count
+        }
+    }
+}
+
+private struct AlanHostMountNativeRequest: Decodable {
+    let id: String
+    let label: String
+    let namespacePath: String
+    let access: String
+    let reason: String
+    let requestingPID: UInt64
+
+    private enum CodingKeys: String, CodingKey {
+        case id, label, access, reason
+        case namespacePath = "namespace_path"
+        case requestingPID = "requesting_pid"
+    }
+}
+
+private struct AlanConnectionNativeRequest: Decodable {
+    let id: String
+    let profileID: String
+    let action: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id, action
+        case profileID = "profile_id"
+    }
+}
+
+private struct AlanConnectionMetadata: Decodable {
+    struct Profile: Decodable {
+        let credentialID: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case credentialID = "credential_id"
+        }
+    }
+
+    let profiles: [String: Profile]
+}
+
+/// Observes service-owned request files and supplies only native capabilities.
+/// It never owns mount grants, Connection profiles, defaults, or Process lifecycle.
+@MainActor
+final class AlanOSNativeCapabilityAdapter {
+    static let shared = AlanOSNativeCapabilityAdapter()
+
+    private var observationTask: Task<Void, Never>?
+    private var inFlight = Set<String>()
+    private var dismissedMountRequests = Set<String>()
+    private var securityScopedDirectories: [String: URL] = [:]
+
+    func start(attachment: AlanOSAttachmentController) {
+        guard observationTask == nil else { return }
+        observationTask = Task { [weak self, weak attachment] in
+            while !Task.isCancelled {
+                if let session = attachment?.session {
+                    await self?.poll(session: session)
+                }
+                try? await Task.sleep(for: .milliseconds(500))
+            }
+        }
+    }
+
+    func stop() {
+        observationTask?.cancel()
+        observationTask = nil
+        inFlight.removeAll()
+        dismissedMountRequests.removeAll()
+        for url in securityScopedDirectories.values {
+            url.stopAccessingSecurityScopedResource()
+        }
+        securityScopedDirectories.removeAll()
+    }
+
+    private func poll(session: AlanOSAttachmentSession) async {
+        await pollHostMounts(session: session)
+        await pollConnections(session: session)
+    }
+
+    private func pollHostMounts(session: AlanOSAttachmentSession) async {
+        guard let data = try? await session.cat("/mnt/host-mount/request"),
+              let requests = try? JSONDecoder().decode([AlanHostMountNativeRequest].self, from: data)
+        else { return }
+        let pendingIDs = Set(requests.map(\.id))
+        dismissedMountRequests.formIntersection(pendingIDs)
+        guard let request = requests.first(where: {
+            !inFlight.contains("mount:\($0.id)") && !dismissedMountRequests.contains($0.id)
+        }) else { return }
+        let key = "mount:\(request.id)"
+        inFlight.insert(key)
+        defer { inFlight.remove(key) }
+
+        let panel = NSOpenPanel()
+        panel.title = request.label
+        panel.message = request.reason
+        panel.prompt = request.access == "read_write" ? "Allow Read & Write" : "Allow Read"
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        guard panel.runModal() == .OK, let directory = panel.url else {
+            dismissedMountRequests.insert(request.id)
+            return
+        }
+        let scoped = directory.startAccessingSecurityScopedResource()
+        do {
+            try AlanOSHostCommandClient.approveHostMount(
+                status: session.status,
+                request: request,
+                directory: directory
+            )
+            if scoped { securityScopedDirectories[request.id] = directory }
+        } catch {
+            if scoped { directory.stopAccessingSecurityScopedResource() }
+            presentNativeError(title: "Directory access failed", error: error)
+        }
+    }
+
+    private func pollConnections(session: AlanOSAttachmentSession) async {
+        guard let data = try? await session.cat("/mnt/connections/native-requests"),
+              let requests = try? JSONDecoder().decode(
+                [String: AlanConnectionNativeRequest].self,
+                from: data
+              ),
+              let request = requests.values
+                .sorted(by: { $0.id < $1.id })
+                .first(where: { !inFlight.contains("connection:\($0.id)") })
+        else { return }
+        let key = "connection:\(request.id)"
+        inFlight.insert(key)
+        defer { inFlight.remove(key) }
+
+        do {
+            switch request.action {
+            case "secret_entry":
+                try await handleSecretEntry(request, session: session)
+            case "browser_login", "device_login":
+                try await runEmbeddedConnectionAdapter(request)
+            case "logout":
+                try await handleLogout(request, session: session)
+            default:
+                try await respondConnection(
+                    requestID: request.id,
+                    opaqueReference: nil,
+                    status: "unavailable",
+                    session: session
+                )
+            }
+        } catch {
+            try? await respondConnection(
+                requestID: request.id,
+                opaqueReference: nil,
+                status: "failed",
+                session: session
+            )
+            presentNativeError(title: "Connection action failed", error: error)
+        }
+    }
+
+    private func handleSecretEntry(
+        _ request: AlanConnectionNativeRequest,
+        session: AlanOSAttachmentSession
+    ) async throws {
+        let metadataData = try await session.cat("/mnt/connections/metadata")
+        let metadata = try JSONDecoder().decode(AlanConnectionMetadata.self, from: metadataData)
+        guard let credentialID = metadata.profiles[request.profileID]?.credentialID else {
+            throw AlanOSAttachmentError.protocolFailure("Connection profile has no credential reference.")
+        }
+        let field = NSSecureTextField(frame: NSRect(x: 0, y: 0, width: 320, height: 24))
+        field.placeholderString = "API key"
+        let alert = NSAlert()
+        alert.messageText = "Set secret for \(request.profileID)"
+        alert.informativeText = "The secret is stored in macOS Keychain. Alan OS receives only an opaque reference."
+        alert.accessoryView = field
+        alert.addButton(withTitle: "Store in Keychain")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn, !field.stringValue.isEmpty else {
+            try await respondConnection(
+                requestID: request.id,
+                opaqueReference: nil,
+                status: "unavailable",
+                session: session
+            )
+            return
+        }
+
+        let channel = AlanInstallChannel.current().installChannelID
+        let service = "app.alanworks.macos.\(channel).connections"
+        try AlanKeychainCredentialStore.save(
+            secret: field.stringValue,
+            service: service,
+            account: credentialID
+        )
+        try await respondConnection(
+            requestID: request.id,
+            opaqueReference: "host-keychain:\(channel):\(credentialID)",
+            status: "ready",
+            session: session
+        )
+    }
+
+    private func runEmbeddedConnectionAdapter(_ request: AlanConnectionNativeRequest) async throws {
+        let channel = AlanInstallChannel.current()
+        guard let executable = Bundle.main.resourceURL?
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent(channel.cliToolName),
+              FileManager.default.isExecutableFile(atPath: executable.path)
+        else {
+            throw AlanOSAttachmentError.hostUnavailable("The signed app does not contain \(channel.cliToolName).")
+        }
+        let process = Process()
+        process.executableURL = executable
+        switch request.action {
+        case "browser_login":
+            process.arguments = ["connection", "login", request.profileID, "browser"]
+        case "device_login":
+            process.arguments = ["connection", "login", request.profileID, "device"]
+        case "logout":
+            process.arguments = ["connection", "logout", request.profileID]
+        default:
+            throw AlanOSAttachmentError.protocolFailure("Unsupported native Connection action.")
+        }
+        var environment = ProcessInfo.processInfo.environment
+        environment["ALAN_NATIVE_CONNECTION_REQUEST_ID"] = request.id
+        environment["ALAN_INSTALL_CHANNEL"] = channel.installChannelID
+        process.environment = environment
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = output
+        try process.run()
+        let data = await Task.detached {
+            let data = output.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            return data
+        }.value
+        guard process.terminationStatus == 0 else {
+            let detail = String(decoding: data, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            throw AlanOSAttachmentError.hostUnavailable(
+                detail.isEmpty ? "Native Connection adapter failed." : detail
+            )
+        }
+    }
+
+    private func handleLogout(
+        _ request: AlanConnectionNativeRequest,
+        session: AlanOSAttachmentSession
+    ) async throws {
+        let metadataData = try await session.cat("/mnt/connections/metadata")
+        let metadata = try JSONDecoder().decode(AlanConnectionMetadata.self, from: metadataData)
+        if let credentialID = metadata.profiles[request.profileID]?.credentialID {
+            let channel = AlanInstallChannel.current().installChannelID
+            let removed = try AlanKeychainCredentialStore.delete(
+                service: "app.alanworks.macos.\(channel).connections",
+                account: credentialID
+            )
+            if removed {
+                try await respondConnection(
+                    requestID: request.id,
+                    opaqueReference: nil,
+                    status: "logged_out",
+                    session: session
+                )
+                return
+            }
+        }
+        try await runEmbeddedConnectionAdapter(request)
+    }
+
+    private func respondConnection(
+        requestID: String,
+        opaqueReference: String?,
+        status: String,
+        session: AlanOSAttachmentSession
+    ) async throws {
+        let body: [String: Any?] = [
+            "request_id": requestID,
+            "opaque_credential_ref": opaqueReference,
+            "status": status,
+        ]
+        let normalized = body.reduce(into: [String: Any]()) { result, pair in
+            result[pair.key] = pair.value ?? NSNull()
+        }
+        try await session.writeFile(
+            "/mnt/connections/native-responses",
+            data: JSONSerialization.data(withJSONObject: normalized)
+        )
+    }
+
+    private func presentNativeError(title: String, error: Error) {
+        let alert = NSAlert(error: error)
+        alert.messageText = title
+        alert.runModal()
+    }
+}
+
+private enum AlanKeychainCredentialStore {
+    static func save(secret: String, service: String, account: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(query as CFDictionary)
+        var item = query
+        item[kSecValueData as String] = Data(secret.utf8)
+        item[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let status = SecItemAdd(item as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw AlanOSAttachmentError.hostUnavailable("macOS Keychain rejected the credential (\(status)).")
+        }
+    }
+
+    static func delete(service: String, account: String) throws -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        if status == errSecSuccess { return true }
+        if status == errSecItemNotFound { return false }
+        throw AlanOSAttachmentError.hostUnavailable(
+            "macOS Keychain rejected credential deletion (\(status))."
+        )
+    }
+}
+
+private enum AlanOSHostCommandClient {
+    static func approveHostMount(
+        status: AlanOSHostStatus,
+        request: AlanHostMountNativeRequest,
+        directory: URL
+    ) throws {
+        let descriptor = try connectUnixSocket(path: status.socket)
+        defer { Darwin.close(descriptor) }
+        let command: [String: Any] = [
+            "op": "approve_host_mount",
+            "request_id": request.id,
+            "host_path": directory.path,
+        ]
+        let payload = try JSONSerialization.data(withJSONObject: command)
+        var length = UInt32(payload.count).bigEndian
+        var frame = Data(bytes: &length, count: MemoryLayout<UInt32>.size)
+        frame.append(payload)
+        try sendAll(descriptor: descriptor, data: frame)
+        let header = try readExact(descriptor: descriptor, count: MemoryLayout<UInt32>.size)
+        var rawResponseLength: UInt32 = 0
+        _ = withUnsafeMutableBytes(of: &rawResponseLength) { header.copyBytes(to: $0) }
+        let responseLength = UInt32(bigEndian: rawResponseLength)
+        guard responseLength <= 64 * 1024 else {
+            throw AlanOSAttachmentError.protocolFailure("Host Mount response exceeded its bound.")
+        }
+        let responseData = try readExact(descriptor: descriptor, count: Int(responseLength))
+        guard let response = try JSONSerialization.jsonObject(with: responseData) as? [String: Any],
+              response["boot_id"] as? String == status.bootID
+        else {
+            throw AlanOSAttachmentError.protocolFailure("Host Mount response has the wrong boot identity.")
+        }
+        if let error = response["error"] as? String {
+            throw AlanOSAttachmentError.hostUnavailable(error)
+        }
+        guard response["host_path"] == nil,
+              let grant = response["grant"] as? [String: Any],
+              grant["host_path"] == nil,
+              grant["id"] as? String == request.id,
+              grant["namespace_path"] as? String == request.namespacePath,
+              grant["access"] as? String == request.access,
+              grant["active"] as? Bool == true
+        else {
+            throw AlanOSAttachmentError.protocolFailure("Host Mount response was unbounded or mismatched.")
+        }
+    }
+}
+
+private func readExact(descriptor: Int32, count: Int) throws -> Data {
+    var result = Data(count: count)
+    try result.withUnsafeMutableBytes { raw in
+        guard let base = raw.baseAddress else { return }
+        var received = 0
+        while received < count {
+            let amount = Darwin.read(descriptor, base.advanced(by: received), count - received)
+            guard amount > 0 else {
+                throw AlanOSAttachmentError.transport("Alan OS Host closed a native command response.")
+            }
+            received += amount
+        }
+    }
+    return result
+}
+#endif

--- a/clients/apple/alan-macos/Services/AlanOS/AlanOSAttachmentService.swift
+++ b/clients/apple/alan-macos/Services/AlanOS/AlanOSAttachmentService.swift
@@ -725,6 +725,11 @@ private struct AlanConnectionMetadata: Decodable {
     let profiles: [String: Profile]
 }
 
+/// CLI-created requests are completed by that CLI process, not by the renderer adapter.
+func alanOSNativeAdapterOwnsConnectionRequest(_ requestID: String) -> Bool {
+    !requestID.hasPrefix("cli-")
+}
+
 /// Observes service-owned request files and supplies only native capabilities.
 /// It never owns mount grants, Connection profiles, defaults, or Process lifecycle.
 @MainActor
@@ -810,7 +815,10 @@ final class AlanOSNativeCapabilityAdapter {
               ),
               let request = requests.values
                 .sorted(by: { $0.id < $1.id })
-                .first(where: { !inFlight.contains("connection:\($0.id)") })
+                .first(where: {
+                    alanOSNativeAdapterOwnsConnectionRequest($0.id)
+                        && !inFlight.contains("connection:\($0.id)")
+                })
         else { return }
         let key = "connection:\(request.id)"
         inFlight.insert(key)

--- a/clients/apple/alan-macos/Services/Shell/ShellContentRenderingRegistry.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellContentRenderingRegistry.swift
@@ -5,6 +5,7 @@ enum ShellContentRenderKind: String, Codable, CaseIterable, Equatable {
     case terminal
     case markdown
     case settings
+    case agent
     case unavailable
 }
 
@@ -72,6 +73,8 @@ enum ShellContentRenderingRegistry {
             return .markdown
         case .settings:
             return .settings
+        case .agent:
+            return .agent
         }
     }
 
@@ -89,6 +92,8 @@ enum ShellContentRenderingRegistry {
             return "doc.text"
         case .settings:
             return "gearshape"
+        case .agent:
+            return "sparkles"
         }
     }
 }

--- a/clients/apple/alan-macos/Services/Shell/ShellCoreFFIMaterialization.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellCoreFFIMaterialization.swift
@@ -184,7 +184,7 @@ struct ShellCorePortableContentInstance: Codable {
             forKey: .capabilities
         ) ?? ShellContentInstance.defaultCapabilities(for: kind)
         payload = try container.decodeIfPresent(ShellContentPayload.self, forKey: .payload)
-            ?? ShellContentPayload(terminal: nil, markdown: nil, settings: nil)
+            ?? ShellContentPayload(terminal: nil, markdown: nil, settings: nil, agent: nil)
         lifecycle = try container.decodeIfPresent(
             ShellContentLifecycleState.self,
             forKey: .lifecycle
@@ -221,6 +221,11 @@ struct ShellCorePortableContentInstance: Codable {
             return ShellContentRendererState(phase: "ready", detail: detail)
         case .settings:
             return ShellContentRendererState(phase: "ready", detail: payload.settings?.surfaceID)
+        case .agent:
+            return ShellContentRendererState(
+                phase: payload.agent == nil ? "unavailable" : "ready",
+                detail: payload.agent.map { "Process \($0.process.pid)" }
+            )
         }
     }
 }

--- a/clients/apple/alan-macos/Services/Shell/ShellCoreFFIReducerAdapter.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellCoreFFIReducerAdapter.swift
@@ -104,6 +104,11 @@ enum ShellCoreReducerOperation: Encodable {
     case movePaneToNewTab(paneSlotID: String, title: String?)
     case movePaneToTab(paneSlotID: String, targetTabID: String, direction: ShellSplitDirection)
     case setAttention(paneSlotID: String, attention: ShellAttentionState)
+    case updateAgentRendererState(
+        paneSlotID: String,
+        offsets: AlanAgentStreamOffsets,
+        presentation: AlanAgentContentPresentation
+    )
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -130,6 +135,8 @@ enum ShellCoreReducerOperation: Encodable {
         case placement
         case kind
         case payload
+        case offsets
+        case presentation
     }
 
     func encode(to encoder: Encoder) throws {
@@ -295,6 +302,11 @@ enum ShellCoreReducerOperation: Encodable {
             try container.encode("set_attention", forKey: .type)
             try container.encode(paneSlotID, forKey: .paneSlotID)
             try container.encode(attention, forKey: .attention)
+        case .updateAgentRendererState(let paneSlotID, let offsets, let presentation):
+            try container.encode("update_agent_renderer_state", forKey: .type)
+            try container.encode(paneSlotID, forKey: .paneSlotID)
+            try container.encode(offsets, forKey: .offsets)
+            try container.encode(presentation, forKey: .presentation)
         }
     }
 }

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -345,6 +345,29 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         terminalContentLifecycle.finalizeAllRuntimes(registry: terminalRuntimeRegistry)
     }
 
+    /// Persist only renderer-owned Agent offsets and presentation. Process identity is immutable.
+    func updateAgentRendererState(
+        paneID: String,
+        offsets: AlanAgentStreamOffsets,
+        presentation: AlanAgentContentPresentation
+    ) {
+        do {
+            let result = try reducerCoordinator.apply(
+                state: shellState,
+                operation: .updateAgentRendererState(
+                    paneSlotID: paneID,
+                    offsets: offsets,
+                    presentation: presentation
+                )
+            )
+            applyMutationResult(result)
+        } catch {
+            recordControlPlaneDiagnostic(
+                "Agent renderer state update failed for \(paneID): \(error)"
+            )
+        }
+    }
+
     static func live(
         fileManager: FileManager = .default,
         windowContext: ShellWindowContext? = nil,
@@ -1256,6 +1279,17 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                         reservedPaneSlotIDs: reservedPaneSlotIDs
                     )
                 )
+            case .agent(let attachment, let title):
+                result = try reducerCoordinator.apply(
+                    state: shellState,
+                    operation: .openContentTab(
+                        spaceID: spaceID,
+                        kind: .agent,
+                        title: title ?? "Agent \(attachment.process.pid)",
+                        payload: .agent(attachment),
+                        reservedPaneSlotIDs: reservedPaneSlotIDs
+                    )
+                )
             }
         } catch {
             return nil
@@ -1382,6 +1416,15 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     @discardableResult
+    func openAgentTab(
+        attachment: AlanAgentAttachment,
+        in spaceID: String? = nil,
+        title: String? = nil
+    ) -> String? {
+        openContentTab(.agent(attachment: attachment, title: title), in: spaceID)
+    }
+
+    @discardableResult
     func splitFocusedPane(
         direction: ShellSplitDirection,
         contentIntent: ShellContentIntent? = nil,
@@ -1481,6 +1524,18 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                             kind: .settings,
                             title: content.title,
                             payload: content.payload,
+                            reservedPaneSlotIDs: reservedPaneSlotIDs
+                        )
+                    )
+                case .agent(let attachment, let title):
+                    result = try reducerCoordinator.apply(
+                        state: shellState,
+                        operation: .splitContentPane(
+                            paneSlotID: paneID,
+                            placement: placement,
+                            kind: .agent,
+                            title: title ?? "Agent \(attachment.process.pid)",
+                            payload: .agent(attachment),
                             reservedPaneSlotIDs: reservedPaneSlotIDs
                         )
                     )

--- a/clients/apple/alan-macos/ShellModel.swift
+++ b/clients/apple/alan-macos/ShellModel.swift
@@ -612,6 +612,8 @@ func shellContentTypeHint(for kind: ShellContentKind) -> String {
         return "Document"
     case .settings:
         return "Settings"
+    case .agent:
+        return "Agent"
     }
 }
 

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -537,7 +537,7 @@ private struct ShellPaneTreeLayoutView: View {
             } else {
                 boundedContentLeaf(descriptor: descriptor, paneSlotID: paneSlotID, backingPane: nil)
             }
-        case .markdown, .settings, .unavailable:
+        case .markdown, .settings, .agent, .unavailable:
             boundedContentLeaf(descriptor: descriptor, paneSlotID: paneSlotID, backingPane: pane)
         }
     }
@@ -633,6 +633,16 @@ private struct ShellPaneTreeLayoutView: View {
         return ShellBoundedContentLeafView(
             descriptor: descriptor,
             paneSlotID: paneSlotID,
+            onAgentRendererStateUpdate: { offsets, presentation in
+                host.updateAgentRendererState(
+                    paneID: paneSlotID,
+                    offsets: offsets,
+                    presentation: presentation
+                )
+            },
+            onOpenAgentView: { attachment in
+                _ = host.openAgentTab(attachment: attachment)
+            },
             isSelected: selectedPaneID == paneSlotID,
             isZoomed: host.isPaneZoomed(paneSlotID),
             canZoom: host.canZoomPane(paneSlotID),
@@ -1059,6 +1069,11 @@ private enum ShellPaneTitleBarAccessoryMode: Equatable {
 private struct ShellBoundedContentLeafView: View {
     let descriptor: ShellContentRenderDescriptor
     let paneSlotID: String
+    let onAgentRendererStateUpdate: (
+        AlanAgentStreamOffsets,
+        AlanAgentContentPresentation
+    ) -> Void
+    let onOpenAgentView: (AlanAgentAttachment) -> Void
     let isSelected: Bool
     let isZoomed: Bool
     let canZoom: Bool
@@ -1089,6 +1104,15 @@ private struct ShellBoundedContentLeafView: View {
                     .onTapGesture(perform: onFocusPane)
             case .settings:
                 ShellSettingsContentView(descriptor: descriptor)
+                    .contentShape(Rectangle())
+                    .onTapGesture(perform: onFocusPane)
+            case .agent:
+                ShellAgentContentView(
+                    descriptor: descriptor,
+                    onRendererStateUpdate: onAgentRendererStateUpdate,
+                    onOpenAnotherView: onOpenAgentView
+                )
+                    .id(descriptor.contentID)
                     .contentShape(Rectangle())
                     .onTapGesture(perform: onFocusPane)
             case .terminal, .unavailable:
@@ -1133,9 +1157,440 @@ private struct ShellBoundedContentLeafView: View {
             return "Document"
         case .settings:
             return "Settings"
+        case .agent:
+            return "Agent Process"
         case .unavailable:
             return "Unavailable"
         }
+    }
+}
+
+private struct ShellAgentContentView: View {
+    let descriptor: ShellContentRenderDescriptor
+    let onRendererStateUpdate: (
+        AlanAgentStreamOffsets,
+        AlanAgentContentPresentation
+    ) -> Void
+    let onOpenAnotherView: (AlanAgentAttachment) -> Void
+
+    @ObservedObject private var hostAttachment = AlanOSAttachmentController.shared
+    @State private var output = ""
+    @State private var activity: [String] = []
+    @State private var continuityNotices: [String] = []
+    @State private var processStatus = "Attaching"
+    @State private var visibleError: String?
+    @State private var input = ""
+    @State private var requestResponse = ""
+    @State private var pendingRequest: AlanAgentPendingRequest?
+    @State private var streamOffsets: AlanAgentStreamOffsets
+    @State private var presentation: AlanAgentContentPresentation
+    @State private var isConfirmingStop = false
+
+    private var agent: AlanAgentAttachment? { descriptor.payload?.agent }
+
+    init(
+        descriptor: ShellContentRenderDescriptor,
+        onRendererStateUpdate: @escaping (
+            AlanAgentStreamOffsets,
+            AlanAgentContentPresentation
+        ) -> Void,
+        onOpenAnotherView: @escaping (AlanAgentAttachment) -> Void
+    ) {
+        self.descriptor = descriptor
+        self.onRendererStateUpdate = onRendererStateUpdate
+        self.onOpenAnotherView = onOpenAnotherView
+        _streamOffsets = State(initialValue: descriptor.payload?.agent?.offsets ?? .zero)
+        _presentation = State(initialValue: descriptor.payload?.agent?.presentation ?? .default)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(statusColor)
+                    .frame(width: 7, height: 7)
+                Text(processStatus)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(ShellPalette.mutedInk)
+                Spacer()
+                Menu {
+                    Toggle("Follow Output", isOn: followOutputBinding)
+                    Button("Open Another View", action: openAnotherView)
+                    Divider()
+                    Button("Compact Context") { performMachineControl("compact") }
+                    Button("Roll Back Last Turn") { performMachineControl("rollback") }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .accessibilityLabel("Agent controls")
+                .disabled(!isProcessRunning)
+                Button("Interrupt") { performInterrupt() }
+                    .buttonStyle(.borderless)
+                    .disabled(!isProcessRunning)
+                Button("Stop…") { isConfirmingStop = true }
+                    .buttonStyle(.borderless)
+                    .disabled(!isProcessRunning)
+            }
+            .padding(.horizontal, 14)
+            .frame(height: 34)
+
+            Divider().opacity(0.45)
+
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text(output.isEmpty ? "No Agent output yet." : output)
+                            .font(.system(.body, design: .monospaced))
+                            .foregroundStyle(output.isEmpty ? ShellPalette.mutedInk : ShellPalette.ink)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .topLeading)
+
+                        if !activity.isEmpty {
+                            Divider().opacity(0.4)
+                            Text("Activity")
+                                .font(.system(size: 10, weight: .semibold))
+                                .textCase(.uppercase)
+                                .foregroundStyle(ShellPalette.mutedInk)
+                            ForEach(Array(activity.enumerated()), id: \.offset) { entry in
+                                Text(entry.element)
+                                    .font(.system(size: 11, design: .monospaced))
+                                    .foregroundStyle(ShellPalette.mutedInk)
+                                    .textSelection(.enabled)
+                            }
+                        }
+
+                        Color.clear.frame(height: 1).id("agent-output-bottom")
+                    }
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                    .padding(14)
+                }
+                .onChange(of: output) { _, _ in
+                    guard presentation.followsOutput else { return }
+                    proxy.scrollTo("agent-output-bottom", anchor: .bottom)
+                }
+            }
+
+            if let pendingRequest {
+                pendingRequestView(pendingRequest)
+            }
+
+            ForEach(Array(continuityNotices.enumerated()), id: \.offset) { notice in
+                Text(notice.element)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.orange)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 14)
+                    .padding(.bottom, 4)
+            }
+
+            if let visibleError {
+                Text(visibleError)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 14)
+                    .padding(.bottom, 6)
+            }
+
+            HStack(spacing: 8) {
+                TextField("Send input to Agent", text: $input)
+                    .textFieldStyle(.plain)
+                    .onSubmit(sendInput)
+                Button("Send", action: sendInput)
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .disabled(
+                        !isProcessRunning
+                            || input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    )
+            }
+            .padding(10)
+            .background(ShellPalette.workspace)
+        }
+        .background(ShellPalette.workspace)
+        .task(id: refreshIdentity) { await tailAgentFiles() }
+        .alert("Stop Agent Process?", isPresented: $isConfirmingStop) {
+            Button("Cancel", role: .cancel) {}
+            Button("Stop Process", role: .destructive) { stopProcess() }
+        } message: {
+            Text("This writes an explicit stop action to Alan OS. Closing this view only detaches.")
+        }
+    }
+
+    private var refreshIdentity: String {
+        guard let agent else { return "missing" }
+        return "\(agent.process.bootID):\(agent.process.pid):\(hostAttachment.state)"
+    }
+
+    private var statusColor: Color {
+        visibleError == nil && isProcessRunning ? .green : .secondary
+    }
+
+    private var isProcessRunning: Bool {
+        processStatus == "Running"
+    }
+
+    private var followOutputBinding: Binding<Bool> {
+        Binding(
+            get: { presentation.followsOutput },
+            set: { followsOutput in
+                presentation.followsOutput = followsOutput
+                onRendererStateUpdate(streamOffsets, presentation)
+            }
+        )
+    }
+
+    private func pendingRequestView(_ request: AlanAgentPendingRequest) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(request.kind.isEmpty ? "Agent request" : request.kind)
+                    .font(.system(size: 11, weight: .semibold))
+                Spacer()
+                Text(request.id)
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundStyle(ShellPalette.mutedInk)
+            }
+            Text(request.prompt)
+                .font(.system(size: 12))
+                .lineLimit(8)
+                .textSelection(.enabled)
+            if !request.options.isEmpty {
+                Text(request.options)
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundStyle(ShellPalette.mutedInk)
+                    .lineLimit(8)
+                    .textSelection(.enabled)
+            }
+            HStack(spacing: 8) {
+                TextField("Response", text: $requestResponse)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit(sendRequestResponse)
+                Button("Respond", action: sendRequestResponse)
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .disabled(requestResponse.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(10)
+        .background(ShellPalette.workspace)
+        .overlay(alignment: .top) { Divider().opacity(0.45) }
+    }
+
+    @MainActor
+    private func tailAgentFiles() async {
+        guard let agent else {
+            processStatus = "Unavailable"
+            visibleError = "This content does not contain an Agent attachment."
+            return
+        }
+        guard let session = hostAttachment.session else {
+            processStatus = "Alan OS unavailable"
+            if case .unavailable(let detail) = hostAttachment.state { visibleError = detail }
+            return
+        }
+        var hydratedOutput = false
+        var hydratedRequest = false
+        while !Task.isCancelled {
+            do {
+                let validated = try await session.validate(agent.process)
+                processStatus = validated.status.isEmpty ? "Running" : validated.status.capitalized
+
+                if !hydratedOutput {
+                    let history = try await session.readAgentStreamWindow(
+                        reference: agent.process,
+                        relativePath: "io/output",
+                        endingAt: streamOffsets.output
+                    )
+                    if !history.isEmpty { output = String(decoding: history, as: UTF8.self) }
+                    hydratedOutput = true
+                }
+
+                var nextOffsets = streamOffsets
+                let outputChunk = try await pollStream(
+                    session: session,
+                    process: agent.process,
+                    path: "io/output",
+                    offset: nextOffsets.output
+                )
+                nextOffsets.output = outputChunk.nextOffset
+                appendOutput(outputChunk.data)
+
+                let requestChunk = try await pollStream(
+                    session: session,
+                    process: agent.process,
+                    path: "requests/events",
+                    offset: nextOffsets.requests
+                )
+                nextOffsets.requests = requestChunk.nextOffset
+                appendActivity("Request", data: requestChunk.data)
+
+                let actionChunk = try await pollStream(
+                    session: session,
+                    process: agent.process,
+                    path: "actions/events",
+                    offset: nextOffsets.actions
+                )
+                nextOffsets.actions = actionChunk.nextOffset
+                appendActivity("Action", data: actionChunk.data)
+
+                let uiChunk = try await pollStream(
+                    session: session,
+                    process: agent.process,
+                    path: "machine/ui/events",
+                    offset: nextOffsets.ui
+                )
+                nextOffsets.ui = uiChunk.nextOffset
+                appendActivity("UI", data: uiChunk.data)
+
+                if !hydratedRequest || !requestChunk.data.isEmpty || pendingRequest != nil {
+                    pendingRequest = try await session.latestPendingRequest(reference: agent.process)
+                    hydratedRequest = true
+                }
+
+                let advanced = nextOffsets != streamOffsets
+                if advanced {
+                    streamOffsets = nextOffsets
+                    onRendererStateUpdate(streamOffsets, presentation)
+                }
+                visibleError = nil
+                if validated.status == "exited" && !advanced { return }
+            } catch let error as AlanOSAttachmentError {
+                if case .retentionGap(let stream, let requested, let available) = error {
+                    recordRetentionGap(stream: stream, requested: requested, available: available)
+                    continue
+                }
+                processStatus = "Unavailable"
+                visibleError = error.localizedDescription
+            } catch {
+                if Task.isCancelled { return }
+                processStatus = "Unavailable"
+                visibleError = error.localizedDescription
+            }
+            try? await Task.sleep(for: .milliseconds(250))
+        }
+    }
+
+    private func pollStream(
+        session: AlanOSAttachmentSession,
+        process: AlanOSProcessReference,
+        path: String,
+        offset: UInt64
+    ) async throws -> (data: Data, nextOffset: UInt64) {
+        let chunk = try await session.readAgentStream(
+            reference: process,
+            relativePath: path,
+            offset: offset,
+            overlap: 256
+        )
+        var accumulator = AlanAgentStreamAccumulator(nextOffset: offset)
+        return (try accumulator.accept(chunk), accumulator.nextOffset)
+    }
+
+    private func appendOutput(_ data: Data) {
+        guard !data.isEmpty else { return }
+        output.append(String(decoding: data, as: UTF8.self))
+        if output.count > 262_144 { output = String(output.suffix(262_144)) }
+    }
+
+    private func appendActivity(_ label: String, data: Data) {
+        guard !data.isEmpty else { return }
+        activity.append(contentsOf: String(decoding: data, as: UTF8.self)
+            .split(whereSeparator: \.isNewline)
+            .map { "\(label): \($0)" })
+        if activity.count > 80 { activity.removeFirst(activity.count - 80) }
+    }
+
+    private func recordRetentionGap(stream: String, requested: UInt64, available: UInt64) {
+        let notice = "Continuity gap in \(stream): saved offset \(requested), available length \(available). Resumed at the visible edge."
+        if continuityNotices.last != notice { continuityNotices.append(notice) }
+        if continuityNotices.count > 4 {
+            continuityNotices.removeFirst(continuityNotices.count - 4)
+        }
+        switch stream {
+        case "io/output": streamOffsets.output = available
+        case "requests/events": streamOffsets.requests = available
+        case "actions/events": streamOffsets.actions = available
+        case "machine/ui/events": streamOffsets.ui = available
+        default: return
+        }
+        onRendererStateUpdate(streamOffsets, presentation)
+    }
+
+    private func sendInput() {
+        guard let agent, let session = hostAttachment.session else { return }
+        let value = input
+        input = ""
+        Task { @MainActor in
+            do {
+                try await session.writeAgentInput(reference: agent.process, data: Data(value.utf8))
+            } catch {
+                visibleError = error.localizedDescription
+            }
+        }
+    }
+
+    private func performInterrupt() {
+        guard let agent, let session = hostAttachment.session else { return }
+        Task { @MainActor in
+            do {
+                try await session.interrupt(reference: agent.process)
+            } catch {
+                visibleError = error.localizedDescription
+            }
+        }
+    }
+
+    private func sendRequestResponse() {
+        guard let agent, let request = pendingRequest, let session = hostAttachment.session else { return }
+        let value = requestResponse
+        requestResponse = ""
+        Task { @MainActor in
+            do {
+                try await session.respond(
+                    reference: agent.process,
+                    requestID: request.id,
+                    data: Data(value.utf8)
+                )
+                pendingRequest = nil
+            } catch {
+                visibleError = error.localizedDescription
+            }
+        }
+    }
+
+    private func performMachineControl(_ command: String) {
+        guard let agent, let session = hostAttachment.session else { return }
+        Task { @MainActor in
+            do {
+                try await session.controlMachine(reference: agent.process, command: command)
+            } catch {
+                visibleError = error.localizedDescription
+            }
+        }
+    }
+
+    private func stopProcess() {
+        guard let agent, let session = hostAttachment.session else { return }
+        Task { @MainActor in
+            do {
+                try await session.stop(reference: agent.process)
+            } catch {
+                visibleError = error.localizedDescription
+            }
+        }
+    }
+
+    private func openAnotherView() {
+        guard let agent else { return }
+        onOpenAnotherView(
+            AlanAgentAttachment(
+                process: agent.process,
+                offsets: streamOffsets,
+                presentation: presentation
+            )
+        )
     }
 }
 

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -1210,7 +1210,7 @@ private struct ShellAgentContentView: View {
                     .fill(statusColor)
                     .frame(width: 7, height: 7)
                 Text(processStatus)
-                    .font(.system(size: 11, weight: .medium))
+                    .font(ShellType.pro(ShellType.caption, weight: .medium))
                     .foregroundStyle(ShellPalette.mutedInk)
                 Spacer()
                 Menu {
@@ -1233,7 +1233,7 @@ private struct ShellAgentContentView: View {
                     .buttonStyle(.borderless)
                     .disabled(!isProcessRunning)
             }
-            .padding(.horizontal, 14)
+            .padding(.horizontal, ShellSpacing.row)
             .frame(height: 34)
 
             Divider().opacity(0.45)
@@ -1250,12 +1250,12 @@ private struct ShellAgentContentView: View {
                         if !activity.isEmpty {
                             Divider().opacity(0.4)
                             Text("Activity")
-                                .font(.system(size: 10, weight: .semibold))
+                                .font(ShellType.pro(ShellType.monoCaption, weight: .semibold))
                                 .textCase(.uppercase)
                                 .foregroundStyle(ShellPalette.mutedInk)
                             ForEach(Array(activity.enumerated()), id: \.offset) { entry in
                                 Text(entry.element)
-                                    .font(.system(size: 11, design: .monospaced))
+                                    .font(ShellType.mono(ShellType.monoLabel))
                                     .foregroundStyle(ShellPalette.mutedInk)
                                     .textSelection(.enabled)
                             }
@@ -1264,7 +1264,7 @@ private struct ShellAgentContentView: View {
                         Color.clear.frame(height: 1).id("agent-output-bottom")
                     }
                     .frame(maxWidth: .infinity, alignment: .topLeading)
-                    .padding(14)
+                    .padding(ShellSpacing.row)
                 }
                 .onChange(of: output) { _, _ in
                     guard presentation.followsOutput else { return }
@@ -1278,20 +1278,20 @@ private struct ShellAgentContentView: View {
 
             ForEach(Array(continuityNotices.enumerated()), id: \.offset) { notice in
                 Text(notice.element)
-                    .font(.system(size: 11))
-                    .foregroundStyle(.orange)
+                    .font(ShellType.pro(ShellType.caption))
+                    .foregroundStyle(ShellSignal.action)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 14)
-                    .padding(.bottom, 4)
+                    .padding(.horizontal, ShellSpacing.row)
+                    .padding(.bottom, ShellSpacing.tight)
             }
 
             if let visibleError {
                 Text(visibleError)
-                    .font(.system(size: 11))
+                    .font(ShellType.pro(ShellType.caption))
                     .foregroundStyle(.red)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 14)
-                    .padding(.bottom, 6)
+                    .padding(.horizontal, ShellSpacing.row)
+                    .padding(.bottom, ShellSpacing.control)
             }
 
             HStack(spacing: 8) {
@@ -1306,7 +1306,7 @@ private struct ShellAgentContentView: View {
                             || input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                     )
             }
-            .padding(10)
+            .padding(ShellSpacing.control)
             .background(ShellPalette.workspace)
         }
         .background(ShellPalette.workspace)
@@ -1346,19 +1346,19 @@ private struct ShellAgentContentView: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack {
                 Text(request.kind.isEmpty ? "Agent request" : request.kind)
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(ShellType.pro(ShellType.caption, weight: .semibold))
                 Spacer()
                 Text(request.id)
-                    .font(.system(size: 10, design: .monospaced))
+                    .font(ShellType.mono(ShellType.monoCaption))
                     .foregroundStyle(ShellPalette.mutedInk)
             }
             Text(request.prompt)
-                .font(.system(size: 12))
+                .font(ShellType.pro(ShellType.row))
                 .lineLimit(8)
                 .textSelection(.enabled)
             if !request.options.isEmpty {
                 Text(request.options)
-                    .font(.system(size: 10, design: .monospaced))
+                    .font(ShellType.mono(ShellType.monoCaption))
                     .foregroundStyle(ShellPalette.mutedInk)
                     .lineLimit(8)
                     .textSelection(.enabled)
@@ -1373,7 +1373,7 @@ private struct ShellAgentContentView: View {
                     .disabled(requestResponse.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
         }
-        .padding(10)
+        .padding(ShellSpacing.control)
         .background(ShellPalette.workspace)
         .overlay(alignment: .top) { Divider().opacity(0.45) }
     }

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -861,6 +861,8 @@ struct ShellSidebarView: View {
             return "doc.text"
         case .settings:
             return "gearshape"
+        case .agent:
+            return "sparkles"
         }
     }
 

--- a/clients/apple/scripts/support/AlanOSAttachmentTestSupport.swift
+++ b/clients/apple/scripts/support/AlanOSAttachmentTestSupport.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+enum AlanInstallChannel: Equatable {
+    case stable
+    case dev
+
+    static func current() -> Self { .dev }
+
+    var installChannelID: String {
+        switch self {
+        case .stable: "stable"
+        case .dev: "dev"
+        }
+    }
+
+    var bundleIdentifier: String {
+        switch self {
+        case .stable: "app.alanworks.macos"
+        case .dev: "app.alanworks.macos.dev"
+        }
+    }
+
+    var cliToolName: String {
+        switch self {
+        case .stable: "alan"
+        case .dev: "alan-dev"
+        }
+    }
+}
+
+struct AlanOSProcessReference: Codable, Equatable, Hashable {
+    let bootID: String
+    let pid: UInt64
+
+    private enum CodingKeys: String, CodingKey {
+        case bootID = "boot_id"
+        case pid
+    }
+}
+
+struct AlanAgentStreamOffsets: Codable, Equatable {
+    var output: UInt64
+    var requests: UInt64
+    var actions: UInt64
+    var ui: UInt64
+
+    static let zero = Self(output: 0, requests: 0, actions: 0, ui: 0)
+}
+
+struct AlanAgentContentPresentation: Codable, Equatable {
+    var followsOutput: Bool
+
+    static let `default` = Self(followsOutput: true)
+
+    private enum CodingKeys: String, CodingKey {
+        case followsOutput = "follows_output"
+    }
+}
+
+struct AlanAgentAttachment: Codable, Equatable {
+    let process: AlanOSProcessReference
+    var offsets: AlanAgentStreamOffsets
+    var presentation: AlanAgentContentPresentation
+}

--- a/clients/apple/scripts/support/ShellCoreFFITestStateBuilder.swift
+++ b/clients/apple/scripts/support/ShellCoreFFITestStateBuilder.swift
@@ -286,6 +286,10 @@ extension ShellStateSnapshot {
                     title: title
                 )
             )
+        case .agent(let attachment, let requestedTitle):
+            kind = .agent
+            title = requestedTitle ?? "Agent \(attachment.process.pid)"
+            payload = .agent(attachment)
         }
 
         return try ShellCoreFFIAdapter().applyReducer(

--- a/clients/apple/scripts/test-alan-os-attachment.sh
+++ b/clients/apple/scripts/test-alan-os-attachment.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BUILD_DIR="${TMPDIR:-/tmp}/alan-os-attachment-tests"
+MODULE_CACHE_DIR="$BUILD_DIR/clang-module-cache"
+TEST_BINARY="$BUILD_DIR/alan-os-attachment-tests"
+
+mkdir -p "$MODULE_CACHE_DIR"
+
+CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
+    "$REPO_ROOT/clients/apple/scripts/support/AlanOSAttachmentTestSupport.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Services/AlanOS/AlanOSAttachmentService.swift" \
+    "$REPO_ROOT/clients/apple/scripts/test-alan-os-attachment.swift" \
+    -o "$TEST_BINARY"
+
+"$TEST_BINARY"
+
+APP_SOURCE="$REPO_ROOT/clients/apple/alan-macos"
+ATTACHMENT_SOURCE="$APP_SOURCE/Services/AlanOS/AlanOSAttachmentService.swift"
+PANE_SOURCE="$APP_SOURCE/TerminalPaneView.swift"
+
+if grep -ERq 'AlanKernel|AlanAgentEngine|AgentExecutionEngine|bootRootAgent|requestHostStop|stopAlanOSHost|terminateAlanOSHost' "$APP_SOURCE"; then
+    echo "Alan for macOS must not own Alan OS or Agent execution lifecycle." >&2
+    exit 1
+fi
+grep -q 'sendAttachRequest(descriptor: descriptor)' "$ATTACHMENT_SOURCE"
+grep -q 'host.updateAgentRendererState' "$PANE_SOURCE"
+grep -Fq 'writeDocument("/proc/\(reference.pid)/ctl"' "$ATTACHMENT_SOURCE"
+grep -Fq 'writeDocument("/agent/\(reference.pid)/machine/ctl"' "$ATTACHMENT_SOURCE"
+grep -Fq '.alert("Stop Agent Process?"' "$PANE_SOURCE"
+grep -Fq 'Closing this view only detaches.' "$PANE_SOURCE"
+grep -Fq 'session.cat("/mnt/host-mount/request")' "$ATTACHMENT_SOURCE"
+grep -q 'let panel = NSOpenPanel()' "$ATTACHMENT_SOURCE"
+grep -q 'approveHostMount(' "$ATTACHMENT_SOURCE"
+grep -Fq 'session.cat("/mnt/connections/native-requests")' "$ATTACHMENT_SOURCE"
+grep -Fq 'host-keychain:\(channel):\(credentialID)' "$ATTACHMENT_SOURCE"
+grep -q 'ALAN_NATIVE_CONNECTION_REQUEST_ID' "$ATTACHMENT_SOURCE"
+grep -q 'AlanOSAttachmentController.shared.detach()' \
+    "$APP_SOURCE/App/AlanMacPrimaryShellOwner.swift"
+grep -q 'agent_attachment_persists_only_reference_offsets_and_presentation' \
+    "$REPO_ROOT/crates/shell-core/tests/manifest_contract.rs"
+
+echo "Alan OS attachment architecture guards passed."

--- a/clients/apple/scripts/test-alan-os-attachment.swift
+++ b/clients/apple/scripts/test-alan-os-attachment.swift
@@ -186,6 +186,17 @@ private func testStreamOverlapAndGap() throws {
     }
 }
 
+private func testNativeConnectionRequestOwnership() throws {
+    try require(
+        !alanOSNativeAdapterOwnsConnectionRequest("cli-1234"),
+        "renderer must not claim CLI-owned native requests"
+    )
+    try require(
+        alanOSNativeAdapterOwnsConnectionRequest("agent-1234"),
+        "renderer must handle non-CLI native requests"
+    )
+}
+
 private func testProtectedStatusDiscovery() throws {
     let fileManager = FileManager.default
     let temporary = try temporaryDirectory()
@@ -255,6 +266,7 @@ private func testAPAttachAndNamespaceValidation() async throws {
 private enum AlanOSAttachmentTests {
     static func main() async throws {
         try testStreamOverlapAndGap()
+        try testNativeConnectionRequestOwnership()
         try testProtectedStatusDiscovery()
         try await testAPAttachAndNamespaceValidation()
         print("Alan OS attachment tests passed.")

--- a/clients/apple/scripts/test-alan-os-attachment.swift
+++ b/clients/apple/scripts/test-alan-os-attachment.swift
@@ -1,0 +1,262 @@
+import Darwin
+import Foundation
+
+private enum TestFailure: Error, CustomStringConvertible {
+    case message(String)
+
+    var description: String {
+        switch self {
+        case .message(let message): message
+        }
+    }
+}
+
+private func require(_ condition: @autoclosure () -> Bool, _ message: String) throws {
+    if !condition() { throw TestFailure.message(message) }
+}
+
+private func temporaryDirectory() throws -> URL {
+    let url = URL(fileURLWithPath: "/tmp", isDirectory: true)
+        .appendingPathComponent("aos-\(getpid())-\(UUID().uuidString.prefix(8))", isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
+    return url
+}
+
+private func makeListener(at path: String) throws -> Int32 {
+    let descriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+    guard descriptor >= 0 else { throw TestFailure.message("socket failed") }
+    var address = sockaddr_un()
+    address.sun_family = sa_family_t(AF_UNIX)
+    let capacity = MemoryLayout.size(ofValue: address.sun_path)
+    guard path.utf8.count < capacity else {
+        Darwin.close(descriptor)
+        throw TestFailure.message("test socket path is too long")
+    }
+    withUnsafeMutablePointer(to: &address.sun_path) { pointer in
+        pointer.withMemoryRebound(to: CChar.self, capacity: capacity) { destination in
+            path.withCString { source in _ = strncpy(destination, source, capacity - 1) }
+        }
+    }
+    let result = withUnsafePointer(to: &address) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+            Darwin.bind(descriptor, socketAddress, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    guard result == 0, Darwin.listen(descriptor, 1) == 0 else {
+        let detail = String(cString: strerror(errno))
+        Darwin.close(descriptor)
+        throw TestFailure.message("bind/listen failed: \(detail)")
+    }
+    guard chmod(path, 0o600) == 0 else {
+        Darwin.close(descriptor)
+        throw TestFailure.message("chmod socket failed")
+    }
+    return descriptor
+}
+
+private func readExact(_ descriptor: Int32, count: Int) throws -> Data {
+    var result = Data(count: count)
+    try result.withUnsafeMutableBytes { raw in
+        guard let base = raw.baseAddress else { return }
+        var received = 0
+        while received < count {
+            let amount = Darwin.read(descriptor, base.advanced(by: received), count - received)
+            guard amount > 0 else { throw TestFailure.message("unexpected socket EOF") }
+            received += amount
+        }
+    }
+    return result
+}
+
+private func readLine(_ descriptor: Int32) throws -> Data? {
+    var data = Data()
+    var byte: UInt8 = 0
+    while true {
+        let amount = Darwin.read(descriptor, &byte, 1)
+        if amount == 0 { return data.isEmpty ? nil : data }
+        guard amount > 0 else { throw TestFailure.message("socket read failed") }
+        if byte == 0x0A { return data }
+        data.append(byte)
+    }
+}
+
+private func sendAll(_ descriptor: Int32, data: Data) throws {
+    try data.withUnsafeBytes { raw in
+        guard let base = raw.baseAddress else { return }
+        var sent = 0
+        while sent < raw.count {
+            let amount = Darwin.write(descriptor, base.advanced(by: sent), raw.count - sent)
+            guard amount > 0 else { throw TestFailure.message("socket write failed") }
+            sent += amount
+        }
+    }
+}
+
+private func uint32BigEndian(_ data: Data) -> UInt32 {
+    var value: UInt32 = 0
+    _ = withUnsafeMutableBytes(of: &value) { destination in data.copyBytes(to: destination) }
+    return UInt32(bigEndian: value)
+}
+
+private func serveMockNamespace(listener: Int32, bootID: String) async throws {
+    try await Task.detached {
+        let descriptor = Darwin.accept(listener, nil, nil)
+        guard descriptor >= 0 else { throw TestFailure.message("accept failed") }
+        defer { Darwin.close(descriptor) }
+
+        let header = try readExact(descriptor, count: MemoryLayout<UInt32>.size)
+        let payload = try readExact(descriptor, count: Int(uint32BigEndian(header)))
+        let attach = try JSONSerialization.jsonObject(with: payload) as? [String: String]
+        try require(attach?["op"] == "attach", "client must send the bounded attach request first")
+
+        var paths: [UInt64: String] = [:]
+        let files: [String: Data] = [
+            "/proc/host/boot_id": Data("\(bootID)\n".utf8),
+            "/proc/host/state": Data("ready\n".utf8),
+            "/agent/root": Data("io\nmachine\nrequests\nactions\n".utf8),
+        ]
+        while let line = try readLine(descriptor) {
+            guard let envelope = try JSONSerialization.jsonObject(with: line) as? [String: Any],
+                  let tag = envelope["tag"],
+                  let request = envelope["request"] as? [String: Any],
+                  let op = request["op"] as? String
+            else { throw TestFailure.message("malformed aP request") }
+
+            let response: [String: Any]
+            switch op {
+            case "walk":
+                let fid = (request["newfid"] as? NSNumber)?.uint64Value ?? 0
+                let names = request["names"] as? [String] ?? []
+                paths[fid] = "/" + names.joined(separator: "/")
+                response = ["op": "walk", "qids": []]
+            case "open":
+                response = ["op": "open"]
+            case "read":
+                let fid = (request["fid"] as? NSNumber)?.uint64Value ?? 0
+                let offset = (request["offset"] as? NSNumber)?.uint64Value ?? 0
+                let count = (request["count"] as? NSNumber)?.uint64Value ?? 0
+                let value = files[paths[fid] ?? ""] ?? Data()
+                let start = min(Int(offset), value.count)
+                let end = min(start + Int(count), value.count)
+                response = ["op": "read", "data": [UInt8](value[start..<end])]
+            case "clunk":
+                let fid = (request["fid"] as? NSNumber)?.uint64Value ?? 0
+                paths.removeValue(forKey: fid)
+                response = ["op": "clunk"]
+            default:
+                throw TestFailure.message("unexpected aP request \(op)")
+            }
+            var encoded = try JSONSerialization.data(withJSONObject: [
+                "tag": tag,
+                "status": "ok",
+                "response": response,
+            ])
+            encoded.append(0x0A)
+            try sendAll(descriptor, data: encoded)
+        }
+    }.value
+}
+
+private func testStreamOverlapAndGap() throws {
+    var accumulator = AlanAgentStreamAccumulator(nextOffset: 5)
+    let fresh = try accumulator.accept(
+        AlanAgentStreamChunk(
+            stream: "io/output",
+            requestedOffset: 3,
+            nextOffset: 8,
+            data: Data("34567".utf8)
+        )
+    )
+    try require(String(decoding: fresh, as: UTF8.self) == "567", "overlap must be deduplicated")
+    try require(accumulator.nextOffset == 8, "caller offset must advance to the returned edge")
+
+    do {
+        _ = try accumulator.accept(
+            AlanAgentStreamChunk(
+                stream: "io/output",
+                requestedOffset: 10,
+                nextOffset: 11,
+                data: Data("x".utf8)
+            )
+        )
+        throw TestFailure.message("a discontinuous stream chunk must fail visibly")
+    } catch AlanOSAttachmentError.retentionGap(let stream, let requested, let available) {
+        try require(stream == "io/output" && requested == 8 && available == 10, "gap details must be stable")
+    }
+}
+
+private func testProtectedStatusDiscovery() throws {
+    let fileManager = FileManager.default
+    let temporary = try temporaryDirectory()
+    defer { try? fileManager.removeItem(at: temporary) }
+    let runtimeRoot = temporary.appendingPathComponent("alan-os-\(getuid())", isDirectory: true)
+    let paths = AlanOSHostEndpointPaths(
+        channel: .dev,
+        fileManager: fileManager,
+        runtimeRoot: runtimeRoot
+    )
+    try fileManager.createDirectory(at: paths.root, withIntermediateDirectories: true)
+    for directory in [runtimeRoot, paths.productRoot, paths.root] {
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+    }
+    let listener = try makeListener(at: paths.socket.path)
+    defer { Darwin.close(listener) }
+    let status = AlanOSHostStatus(
+        version: 1,
+        channelID: "dev",
+        bootID: UUID().uuidString.lowercased(),
+        pid: UInt32(getpid()),
+        readiness: "ready",
+        socket: paths.socket.path
+    )
+    try JSONEncoder().encode(status).write(to: paths.status)
+    try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: paths.status.path)
+    let discovered = try paths.readStatus()
+    try require(discovered == status, "protected status must resolve the matching endpoint")
+
+    let target = paths.root.appendingPathComponent("redirected-status.json")
+    try fileManager.moveItem(at: paths.status, to: target)
+    try fileManager.createSymbolicLink(at: paths.status, withDestinationURL: target)
+    do {
+        _ = try paths.readStatus()
+        throw TestFailure.message("status discovery must reject symlink redirection")
+    } catch is AlanOSAttachmentError {
+        // Expected.
+    }
+}
+
+private func testAPAttachAndNamespaceValidation() async throws {
+    let fileManager = FileManager.default
+    let temporary = try temporaryDirectory()
+    defer { try? fileManager.removeItem(at: temporary) }
+    let socket = temporary.appendingPathComponent("namespace.ap.sock")
+    let listener = try makeListener(at: socket.path)
+    let bootID = UUID().uuidString.lowercased()
+    let status = AlanOSHostStatus(
+        version: 1,
+        channelID: "dev",
+        bootID: bootID,
+        pid: UInt32(getpid()),
+        readiness: "ready",
+        socket: socket.path
+    )
+
+    async let server: Void = serveMockNamespace(listener: listener, bootID: bootID)
+    let session = try await AlanOSAttachmentSession.connect(status: status, channel: .dev)
+    let published = try await session.cat("/proc/host/boot_id")
+    try require(String(decoding: published, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines) == bootID, "aP client must read the attached namespace")
+    await session.detach()
+    try await server
+    Darwin.close(listener)
+}
+
+@main
+private enum AlanOSAttachmentTests {
+    static func main() async throws {
+        try testStreamOverlapAndGap()
+        try testProtectedStatusDiscovery()
+        try await testAPAttachAndNamespaceValidation()
+        print("Alan OS attachment tests passed.")
+    }
+}

--- a/clients/apple/scripts/test-shell-ui-smoke.sh
+++ b/clients/apple/scripts/test-shell-ui-smoke.sh
@@ -987,7 +987,7 @@ run_restart_restore_step() {
 
     wait_for_file "$pwd_file" "restart restore cwd proof file"
     cwd_result=$(cat "$pwd_file")
-    [[ "$cwd_result" == "$RESTART_RESTORE_CWD" ]] \
+    [[ "$cwd_result" == "$RESTART_RESTORE_CWD" || "$cwd_result" -ef "$RESTART_RESTORE_CWD" ]] \
         || fail "restored terminal cwd mismatch: expected $RESTART_RESTORE_CWD, got ${cwd_result:-<empty>}"
 
     append_manifest "restart_restore_after_input=$after_token"

--- a/clients/apple/scripts/test-shell-workspace-manifest.swift
+++ b/clients/apple/scripts/test-shell-workspace-manifest.swift
@@ -64,12 +64,100 @@ private enum ShellWorkspaceManifestTests {
         try verifiesMaterializerPreservesEmptySelectedSpaceWithOtherTabs()
         try verifiesMaterializerPreservesInactiveSpaceSelection()
         try verifiesShellCoreFFIMaterializerPreservesPayloadProfileAndTranscript()
+        try verifiesAgentAttachmentsRoundTripWithoutRuntimeAuthority()
         try verifiesManifestRoundTripPreservesSpaceLocalSelection()
         try verifiesPinnedSnapshotWinsOverLaterLiveSnapshot()
         try verifiesPinnedSplitSnapshotRestoresSplitTree()
         try verifiesUnpinnedTabPruningUsesTtlAndActiveTask()
         try verifiesSelectedTabPruningCanLeaveSelectedSpaceEmpty()
         print("Shell workspace manifest tests passed.")
+    }
+
+    private static func verifiesAgentAttachmentsRoundTripWithoutRuntimeAuthority() throws {
+        var manifest = try defaultManifestWithShellCore(
+            windowID: "window_agent",
+            defaultWorkingDirectory: "/unused",
+            now: referenceDate
+        )
+        let reference = AlanOSProcessReference(bootID: "boot-live", pid: 42)
+        let first = AlanAgentAttachment(
+            process: reference,
+            offsets: AlanAgentStreamOffsets(output: 10, requests: 20, actions: 30, ui: 40),
+            presentation: .default
+        )
+        let second = AlanAgentAttachment(
+            process: reference,
+            offsets: AlanAgentStreamOffsets(output: 100, requests: 200, actions: 300, ui: 400),
+            presentation: AlanAgentContentPresentation(followsOutput: false)
+        )
+        let snapshot = ShellContentTabRestoreSnapshot(
+            paneTree: ShellPaneSlotTreeNode(
+                nodeID: "node_agent_split",
+                kind: .split,
+                direction: .vertical,
+                paneSlotID: nil,
+                children: [
+                    ShellPaneSlotTreeNode(
+                        nodeID: "node_agent_left",
+                        kind: .pane,
+                        direction: nil,
+                        paneSlotID: "pane_agent_left",
+                        children: nil
+                    ),
+                    ShellPaneSlotTreeNode(
+                        nodeID: "node_agent_right",
+                        kind: .pane,
+                        direction: nil,
+                        paneSlotID: "pane_agent_right",
+                        children: nil
+                    ),
+                ]
+            ),
+            paneSlots: [
+                ShellPaneSlotRestoreRecord(
+                    paneSlotID: "pane_agent_left",
+                    contentID: "content_agent_left"
+                ),
+                ShellPaneSlotRestoreRecord(
+                    paneSlotID: "pane_agent_right",
+                    contentID: "content_agent_right"
+                ),
+            ],
+            contents: [
+                ShellContentRestoreRecord(
+                    contentID: "content_agent_left",
+                    kind: .agent,
+                    title: "Agent 42",
+                    payload: .agent(first)
+                ),
+                ShellContentRestoreRecord(
+                    contentID: "content_agent_right",
+                    kind: .agent,
+                    title: "Agent 42 detail",
+                    payload: .agent(second)
+                ),
+            ]
+        )
+        manifest.spaces[0].tabs[0].liveSnapshot = snapshot
+
+        let encoded = try JSONEncoder().encode(manifest)
+        let text = String(decoding: encoded, as: UTF8.self)
+        for forbidden in ["tape", "provider", "tool_state", "socket_path", "host_path", "secret"] {
+            expect(!text.contains(forbidden), "Agent manifest must not persist \(forbidden)")
+        }
+
+        let state = try materializeManifestWithShellCore(
+            manifest: manifest,
+            defaultWorkingDirectory: "/fallback",
+            now: referenceDate
+        )
+        let attachments = (state.contents ?? []).compactMap { $0.payload.agent }
+        expect(attachments.count == 2, "two Agent renderers must restore independently")
+        expect(attachments.allSatisfy { $0.process == reference }, "duplicate views must share Process Reference")
+        expect(
+            Set(attachments.map { $0.offsets.output }) == Set([10, 100]),
+            "duplicate views must retain independent caller offsets"
+        )
     }
 
     private static func verifiesMissingManifestCreatesCurrentDefault() throws {

--- a/crates/agent-engine/src/connections.rs
+++ b/crates/agent-engine/src/connections.rs
@@ -128,9 +128,20 @@ pub struct ProviderDescriptor {
     pub default_settings: &'static [(&'static str, &'static str)],
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SecretStore {
     credentials_dir: PathBuf,
+    resolved_secrets: BTreeMap<String, String>,
+}
+
+impl std::fmt::Debug for SecretStore {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SecretStore")
+            .field("credentials_dir", &self.credentials_dir)
+            .field("resolved_secret_count", &self.resolved_secrets.len())
+            .finish()
+    }
 }
 
 impl SecretStore {
@@ -138,17 +149,36 @@ impl SecretStore {
         validate_safe_absolute_path("Host credential directory", credentials_dir)?;
         Ok(Self {
             credentials_dir: credentials_dir.to_path_buf(),
+            resolved_secrets: BTreeMap::new(),
         })
     }
+
+    pub fn with_resolved_secret(
+        credentials_dir: &Path,
+        credential_id: &str,
+        secret: String,
+    ) -> anyhow::Result<Self> {
+        let mut store = Self::from_directory(credentials_dir)?;
+        let credential_id = validated_identifier_component("credential id", credential_id)?;
+        store
+            .resolved_secrets
+            .insert(credential_id.to_string(), secret);
+        Ok(store)
+    }
+
     #[cfg(test)]
     pub fn new(root_dir: PathBuf) -> Self {
         Self {
             credentials_dir: root_dir,
+            resolved_secrets: BTreeMap::new(),
         }
     }
 
     pub fn load(&self, credential_id: &str) -> anyhow::Result<Option<String>> {
         let credential_id = validated_identifier_component("credential id", credential_id)?;
+        if let Some(secret) = self.resolved_secrets.get(credential_id) {
+            return Ok(Some(secret.clone()));
+        }
         let secrets = self.read_secret_file()?;
         Ok(secrets.secrets.get(credential_id).cloned())
     }
@@ -824,6 +854,21 @@ mod tests {
         assert_eq!(store.load("kimi").unwrap().as_deref(), Some("sk-test"));
         assert!(store.delete("kimi").unwrap());
         assert_eq!(store.load("kimi").unwrap(), None);
+    }
+
+    #[test]
+    fn secret_store_accepts_one_host_resolved_secret_without_platform_logic() {
+        let temp = TempDir::new().unwrap();
+        let store =
+            SecretStore::with_resolved_secret(temp.path(), "native", "host-secret".to_string())
+                .unwrap();
+
+        assert_eq!(
+            store.load("native").unwrap().as_deref(),
+            Some("host-secret")
+        );
+        assert_eq!(store.load("missing").unwrap(), None);
+        assert!(!format!("{store:?}").contains("host-secret"));
     }
 
     #[test]

--- a/crates/alan/src/cli/connection.rs
+++ b/crates/alan/src/cli/connection.rs
@@ -19,6 +19,10 @@ use std::{
     time::Duration,
 };
 
+/// Existing Connection Service request selected by a native renderer adapter.
+/// The value is an opaque request id, never credential material.
+pub const NATIVE_CONNECTION_REQUEST_ENV: &str = "ALAN_NATIVE_CONNECTION_REQUEST_ID";
+
 struct ConnectionStores {
     bindings: ConnectionStoreBindings,
     managed_auth: PathBuf,
@@ -71,6 +75,30 @@ async fn request_native(
     profile_id: &str,
     action: &str,
 ) -> Result<String> {
+    if let Some(request_id) = std::env::var_os(NATIVE_CONNECTION_REQUEST_ENV) {
+        let request_id = request_id
+            .into_string()
+            .map_err(|_| anyhow::anyhow!("native Connection request id is not UTF-8"))?;
+        let requests: serde_json::Value = serde_json::from_slice(
+            &stores
+                .shell
+                .cat("/mnt/connections/native-requests")
+                .await
+                .map_err(|error| anyhow::anyhow!("read native Connection requests: {error}"))?,
+        )?;
+        let request = requests
+            .get(&request_id)
+            .context("native Connection request is no longer pending")?;
+        anyhow::ensure!(
+            request
+                .get("profile_id")
+                .and_then(serde_json::Value::as_str)
+                == Some(profile_id)
+                && request.get("action").and_then(serde_json::Value::as_str) == Some(action),
+            "native Connection request does not match the requested profile/action"
+        );
+        return Ok(request_id);
+    }
     let request_id = format!("cli-{}", uuid::Uuid::new_v4().simple());
     let command = serde_json::json!({
         "op": "request_native",

--- a/crates/os-host/src/boot.rs
+++ b/crates/os-host/src/boot.rs
@@ -21,7 +21,48 @@ pub struct HostBootConfig(ServiceManagerConfig);
 #[derive(Debug)]
 struct ProductLlmClientFactory {
     credentials_dir: std::path::PathBuf,
+    keychain_service: Option<String>,
     managed_auth: Option<std::path::PathBuf>,
+}
+
+#[cfg(target_os = "macos")]
+fn load_macos_keychain_secret(service: &str, credential_id: &str) -> Result<Option<String>> {
+    let output = std::process::Command::new("/usr/bin/security")
+        .args([
+            "find-generic-password",
+            "-s",
+            service,
+            "-a",
+            credential_id,
+            "-w",
+        ])
+        .output()
+        .context("read macOS Keychain credential")?;
+    if !output.status.success() {
+        let detail = String::from_utf8_lossy(&output.stderr);
+        if detail.contains("could not be found") {
+            return Ok(None);
+        }
+        bail!(
+            "macOS Keychain rejected credential lookup: {}",
+            detail.trim()
+        );
+    }
+    let secret = String::from_utf8(output.stdout)
+        .context("macOS Keychain credential is not UTF-8")?
+        .trim_end_matches(['\r', '\n'])
+        .to_string();
+    Ok((!secret.is_empty()).then_some(secret))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn load_macos_keychain_secret(_service: &str, _credential_id: &str) -> Result<Option<String>> {
+    Ok(None)
+}
+
+#[cfg(target_os = "macos")]
+fn macos_keychain_service(channel_id: &str) -> String {
+    format!("app.alanworks.macos.{channel_id}.connections")
 }
 
 struct UnconfiguredLlmProvider;
@@ -59,9 +100,26 @@ impl LlmClientFactory for ProductLlmClientFactory {
             return Ok(LlmClient::new(UnconfiguredLlmProvider));
         };
         let mut core_config = base_config.clone();
+        let resolved = connections.resolve_profile(Some(selected_profile))?;
+        let secret_store = match (
+            self.keychain_service.as_deref(),
+            resolved.credential_id.as_deref(),
+        ) {
+            (Some(service), Some(credential_id)) => {
+                match load_macos_keychain_secret(service, credential_id)? {
+                    Some(secret) => SecretStore::with_resolved_secret(
+                        &self.credentials_dir,
+                        credential_id,
+                        secret,
+                    )?,
+                    None => SecretStore::from_directory(&self.credentials_dir)?,
+                }
+            }
+            _ => SecretStore::from_directory(&self.credentials_dir)?,
+        };
         connections.apply_profile_to_config(
             Some(selected_profile),
-            &SecretStore::from_directory(&self.credentials_dir)?,
+            &secret_store,
             &mut core_config,
         )?;
         LlmClient::from_core_config_with_chatgpt_auth_storage_path(
@@ -130,6 +188,16 @@ impl HostBootConfig {
         let tools = ToolRegistry::with_config(Arc::new(process.agent_config.core_config.clone()));
         let llm_factory = Arc::new(ProductLlmClientFactory {
             credentials_dir: connection_store.credentials_dir.clone(),
+            keychain_service: {
+                #[cfg(target_os = "macos")]
+                {
+                    Some(macos_keychain_service(channel_id))
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    None
+                }
+            },
             managed_auth: Some(host_store.managed_auth),
         });
 
@@ -173,6 +241,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let factory = ProductLlmClientFactory {
             credentials_dir: temp.path().to_path_buf(),
+            keychain_service: None,
             managed_auth: None,
         };
 
@@ -184,6 +253,19 @@ mod tests {
         assert_eq!(
             client.chat(None, "hello").await.unwrap_err().to_string(),
             "no Connection Service profile selected"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn keychain_adapter_is_channel_isolated() {
+        assert_eq!(
+            macos_keychain_service("stable"),
+            "app.alanworks.macos.stable.connections"
+        );
+        assert_eq!(
+            macos_keychain_service("dev"),
+            "app.alanworks.macos.dev.connections"
         );
     }
 }

--- a/crates/os-host/src/local.rs
+++ b/crates/os-host/src/local.rs
@@ -258,7 +258,7 @@ impl AlanOsHost {
                                     &host_mount,
                                     &request_id,
                                     &host_path,
-                                    "cli",
+                                    "native-command-plane",
                                     "local-user",
                                 );
                                 write_local_response(

--- a/crates/service-manager/Cargo.toml
+++ b/crates/service-manager/Cargo.toml
@@ -22,6 +22,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 toml = "1.1"
+tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/crates/service-manager/src/connection.rs
+++ b/crates/service-manager/src/connection.rs
@@ -199,8 +199,7 @@ impl ConnectionService {
         llmfs: Arc<alan_llmfs::LlmFs>,
         factory: Arc<dyn LlmClientFactory>,
         base_config: Config,
-        bootstrap_name: String,
-        bootstrap_client: LlmClient,
+        bootstrap: Option<(String, LlmClient)>,
     ) -> Result<()> {
         let mut callables = self.callables.lock().await;
         ensure!(callables.is_none(), "callable registry is already attached");
@@ -208,7 +207,7 @@ impl ConnectionService {
             llmfs,
             factory,
             base_config,
-            bootstrap: Some((bootstrap_name, bootstrap_client)),
+            bootstrap,
             published_profiles: BTreeMap::new(),
             published_fallbacks: BTreeSet::new(),
             published_default: None,
@@ -867,8 +866,10 @@ mod tests {
                 llmfs.clone(),
                 factory.clone(),
                 Config::default(),
-                "default".to_string(),
-                LlmClient::new(MockLlmProvider::new()),
+                Some((
+                    "default".to_string(),
+                    LlmClient::new(MockLlmProvider::new()),
+                )),
             )
             .await
             .unwrap();
@@ -1011,6 +1012,37 @@ mod tests {
         );
         assert!(
             !callable
+                .ls("/connections")
+                .await
+                .unwrap()
+                .contains(&"broken".to_string())
+        );
+
+        control
+            .write(
+                "/ctl",
+                br#"{"op":"request_native","request":{"id":"repair-1","profile_id":"broken","action":"secret_entry"}}"#,
+            )
+            .await
+            .unwrap();
+        factory.unavailable.lock().unwrap().remove("broken");
+        control
+            .write(
+                "/native-responses",
+                &serde_json::to_vec(&NativeConnectionResponse {
+                    request_id: "repair-1".to_string(),
+                    opaque_credential_ref: Some("host-keychain:broken".to_string()),
+                    status: "ready".to_string(),
+                })
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        let validation: BTreeMap<String, String> =
+            serde_json::from_slice(&control.cat("/validation").await.unwrap()).unwrap();
+        assert_eq!(validation.get("broken").map(String::as_str), Some("ready"));
+        assert!(
+            callable
                 .ls("/connections")
                 .await
                 .unwrap()

--- a/crates/service-manager/src/runtime.rs
+++ b/crates/service-manager/src/runtime.rs
@@ -7,7 +7,8 @@ use std::time::{Duration, Instant};
 
 use alan_agent_engine::{
     AgentProcessConfig, ConnectionsFile, LlmClient, ProcessLaunchContext, RuntimeController,
-    ToolRegistry, configure_runtime_tool_execution_binding, spawn_with_namespace_environment,
+    ToolRegistry, configure_runtime_tool_execution_binding, provider_capabilities_for_config,
+    spawn_with_namespace_environment,
 };
 use alan_ap::{Fid, FileServer, InProcessTransport, OpenMode};
 use alan_kernel::{Access, Credentials, LiveNamespace, Namespace, Pid, Status};
@@ -190,11 +191,26 @@ impl ServiceManager {
         config
             .tools
             .set_config(Arc::new(config.process.agent_config.core_config.clone()));
-        let llm_client =
-            config
-                .llm_factory
-                .create(&connection_base_config, selected_profile, &connections)?;
-        let generation_capabilities = llm_client.capabilities();
+        let bootstrap = match config.llm_factory.create(
+            &connection_base_config,
+            selected_profile,
+            &connections,
+        ) {
+            Ok(client) => Some((llm_connection.clone(), client)),
+            Err(_) => {
+                tracing::warn!(
+                    profile_id = %llm_connection,
+                    "LLM connection is unavailable during boot; Alan OS will continue without a callable provider"
+                );
+                None
+            }
+        };
+        let generation_capabilities = bootstrap
+            .as_ref()
+            .map(|(_, client)| client.capabilities())
+            .unwrap_or_else(|| {
+                provider_capabilities_for_config(&config.process.agent_config.core_config)
+            });
         let host_capabilities = alan_agent_engine::skills::build_skill_host_capabilities(
             config.tools.list_tools().into_iter().map(str::to_string),
             true,
@@ -204,7 +220,7 @@ impl ServiceManager {
             manifest,
             connection_service,
             llm_connection,
-            llm_client,
+            bootstrap,
             llm_factory: config.llm_factory.clone(),
             connection_base_config,
             host_mount_adapter: config.host_mount_adapter.clone(),
@@ -396,7 +412,7 @@ struct AssembleInputs<'a> {
     manifest: BootManifest,
     connection_service: Arc<ConnectionService>,
     llm_connection: String,
-    llm_client: LlmClient,
+    bootstrap: Option<(String, LlmClient)>,
     llm_factory: Arc<dyn LlmClientFactory>,
     connection_base_config: alan_agent_engine::Config,
     host_mount_adapter: Arc<dyn HostMountExportAdapter>,
@@ -801,7 +817,7 @@ async fn assemble_environment(inputs: AssembleInputs<'_>) -> Result<AssembledEnv
         manifest,
         connection_service,
         llm_connection,
-        llm_client,
+        bootstrap,
         llm_factory,
         connection_base_config,
         host_mount_adapter,
@@ -815,8 +831,7 @@ async fn assemble_environment(inputs: AssembleInputs<'_>) -> Result<AssembledEnv
             llmfs.clone(),
             llm_factory,
             connection_base_config,
-            llm_connection.clone(),
-            llm_client,
+            bootstrap,
         )
         .await?;
     let routefs = Arc::new(alan_routefs::RouteFs::new());
@@ -1430,7 +1445,87 @@ async fn verify_readiness(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alan_agent_engine::{
+        ConnectionCredential, ConnectionProfile, ConnectionStoreBindings, CredentialKind,
+        LlmProvider as ConnectionProvider,
+    };
     use alan_llm::MockLlmProvider;
+
+    #[derive(Debug)]
+    struct MissingSecretFactory;
+
+    impl LlmClientFactory for MissingSecretFactory {
+        fn create(
+            &self,
+            _base_config: &alan_agent_engine::Config,
+            _selected_profile: Option<&str>,
+            _connections: &ConnectionsFile,
+        ) -> Result<LlmClient> {
+            anyhow::bail!("selected profile is missing a secret")
+        }
+    }
+
+    #[tokio::test]
+    async fn unavailable_default_connection_does_not_prevent_system_boot() {
+        let temp = tempfile::tempdir().unwrap();
+        let metadata = temp.path().join("connections.toml");
+        let credential_id = "missing-secret".to_string();
+        let profile_id = "default-profile".to_string();
+        let now = chrono::Utc::now();
+        let connections = ConnectionsFile {
+            version: 1,
+            default_profile: Some(profile_id.clone()),
+            credentials: [(
+                credential_id.clone(),
+                ConnectionCredential {
+                    kind: CredentialKind::SecretString,
+                    provider_family: ConnectionProvider::OpenAiResponses,
+                    label: "Missing secret".to_string(),
+                    backend: "host_credential_store".to_string(),
+                },
+            )]
+            .into_iter()
+            .collect(),
+            profiles: [(
+                profile_id.clone(),
+                ConnectionProfile {
+                    provider: ConnectionProvider::OpenAiResponses,
+                    label: None,
+                    credential_id: Some(credential_id),
+                    created_at: now,
+                    updated_at: now,
+                    source: "managed".to_string(),
+                    settings: BTreeMap::new(),
+                },
+            )]
+            .into_iter()
+            .collect(),
+        };
+        connections.save_to_path(&metadata).unwrap();
+
+        let mut config = ServiceManagerConfig::ephemeral(
+            "test",
+            AgentProcessConfig::default(),
+            LlmClient::new(MockLlmProvider::new()),
+            ToolRegistry::new(),
+        );
+        config.connection_store =
+            Some(ConnectionStoreBindings::new(metadata, temp.path().join("credentials")).unwrap());
+        config.llm_factory = Arc::new(MissingSecretFactory);
+
+        let manager = ServiceManager::boot(config).await.unwrap();
+        let (_, _, namespace) = manager.local_entry().create_and_handoff().await.unwrap();
+        let shell = alan_shell::Shell::new(InProcessTransport::new(namespace));
+        let status =
+            String::from_utf8(shell.cat("/mnt/connections/status").await.unwrap()).unwrap();
+        assert!(status.contains("ready=0") && status.contains("unavailable=1"));
+        assert_eq!(
+            shell.cat("/mnt/connections/validation").await.unwrap(),
+            br#"{"default-profile":"unavailable"}"#
+        );
+        assert_eq!(shell.cat(BOOT_STATE_PATH).await.unwrap(), b"ready\n");
+        manager.shutdown().await.unwrap();
+    }
 
     #[tokio::test]
     async fn root_agent_is_replaced_without_pid_continuity() {

--- a/crates/shell-core/src/lib.rs
+++ b/crates/shell-core/src/lib.rs
@@ -38,6 +38,7 @@ pub use manifest::{
     ShellContentWorkspaceSpaceRecord, ShellContentWorkspaceTabRecord, ShellPaneSlotRestoreRecord,
 };
 pub use model::{
+    AgentAttachment, AgentContentPresentation, AgentProcessReference, AgentStreamOffsets,
     ContentCapability, ContentInstance, ContentKind, ContentLifecycleState, PaneSlot, PaneTreeKind,
     PaneTreeNode, PaneTreeNodeResizeOutcome, PaneTreeNodeResizeResult, ShellAttentionState,
     ShellContentPayload, ShellLaunchTarget, ShellTabActiveTaskState, ShellTerminalContentPayload,

--- a/crates/shell-core/src/manifest.rs
+++ b/crates/shell-core/src/manifest.rs
@@ -536,6 +536,7 @@ fn restored_content_instance(
             ContentKind::Terminal => ContentKind::Terminal.default_capabilities(),
             ContentKind::Markdown => vec![ContentCapability::MarkdownReadOnlyViewer],
             ContentKind::Settings => vec![ContentCapability::SettingsSurface],
+            ContentKind::Agent => ContentKind::Agent.default_capabilities(),
         },
         payload,
         terminal_metadata,

--- a/crates/shell-core/src/model.rs
+++ b/crates/shell-core/src/model.rs
@@ -224,8 +224,64 @@ pub struct ShellTerminalContentPayload {
     pub terminal_profile_id: Option<String>,
 }
 
+/// Stable identity of one Alan OS Process within a single Host boot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentProcessReference {
+    /// Alan OS Host boot identity.
+    pub boot_id: String,
+    /// Kernel Process identifier.
+    pub pid: u64,
+}
+
+/// Renderer-owned byte offsets for AgentFS streams.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentStreamOffsets {
+    /// `/agent/<pid>/io/output` offset.
+    pub output: u64,
+    /// `/agent/<pid>/requests/events` offset.
+    pub requests: u64,
+    /// `/agent/<pid>/actions/events` offset.
+    pub actions: u64,
+    /// `/agent/<pid>/machine/ui/events` offset.
+    pub ui: u64,
+}
+
+/// Host-owned presentation preferences for an Agent ContentInstance.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentContentPresentation {
+    /// Whether a live renderer follows newly appended output.
+    #[serde(default)]
+    pub follows_output: bool,
+}
+
+impl Default for AgentContentPresentation {
+    fn default() -> Self {
+        Self {
+            follows_output: true,
+        }
+    }
+}
+
+/// Narrow persisted attachment to an Agent Process.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentAttachment {
+    /// Process identity validated through `/proc` before AgentFS access.
+    pub process: AgentProcessReference,
+    /// Independent caller-held stream positions.
+    #[serde(default)]
+    pub offsets: AgentStreamOffsets,
+    /// Host presentation only; never Agent Machine state.
+    #[serde(default)]
+    pub presentation: AgentContentPresentation,
+}
+
 /// Portable content restore payload.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ShellContentPayload {
     /// Terminal payload.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -236,6 +292,9 @@ pub struct ShellContentPayload {
     /// Settings payload, preserved opaquely by shell core.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub settings: Option<Value>,
+    /// Agent Process attachment reference and renderer-owned offsets.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent: Option<AgentAttachment>,
 }
 
 impl ShellContentPayload {
@@ -264,12 +323,16 @@ impl ShellContentPayload {
             }),
             markdown: None,
             settings: None,
+            agent: None,
         }
     }
 
     /// Returns whether the payload carries no restorable content-specific data.
     pub fn is_empty(&self) -> bool {
-        self.terminal.is_none() && self.markdown.is_none() && self.settings.is_none()
+        self.terminal.is_none()
+            && self.markdown.is_none()
+            && self.settings.is_none()
+            && self.agent.is_none()
     }
 }
 
@@ -311,6 +374,8 @@ pub enum ContentKind {
     Markdown,
     /// Settings surface content.
     Settings,
+    /// File-backed Agent Process renderer.
+    Agent,
 }
 
 impl ContentKind {
@@ -325,6 +390,12 @@ impl ContentKind {
             ],
             ContentKind::Markdown => vec![ContentCapability::MarkdownReadOnlyViewer],
             ContentKind::Settings => vec![ContentCapability::SettingsSurface],
+            ContentKind::Agent => vec![
+                ContentCapability::AgentInput,
+                ContentCapability::AgentRequestResponse,
+                ContentCapability::AgentMachineControl,
+                ContentCapability::AgentStopProcess,
+            ],
         }
     }
 }
@@ -345,6 +416,14 @@ pub enum ContentCapability {
     MarkdownReadOnlyViewer,
     /// Settings content renders a settings surface.
     SettingsSurface,
+    /// AgentFS input writes.
+    AgentInput,
+    /// AgentFS request response writes.
+    AgentRequestResponse,
+    /// Agent Machine control and interrupt writes.
+    AgentMachineControl,
+    /// Explicit `/proc/<pid>/ctl` stop action.
+    AgentStopProcess,
 }
 
 /// Portable content lifecycle state.

--- a/crates/shell-core/src/reducer.rs
+++ b/crates/shell-core/src/reducer.rs
@@ -1,8 +1,9 @@
 use crate::{
-    ContentInstance, ContentKind, ContentLifecycleState, PaneSlot, PaneTreeNode,
-    PaneTreeNodeResizeOutcome, ShellAttentionState, ShellContentPayload, ShellLaunchTarget,
-    ShellTabActiveTaskState, Space, SpatialFocusDirection, SplitDirection, SplitPlacement, Tab,
-    TabKind, TabOrganizationSection, TerminalActivitySnapshot, WorkspaceState,
+    AgentContentPresentation, AgentStreamOffsets, ContentInstance, ContentKind,
+    ContentLifecycleState, PaneSlot, PaneTreeNode, PaneTreeNodeResizeOutcome, ShellAttentionState,
+    ShellContentPayload, ShellLaunchTarget, ShellTabActiveTaskState, Space, SpatialFocusDirection,
+    SplitDirection, SplitPlacement, Tab, TabKind, TabOrganizationSection, TerminalActivitySnapshot,
+    WorkspaceState,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
@@ -262,6 +263,15 @@ pub enum ReducerOperation {
         /// Optional activity snapshot.
         activity: Option<TerminalActivitySnapshot>,
     },
+    /// Persist renderer-owned progress for one mounted Agent ContentInstance.
+    UpdateAgentRendererState {
+        /// Pane slot mounting the Agent ContentInstance.
+        pane_slot_id: String,
+        /// Caller-owned AgentFS stream offsets.
+        offsets: AgentStreamOffsets,
+        /// Host presentation only; never Agent Machine state.
+        presentation: AgentContentPresentation,
+    },
     /// Apply an agent activity snapshot to a pane's mounted terminal content.
     ApplyAgentActivity {
         /// Target pane slot id.
@@ -483,6 +493,13 @@ pub enum DomainEvent {
     },
     /// Agent activity metadata changed.
     AgentActivityUpdated {
+        /// Pane slot id.
+        pane_slot_id: String,
+        /// Content id.
+        content_id: String,
+    },
+    /// An Agent renderer advanced its caller-owned offsets or presentation.
+    AgentRendererStateUpdated {
         /// Pane slot id.
         pane_slot_id: String,
         /// Content id.
@@ -741,6 +758,11 @@ impl WorkspaceReducer {
                 active_task_state,
                 activity,
             )?,
+            ReducerOperation::UpdateAgentRendererState {
+                pane_slot_id,
+                offsets,
+                presentation,
+            } => self.update_agent_renderer_state(&pane_slot_id, offsets, presentation)?,
             ReducerOperation::ApplyAgentActivity {
                 pane_slot_id,
                 activity,
@@ -2056,6 +2078,52 @@ impl WorkspaceReducer {
         Ok(())
     }
 
+    fn update_agent_renderer_state(
+        &mut self,
+        pane_slot_id: &str,
+        offsets: AgentStreamOffsets,
+        presentation: AgentContentPresentation,
+    ) -> Result<(), ReducerError> {
+        let slot = self.require_pane_slot(pane_slot_id)?.clone();
+        let content = self
+            .state
+            .contents
+            .iter_mut()
+            .find(|content| content.content_id == slot.content_id)
+            .ok_or_else(|| {
+                ReducerError::new(
+                    ReducerErrorCode::UnsupportedContent,
+                    "pane does not mount an Agent ContentInstance",
+                )
+            })?;
+        if content.kind != ContentKind::Agent {
+            return Err(ReducerError::new(
+                ReducerErrorCode::UnsupportedContent,
+                "renderer offsets belong only to Agent content",
+            ));
+        }
+        let attachment = content.payload.agent.as_mut().ok_or_else(|| {
+            ReducerError::new(
+                ReducerErrorCode::UnsupportedContent,
+                "Agent content has no Process Reference",
+            )
+        })?;
+        if attachment.offsets == offsets && attachment.presentation == presentation {
+            return Ok(());
+        }
+        attachment.offsets = offsets;
+        attachment.presentation = presentation;
+        self.changed_ids
+            .updated_content_ids
+            .push(content.content_id.clone());
+        self.domain_events
+            .push(DomainEvent::AgentRendererStateUpdated {
+                pane_slot_id: pane_slot_id.to_string(),
+                content_id: content.content_id.clone(),
+            });
+        Ok(())
+    }
+
     fn apply_agent_activity(
         &mut self,
         pane_slot_id: &str,
@@ -2503,6 +2571,7 @@ fn content_id_for_mount(kind: ContentKind, pane_slot_id: &str) -> String {
         ContentKind::Terminal => terminal_content_id(pane_slot_id),
         ContentKind::Markdown => format!("content_markdown_{pane_slot_id}"),
         ContentKind::Settings => SETTINGS_CONTENT_ID.to_string(),
+        ContentKind::Agent => format!("content_agent_{pane_slot_id}"),
     }
 }
 

--- a/crates/shell-core/tests/manifest_contract.rs
+++ b/crates/shell-core/tests/manifest_contract.rs
@@ -1,12 +1,80 @@
 use alan_shell_core::{
+    AgentAttachment, AgentContentPresentation, AgentProcessReference, AgentStreamOffsets,
     ContentKind, PaneTreeNode, ShellContentPayload, ShellContentRestoreRecord,
     ShellContentTabRestoreSnapshot, ShellContentWorkspaceManifest,
     ShellContentWorkspaceSpaceRecord, ShellContentWorkspaceTabRecord, ShellLaunchTarget,
     ShellPaneSlotRestoreRecord, ShellTabActiveTaskState, TabKind,
 };
 use chrono::{DateTime, Utc};
+use serde_json::json;
 
 const REFERENCE_TIME: &str = "2027-01-15T08:00:00Z";
+
+#[test]
+fn agent_attachment_persists_only_reference_offsets_and_presentation() {
+    let payload = ShellContentPayload {
+        agent: Some(AgentAttachment {
+            process: AgentProcessReference {
+                boot_id: "boot-a".to_string(),
+                pid: 42,
+            },
+            offsets: AgentStreamOffsets {
+                output: 10,
+                requests: 20,
+                actions: 30,
+                ui: 40,
+            },
+            presentation: AgentContentPresentation {
+                follows_output: true,
+            },
+        }),
+        ..Default::default()
+    };
+
+    let encoded = serde_json::to_value(&payload).unwrap();
+    assert_eq!(
+        encoded,
+        json!({
+            "agent": {
+                "process": { "boot_id": "boot-a", "pid": 42 },
+                "offsets": { "output": 10, "requests": 20, "actions": 30, "ui": 40 },
+                "presentation": { "follows_output": true }
+            }
+        })
+    );
+    let text = encoded.to_string();
+    for forbidden in [
+        "tape",
+        "machine",
+        "provider",
+        "tool",
+        "socket",
+        "host_path",
+        "secret",
+    ] {
+        assert!(
+            !text.contains(forbidden),
+            "manifest leaked forbidden Agent state: {forbidden}"
+        );
+    }
+
+    let forbidden_agent_state = json!({
+        "agent": {
+            "process": { "boot_id": "boot-a", "pid": 42 },
+            "offsets": { "output": 0, "requests": 0, "actions": 0, "ui": 0 },
+            "presentation": { "follows_output": true },
+            "tape": ["must not persist"]
+        }
+    });
+    assert!(serde_json::from_value::<ShellContentPayload>(forbidden_agent_state).is_err());
+    assert!(
+        serde_json::from_value::<ShellContentPayload>(json!({
+            "agent": null,
+            "socket": "/tmp/authority.sock"
+        }))
+        .is_err()
+    );
+}
 
 #[test]
 fn default_manifest_materializes_single_terminal_workspace() {

--- a/crates/shell-core/tests/reducer_contract.rs
+++ b/crates/shell-core/tests/reducer_contract.rs
@@ -1,4 +1,5 @@
 use alan_shell_core::{
+    AgentAttachment, AgentContentPresentation, AgentProcessReference, AgentStreamOffsets,
     ContentInstance, ContentKind, ContentLifecycleState, ManifestSyncHint, PaneSlot, PaneTreeNode,
     ReducerErrorCode, ReducerOperation, RuntimeIntent, ShellAttentionState, ShellContentPayload,
     ShellLaunchTarget, ShellTabActiveTaskState, Space, SplitDirection, SplitPlacement, Tab,
@@ -574,6 +575,7 @@ fn content_reducers_open_split_and_focus_existing_settings_content() {
                     "title": "Guide.md"
                 })),
                 settings: None,
+                agent: None,
             },
             reserved_pane_slot_ids: Vec::new(),
         })
@@ -613,6 +615,7 @@ fn content_reducers_open_split_and_focus_existing_settings_content() {
                     "surface_id": "settings_main",
                     "title": "Settings"
                 })),
+                agent: None,
             },
             reserved_pane_slot_ids: Vec::new(),
         })
@@ -634,6 +637,7 @@ fn content_reducers_open_split_and_focus_existing_settings_content() {
                     "surface_id": "settings_main",
                     "title": "Settings"
                 })),
+                agent: None,
             },
             reserved_pane_slot_ids: Vec::new(),
         })
@@ -663,6 +667,7 @@ fn content_reducers_open_split_and_focus_existing_settings_content() {
                     "title": "Split Notes"
                 })),
                 settings: None,
+                agent: None,
             },
             reserved_pane_slot_ids: Vec::new(),
         })
@@ -1166,6 +1171,60 @@ fn split_reducer_rejects_unsupported_non_terminal_content() {
         .unwrap_err();
 
     assert_eq!(error.code, ReducerErrorCode::UnsupportedContent);
+}
+
+#[test]
+fn agent_renderer_progress_updates_only_the_mounted_content_payload() {
+    let mut state = base_state();
+    state.contents[0] = ContentInstance {
+        content_id: "content_pane_1".to_string(),
+        kind: ContentKind::Agent,
+        title: "Agent 7".to_string(),
+        icon_name: None,
+        capabilities: ContentKind::Agent.default_capabilities(),
+        payload: ShellContentPayload {
+            agent: Some(AgentAttachment {
+                process: AgentProcessReference {
+                    boot_id: "boot-a".to_string(),
+                    pid: 7,
+                },
+                offsets: AgentStreamOffsets::default(),
+                presentation: AgentContentPresentation::default(),
+            }),
+            ..ShellContentPayload::default()
+        },
+        terminal_metadata: None,
+        lifecycle: ContentLifecycleState::Active,
+        renderer_state: Default::default(),
+    };
+    let offsets = AgentStreamOffsets {
+        output: 42,
+        requests: 3,
+        actions: 5,
+        ui: 8,
+    };
+    let presentation = AgentContentPresentation {
+        follows_output: true,
+    };
+
+    let result = state
+        .reduce(ReducerOperation::UpdateAgentRendererState {
+            pane_slot_id: "pane_1".to_string(),
+            offsets: offsets.clone(),
+            presentation: presentation.clone(),
+        })
+        .expect("Agent renderer progress update succeeds");
+    let attachment = result.state.contents[0]
+        .payload
+        .agent
+        .as_ref()
+        .expect("Agent attachment remains present");
+
+    assert_eq!(attachment.process.boot_id, "boot-a");
+    assert_eq!(attachment.process.pid, 7);
+    assert_eq!(attachment.offsets, offsets);
+    assert_eq!(attachment.presentation, presentation);
+    assert_eq!(result.changed_ids.updated_content_ids, ["content_pane_1"]);
 }
 
 fn sample_activity() -> TerminalActivitySnapshot {

--- a/justfile
+++ b/justfile
@@ -102,6 +102,7 @@ dev-channel-smoke:
 
 # Run focused macOS shell tests that do not require real Ghostty artifacts
 apple-shell-focused-tests:
+    bash clients/apple/scripts/test-alan-os-attachment.sh
     bash clients/apple/scripts/test-shell-workspace-manifest.sh
     bash clients/apple/scripts/test-shell-performance-diagnostics.sh
     bash clients/apple/scripts/test-terminal-runtime-service.sh

--- a/openspec/changes/attach-macos-to-alan-os/tasks.md
+++ b/openspec/changes/attach-macos-to-alan-os/tasks.md
@@ -1,56 +1,56 @@
 ## 1. Attach Alan for macOS to the system Host
 
-- [ ] 1.1 Add Swift aP wire client/import adapter using the matching stable/dev Unix endpoint
-- [ ] 1.2 Add platform Host start/discovery, channel, peer, boot-ID, and readiness validation
-- [ ] 1.3 Obtain one app-level Shell Process through Local Entry Service and render basic namespace Shell behavior
-- [ ] 1.4 Prove app/window exit releases connections without stopping Alan OS or its Processes
+- [x] 1.1 Add Swift aP wire client/import adapter using the matching stable/dev Unix endpoint
+- [x] 1.2 Add platform Host start/discovery, channel, peer, boot-ID, and readiness validation
+- [x] 1.3 Obtain one app-level Shell Process through Local Entry Service and render basic namespace Shell behavior
+- [x] 1.4 Prove app/window exit releases connections without stopping Alan OS or its Processes
 
 ## 2. Add Agent attachment domain state
 
-- [ ] 2.1 Add Process Reference with boot ID and PID plus qid/reference verification
-- [ ] 2.2 Add Agent Attachment with caller-held output/request/action/UI offsets
-- [ ] 2.3 Add Agent ContentInstance payload containing only reference, offsets, and presentation
-- [ ] 2.4 Guard shell persistence against Tape, Agent Machine, provider, Tool, socket, raw Host path, or secret state
+- [x] 2.1 Add Process Reference with boot ID and PID plus qid/reference verification
+- [x] 2.2 Add Agent Attachment with caller-held output/request/action/UI offsets
+- [x] 2.3 Add Agent ContentInstance payload containing only reference, offsets, and presentation
+- [x] 2.4 Guard shell persistence against Tape, Agent Machine, provider, Tool, socket, raw Host path, or secret state
 
 ## 3. Build the file-backed Agent renderer
 
-- [ ] 3.1 Hydrate `/proc/<pid>` and `/agent/<pid>` through Alan Shell/aP file operations
-- [ ] 3.2 Tail AgentFS streams from saved offsets with overlap dedupe and visible retention-gap handling
-- [ ] 3.3 Write input, request responses, machine control, interrupts, and explicit stop through files
-- [ ] 3.4 Support multiple ContentInstances/renderers attached to one Process with independent fids and offsets
+- [x] 3.1 Hydrate `/proc/<pid>` and `/agent/<pid>` through Alan Shell/aP file operations
+- [x] 3.2 Tail AgentFS streams from saved offsets with overlap dedupe and visible retention-gap handling
+- [x] 3.3 Write input, request responses, machine control, interrupts, and explicit stop through files
+- [x] 3.4 Support multiple ContentInstances/renderers attached to one Process with independent fids and offsets
 
 ## 4. Implement restore and lifecycle semantics
 
-- [ ] 4.1 Restore live Agent views after SwiftUI view and macOS app recreation without creating Processes
-- [ ] 4.2 Render exited Process evidence and missing/boot-mismatched Process unavailability without PID redirection
-- [ ] 4.3 Make Pane, Tab, window, ContentInstance, and app close detach only
-- [ ] 4.4 Make Stop Process an explicit `/proc/<pid>/ctl` action with distinct confirmation/copy
-- [ ] 4.5 Test layout move, duplicate view, last-view close, app crash/relaunch, Host restart, and PID reuse
+- [x] 4.1 Restore live Agent views after SwiftUI view and macOS app recreation without creating Processes
+- [x] 4.2 Render exited Process evidence and missing/boot-mismatched Process unavailability without PID redirection
+- [x] 4.3 Make Pane, Tab, window, ContentInstance, and app close detach only
+- [x] 4.4 Make Stop Process an explicit `/proc/<pid>/ctl` action with distinct confirmation/copy
+- [x] 4.5 Test layout move, duplicate view, last-view close, app crash/relaunch, Host restart, and PID reuse
 
 ## 5. Wire native capability adapters
 
-- [ ] 5.1 Observe Host Mount Service requests and connect native directory authorization/security scope
-- [ ] 5.2 Return bounded hostfs export results without projecting raw Host paths into Alan OS
-- [ ] 5.3 Observe Connection Service requests and connect browser/device login plus Keychain
-- [ ] 5.4 Return only opaque credential references and remove local profile/default authority
+- [x] 5.1 Observe Host Mount Service requests and connect native directory authorization/security scope
+- [x] 5.2 Return bounded hostfs export results without projecting raw Host paths into Alan OS
+- [x] 5.3 Observe Connection Service requests and connect browser/device login plus Keychain
+- [x] 5.4 Return only opaque credential references and remove local profile/default authority
 
 ## 6. Remove app-owned runtime paths
 
-- [ ] 6.1 Remove any macOS app-owned Kernel, Agent Execution Engine, Root Agent, or Alan OS boot path
-- [ ] 6.2 Keep Space/Tab/Pane/window commands host-owned and route Agent/Shell commands through Alan OS files
-- [ ] 6.3 Preserve existing terminal ContentInstance/Ghostty ownership without folding it into Agent attachment
-- [ ] 6.4 Add architecture guards against runtime-state duplication and app-owned Alan OS lifecycle
+- [x] 6.1 Remove any macOS app-owned Kernel, Agent Execution Engine, Root Agent, or Alan OS boot path
+- [x] 6.2 Keep Space/Tab/Pane/window commands host-owned and route Agent/Shell commands through Alan OS files
+- [x] 6.3 Preserve existing terminal ContentInstance/Ghostty ownership without folding it into Agent attachment
+- [x] 6.4 Add architecture guards against runtime-state duplication and app-owned Alan OS lifecycle
 
 ## 7. Verify product behavior
 
-- [ ] 7.1 Run Rust aP/attachment tests, shell-core/FFI tests, focused Apple shell tests, and strict OpenSpec validation
-- [ ] 7.2 Build and install a fresh `Alan Dev.app` without touching Alan stable
-- [ ] 7.3 Run fresh-relaunch UI smoke for Shell entry, Agent attach, detach, stop, restore, Host Mount, and Connection login request surfaces
-- [ ] 7.4 Verify stable/dev endpoint and System Store isolation in signed app builds
+- [x] 7.1 Run Rust aP/attachment tests, shell-core/FFI tests, focused Apple shell tests, and strict OpenSpec validation
+- [x] 7.2 Build and install a fresh `Alan Dev.app` without touching Alan stable
+- [x] 7.3 Run fresh-relaunch UI smoke for Shell entry, Agent attach, detach, stop, restore, Host Mount, and Connection login request surfaces
+- [x] 7.4 Verify stable/dev endpoint and System Store isolation in signed app builds
 
 ## 8. Review and archive readiness
 
-- [ ] 8.1 Submit after `implement-minimal-service-manager` is merged and archived
+- [x] 8.1 Submit after `implement-minimal-service-manager` is merged and archived
 - [ ] 8.2 Complete current-HEAD Codex review, zero unresolved threads, green CI, and delayed recheck before merge
 - [ ] 8.3 Sync macOS attachment deltas into canonical specs after implementation merge
 - [ ] 8.4 Archive only after source tests, rendered verification, implementation merge, and canonical sync are complete


### PR DESCRIPTION
## Summary

- attach Alan for macOS to its channel system Host over the protected aP endpoint
- add file-backed Agent Process views with narrow persisted references, independent offsets, detach-only close, and explicit stop
- wire Host Mount and Connection native adapters without moving grant, profile, secret, Kernel, or Agent Engine authority into the app
- keep Alan OS bootable when a configured Connection is temporarily unavailable

## Verification

- `just check`
- `just apple-shell-focused-tests`
- `openspec validate attach-macos-to-alan-os --strict`
- signed `just install-dev`
- signed app attachment smoke and fresh Root Agent rendered verification
- stable/dev Host status and System Store isolation checks