### PR TITLE
docs(openspec): sync macOS Alan OS attachment

### DIFF
--- a/openspec/changes/attach-macos-to-alan-os/tasks.md
+++ b/openspec/changes/attach-macos-to-alan-os/tasks.md
@@ -51,6 +51,6 @@
 ## 8. Review and archive readiness
 
 - [x] 8.1 Submit after `implement-minimal-service-manager` is merged and archived
-- [ ] 8.2 Complete current-HEAD Codex review, zero unresolved threads, green CI, and delayed recheck before merge
-- [ ] 8.3 Sync macOS attachment deltas into canonical specs after implementation merge
+- [x] 8.2 Complete current-HEAD Codex review, zero unresolved threads, green CI, and delayed recheck before merge
+- [x] 8.3 Sync macOS attachment deltas into canonical specs after implementation merge
 - [ ] 8.4 Archive only after source tests, rendered verification, implementation merge, and canonical sync are complete

--- a/openspec/specs/alan-renderer-host-contract/spec.md
+++ b/openspec/specs/alan-renderer-host-contract/spec.md
@@ -25,3 +25,22 @@ A local renderer host SHALL start from a mounted Alan OS root plus a concrete Ag
 - **WHEN** the renderer receives a namespace root and `/agent/root`
 - **THEN** it reads and tails AgentFS output and state files
 - **AND** it writes input and Process control through the corresponding files
+
+### Requirement: Renderer attachments use Process Reference and offsets
+An Alan renderer host SHALL identify a Process by boot ID and PID, verify it
+through `/proc`, and own the byte offsets of each stream it reads. Recreating or
+duplicating a renderer MUST NOT create, restore, or become authority for the
+Process.
+
+#### Scenario: Second renderer attaches
+- **WHEN** another renderer opens the same Agent Process
+- **THEN** it maintains independent fids and offsets
+- **AND** both observe the same Alan OS file authority
+
+### Requirement: Retention gaps are visible
+When a saved stream offset can no longer be served, the renderer SHALL surface
+the gap and MUST NOT silently jump forward or claim complete continuity.
+
+#### Scenario: Saved offset predates retained history
+- **WHEN** a renderer reattaches after retention has truncated earlier bytes
+- **THEN** it reports the missing range before continuing

--- a/openspec/specs/host-directory-mounts/spec.md
+++ b/openspec/specs/host-directory-mounts/spec.md
@@ -83,3 +83,14 @@ maintain a second grant registry.
 - **WHEN** CLI Host Command Plane approves a Host directory
 - **THEN** its adapter returns the export to Host Mount Service
 - **AND** only the service publishes Alan OS-visible grant state
+
+### Requirement: macOS is a Host Mount native adapter
+Alan for macOS SHALL observe Host Mount Service requests, present native
+directory authorization, and return bounded hostfs export results. Raw Host OS
+paths and security-scoped handles SHALL remain in the platform adapter and MUST
+NOT appear in Agent-visible grant files.
+
+#### Scenario: Agent requests a read-only directory
+- **WHEN** the user approves it in macOS
+- **THEN** Host Mount Service receives a read-only export result
+- **AND** the Agent sees only its Alan OS mount path and grant metadata

--- a/openspec/specs/macos-alan-os-attachment/spec.md
+++ b/openspec/specs/macos-alan-os-attachment/spec.md
@@ -1,0 +1,53 @@
+# macos-alan-os-attachment Specification
+
+## Purpose
+Define how Alan for macOS attaches to the matching system Alan OS Host, renders
+Shell and Agent Processes through file-backed references, and supplies bounded
+native capabilities without owning Alan OS lifecycle or secrets.
+
+## Requirements
+### Requirement: Alan for macOS attaches to the channel system Host
+Alan for macOS SHALL connect to the matching stable/dev Alan OS Host over its
+protected aP endpoint and SHALL obtain a Shell Process through Local Entry
+Service. It MUST NOT boot Kernel or Agent Execution Engine inside the app.
+
+#### Scenario: App launches while Host already runs
+- **WHEN** channel and readiness validation succeed
+- **THEN** the app attaches without restarting Alan OS or its Processes
+
+### Requirement: Agent ContentInstance stores an Agent Attachment
+An Agent ContentInstance SHALL persist only Process Reference (boot ID and PID),
+caller-held stream offsets, and host presentation. It MUST NOT persist Agent
+Machine, Tape, request, Tool, provider, Process status, or socket authority.
+
+#### Scenario: Agent view is restored
+- **WHEN** the saved boot ID matches and `/proc/<pid>` exists
+- **THEN** macOS reopens `/agent/<pid>` streams at saved offsets
+- **AND** no Agent Process is created
+
+### Requirement: Reattachment validates Process identity
+Before reading AgentFS, macOS SHALL verify the Alan OS boot identity and
+Process reference. A Host restart or missing Process SHALL produce an
+unavailable/terminal view and MUST NOT attach a reused PID.
+
+#### Scenario: PID is reused after Host restart
+- **WHEN** the current boot ID differs from the saved reference
+- **THEN** macOS rejects the attachment regardless of PID equality
+
+### Requirement: Closing a view only detaches
+Closing Agent content, Pane, Tab, window, or app SHALL release renderer fids and
+MUST NOT terminate the Agent Process. Stop SHALL be a separate explicit write
+to `/proc/<pid>/ctl`.
+
+#### Scenario: Last visible Agent view closes
+- **WHEN** no macOS ContentInstance remains visible for the Process
+- **THEN** its `/proc` lifecycle is unchanged
+
+### Requirement: Native adapters answer service requests
+macOS directory authorization and connection login/Keychain adapters SHALL
+answer Host Mount Service and Connection Service request files. They MUST NOT
+own grants, profiles, or expose raw paths/secrets into Alan OS.
+
+#### Scenario: User approves a directory picker
+- **WHEN** the native adapter obtains platform authorization
+- **THEN** it returns a bounded hostfs export result to Host Mount Service

--- a/openspec/specs/macos-app-instance-lifecycle/spec.md
+++ b/openspec/specs/macos-app-instance-lifecycle/spec.md
@@ -220,3 +220,13 @@ separate from Alan OS Host singleton lifetime.
 - **WHEN** the stable app terminates
 - **THEN** the stable Alan OS Host remains running
 - **AND** the dev channel is unaffected
+
+### Requirement: App lifetime does not own Alan OS lifetime
+Alan for macOS startup, window closure, app termination, crash, and update SHALL
+not shut down the dedicated Alan OS Host or its Processes. The app SHALL
+release only its own connections, fids, views, and Host adapter work.
+
+#### Scenario: App quits with active Agent Processes
+- **WHEN** the app terminates normally
+- **THEN** the Alan OS Host and Agent Processes continue
+- **AND** a later app launch can reattach by Process Reference

--- a/openspec/specs/macos-shell-content-containers/spec.md
+++ b/openspec/specs/macos-shell-content-containers/spec.md
@@ -120,3 +120,22 @@ surface；超出边界的编辑器、browser content、浏览器权限和扩展�
 - **WHEN** 维护者检查 v0.2 content-container 模型
 - **THEN** v1 SHALL NOT 要求 browser ContentInstance kind、browser renderer、WKWebView host、browser profile/cookie policy、download manager 或 browser permission model
 - **AND** 模型 SHALL 保持通用 `ContentInstance`、content kind、payload、capability、renderer、lifecycle 和 PaneSlot 命名，使后续 browser change 可以新增 browser-specific descriptors，而不需要重命名 container contract
+
+### Requirement: Agent content references an Alan OS Process
+Alan for macOS SHALL support an Agent ContentInstance whose domain payload is an
+Agent Attachment reference and whose placement remains owned by Space, Tab,
+PaneSlot, and window presentation state.
+
+#### Scenario: Agent content moves between Panes
+- **WHEN** the user moves the ContentInstance
+- **THEN** its Process Reference remains unchanged
+- **AND** Alan OS Process lifecycle receives no mutation
+
+### Requirement: Multiple Agent content views may share a Process
+Alan for macOS SHALL allow more than one ContentInstance to attach to the same
+Process Reference. Each SHALL own renderer offsets and neither SHALL infer
+exclusive Process ownership.
+
+#### Scenario: One duplicate view closes
+- **WHEN** another view remains attached
+- **THEN** the Process and other view remain unaffected

--- a/openspec/specs/macos-shell-workspace-persistence/spec.md
+++ b/openspec/specs/macos-shell-workspace-persistence/spec.md
@@ -537,3 +537,18 @@ of state rather than rewriting every file on every runtime event:
 - **WHEN** Alan for macOS resigns active, is backgrounded, or is asked to quit
 - **THEN** Alan force-flushes pending transcript snapshots and the transient
   control-plane mirror before completing the transition
+
+### Requirement: Shell persistence stores Agent Attachments narrowly
+The macOS shell manifest SHALL store Agent Process boot ID, PID, caller-held
+stream offsets, and presentation needed to restore an Agent ContentInstance. It
+MUST NOT store Agent runtime state, Host socket objects, raw Host paths, secrets,
+or claim Process continuity.
+
+#### Scenario: Manifest restores after app restart
+- **WHEN** Alan OS boot identity and Process still match
+- **THEN** the ContentInstance reattaches from its stored offsets
+
+#### Scenario: Manifest refers to a prior Host boot
+- **WHEN** the boot identity no longer matches
+- **THEN** the restored content is marked unavailable
+- **AND** the manifest does not redirect it to a new PID

--- a/openspec/specs/provider-connection-contract/spec.md
+++ b/openspec/specs/provider-connection-contract/spec.md
@@ -346,3 +346,14 @@ adapters SHALL own only native login and secret storage.
 - **WHEN** Connection Service remains running
 - **THEN** profile identity and non-secret settings remain authoritative
 - **AND** the adapter can reconnect without reconstructing profiles
+
+### Requirement: macOS is a Connection Service native adapter
+Alan for macOS SHALL observe Connection Service native requests and perform
+approved browser/device login and Keychain operations. It SHALL return only
+opaque credential references and bounded results and MUST NOT maintain a second
+profile/default registry.
+
+#### Scenario: App reconnects after login
+- **WHEN** the profile already exists in Connection Service
+- **THEN** macOS reads its service status
+- **AND** it does not recreate metadata from local preferences


### PR DESCRIPTION
## Summary
- sync all seven `attach-macos-to-alan-os` delta specs into canonical OpenSpec
- add the canonical `macos-alan-os-attachment` capability with a concrete purpose
- record the completed implementation PR gate and canonical sync tasks while leaving archive readiness pending

## Verification
- `openspec validate --all --strict` (87 passed)
- `git diff --check`
- audited every delta requirement title against its canonical capability