### PR TITLE
refactor: separate connection service and host ownership

### DIFF
--- a/crates/agent-engine/src/lib.rs
+++ b/crates/agent-engine/src/lib.rs
@@ -13,7 +13,6 @@ mod agent_definition;
 mod agent_machine;
 mod approval;
 mod config;
-mod connections;
 mod evidence;
 mod file_tree;
 mod install_channel;
@@ -38,12 +37,6 @@ pub use agent_machine::{
 };
 pub use config::{
     Config, ConfigSourceKind, LlmProvider, LoadedConfig, PartialStreamRecoveryMode, StreamingMode,
-};
-pub use connections::{
-    ConnectionCredential, ConnectionProfile, ConnectionStoreBindings, ConnectionsFile,
-    CredentialKind, ProviderDescriptor, ResolvedConnectionProfile, SecretStore,
-    default_credential_backend, normalize_profile_settings, provider_catalog, sanitize_identifier,
-    validate_profile_settings,
 };
 pub use file_tree::ProcessFileTree;
 pub use install_channel::{INSTALL_CHANNEL_ENV, InstallChannel, InstallChannelDescriptor};

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -5,6 +5,11 @@ fn read_runtime_source(path: &str) -> String {
         .unwrap_or_else(|error| panic!("read src/runtime/{path}: {error}"))
 }
 
+fn read_crate_source(path: &str) -> String {
+    std::fs::read_to_string(format!("{}/src/{path}", env!("CARGO_MANIFEST_DIR")))
+        .unwrap_or_else(|error| panic!("read src/{path}: {error}"))
+}
+
 fn rust_item_body<'a>(source: &'a str, marker: &str) -> &'a str {
     let item = &source[source
         .find(marker)
@@ -165,4 +170,29 @@ fn engine_has_no_host_connection_store_or_provider_factory_authority() {
     }
     assert!(child.contains("ensure_child_connection_is_passed"));
     assert!(child.contains("parent namespace missing callable Connection service"));
+}
+
+#[test]
+fn engine_does_not_own_connection_profile_metadata_or_selection() {
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    assert!(
+        !manifest_dir.join("src/connections.rs").exists(),
+        "Connection profile metadata must be owned by Connection Service"
+    );
+
+    let public_api = read_crate_source("lib.rs");
+    for forbidden in [
+        "mod connections",
+        "ConnectionCredential",
+        "ConnectionProfile",
+        "ConnectionStoreBindings",
+        "ConnectionsFile",
+        "ResolvedConnectionProfile",
+        "SecretStore",
+    ] {
+        assert!(
+            !public_api.contains(forbidden),
+            "Agent Execution Engine still exports Connection authority through {forbidden}"
+        );
+    }
 }

--- a/crates/alan/src/cli/connection.rs
+++ b/crates/alan/src/cli/connection.rs
@@ -1,13 +1,15 @@
-use alan_agent_engine::{
-    Config, ConnectionCredential, ConnectionProfile, ConnectionStoreBindings, ConnectionsFile,
-    CredentialKind, InstallChannel, LlmProvider, SecretStore, default_credential_backend,
-    normalize_profile_settings, sanitize_identifier, validate_profile_settings,
-};
+use alan_agent_engine::{Config, InstallChannel, LlmProvider};
 use alan_auth::{
     BrowserLoginOptions, ChatgptAuthConfig, ChatgptAuthManager, DeviceCodeLoginOptions,
 };
 use alan_os_host::{
-    HostStorePaths, LegacyConnectionPaths, SystemStorePaths, migrate_legacy_connections,
+    HostStorePaths, LegacyConnectionPaths, SecretStore, SystemStorePaths, apply_profile_to_config,
+    migrate_legacy_connections,
+};
+use alan_service_manager::{
+    ConnectionCredential, ConnectionProfile, ConnectionsFile, CredentialKind,
+    default_credential_backend, normalize_profile_settings, sanitize_identifier,
+    validate_profile_settings,
 };
 use alan_shell::Shell;
 use anyhow::{Context, Result};
@@ -24,7 +26,7 @@ use std::{
 pub const NATIVE_CONNECTION_REQUEST_ENV: &str = "ALAN_NATIVE_CONNECTION_REQUEST_ID";
 
 struct ConnectionStores {
-    bindings: ConnectionStoreBindings,
+    credentials_dir: PathBuf,
     managed_auth: PathBuf,
     shell: Shell,
 }
@@ -37,7 +39,7 @@ async fn connection_stores() -> Result<ConnectionStores> {
         migrate_legacy_connections(&legacy, &system, &host)?;
     }
     Ok(ConnectionStores {
-        bindings: system.connection_bindings(&host)?,
+        credentials_dir: host.credentials,
         managed_auth: host.managed_auth,
         shell: Shell::new(super::host::attach_or_start_host(channel).await?.root),
     })
@@ -141,7 +143,7 @@ async fn respond_native(
 }
 
 fn secret_store(stores: &ConnectionStores) -> Result<SecretStore> {
-    SecretStore::from_directory(&stores.bindings.credentials_dir)
+    SecretStore::from_directory(&stores.credentials_dir)
 }
 
 fn chatgpt_auth_manager(stores: &ConnectionStores) -> Result<ChatgptAuthManager> {
@@ -598,7 +600,8 @@ pub async fn run_connection_test(profile_id: Option<String>) -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("no profile selected"))?;
     let profile = connection_profile(&connections, &profile_id)?;
     let mut config = Config::default();
-    let resolved = connections.apply_profile_to_config(
+    let resolved = apply_profile_to_config(
+        &connections,
         Some(&profile_id),
         &secret_store(&stores)?,
         &mut config,

--- a/crates/alan/src/legacy_state.rs
+++ b/crates/alan/src/legacy_state.rs
@@ -713,13 +713,13 @@ fn path_exists_without_following(path: &Path) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alan_agent_engine::{
-        ConnectionCredential, ConnectionProfile, ConnectionsFile, CredentialKind, LlmProvider,
+    use alan_agent_engine::LlmProvider;
+    use alan_service_manager::{
+        ConnectionCredential, ConnectionProfile, ConnectionsFile, CredentialKind,
         default_credential_backend,
     };
     use chrono::Utc;
     use tempfile::TempDir;
-
     fn stores(root: &Path, channel: InstallChannel) -> (SystemStorePaths, HostStorePaths) {
         let data = root.join("data");
         fs::create_dir_all(&data).unwrap();

--- a/crates/alan/tests/legacy_state_cli_integration_test.rs
+++ b/crates/alan/tests/legacy_state_cli_integration_test.rs
@@ -3,7 +3,8 @@ use std::{
     process::Command,
 };
 
-use alan_agent_engine::{ConnectionsFile, InstallChannel};
+use alan_agent_engine::InstallChannel;
+use alan_service_manager::ConnectionsFile;
 use tempfile::TempDir;
 
 fn detected_data_dir(home: &Path, xdg_data: &Path) -> PathBuf {

--- a/crates/os-host/src/boot.rs
+++ b/crates/os-host/src/boot.rs
@@ -3,17 +3,19 @@
 use std::sync::Arc;
 
 use alan_agent_engine::{
-    AgentProcessConfig, Config, ConnectionsFile, HostMountGrant, InstallChannel, LlmClient,
-    ProcessDescriptor, ProcessLaunchContext, SecretStore, ToolRegistry,
+    AgentProcessConfig, Config, HostMountGrant, InstallChannel, LlmClient, ProcessDescriptor,
+    ProcessLaunchContext, ToolRegistry,
 };
 use alan_ap::InProcessTransport;
 use alan_kernel::{Access, Credentials, Namespace};
 use alan_llm::{GenerationRequest, GenerationResponse, LlmProvider, StreamChunk};
-use alan_service_manager::{LlmClientFactory, ServiceManagerConfig};
+use alan_service_manager::{ConnectionsFile, LlmClientFactory, ServiceManagerConfig};
 use anyhow::{Context, Result, bail};
 
 use crate::paths::{HostStorePaths, SystemStorePaths};
-use crate::{LegacyConnectionPaths, migrate_legacy_connections};
+use crate::{
+    LegacyConnectionPaths, SecretStore, apply_profile_to_config, migrate_legacy_connections,
+};
 
 /// Host-supplied adapters and durable bindings needed by Service Manager.
 pub struct HostBootConfig(ServiceManagerConfig);
@@ -117,7 +119,8 @@ impl LlmClientFactory for ProductLlmClientFactory {
             }
             _ => SecretStore::from_directory(&self.credentials_dir)?,
         };
-        connections.apply_profile_to_config(
+        apply_profile_to_config(
+            connections,
             Some(selected_profile),
             &secret_store,
             &mut core_config,
@@ -184,10 +187,10 @@ impl HostBootConfig {
             );
         process.store_bindings = Some(system_store.agent_runtime_bindings()?);
         process.memory_store_backing = Some(memory_store_backing);
-        let connection_store = system_store.connection_bindings(&host_store)?;
+        let connection_store = system_store.connection_bindings()?;
         let tools = ToolRegistry::with_config(Arc::new(process.agent_config.core_config.clone()));
         let llm_factory = Arc::new(ProductLlmClientFactory {
-            credentials_dir: connection_store.credentials_dir.clone(),
+            credentials_dir: host_store.credentials.clone(),
             keychain_service: {
                 #[cfg(target_os = "macos")]
                 {

--- a/crates/os-host/src/legacy_connections.rs
+++ b/crates/os-host/src/legacy_connections.rs
@@ -6,7 +6,8 @@ use std::{
     path::{Component, Path, PathBuf},
 };
 
-use alan_agent_engine::{ConnectionsFile, InstallChannel, default_credential_backend};
+use alan_agent_engine::InstallChannel;
+use alan_service_manager::{ConnectionsFile, default_credential_backend};
 use anyhow::{Context, Result, ensure};
 use serde::Serialize;
 

--- a/crates/os-host/src/lib.rs
+++ b/crates/os-host/src/lib.rs
@@ -9,6 +9,7 @@ pub mod host_mounts;
 mod legacy_connections;
 mod local;
 pub mod paths;
+mod secret_store;
 
 pub use boot::HostBootConfig;
 pub use legacy_connections::{
@@ -19,3 +20,4 @@ pub use local::{
     HostReadiness, HostStatus, LocalAttachment, request_host_stop, run_host_process,
 };
 pub use paths::{AgentRuntimeStorePaths, HostStorePaths, SystemStorePaths};
+pub use secret_store::{SecretStore, apply_profile_to_config};

--- a/crates/os-host/src/paths.rs
+++ b/crates/os-host/src/paths.rs
@@ -1,6 +1,7 @@
 use std::path::{Component, Path, PathBuf};
 
-use alan_agent_engine::{AgentRuntimeStoreBindings, ConnectionStoreBindings};
+use alan_agent_engine::AgentRuntimeStoreBindings;
+use alan_service_manager::ConnectionStoreBindings;
 use anyhow::{Context, Result, ensure};
 
 const PRODUCT_DIR: &str = "Alan";
@@ -82,8 +83,8 @@ impl SystemStorePaths {
         Ok(self.service("connections")?.join("connections.toml"))
     }
 
-    pub fn connection_bindings(&self, host: &HostStorePaths) -> Result<ConnectionStoreBindings> {
-        ConnectionStoreBindings::new(self.connections_metadata()?, host.credentials.clone())
+    pub fn connection_bindings(&self) -> Result<ConnectionStoreBindings> {
+        ConnectionStoreBindings::new(self.connections_metadata()?)
     }
 }
 

--- a/crates/os-host/src/secret_store.rs
+++ b/crates/os-host/src/secret_store.rs
@@ -1,0 +1,339 @@
+//! Host credential-store adapter used while materializing callable connections.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use alan_agent_engine::{Config, LlmProvider};
+use alan_service_manager::{ConnectionsFile, ResolvedConnectionProfile};
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+
+const SECRET_STORE_FILE_NAME: &str = "secrets.toml";
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct SecretStoreFile {
+    #[serde(default)]
+    secrets: BTreeMap<String, String>,
+}
+
+/// Explicit Host credential-store binding. Connection Service receives only
+/// metadata and opaque references; secret bytes never enter its file tree.
+#[derive(Clone)]
+pub struct SecretStore {
+    credentials_dir: PathBuf,
+    resolved_secrets: BTreeMap<String, String>,
+}
+
+impl std::fmt::Debug for SecretStore {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SecretStore")
+            .field("credentials_dir", &self.credentials_dir)
+            .field("resolved_secret_count", &self.resolved_secrets.len())
+            .finish()
+    }
+}
+
+impl SecretStore {
+    pub fn from_directory(credentials_dir: &Path) -> anyhow::Result<Self> {
+        validate_safe_absolute_path("Host credential directory", credentials_dir)?;
+        Ok(Self {
+            credentials_dir: credentials_dir.to_path_buf(),
+            resolved_secrets: BTreeMap::new(),
+        })
+    }
+
+    pub fn with_resolved_secret(
+        credentials_dir: &Path,
+        credential_id: &str,
+        secret: String,
+    ) -> anyhow::Result<Self> {
+        let mut store = Self::from_directory(credentials_dir)?;
+        let credential_id = validated_identifier_component("credential id", credential_id)?;
+        store
+            .resolved_secrets
+            .insert(credential_id.to_string(), secret);
+        Ok(store)
+    }
+
+    pub fn load(&self, credential_id: &str) -> anyhow::Result<Option<String>> {
+        let credential_id = validated_identifier_component("credential id", credential_id)?;
+        if let Some(secret) = self.resolved_secrets.get(credential_id) {
+            return Ok(Some(secret.clone()));
+        }
+        let secrets = self.read_secret_file()?;
+        Ok(secrets.secrets.get(credential_id).cloned())
+    }
+
+    pub fn save(&self, credential_id: &str, secret: &str) -> anyhow::Result<()> {
+        let credential_id = validated_identifier_component("credential id", credential_id)?;
+        let mut secrets = self.read_secret_file()?;
+        secrets
+            .secrets
+            .insert(credential_id.to_string(), secret.trim().to_string());
+        self.write_secret_file(&secrets)
+    }
+
+    pub fn delete(&self, credential_id: &str) -> anyhow::Result<bool> {
+        let credential_id = validated_identifier_component("credential id", credential_id)?;
+        let mut secrets = self.read_secret_file()?;
+        let removed = secrets.secrets.remove(credential_id).is_some();
+        if removed {
+            self.write_secret_file(&secrets)?;
+        }
+        Ok(removed)
+    }
+
+    fn secret_file_path(&self) -> anyhow::Result<PathBuf> {
+        let path = self.credentials_dir.join(SECRET_STORE_FILE_NAME);
+        validate_safe_absolute_path("secret store path", &path)?;
+        Ok(path)
+    }
+
+    fn read_secret_file(&self) -> anyhow::Result<SecretStoreFile> {
+        let path = self.secret_file_path()?;
+        match std::fs::read_to_string(&path) {
+            Ok(content) => toml::from_str(&content)
+                .with_context(|| format!("failed to parse secret store {}", path.display())),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                Ok(SecretStoreFile::default())
+            }
+            Err(error) => Err(error)
+                .with_context(|| format!("failed to read secret store {}", path.display())),
+        }
+    }
+
+    fn write_secret_file(&self, secret_file: &SecretStoreFile) -> anyhow::Result<()> {
+        let path = self.secret_file_path()?;
+        if secret_file.secrets.is_empty() {
+            match std::fs::remove_file(&path) {
+                Ok(()) => return Ok(()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("failed to remove secret store {}", path.display())
+                    });
+                }
+            }
+        }
+        let rendered = toml::to_string_pretty(secret_file)
+            .context("failed to encode secret store while saving")?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "failed to create credentials directory {}",
+                    parent.display()
+                )
+            })?;
+        }
+        #[cfg(unix)]
+        {
+            use std::io::Write;
+            use std::os::unix::fs::OpenOptionsExt;
+
+            let mut file = std::fs::OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .mode(0o600)
+                .open(&path)
+                .with_context(|| format!("failed to open secret store {}", path.display()))?;
+            file.write_all(rendered.as_bytes())
+                .with_context(|| format!("failed to write secret store {}", path.display()))?;
+        }
+        #[cfg(not(unix))]
+        {
+            std::fs::write(&path, rendered)
+                .with_context(|| format!("failed to write secret store {}", path.display()))?;
+        }
+        Ok(())
+    }
+}
+
+/// Resolve Connection Service metadata, then project Host-owned credential
+/// material into the runtime provider config without exposing it to the service.
+pub fn apply_profile_to_config(
+    connections: &ConnectionsFile,
+    profile_id: Option<&str>,
+    secret_store: &SecretStore,
+    config: &mut Config,
+) -> anyhow::Result<ResolvedConnectionProfile> {
+    let resolved = connections.apply_profile_metadata_to_config(profile_id, config)?;
+    if matches!(
+        resolved.provider,
+        LlmProvider::Chatgpt | LlmProvider::GoogleGeminiGenerateContent
+    ) {
+        return Ok(resolved);
+    }
+    let Some(credential_id) = resolved.credential_id.as_deref() else {
+        anyhow::bail!("Profile `{}` is missing a credential", resolved.profile_id);
+    };
+    let api_key = secret_store.load(credential_id)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Credential `{credential_id}` for profile `{}` is missing a secret",
+            resolved.profile_id
+        )
+    })?;
+    match resolved.provider {
+        LlmProvider::OpenAiResponses => config.openai_responses_api_key = Some(api_key),
+        LlmProvider::OpenAiChatCompletions => {
+            config.openai_chat_completions_api_key = Some(api_key)
+        }
+        LlmProvider::OpenAiChatCompletionsCompatible => {
+            config.openai_chat_completions_compatible_api_key = Some(api_key)
+        }
+        LlmProvider::OpenRouter => config.openrouter_api_key = Some(api_key),
+        LlmProvider::AnthropicMessages => config.anthropic_messages_api_key = Some(api_key),
+        LlmProvider::Chatgpt | LlmProvider::GoogleGeminiGenerateContent => unreachable!(),
+    }
+    Ok(resolved)
+}
+
+fn validated_identifier_component<'a>(label: &str, value: &'a str) -> anyhow::Result<&'a str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty()
+        || trimmed.contains("..")
+        || trimmed.contains('/')
+        || trimmed.contains('\\')
+        || !trimmed
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+    {
+        anyhow::bail!("invalid {label} `{value}`");
+    }
+    Ok(trimmed)
+}
+
+fn validate_safe_absolute_path(label: &str, path: &Path) -> anyhow::Result<()> {
+    if !path.is_absolute() {
+        anyhow::bail!("{label} must be absolute: {}", path.display());
+    }
+    if path.components().any(|component| {
+        matches!(
+            component,
+            std::path::Component::CurDir | std::path::Component::ParentDir
+        )
+    }) {
+        anyhow::bail!(
+            "{label} must not contain relative components: {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use alan_service_manager::{
+        ConnectionCredential, ConnectionProfile, CredentialKind, default_credential_backend,
+    };
+
+    use super::*;
+
+    #[test]
+    fn secret_store_round_trips_secret() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = SecretStore::from_directory(temp.path()).unwrap();
+        store.save("kimi", "sk-test").unwrap();
+        assert_eq!(store.load("kimi").unwrap().as_deref(), Some("sk-test"));
+        assert!(store.delete("kimi").unwrap());
+        assert_eq!(store.load("kimi").unwrap(), None);
+    }
+
+    #[test]
+    fn resolved_host_secret_is_not_exposed_by_debug_output() {
+        let temp = tempfile::tempdir().unwrap();
+        let store =
+            SecretStore::with_resolved_secret(temp.path(), "native", "host-secret".to_string())
+                .unwrap();
+
+        assert_eq!(
+            store.load("native").unwrap().as_deref(),
+            Some("host-secret")
+        );
+        assert_eq!(store.load("missing").unwrap(), None);
+        assert!(!format!("{store:?}").contains("host-secret"));
+    }
+
+    #[test]
+    fn secret_store_uses_only_the_explicit_host_credentials_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let credentials = temp.path().join("host-store/dev/credentials");
+        let store = SecretStore::from_directory(&credentials).unwrap();
+
+        store.save("dev-profile", "sk-dev").unwrap();
+
+        assert!(
+            std::fs::read_to_string(credentials.join("secrets.toml"))
+                .unwrap()
+                .contains("sk-dev")
+        );
+        assert!(
+            !temp
+                .path()
+                .join("host-store/stable/credentials/secrets.toml")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn host_projection_combines_profile_metadata_with_secret_material() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = SecretStore::from_directory(temp.path()).unwrap();
+        store.save("openrouter-main", "sk-or").unwrap();
+        let connections = ConnectionsFile {
+            credentials: BTreeMap::from([(
+                "openrouter-main".to_string(),
+                ConnectionCredential {
+                    kind: CredentialKind::SecretString,
+                    provider_family: LlmProvider::OpenRouter,
+                    label: "OpenRouter credential".to_string(),
+                    backend: default_credential_backend(CredentialKind::SecretString).to_string(),
+                },
+            )]),
+            profiles: BTreeMap::from([(
+                "openrouter-main".to_string(),
+                ConnectionProfile {
+                    provider: LlmProvider::OpenRouter,
+                    label: Some("OpenRouter".to_string()),
+                    credential_id: Some("openrouter-main".to_string()),
+                    created_at: "2026-01-01T00:00:00Z".parse().unwrap(),
+                    updated_at: "2026-01-01T00:00:00Z".parse().unwrap(),
+                    source: "managed".to_string(),
+                    settings: BTreeMap::from([
+                        ("http_referer".to_string(), "https://alan.local".to_string()),
+                        ("x_title".to_string(), "alan".to_string()),
+                        (
+                            "app_categories".to_string(),
+                            "cli-agent,devtool".to_string(),
+                        ),
+                    ]),
+                },
+            )]),
+            ..ConnectionsFile::default()
+        };
+        let mut config = Config::default();
+
+        let resolved =
+            apply_profile_to_config(&connections, Some("openrouter-main"), &store, &mut config)
+                .unwrap();
+
+        assert_eq!(resolved.provider, LlmProvider::OpenRouter);
+        assert_eq!(config.llm_provider, LlmProvider::OpenRouter);
+        assert_eq!(config.openrouter_api_key.as_deref(), Some("sk-or"));
+        assert_eq!(config.openrouter_base_url, "https://openrouter.ai/api/v1");
+        assert_eq!(config.openrouter_model, "moonshotai/kimi-k2.6");
+        assert_eq!(
+            config.openrouter_http_referer.as_deref(),
+            Some("https://alan.local")
+        );
+        assert_eq!(config.openrouter_x_title.as_deref(), Some("alan"));
+        assert_eq!(
+            config.openrouter_app_categories,
+            vec!["cli-agent", "devtool"]
+        );
+    }
+}

--- a/crates/os-host/tests/architecture_boundary.rs
+++ b/crates/os-host/tests/architecture_boundary.rs
@@ -20,6 +20,40 @@ fn host_has_no_service_supervision_or_fixed_composition() {
     assert!(source.contains("ServiceManager::boot"));
 }
 
+#[test]
+fn host_owns_secret_materialization_while_connection_service_owns_metadata() {
+    let host_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let service_root = host_root.parent().unwrap().join("service-manager/src");
+    let mut service_files = Vec::new();
+    collect_rust_sources(&service_root, &mut service_files);
+    let service_source = service_files
+        .into_iter()
+        .map(|path| std::fs::read_to_string(path).unwrap())
+        .collect::<String>();
+    for forbidden in [
+        "struct SecretStore",
+        "apply_profile_to_config",
+        "credentials_dir",
+    ] {
+        assert!(
+            !service_source.contains(forbidden),
+            "Connection Service retained Host credential authority through `{forbidden}`"
+        );
+    }
+
+    let host_adapter = std::fs::read_to_string(host_root.join("src/secret_store.rs")).unwrap();
+    for required in [
+        "struct SecretStore",
+        "apply_profile_to_config",
+        "secrets.toml",
+    ] {
+        assert!(
+            host_adapter.contains(required),
+            "Host credential adapter is missing `{required}`"
+        );
+    }
+}
+
 fn collect_rust_sources(directory: &std::path::Path, files: &mut Vec<std::path::PathBuf>) {
     for entry in std::fs::read_dir(directory).unwrap() {
         let path = entry.unwrap().path();

--- a/crates/service-manager/src/connection.rs
+++ b/crates/service-manager/src/connection.rs
@@ -2,17 +2,17 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
-use alan_agent_engine::{
-    Config, ConnectionProfile, ConnectionStoreBindings, ConnectionsFile, LlmClient,
-    sanitize_identifier, validate_profile_settings,
+use crate::connection_profile::{
+    ConnectionProfile, ConnectionStoreBindings, ConnectionsFile, sanitize_identifier,
+    validate_profile_settings,
 };
+use crate::flat_fs::{FlatFileService, FlatServiceFs};
+use crate::runtime::LlmClientFactory;
+use alan_agent_engine::{Config, LlmClient};
 use alan_ap::{ErrorCode, FileServer};
 use alan_llm::{GenerationRequest, GenerationResponse, LlmProvider, StreamChunk};
 use anyhow::{Context, Result, ensure};
 use serde::{Deserialize, Serialize};
-
-use crate::flat_fs::{FlatFileService, FlatServiceFs};
-use crate::runtime::LlmClientFactory;
 
 const FILES: &[(&str, bool)] = &[
     ("metadata", false),
@@ -718,11 +718,7 @@ mod tests {
     #[tokio::test]
     async fn metadata_is_persistent_and_secret_bytes_never_enter_files() {
         let temp = tempfile::tempdir().unwrap();
-        let bindings = ConnectionStoreBindings::new(
-            temp.path().join("connections.toml"),
-            temp.path().join("credentials"),
-        )
-        .unwrap();
+        let bindings = ConnectionStoreBindings::new(temp.path().join("connections.toml")).unwrap();
         let service = ConnectionService::open("test", &bindings).unwrap();
         let shell = Shell::new(InProcessTransport::new(service.file_server()));
         let command = serde_json::json!({

--- a/crates/service-manager/src/connection_profile.rs
+++ b/crates/service-manager/src/connection_profile.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, LlmProvider};
+use alan_agent_engine::{Config, LlmProvider};
 use anyhow::Context;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -9,23 +9,17 @@ const CONNECTIONS_VERSION: u32 = 1;
 const CHATGPT_AUTH_BACKEND: &str = "host_managed_auth";
 const SECRET_STORE_BACKEND: &str = "host_credential_store";
 const AMBIENT_BACKEND: &str = "ambient";
-const SECRET_STORE_FILE_NAME: &str = "secrets.toml";
 
-/// Host-selected backing for Connection Service metadata and Host-owned secrets.
+/// Host-selected System Store backing for Connection Service metadata.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConnectionStoreBindings {
     pub metadata_path: PathBuf,
-    pub credentials_dir: PathBuf,
 }
 
 impl ConnectionStoreBindings {
-    pub fn new(metadata_path: PathBuf, credentials_dir: PathBuf) -> anyhow::Result<Self> {
+    pub fn new(metadata_path: PathBuf) -> anyhow::Result<Self> {
         validate_safe_absolute_path("connection metadata path", &metadata_path)?;
-        validate_safe_absolute_path("Host credential directory", &credentials_dir)?;
-        Ok(Self {
-            metadata_path,
-            credentials_dir,
-        })
+        Ok(Self { metadata_path })
     }
 }
 
@@ -86,13 +80,6 @@ pub struct ConnectionsFile {
     pub profiles: BTreeMap<String, ConnectionProfile>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-struct SecretStoreFile {
-    #[serde(default)]
-    secrets: BTreeMap<String, String>,
-}
-
 impl Default for ConnectionsFile {
     fn default() -> Self {
         Self {
@@ -126,146 +113,6 @@ pub struct ProviderDescriptor {
     pub required_settings: &'static [&'static str],
     pub optional_settings: &'static [&'static str],
     pub default_settings: &'static [(&'static str, &'static str)],
-}
-
-#[derive(Clone)]
-pub struct SecretStore {
-    credentials_dir: PathBuf,
-    resolved_secrets: BTreeMap<String, String>,
-}
-
-impl std::fmt::Debug for SecretStore {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter
-            .debug_struct("SecretStore")
-            .field("credentials_dir", &self.credentials_dir)
-            .field("resolved_secret_count", &self.resolved_secrets.len())
-            .finish()
-    }
-}
-
-impl SecretStore {
-    pub fn from_directory(credentials_dir: &Path) -> anyhow::Result<Self> {
-        validate_safe_absolute_path("Host credential directory", credentials_dir)?;
-        Ok(Self {
-            credentials_dir: credentials_dir.to_path_buf(),
-            resolved_secrets: BTreeMap::new(),
-        })
-    }
-
-    pub fn with_resolved_secret(
-        credentials_dir: &Path,
-        credential_id: &str,
-        secret: String,
-    ) -> anyhow::Result<Self> {
-        let mut store = Self::from_directory(credentials_dir)?;
-        let credential_id = validated_identifier_component("credential id", credential_id)?;
-        store
-            .resolved_secrets
-            .insert(credential_id.to_string(), secret);
-        Ok(store)
-    }
-
-    #[cfg(test)]
-    pub fn new(root_dir: PathBuf) -> Self {
-        Self {
-            credentials_dir: root_dir,
-            resolved_secrets: BTreeMap::new(),
-        }
-    }
-
-    pub fn load(&self, credential_id: &str) -> anyhow::Result<Option<String>> {
-        let credential_id = validated_identifier_component("credential id", credential_id)?;
-        if let Some(secret) = self.resolved_secrets.get(credential_id) {
-            return Ok(Some(secret.clone()));
-        }
-        let secrets = self.read_secret_file()?;
-        Ok(secrets.secrets.get(credential_id).cloned())
-    }
-
-    pub fn save(&self, credential_id: &str, secret: &str) -> anyhow::Result<()> {
-        let credential_id = validated_identifier_component("credential id", credential_id)?;
-        let mut secrets = self.read_secret_file()?;
-        secrets
-            .secrets
-            .insert(credential_id.to_string(), secret.trim().to_string());
-        self.write_secret_file(&secrets)
-    }
-
-    pub fn delete(&self, credential_id: &str) -> anyhow::Result<bool> {
-        let credential_id = validated_identifier_component("credential id", credential_id)?;
-        let mut secrets = self.read_secret_file()?;
-        let removed = secrets.secrets.remove(credential_id).is_some();
-        if removed {
-            self.write_secret_file(&secrets)?;
-        }
-        Ok(removed)
-    }
-
-    fn secret_file_path(&self) -> anyhow::Result<PathBuf> {
-        let path = self.credentials_dir.join(SECRET_STORE_FILE_NAME);
-        validate_safe_absolute_path("secret store path", &path)?;
-        Ok(path)
-    }
-
-    fn read_secret_file(&self) -> anyhow::Result<SecretStoreFile> {
-        let path = self.secret_file_path()?;
-        match std::fs::read_to_string(&path) {
-            Ok(content) => toml::from_str(&content)
-                .with_context(|| format!("failed to parse secret store {}", path.display())),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                Ok(SecretStoreFile::default())
-            }
-            Err(error) => Err(error)
-                .with_context(|| format!("failed to read secret store {}", path.display())),
-        }
-    }
-
-    fn write_secret_file(&self, secret_file: &SecretStoreFile) -> anyhow::Result<()> {
-        let path = self.secret_file_path()?;
-        if secret_file.secrets.is_empty() {
-            match std::fs::remove_file(&path) {
-                Ok(()) => return Ok(()),
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-                Err(error) => {
-                    return Err(error).with_context(|| {
-                        format!("failed to remove secret store {}", path.display())
-                    });
-                }
-            }
-        }
-        let rendered = toml::to_string_pretty(secret_file)
-            .context("failed to encode secret store while saving")?;
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).with_context(|| {
-                format!(
-                    "failed to create credentials directory {}",
-                    parent.display()
-                )
-            })?;
-        }
-        #[cfg(unix)]
-        {
-            use std::io::Write;
-            use std::os::unix::fs::OpenOptionsExt;
-
-            let mut file = std::fs::OpenOptions::new()
-                .create(true)
-                .truncate(true)
-                .write(true)
-                .mode(0o600)
-                .open(&path)
-                .with_context(|| format!("failed to open secret store {}", path.display()))?;
-            file.write_all(rendered.as_bytes())
-                .with_context(|| format!("failed to write secret store {}", path.display()))?;
-        }
-        #[cfg(not(unix))]
-        {
-            std::fs::write(&path, rendered)
-                .with_context(|| format!("failed to write secret store {}", path.display()))?;
-        }
-        Ok(())
-    }
 }
 
 impl ConnectionsFile {
@@ -382,17 +229,6 @@ impl ConnectionsFile {
             credential_kind,
             settings: normalized,
         })
-    }
-
-    pub fn apply_profile_to_config(
-        &self,
-        profile_id: Option<&str>,
-        secret_store: &SecretStore,
-        config: &mut Config,
-    ) -> anyhow::Result<ResolvedConnectionProfile> {
-        let resolved = self.resolve_profile(profile_id)?;
-        apply_resolved_profile_to_config(&resolved, secret_store, config)?;
-        Ok(resolved)
     }
 
     pub fn apply_profile_metadata_to_config(
@@ -632,21 +468,6 @@ pub fn sanitize_identifier(value: &str) -> Option<String> {
     Some(sanitized)
 }
 
-fn validated_identifier_component<'a>(label: &str, value: &'a str) -> anyhow::Result<&'a str> {
-    let trimmed = value.trim();
-    if trimmed.is_empty()
-        || trimmed.contains("..")
-        || trimmed.contains('/')
-        || trimmed.contains('\\')
-        || !trimmed
-            .chars()
-            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
-    {
-        anyhow::bail!("invalid {label} `{value}`");
-    }
-    Ok(trimmed)
-}
-
 fn validate_safe_absolute_path(label: &str, path: &Path) -> anyhow::Result<()> {
     if !path.is_absolute() {
         anyhow::bail!("{label} must be absolute: {}", path.display());
@@ -659,42 +480,6 @@ fn validate_safe_absolute_path(label: &str, path: &Path) -> anyhow::Result<()> {
             "{label} must not contain relative components: {}",
             path.display()
         );
-    }
-    Ok(())
-}
-
-fn apply_resolved_profile_to_config(
-    resolved: &ResolvedConnectionProfile,
-    secret_store: &SecretStore,
-    config: &mut Config,
-) -> anyhow::Result<()> {
-    apply_resolved_profile_metadata_to_config(resolved, config);
-    if matches!(
-        resolved.provider,
-        LlmProvider::Chatgpt | LlmProvider::GoogleGeminiGenerateContent
-    ) {
-        return Ok(());
-    }
-    let Some(credential_id) = resolved.credential_id.as_deref() else {
-        anyhow::bail!("Profile `{}` is missing a credential", resolved.profile_id);
-    };
-    let api_key = secret_store.load(credential_id)?.ok_or_else(|| {
-        anyhow::anyhow!(
-            "Credential `{credential_id}` for profile `{}` is missing a secret",
-            resolved.profile_id
-        )
-    })?;
-    match resolved.provider {
-        LlmProvider::OpenAiResponses => config.openai_responses_api_key = Some(api_key),
-        LlmProvider::OpenAiChatCompletions => {
-            config.openai_chat_completions_api_key = Some(api_key)
-        }
-        LlmProvider::OpenAiChatCompletionsCompatible => {
-            config.openai_chat_completions_compatible_api_key = Some(api_key)
-        }
-        LlmProvider::OpenRouter => config.openrouter_api_key = Some(api_key),
-        LlmProvider::AnthropicMessages => config.anthropic_messages_api_key = Some(api_key),
-        LlmProvider::Chatgpt | LlmProvider::GoogleGeminiGenerateContent => unreachable!(),
     }
     Ok(())
 }
@@ -847,52 +632,6 @@ mod tests {
     }
 
     #[test]
-    fn secret_store_round_trips_secret() {
-        let temp = TempDir::new().unwrap();
-        let store = SecretStore::from_directory(temp.path()).unwrap();
-        store.save("kimi", "sk-test").unwrap();
-        assert_eq!(store.load("kimi").unwrap().as_deref(), Some("sk-test"));
-        assert!(store.delete("kimi").unwrap());
-        assert_eq!(store.load("kimi").unwrap(), None);
-    }
-
-    #[test]
-    fn secret_store_accepts_one_host_resolved_secret_without_platform_logic() {
-        let temp = TempDir::new().unwrap();
-        let store =
-            SecretStore::with_resolved_secret(temp.path(), "native", "host-secret".to_string())
-                .unwrap();
-
-        assert_eq!(
-            store.load("native").unwrap().as_deref(),
-            Some("host-secret")
-        );
-        assert_eq!(store.load("missing").unwrap(), None);
-        assert!(!format!("{store:?}").contains("host-secret"));
-    }
-
-    #[test]
-    fn secret_store_uses_only_explicit_credentials_dir() {
-        let temp = TempDir::new().unwrap();
-        let credentials = temp.path().join("host-store/dev/credentials");
-        let store = SecretStore::from_directory(&credentials).unwrap();
-
-        store.save("dev-profile", "sk-dev").unwrap();
-
-        assert!(
-            std::fs::read_to_string(credentials.join("secrets.toml"))
-                .unwrap()
-                .contains("sk-dev")
-        );
-        assert!(
-            !temp
-                .path()
-                .join("host-store/stable/credentials/secrets.toml")
-                .exists()
-        );
-    }
-
-    #[test]
     fn dev_connection_store_does_not_fall_back_to_stable_store() {
         let temp = TempDir::new().unwrap();
         let stable_path = temp.path().join("system-store/stable/connections.toml");
@@ -958,65 +697,6 @@ mod tests {
         assert_eq!(
             resolved.settings.get("model").map(String::as_str),
             Some("gpt-5.3-codex")
-        );
-    }
-
-    #[test]
-    fn apply_openrouter_profile_to_config_loads_secret_and_metadata() {
-        let temp = TempDir::new().unwrap();
-        let store = SecretStore::from_directory(temp.path()).unwrap();
-        store.save("openrouter-main", "sk-or").unwrap();
-
-        let file = ConnectionsFile {
-            credentials: BTreeMap::from([(
-                "openrouter-main".to_string(),
-                ConnectionCredential {
-                    kind: CredentialKind::SecretString,
-                    provider_family: LlmProvider::OpenRouter,
-                    label: "OpenRouter credential".to_string(),
-                    backend: SECRET_STORE_BACKEND.to_string(),
-                },
-            )]),
-            profiles: BTreeMap::from([(
-                "openrouter-main".to_string(),
-                ConnectionProfile {
-                    provider: LlmProvider::OpenRouter,
-                    label: Some("OpenRouter".to_string()),
-                    credential_id: Some("openrouter-main".to_string()),
-                    created_at: default_profile_timestamp(),
-                    updated_at: default_profile_timestamp(),
-                    source: default_profile_source(),
-                    settings: BTreeMap::from([
-                        ("http_referer".to_string(), "https://alan.local".to_string()),
-                        ("x_title".to_string(), "alan".to_string()),
-                        (
-                            "app_categories".to_string(),
-                            "cli-agent,devtool".to_string(),
-                        ),
-                    ]),
-                },
-            )]),
-            ..ConnectionsFile::default()
-        };
-
-        let mut config = Config::default();
-        let resolved = file
-            .apply_profile_to_config(Some("openrouter-main"), &store, &mut config)
-            .unwrap();
-
-        assert_eq!(resolved.provider, LlmProvider::OpenRouter);
-        assert_eq!(config.llm_provider, LlmProvider::OpenRouter);
-        assert_eq!(config.openrouter_api_key.as_deref(), Some("sk-or"));
-        assert_eq!(config.openrouter_base_url, "https://openrouter.ai/api/v1");
-        assert_eq!(config.openrouter_model, "moonshotai/kimi-k2.6");
-        assert_eq!(
-            config.openrouter_http_referer.as_deref(),
-            Some("https://alan.local")
-        );
-        assert_eq!(config.openrouter_x_title.as_deref(), Some("alan"));
-        assert_eq!(
-            config.openrouter_app_categories,
-            vec!["cli-agent", "devtool"]
         );
     }
 

--- a/crates/service-manager/src/lib.rs
+++ b/crates/service-manager/src/lib.rs
@@ -7,6 +7,7 @@
 
 mod boot_unit;
 mod connection;
+mod connection_profile;
 mod control_fs;
 mod flat_fs;
 mod host_mount;
@@ -20,6 +21,11 @@ pub use boot_unit::{
 };
 pub use connection::{
     ConnectionService, NativeConnectionAction, NativeConnectionRequest, NativeConnectionResponse,
+};
+pub use connection_profile::{
+    ConnectionCredential, ConnectionProfile, ConnectionStoreBindings, ConnectionsFile,
+    CredentialKind, ProviderDescriptor, ResolvedConnectionProfile, default_credential_backend,
+    normalize_profile_settings, provider_catalog, sanitize_identifier, validate_profile_settings,
 };
 pub use control_fs::{
     ManagerState, RestartDecision, ServiceManagerFs, SystemStatus, UnitSnapshot, UnitStatus,

--- a/crates/service-manager/src/runtime.rs
+++ b/crates/service-manager/src/runtime.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use alan_agent_engine::{
-    AgentProcessConfig, ConnectionsFile, LlmClient, ProcessLaunchContext, ProcessPackageKind,
+    AgentProcessConfig, LlmClient, ProcessLaunchContext, ProcessPackageKind,
     ProcessPackageReference, ProcessPackageSkillReference, RuntimeController, ToolRegistry,
     configure_runtime_tool_execution_binding, provider_capabilities_for_config,
     spawn_with_namespace_environment,
@@ -21,9 +21,10 @@ use async_trait::async_trait;
 use uuid::Uuid;
 
 use crate::{
-    BootManifest, BootUnit, ConnectionService, HostMountApplicatorFactory, HostMountExportAdapter,
-    HostMountService, LocalEntryService, ManagerState, PackageService, RestartDecision,
-    ServiceManagerFs, UnavailableHostMountExportAdapter,
+    BootManifest, BootUnit, ConnectionService, ConnectionStoreBindings, ConnectionsFile,
+    HostMountApplicatorFactory, HostMountExportAdapter, HostMountService, LocalEntryService,
+    ManagerState, PackageService, RestartDecision, ServiceManagerFs,
+    UnavailableHostMountExportAdapter,
     quartermaster::{QUARTERMASTER_EXECUTABLE, SystemProcessRunner},
 };
 
@@ -136,7 +137,7 @@ impl FileServer for SwitchableFileServer {
 pub struct ServiceManagerConfig {
     pub channel_id: String,
     pub process: AgentProcessConfig,
-    pub connection_store: Option<alan_agent_engine::ConnectionStoreBindings>,
+    pub connection_store: Option<ConnectionStoreBindings>,
     pub package_store: Option<std::path::PathBuf>,
     pub llm_factory: Arc<dyn LlmClientFactory>,
     pub host_mount_adapter: Arc<dyn HostMountExportAdapter>,
@@ -213,7 +214,7 @@ impl ServiceManagerConfig {
     pub fn with_factory(
         channel_id: impl Into<String>,
         process: AgentProcessConfig,
-        connection_store: Option<alan_agent_engine::ConnectionStoreBindings>,
+        connection_store: Option<ConnectionStoreBindings>,
         package_store: Option<std::path::PathBuf>,
         llm_factory: Arc<dyn LlmClientFactory>,
         host_mount_adapter: Arc<dyn HostMountExportAdapter>,
@@ -1730,11 +1731,10 @@ async fn verify_readiness(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alan_agent_engine::{
-        ConnectionCredential, ConnectionProfile, ConnectionStoreBindings, CredentialKind,
-        LlmProvider as ConnectionProvider,
-    };
+    use alan_agent_engine::LlmProvider as ConnectionProvider;
     use alan_llm::MockLlmProvider;
+
+    use crate::{ConnectionCredential, ConnectionProfile, CredentialKind};
 
     #[derive(Debug)]
     struct MissingSecretFactory;
@@ -2004,8 +2004,7 @@ mod tests {
             LlmClient::new(MockLlmProvider::new()),
             ToolRegistry::new(),
         );
-        config.connection_store =
-            Some(ConnectionStoreBindings::new(metadata, temp.path().join("credentials")).unwrap());
+        config.connection_store = Some(ConnectionStoreBindings::new(metadata).unwrap());
         config.llm_factory = Arc::new(MissingSecretFactory);
 
         let manager = ServiceManager::boot(config).await.unwrap();
@@ -2077,8 +2076,7 @@ mod tests {
             LlmClient::new(MockLlmProvider::new()),
             ToolRegistry::new(),
         );
-        config.connection_store =
-            Some(ConnectionStoreBindings::new(metadata, temp.path().join("credentials")).unwrap());
+        config.connection_store = Some(ConnectionStoreBindings::new(metadata).unwrap());
         let factory = Arc::new(RecordingFactory::default());
         config.llm_factory = factory.clone();
 

--- a/crates/service-manager/tests/connection_service_contract.rs
+++ b/crates/service-manager/tests/connection_service_contract.rs
@@ -1,0 +1,71 @@
+use std::collections::BTreeMap;
+
+use alan_agent_engine::LlmProvider;
+use alan_ap::InProcessTransport;
+use alan_service_manager::{ConnectionProfile, ConnectionService};
+use alan_shell::Shell;
+use chrono::Utc;
+
+fn profile() -> ConnectionProfile {
+    ConnectionProfile {
+        provider: LlmProvider::OpenAiResponses,
+        label: None,
+        credential_id: Some("openai-main".to_string()),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        source: "managed".to_string(),
+        settings: BTreeMap::from([
+            (
+                "base_url".to_string(),
+                "https://api.openai.com/v1".to_string(),
+            ),
+            ("model".to_string(), "gpt-5.4".to_string()),
+        ]),
+    }
+}
+
+async fn add_profile(shell: &Shell, profile_id: &str) {
+    shell
+        .write(
+            "/ctl",
+            &serde_json::to_vec(&serde_json::json!({
+                "op": "add_profile",
+                "profile_id": profile_id,
+                "profile": profile(),
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn process_selection_overrides_and_then_falls_back_to_service_default() {
+    let service = ConnectionService::ephemeral("test");
+    let shell = Shell::new(InProcessTransport::new(service.file_server()));
+    add_profile(&shell, "default-profile").await;
+    add_profile(&shell, "process-profile").await;
+    shell
+        .write(
+            "/ctl",
+            br#"{"op":"set_default","profile_id":"default-profile"}"#,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        service.selected_profile(42).as_deref(),
+        Some("default-profile")
+    );
+    service.select(42, "process-profile").unwrap();
+    assert_eq!(
+        service.selected_profile(42).as_deref(),
+        Some("process-profile")
+    );
+
+    service.release_process(42);
+    assert_eq!(
+        service.selected_profile(42).as_deref(),
+        Some("default-profile")
+    );
+}

--- a/openspec/changes/refactor-clean-code-architecture-debt/tasks.md
+++ b/openspec/changes/refactor-clean-code-architecture-debt/tasks.md
@@ -1,13 +1,13 @@
 ## 1. Immediate Connection Service PR
 
-- [ ] 1.1 Confirm `enforce-clean-code-architecture-gates` is merged and branch
+- [x] 1.1 Confirm `enforce-clean-code-architecture-gates` is merged and branch
   the next PR from that exact `main` before unrelated feature work.
-- [ ] 1.2 Characterize current profile metadata, default selection, mounted
+- [x] 1.2 Characterize current profile metadata, default selection, mounted
   connection publication, and engine consumption with focused contract tests.
-- [ ] 1.3 Move one complete profile metadata/selection responsibility from
+- [x] 1.3 Move one complete profile metadata/selection responsibility from
   Agent Execution Engine into Connection Service without adding a bridge or
   dual writer.
-- [ ] 1.4 Delete the displaced engine path, remove any dependency it made
+- [x] 1.4 Delete the displaced engine path, remove any dependency it made
   unnecessary, and tighten the source-size and dependency baselines.
 - [ ] 1.5 Run the canonical gate and focused tests, open the behavior-preserving
   PR, and resolve Codex review until no new issue remains.

--- a/openspec/changes/refactor-clean-code-architecture-debt/tasks.md
+++ b/openspec/changes/refactor-clean-code-architecture-debt/tasks.md
@@ -9,7 +9,7 @@
   dual writer.
 - [x] 1.4 Delete the displaced engine path, remove any dependency it made
   unnecessary, and tighten the source-size and dependency baselines.
-- [ ] 1.5 Run the canonical gate and focused tests, open the behavior-preserving
+- [x] 1.5 Run the canonical gate and focused tests, open the behavior-preserving
   PR, and resolve Codex review until no new issue remains.
 
 ## 2. Agent Runtime Service Ownership

--- a/scripts/rust-source-size-baseline.txt
+++ b/scripts/rust-source-size-baseline.txt
@@ -4,7 +4,6 @@ crates/agent-engine/skills/swebench/tooling/src/swebench_lite.rs 1389
 crates/agent-engine/src/agent_definition.rs 1005
 crates/agent-engine/src/agent_machine.rs 3661
 crates/agent-engine/src/config.rs 2556
-crates/agent-engine/src/connections.rs 1061
 crates/agent-engine/src/policy.rs 1177
 crates/agent-engine/src/rollout.rs 2266
 crates/agent-engine/src/runtime/agent_loop.rs 2771
@@ -52,9 +51,9 @@ crates/llm/src/openai_chat_completions.rs 3324
 crates/llm/src/openrouter.rs 1235
 crates/llmfs/src/lib.rs 1937
 crates/llmfs/tests/generation.rs 1627
-crates/service-manager/src/connection.rs 1052
+crates/service-manager/src/connection.rs 1048
 crates/service-manager/src/package.rs 2947
-crates/service-manager/src/runtime.rs 2439
+crates/service-manager/src/runtime.rs 2437
 crates/shell-core/src/actions.rs 1591
 crates/shell-core/src/control.rs 1183
 crates/shell-core/src/model.rs 1320


### PR DESCRIPTION
## Summary

- move connection profile metadata, defaults, validation, persistence, and runtime projection out of `alan-agent-engine` into `alan-service-manager`
- keep Host credential storage and secret-to-provider projection in `alan-os-host`; Service Manager now receives only the System Store metadata path
- add executable ownership guards plus metadata/default/Process-selection/callable-publication contract coverage
- remove the retired 1,061-line Engine module from the source-size debt ledger and tighten touched ratchets
- mark OpenSpec tasks 1.1 through 1.4 complete in `refactor-clean-code-architecture-debt`

## Verification

- `just quality`
- `just test`
- `openspec validate --all --strict` (88 passed)
- focused Engine, Connection Service, Host secret-store, and architecture-boundary tests

This is the immediate debt PR recorded after the repository quality-gate PR. It is behavior-preserving and intentionally excludes the later Agent Runtime, broad Rust source, and Apple architecture slices.