### PR TITLE
refactor: deepen delegated child run supervision

### DIFF
--- a/crates/agent-engine/src/runtime/child_agents.rs
+++ b/crates/agent-engine/src/runtime/child_agents.rs
@@ -1,9 +1,10 @@
 use super::agent_loop::RuntimeLoopState;
-use super::child_runs::{
-    ChildRunRecord, ChildRunRegistry, ChildRunStatus, ChildRunTerminationMode,
-    ChildRunTerminationRequest,
-};
-use super::delegated_child_run::{ChildRuntimePause, ChildRuntimeResult, ChildRuntimeStatus};
+#[cfg(test)]
+use super::child_runs::ChildRunRegistry;
+use super::child_runs::{ChildRunRecord, ChildRunStatus};
+#[cfg(test)]
+use super::delegated_child_run::ChildRuntimeStatus;
+use super::delegated_child_run::{DelegatedChildRunSupervision, DelegatedChildRunSupervisor};
 use super::delegation_capabilities::{
     DelegatedSpawnRejected, evaluate_delegated_namespace, namespace_summary_from_bindings,
 };
@@ -17,7 +18,7 @@ use crate::llm::LlmClient;
 use crate::tape::{ContentPart, Message};
 use alan_agent_protocol::{
     DelegatedCapabilityDecision, DelegatedCapabilityRecovery, GovernanceConfig, Op, SpawnHandle,
-    SpawnSpec, SpawnTarget, Submission, YieldKind,
+    SpawnSpec, SpawnTarget, Submission,
 };
 #[cfg(test)]
 use alan_ap::{Fid, FileServer, InProcessTransport, OpenMode};
@@ -27,23 +28,22 @@ use alan_kernel::{ExecNamespaceAccess, ExecNamespaceManifest, ExecNamespaceMount
 use alan_llm::{GenerationRequest, GenerationResponse, LlmProvider, StreamChunk};
 use anyhow::{Context, Result, bail};
 use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 #[cfg(test)]
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
-const CHILD_AGENT_LAUNCH_CANCELLED_MESSAGE: &str = "Child-agent launch cancelled";
+const CHILD_AGENT_LAUNCH_CANCELLED_MESSAGE: &str = "Child Agent Process launch cancelled";
 const MAX_CHILD_CONVERSATION_MESSAGES: usize = 8;
 const MAX_CHILD_CONVERSATION_CHARS: usize = 4_000;
 const MAX_CHILD_PLAN_ITEMS: usize = 16;
 const MAX_CHILD_PLAN_ITEM_CHARS: usize = 240;
 const MAX_CHILD_TOOL_RESULTS: usize = 6;
 const MAX_CHILD_TOOL_RESULT_CHARS: usize = 1_200;
-const MAX_OBSERVED_CHILD_WARNINGS: usize = 32;
-const MAX_OBSERVED_CHILD_WARNING_CHARS: usize = 512;
-const MAX_CHILD_FILE_OBSERVATION_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const ROUTE_MOUNT_PATH: &str = "/mnt/route";
 #[cfg(test)]
 static NEXT_CHILD_NAMESPACE_FID: AtomicU64 = AtomicU64::new(80_000);
@@ -83,95 +83,11 @@ impl LlmProvider for ChildLlmProvider {
     }
 }
 
-#[derive(Debug)]
-struct ObservedChildTerminalEvent {
-    output_text: String,
-    turn_summary: Option<String>,
-    structured_output: Option<serde_json::Value>,
-    warnings: Vec<String>,
-    error_message: Option<String>,
-    pause: Option<ChildRuntimePause>,
-    status: ChildRuntimeStatus,
-}
-
-enum ChildRuntimeWaitOutcome {
-    Observed(ObservedChildTerminalEvent),
-    Cancelled,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ChildFileObservation {
-    process_exited: bool,
-    process_exit_code: Option<i32>,
-    output_text: String,
-    process_output_offset: u64,
-    process_io_events_offset: u64,
-    request_ids: Vec<String>,
-    pending_request_id: Option<String>,
-    request_events_offset: u64,
-    action_ids: Vec<String>,
-    action_events_offset: u64,
-    ui_events_offset: u64,
-    terminal_error: Option<String>,
-    activity: alan_agent_protocol::UiActivitySnapshot,
-    notice: alan_agent_protocol::UiNoticeSnapshot,
-}
-
-fn push_bounded_child_warning(warnings: &mut Vec<String>, warning: String) {
-    while warnings.len() >= MAX_OBSERVED_CHILD_WARNINGS {
-        warnings.remove(0);
-    }
-    warnings.push(truncate_child_text_with_suffix(
-        &warning,
-        MAX_OBSERVED_CHILD_WARNING_CHARS,
-        "...",
-    ));
-}
-
-fn truncate_child_text_with_suffix(text: &str, max_chars: usize, suffix: &str) -> String {
-    if text.chars().count() <= max_chars {
-        return text.to_string();
-    }
-
-    let suffix_len = suffix.chars().count();
-    if max_chars <= suffix_len {
-        return suffix.chars().take(max_chars).collect();
-    }
-
-    let mut truncated = text
-        .chars()
-        .take(max_chars.saturating_sub(suffix_len))
-        .collect::<String>();
-    truncated.push_str(suffix);
-    truncated
-}
-
-#[cfg_attr(
-    not(test),
-    allow(
-        dead_code,
-        reason = "controller is currently constructed only by the focused child-runtime tests"
-    )
-)]
-pub(crate) struct ChildRuntimeController {
-    runtime: Option<RuntimeController>,
-    startup_metadata: RuntimeStartupMetadata,
-    child_run_id: String,
-    child_run_registry: ChildRunRegistry,
-    timeout: Option<Duration>,
-    process_lifecycle: Arc<dyn super::AgentProcessLifecycle>,
-    process_environment: super::NamespaceRuntimeEnvironment,
-    process_pid: String,
-}
-
-#[allow(
-    dead_code,
-    reason = "non-cancellable adapter remains available to focused child-runtime tests"
-)]
+#[cfg(test)]
 pub(crate) async fn spawn_child_runtime(
     parent: &RuntimeLoopState,
     spec: SpawnSpec,
-) -> Result<ChildRuntimeController> {
+) -> Result<DelegatedChildRunSupervisor> {
     spawn_child_runtime_with_optional_cancel(parent, spec, None).await
 }
 
@@ -183,7 +99,7 @@ pub(crate) async fn spawn_child_runtime_cancellable(
     parent: &RuntimeLoopState,
     spec: SpawnSpec,
     cancel: &CancellationToken,
-) -> Result<ChildRuntimeController> {
+) -> Result<DelegatedChildRunSupervisor> {
     spawn_child_runtime_with_optional_cancel(parent, spec, Some(cancel)).await
 }
 
@@ -191,7 +107,7 @@ async fn spawn_child_runtime_with_optional_cancel(
     parent: &RuntimeLoopState,
     spec: SpawnSpec,
     cancel: Option<&CancellationToken>,
-) -> Result<ChildRuntimeController> {
+) -> Result<DelegatedChildRunSupervisor> {
     #[cfg(test)]
     {
         return spawn_child_runtime_inner(parent, spec, None, cancel).await;
@@ -207,7 +123,7 @@ async fn spawn_child_runtime_with_client_factory<F>(
     parent: &RuntimeLoopState,
     spec: SpawnSpec,
     llm_client_factory: F,
-) -> Result<ChildRuntimeController>
+) -> Result<DelegatedChildRunSupervisor>
 where
     F: FnOnce(&crate::Config) -> Result<LlmClient> + Send,
 {
@@ -223,7 +139,7 @@ async fn spawn_child_runtime_inner(
     mut spec: SpawnSpec,
     #[cfg(test)] llm_client_factory: Option<TestChildLlmClientFactory<'_>>,
     cancel: Option<&CancellationToken>,
-) -> Result<ChildRuntimeController> {
+) -> Result<DelegatedChildRunSupervisor> {
     if cancel.is_some_and(CancellationToken::is_cancelled) {
         bail!(CHILD_AGENT_LAUNCH_CANCELLED_MESSAGE);
     }
@@ -265,10 +181,10 @@ async fn spawn_child_runtime_inner(
             .resolved_skill_overrides(),
         child_config.core_config_source,
     )
-    .context("Failed to resolve child-agent definition")?;
+    .context("Failed to resolve child Agent Process definition")?;
     let mut resolved_child_agent_config = resolved_child_definition
         .apply_to_agent_config(&child_agent_config)
-        .context("Failed to resolve effective child-agent config")?;
+        .context("Failed to resolve effective child Agent Process config")?;
     if spec.has_handle(SpawnHandle::Memory) {
         resolved_child_agent_config.core_config.memory.store_dir =
             parent.core_config.memory.store_dir.clone();
@@ -278,7 +194,7 @@ async fn spawn_child_runtime_inner(
     child_config.agent_config = resolved_child_agent_config;
     child_config.core_config_source = crate::ConfigSourceKind::EnvOverride;
     let effective_child_core_config = effective_core_config_for_runtime(&child_config)
-        .context("Failed to resolve effective child-agent runtime config")?;
+        .context("Failed to resolve effective child Agent Process runtime config")?;
     let child_namespace_plan = build_child_namespace_assembly_plan(
         parent,
         &spec,
@@ -286,7 +202,7 @@ async fn spawn_child_runtime_inner(
         child_config.launch_context.clone(),
     )
     .await
-    .context("Failed to assemble child-agent namespace plan")?;
+    .context("Failed to assemble child Agent Process namespace plan")?;
     let child_connection = child_namespace_plan.llm_connection_name()?;
     ensure_child_connection_is_passed(parent, &child_connection)?;
     let delegation_capability_decision =
@@ -294,7 +210,7 @@ async fn spawn_child_runtime_inner(
     #[cfg(test)]
     let test_llm = if let Some(factory) = llm_client_factory {
         let client = factory(&effective_child_core_config)
-            .context("Failed to create test child-agent LLM client")?;
+            .context("Failed to create test child Agent Process LLM client")?;
         let llmfs = Arc::new(alan_llmfs::LlmFs::new());
         llmfs.register_connection(
             &child_namespace_plan.llm_connection_name()?,
@@ -320,7 +236,7 @@ async fn spawn_child_runtime_inner(
             llm_override: test_llm,
         })
         .await
-        .context("Failed to spawn child-agent process namespace")?;
+        .context("Failed to spawn child Agent Process namespace")?;
     let child_process_pid = assembly.pid.clone();
     let child_process_environment = assembly.observation_environment;
     let process_lifecycle = assembly.lifecycle;
@@ -338,7 +254,7 @@ async fn spawn_child_runtime_inner(
         host_capabilities,
         generation_capabilities,
     )
-    .context("Failed to spawn child-agent namespace runtime")
+    .context("Failed to spawn child Agent Process runtime")
     {
         Ok(runtime) => runtime,
         Err(err) => {
@@ -381,23 +297,25 @@ async fn spawn_child_runtime_inner(
     };
     child_run_registry.mark_running(&child_run_id);
 
-    Ok(ChildRuntimeController {
-        runtime: Some(runtime),
-        startup_metadata,
-        child_run_id,
-        child_run_registry,
-        timeout: spec.launch.timeout_secs.map(Duration::from_secs),
-        process_lifecycle,
-        process_environment: child_process_environment,
-        process_pid: child_process_pid,
-    })
+    Ok(DelegatedChildRunSupervisor::new(
+        DelegatedChildRunSupervision {
+            runtime: Some(runtime),
+            startup_metadata,
+            child_run_id,
+            child_run_registry,
+            timeout: spec.launch.timeout_secs.map(Duration::from_secs),
+            process_lifecycle,
+            process_environment: child_process_environment,
+            process_pid: child_process_pid,
+        },
+    ))
 }
 
 fn ensure_child_connection_is_passed(parent: &RuntimeLoopState, requested: &str) -> Result<()> {
     let passed = parent.namespace_environment().llm_connection();
     if requested != passed {
         bail!(
-            "Child-agent Connection '{requested}' was not passed by the parent Process; available Connection is '{passed}'."
+            "Connection '{requested}' was not passed to the child Agent Process by the parent Process; available Connection is '{passed}'."
         );
     }
     Ok(())
@@ -423,7 +341,9 @@ fn build_child_launch_context(
                 .iter()
                 .any(|grant| grant.resolve_host_path(cwd).is_some())
         {
-            bail!("Child-agent launch cwd '{cwd}' requires the explicit host_mounts handle.");
+            bail!(
+                "Child Agent Process launch cwd '{cwd}' requires the explicit host_mounts handle."
+            );
         }
         if child_cwd.is_none()
             && inherited_mounts
@@ -461,7 +381,7 @@ fn build_child_launch_context(
     {
         let descriptor_path = root_dir
             .to_str()
-            .context("package child-agent descriptor path is not UTF-8")?;
+            .context("package child Agent Executable descriptor path is not UTF-8")?;
         if !spec.has_handle(SpawnHandle::HostMounts)
             && let Some(parent_definition_path) = parent_definition_path.as_deref()
         {
@@ -617,14 +537,14 @@ async fn wait_for_child_runtime_startup(
                 bail!(CHILD_AGENT_LAUNCH_CANCELLED_MESSAGE);
             }
             ready = runtime.wait_until_ready() => {
-                ready.context("Child-agent runtime failed to start")?
+                ready.context("Child Agent Process runtime failed to start")?
             }
         }
     } else {
         runtime
             .wait_until_ready()
             .await
-            .context("Child-agent runtime failed to start")?
+            .context("Child Agent Process runtime failed to start")?
     };
 
     Ok((runtime, startup_metadata))
@@ -646,7 +566,7 @@ async fn send_initial_child_submission(
                 bail!(CHILD_AGENT_LAUNCH_CANCELLED_MESSAGE);
             }
             result = runtime.handle.submission_tx.send(submission) => {
-                result.context("Failed to submit initial child-agent turn")?
+                result.context("Failed to submit initial child Agent Process turn")?
             }
         }
     } else {
@@ -655,7 +575,7 @@ async fn send_initial_child_submission(
             .submission_tx
             .send(submission)
             .await
-            .context("Failed to submit initial child-agent turn")?;
+            .context("Failed to submit initial child Agent Process turn")?;
     }
 
     Ok(runtime)
@@ -664,7 +584,7 @@ async fn send_initial_child_submission(
 fn validate_child_launch_contract(spec: &SpawnSpec) -> Result<Option<String>> {
     if spec.has_handle(SpawnHandle::Artifacts) || spec.launch.output_dir.is_some() {
         bail!(
-            "Child-agent launches do not support artifact routing yet; omit SpawnHandle::Artifacts and launch.output_dir."
+            "Child Agent Process launches do not support artifact routing yet; omit SpawnHandle::Artifacts and launch.output_dir."
         );
     }
 
@@ -672,7 +592,7 @@ fn validate_child_launch_contract(spec: &SpawnSpec) -> Result<Option<String>> {
         && !cwd.is_absolute()
     {
         bail!(
-            "Child-agent launch cwd '{}' must be absolute.",
+            "Child Agent Process launch cwd '{}' must be absolute.",
             cwd.display()
         );
     }
@@ -684,12 +604,12 @@ fn validate_child_launch_contract(spec: &SpawnSpec) -> Result<Option<String>> {
         .map(|cwd| {
             let cwd = cwd.to_str().with_context(|| {
                 format!(
-                    "Child-agent launch cwd '{}' must be valid Unicode.",
+                    "Child Agent Process launch cwd '{}' must be valid Unicode.",
                     cwd.display()
                 )
             })?;
             crate::process_launch::normalize_namespace_path(cwd)
-                .with_context(|| format!("Invalid child-agent launch cwd '{}'.", cwd))
+                .with_context(|| format!("Invalid child Agent Process launch cwd '{}'.", cwd))
         })
         .transpose()?;
 
@@ -732,7 +652,9 @@ fn resolve_launch_root_dir(
                 .capability_view()
                 .map(crate::skills::ResolvedCapabilityView::refresh)
                 .and_then(|view| view.resolve_child_agent_export(target).cloned())
-                .ok_or_else(|| anyhow::anyhow!("Unknown package child-agent target: {target:?}"))?;
+                .ok_or_else(|| {
+                    anyhow::anyhow!("Unknown package child Agent Executable target: {target:?}")
+                })?;
             Ok(Some(ResolvedLaunchRoot {
                 root_dir: export.root_dir,
                 file_tree: export.file_tree,
@@ -745,554 +667,6 @@ struct ResolvedLaunchRoot {
     root_dir: PathBuf,
     file_tree: Option<crate::ProcessFileTree>,
 }
-
-#[allow(
-    dead_code,
-    reason = "file observation helpers are exercised through focused child-runtime tests"
-)]
-impl ChildRuntimeController {
-    async fn observe_files(&self) -> Result<Option<ChildFileObservation>> {
-        let environment = &self.process_environment;
-        let pid = self.process_pid.as_str();
-        let timeout = Duration::from_secs(1);
-        let process_exit_code = environment.read_process_exit_code(pid).await?;
-        let (process_output_offset, process_io_events_offset) =
-            environment.read_process_io_offsets(pid).await?;
-        let activity = tokio::time::timeout(timeout, environment.read_ui_activity_snapshot())
-            .await
-            .context("observe child activity timed out")??;
-        let output_text = tokio::time::timeout(timeout, environment.read_assistant_output())
-            .await
-            .context("observe child output timed out")??;
-        let ui_events_offset = tokio::time::timeout(timeout, environment.ui_events_offset())
-            .await
-            .context("observe child UI events offset timed out")??;
-        let notice = tokio::time::timeout(timeout, environment.read_ui_notice_snapshot())
-            .await
-            .context("observe child notice timed out")??;
-        let request_ids = tokio::time::timeout(timeout, environment.request_ids())
-            .await
-            .context("observe child requests timed out")??;
-        let pending_request_id =
-            tokio::time::timeout(timeout, environment.pending_request_id(&request_ids))
-                .await
-                .context("observe child pending request timed out")??;
-        let request_events_offset =
-            tokio::time::timeout(timeout, environment.request_events_offset())
-                .await
-                .context("observe child request stream offset timed out")??;
-        let action_ids = tokio::time::timeout(timeout, environment.action_ids())
-            .await
-            .context("observe child actions timed out")??;
-        let action_events_offset =
-            tokio::time::timeout(timeout, environment.action_events_offset())
-                .await
-                .context("observe child action stream offset timed out")??;
-        Ok(Some(ChildFileObservation {
-            process_exited: process_exit_code.is_some(),
-            process_exit_code,
-            output_text,
-            process_output_offset,
-            process_io_events_offset,
-            request_ids,
-            pending_request_id,
-            request_events_offset,
-            action_ids,
-            action_events_offset,
-            ui_events_offset,
-            terminal_error: if notice.kind == alan_agent_protocol::UiNoticeKind::Error {
-                Some(notice.message.clone())
-            } else {
-                None
-            },
-            activity,
-            notice,
-        }))
-    }
-
-    pub(crate) fn startup_metadata(&self) -> &RuntimeStartupMetadata {
-        &self.startup_metadata
-    }
-
-    pub(crate) async fn join(mut self) -> Result<ChildRuntimeResult> {
-        let observed = match self
-            .wait_for_terminal_event_with_optional_cancel(None)
-            .await?
-        {
-            ChildRuntimeWaitOutcome::Observed(observed) => observed,
-            ChildRuntimeWaitOutcome::Cancelled => {
-                return Ok(self.cancelled_result());
-            }
-        };
-
-        self.finish_after_observed_terminal_event(observed).await
-    }
-
-    pub(crate) async fn join_until_cancelled(
-        mut self,
-        cancel: &CancellationToken,
-    ) -> Result<ChildRuntimeResult> {
-        match self
-            .wait_for_terminal_event_with_optional_cancel(Some(cancel))
-            .await?
-        {
-            ChildRuntimeWaitOutcome::Observed(observed) => {
-                self.finish_after_observed_terminal_event(observed).await
-            }
-            ChildRuntimeWaitOutcome::Cancelled => Ok(self.cancelled_result()),
-        }
-    }
-
-    async fn finish_after_observed_terminal_event(
-        &mut self,
-        observed: ObservedChildTerminalEvent,
-    ) -> Result<ChildRuntimeResult> {
-        let mut warnings = Vec::new();
-        for warning in self
-            .startup_metadata
-            .warnings
-            .iter()
-            .cloned()
-            .chain(observed.warnings)
-        {
-            push_bounded_child_warning(&mut warnings, warning);
-        }
-        self.finish_runtime_and_process(&observed.status).await;
-        let output_text = observed.output_text;
-        let rollout_fallback_text = if output_text.trim().is_empty() {
-            read_latest_assistant_text_from_rollout(self.startup_metadata.rollout_path.as_deref())
-                .await
-        } else {
-            None
-        };
-        let output_text = if output_text.trim().is_empty() {
-            rollout_fallback_text.unwrap_or(output_text)
-        } else {
-            output_text
-        };
-        let structured_output = observed
-            .structured_output
-            .or_else(|| parse_child_structured_output(output_text.as_str()));
-        let child_status = child_run_status_for_runtime_status(observed.status.clone());
-        self.child_run_registry.mark_terminal(
-            &self.child_run_id,
-            child_status,
-            observed.error_message.clone(),
-        );
-
-        Ok(ChildRuntimeResult {
-            status: observed.status,
-            process_path: self.startup_metadata.process_path.clone(),
-            child_run_id: Some(self.child_run_id.clone()),
-            rollout_path: self.startup_metadata.rollout_path.clone(),
-            output_text,
-            turn_summary: observed.turn_summary,
-            structured_output,
-            warnings,
-            error_message: observed.error_message,
-            pause: observed.pause,
-            child_run: self.child_run_registry.get(&self.child_run_id),
-        })
-    }
-
-    pub(crate) async fn cancel(mut self) -> Result<ChildRuntimeResult> {
-        let result = self.cancelled_result();
-        self.terminate_runtime().await;
-        Ok(result)
-    }
-
-    fn cancelled_result(&self) -> ChildRuntimeResult {
-        self.child_run_registry
-            .mark_terminal(&self.child_run_id, ChildRunStatus::Cancelled, None);
-        let mut warnings = Vec::new();
-        for warning in self.startup_metadata.warnings.iter().cloned() {
-            push_bounded_child_warning(&mut warnings, warning);
-        }
-        ChildRuntimeResult {
-            status: ChildRuntimeStatus::Cancelled,
-            process_path: self.startup_metadata.process_path.clone(),
-            child_run_id: Some(self.child_run_id.clone()),
-            rollout_path: self.startup_metadata.rollout_path.clone(),
-            output_text: String::new(),
-            turn_summary: None,
-            structured_output: None,
-            warnings,
-            error_message: None,
-            pause: None,
-            child_run: self.child_run_registry.get(&self.child_run_id),
-        }
-    }
-
-    async fn wait_for_terminal_event_with_optional_cancel(
-        &mut self,
-        cancel: Option<&CancellationToken>,
-    ) -> Result<ChildRuntimeWaitOutcome> {
-        if cancel.is_some_and(CancellationToken::is_cancelled) {
-            self.terminate_runtime().await;
-            return Ok(ChildRuntimeWaitOutcome::Cancelled);
-        }
-
-        let mut output_text = String::new();
-        let mut warnings = Vec::new();
-        let mut latest_liveness_at = Instant::now();
-        let started_at = Instant::now();
-        let wall_clock_cap = self.timeout.map(|timeout| timeout.saturating_mul(4));
-        let file_poll_interval = self
-            .timeout
-            .map(|timeout| (timeout / 4).min(MAX_CHILD_FILE_OBSERVATION_POLL_INTERVAL))
-            .unwrap_or(MAX_CHILD_FILE_OBSERVATION_POLL_INTERVAL)
-            .max(Duration::from_millis(10));
-        let mut last_file_observation = None;
-
-        loop {
-            if let Some(observation) = self.observe_files().await? {
-                if last_file_observation.as_ref() != Some(&observation) {
-                    latest_liveness_at = Instant::now();
-                    self.child_run_registry.observe_progress(
-                        &self.child_run_id,
-                        "agentfs",
-                        Some(format!(
-                            "process={:?} exit={:?} activity={:?} output={} output_offset={} io_offset={} requests={} request_offset={} actions={} action_offset={} ui_offset={}",
-                            if observation.process_exited { "exited" } else { "running" },
-                            observation.process_exit_code,
-                            observation.activity.state,
-                            observation.output_text.len(),
-                            observation.process_output_offset,
-                            observation.process_io_events_offset,
-                            observation.request_ids.len(),
-                            observation.request_events_offset,
-                            observation.action_ids.len(),
-                            observation.action_events_offset,
-                            observation.ui_events_offset,
-                        )),
-                    );
-                    if last_file_observation.as_ref().is_none_or(
-                        |previous: &ChildFileObservation| previous.notice != observation.notice,
-                    ) && observation.notice.kind == alan_agent_protocol::UiNoticeKind::Warning
-                        && !observation.notice.message.is_empty()
-                    {
-                        push_bounded_child_warning(
-                            &mut warnings,
-                            observation.notice.message.clone(),
-                        );
-                    }
-                }
-                output_text.clone_from(&observation.output_text);
-                if observation.process_exited {
-                    let exit_code = observation.process_exit_code.unwrap_or(1);
-                    if exit_code == 130 {
-                        return Ok(ChildRuntimeWaitOutcome::Observed(
-                            self.externally_stopped_observed_event(
-                                &observation.output_text,
-                                &warnings,
-                            ),
-                        ));
-                    }
-                    return Ok(ChildRuntimeWaitOutcome::Observed(
-                        file_terminal_observation(
-                            observation.output_text,
-                            warnings,
-                            if exit_code == 0 {
-                                ChildRuntimeStatus::Completed
-                            } else {
-                                ChildRuntimeStatus::Failed
-                            },
-                            (exit_code != 0)
-                                .then(|| format!("Child Process exited with code {exit_code}")),
-                            None,
-                        ),
-                    ));
-                }
-                if observation.activity.state == alan_agent_protocol::UiActivityState::Paused
-                    && let Some(request_id) = observation.pending_request_id.as_ref()
-                {
-                    let kind = self
-                        .process_environment
-                        .read_request_kind(request_id)
-                        .await?;
-                    let kind = match kind.as_str() {
-                        "confirmation" => YieldKind::Confirmation,
-                        "structured_input" => YieldKind::StructuredInput,
-                        other => YieldKind::Custom(other.to_string()),
-                    };
-                    return Ok(ChildRuntimeWaitOutcome::Observed(
-                        file_terminal_observation(
-                            observation.output_text,
-                            warnings,
-                            ChildRuntimeStatus::Paused,
-                            None,
-                            Some(ChildRuntimePause {
-                                request_id: request_id.clone(),
-                                kind,
-                            }),
-                        ),
-                    ));
-                }
-                if observation.activity.state == alan_agent_protocol::UiActivityState::Idle
-                    && observation.ui_events_offset > 0
-                {
-                    let status = if observation.terminal_error.is_some() {
-                        ChildRuntimeStatus::Failed
-                    } else {
-                        ChildRuntimeStatus::Completed
-                    };
-                    return Ok(ChildRuntimeWaitOutcome::Observed(
-                        file_terminal_observation(
-                            observation.output_text,
-                            warnings,
-                            status,
-                            observation.terminal_error,
-                            None,
-                        ),
-                    ));
-                }
-                last_file_observation = Some(observation);
-            }
-
-            if let Some(request) = self
-                .child_run_registry
-                .termination_request(&self.child_run_id)
-            {
-                match request.mode {
-                    ChildRunTerminationMode::Graceful => self.terminate_runtime().await,
-                    ChildRunTerminationMode::Forceful => self.abort_runtime().await,
-                }
-                return Ok(ChildRuntimeWaitOutcome::Observed(
-                    self.terminated_observed_event(request),
-                ));
-            }
-
-            if let Some(cap) = wall_clock_cap
-                && started_at.elapsed() >= cap
-            {
-                self.abort_runtime_for_status(&ChildRuntimeStatus::TimedOut)
-                    .await;
-                return Ok(ChildRuntimeWaitOutcome::Observed(
-                    self.timed_out_observed_event("Child-agent wall-clock cap exceeded"),
-                ));
-            }
-
-            if let Some(timeout) = self.timeout {
-                let deadline = latest_liveness_at + timeout;
-                let idle_remaining = deadline.saturating_duration_since(Instant::now());
-                if let Some(cancel) = cancel {
-                    tokio::select! {
-                        _ = cancel.cancelled() => {
-                            self.terminate_runtime().await;
-                            return Ok(ChildRuntimeWaitOutcome::Cancelled);
-                        }
-                        _ = tokio::time::sleep(idle_remaining) => {
-                            self.abort_runtime_for_status(&ChildRuntimeStatus::TimedOut).await;
-                            return Ok(ChildRuntimeWaitOutcome::Observed(
-                                self.timed_out_observed_event("Child-agent turn idle timed out"),
-                            ));
-                        }
-                        _ = tokio::time::sleep(file_poll_interval) => {
-                            continue;
-                        }
-                    }
-                } else {
-                    tokio::select! {
-                        _ = tokio::time::sleep(idle_remaining) => {
-                            self.abort_runtime_for_status(&ChildRuntimeStatus::TimedOut).await;
-                            return Ok(ChildRuntimeWaitOutcome::Observed(
-                                self.timed_out_observed_event("Child-agent turn idle timed out"),
-                            ));
-                        }
-                        _ = tokio::time::sleep(file_poll_interval) => {
-                            continue;
-                        }
-                    }
-                }
-            } else if let Some(cancel) = cancel {
-                tokio::select! {
-                    _ = cancel.cancelled() => {
-                        self.terminate_runtime().await;
-                        return Ok(ChildRuntimeWaitOutcome::Cancelled);
-                    }
-                    _ = tokio::time::sleep(file_poll_interval) => {
-                        continue;
-                    }
-                }
-            } else {
-                tokio::time::sleep(file_poll_interval).await;
-            }
-        }
-    }
-
-    async fn terminate_runtime(&mut self) {
-        if let Some(runtime) = self.runtime.take() {
-            let _ = runtime.shutdown().await;
-        }
-        self.terminate_process_and_reconcile().await;
-    }
-
-    async fn finish_runtime_and_process(&mut self, status: &ChildRuntimeStatus) {
-        if let Some(runtime) = self.runtime.take() {
-            let _ = runtime.shutdown().await;
-        }
-        self.process_lifecycle
-            .finish(child_runtime_process_exit_code(status))
-            .await;
-        self.reconcile_exited_process().await;
-    }
-
-    async fn abort_runtime(&mut self) {
-        if let Some(runtime) = self.runtime.take() {
-            runtime.abort().await;
-        }
-        self.terminate_process_and_reconcile().await;
-    }
-
-    async fn abort_runtime_for_status(&mut self, status: &ChildRuntimeStatus) {
-        if let Some(runtime) = self.runtime.take() {
-            runtime.abort().await;
-        }
-        self.process_lifecycle
-            .finish(child_runtime_process_exit_code(status))
-            .await;
-        self.reconcile_exited_process().await;
-    }
-
-    async fn terminate_process_and_reconcile(&self) {
-        let environment = &self.process_environment;
-        let pid = self.process_pid.as_str();
-        if let Ok(Some(exit_code)) = environment.read_process_exit_code(pid).await {
-            self.process_lifecycle.finish(exit_code).await;
-            self.child_run_registry
-                .reconcile_process_exit(&self.child_run_id, exit_code);
-            return;
-        }
-        let _ = environment
-            .write_process_control_for_pid(pid, "cancel")
-            .await;
-        let exit_code = environment
-            .read_process_exit_code(pid)
-            .await
-            .ok()
-            .flatten()
-            .unwrap_or(130);
-        self.process_lifecycle.finish(exit_code).await;
-        if let Ok(Some(exit_code)) = environment.read_process_exit_code(pid).await {
-            self.child_run_registry
-                .reconcile_process_exit(&self.child_run_id, exit_code);
-        }
-    }
-
-    async fn reconcile_exited_process(&self) {
-        let environment = &self.process_environment;
-        let pid = self.process_pid.as_str();
-        if let Ok(Some(exit_code)) = environment.read_process_exit_code(pid).await {
-            self.child_run_registry
-                .reconcile_process_exit(&self.child_run_id, exit_code);
-        }
-    }
-
-    async fn external_process_stop_observed(&self) -> bool {
-        let environment = &self.process_environment;
-        let pid = self.process_pid.as_str();
-        matches!(environment.read_process_exit_code(pid).await, Ok(Some(130)))
-    }
-
-    fn timed_out_observed_event(&self, message: &str) -> ObservedChildTerminalEvent {
-        ObservedChildTerminalEvent {
-            output_text: String::new(),
-            turn_summary: None,
-            structured_output: None,
-            warnings: Vec::new(),
-            error_message: Some(message.to_string()),
-            pause: None,
-            status: ChildRuntimeStatus::TimedOut,
-        }
-    }
-
-    fn terminated_observed_event(
-        &self,
-        request: ChildRunTerminationRequest,
-    ) -> ObservedChildTerminalEvent {
-        ObservedChildTerminalEvent {
-            output_text: String::new(),
-            turn_summary: None,
-            structured_output: None,
-            warnings: Vec::new(),
-            error_message: Some(format!(
-                "Child-agent terminated by {} with {:?} mode: {}",
-                request.actor, request.mode, request.reason
-            )),
-            pause: None,
-            status: ChildRuntimeStatus::Terminated,
-        }
-    }
-
-    fn externally_stopped_observed_event(
-        &self,
-        output_text: &str,
-        warnings: &[String],
-    ) -> ObservedChildTerminalEvent {
-        ObservedChildTerminalEvent {
-            output_text: output_text.to_string(),
-            turn_summary: None,
-            structured_output: parse_child_structured_output(output_text),
-            warnings: warnings.to_vec(),
-            error_message: Some(
-                "Child-agent terminated through external /proc/<pid>/ctl process control"
-                    .to_string(),
-            ),
-            pause: None,
-            status: ChildRuntimeStatus::Terminated,
-        }
-    }
-}
-
-fn parse_child_structured_output(text: &str) -> Option<serde_json::Value> {
-    let trimmed = text.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-
-    serde_json::from_str::<serde_json::Value>(trimmed)
-        .ok()
-        .or_else(|| parse_last_json_fenced_block(trimmed))
-}
-
-fn file_terminal_observation(
-    output_text: String,
-    warnings: Vec<String>,
-    status: ChildRuntimeStatus,
-    error_message: Option<String>,
-    pause: Option<ChildRuntimePause>,
-) -> ObservedChildTerminalEvent {
-    ObservedChildTerminalEvent {
-        structured_output: parse_child_structured_output(&output_text),
-        output_text,
-        turn_summary: None,
-        warnings,
-        error_message,
-        pause,
-        status,
-    }
-}
-
-fn child_run_status_for_runtime_status(status: ChildRuntimeStatus) -> ChildRunStatus {
-    match status {
-        ChildRuntimeStatus::Completed => ChildRunStatus::Completed,
-        ChildRuntimeStatus::Paused => ChildRunStatus::Failed,
-        ChildRuntimeStatus::Cancelled => ChildRunStatus::Cancelled,
-        ChildRuntimeStatus::TimedOut => ChildRunStatus::TimedOut,
-        ChildRuntimeStatus::Terminated => ChildRunStatus::Terminated,
-        ChildRuntimeStatus::Failed => ChildRunStatus::Failed,
-    }
-}
-
-fn child_runtime_process_exit_code(status: &ChildRuntimeStatus) -> i32 {
-    match status {
-        ChildRuntimeStatus::Completed => 0,
-        ChildRuntimeStatus::TimedOut => 124,
-        ChildRuntimeStatus::Cancelled | ChildRuntimeStatus::Terminated => 130,
-        ChildRuntimeStatus::Paused | ChildRuntimeStatus::Failed => 1,
-    }
-}
-
 fn child_run_status_for_launch_error(error: &anyhow::Error) -> ChildRunStatus {
     if error.chain().any(|cause| {
         cause
@@ -1314,101 +688,6 @@ async fn record_child_launch_failure_process(
         _ => 1,
     };
     lifecycle.finish(exit_code).await;
-}
-
-async fn read_latest_assistant_text_from_rollout(rollout_path: Option<&Path>) -> Option<String> {
-    let rollout_path = rollout_path?;
-    let contents = tokio::fs::read_to_string(rollout_path).await.ok()?;
-    extract_latest_assistant_text_from_rollout(contents.as_str())
-}
-
-fn extract_latest_assistant_text_from_rollout(contents: &str) -> Option<String> {
-    let mut last_text = None;
-
-    for line in contents.lines().filter(|line| !line.trim().is_empty()) {
-        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
-            continue;
-        };
-        let Some(object) = value.as_object() else {
-            continue;
-        };
-        if object.get("type").and_then(serde_json::Value::as_str) != Some("message") {
-            continue;
-        }
-        if object.get("role").and_then(serde_json::Value::as_str) != Some("assistant") {
-            continue;
-        }
-
-        let direct_content = object
-            .get("content")
-            .and_then(serde_json::Value::as_str)
-            .and_then(non_empty_trimmed);
-        if direct_content.is_some() {
-            last_text = direct_content;
-            continue;
-        }
-
-        let nested_parts = object
-            .get("message")
-            .and_then(|message| message.get("parts"))
-            .and_then(serde_json::Value::as_array)
-            .map(|parts| {
-                parts
-                    .iter()
-                    .filter_map(|part| {
-                        if part.get("type").and_then(serde_json::Value::as_str) == Some("text") {
-                            part.get("text")
-                                .and_then(serde_json::Value::as_str)
-                                .map(str::trim)
-                                .filter(|text| !text.is_empty())
-                                .map(ToOwned::to_owned)
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .filter(|parts| !parts.is_empty())
-            .map(|parts| parts.join("\n"));
-        if nested_parts.is_some() {
-            last_text = nested_parts;
-        }
-    }
-
-    last_text
-}
-
-fn non_empty_trimmed(text: &str) -> Option<String> {
-    let trimmed = text.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
-}
-
-fn parse_last_json_fenced_block(text: &str) -> Option<serde_json::Value> {
-    let mut remainder = text;
-    let mut last_match = None;
-
-    while let Some(start_idx) = remainder.find("```") {
-        let fence_remainder = &remainder[start_idx + 3..];
-        let Some(newline_idx) = fence_remainder.find('\n') else {
-            break;
-        };
-        let info_string = fence_remainder[..newline_idx].trim().to_ascii_lowercase();
-        let content_start = start_idx + 3 + newline_idx + 1;
-        let content_remainder = &remainder[content_start..];
-        let Some(end_idx) = content_remainder.find("```") else {
-            break;
-        };
-        if info_string.is_empty() || info_string == "json" {
-            last_match = Some(content_remainder[..end_idx].trim().to_string());
-        }
-        remainder = &content_remainder[end_idx + 3..];
-    }
-
-    last_match.and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
 }
 
 fn build_child_agent_config(parent: &RuntimeLoopState, spec: &SpawnSpec) -> AgentConfig {
@@ -1754,7 +1033,7 @@ async fn spawn_child_namespace_runtime_environment(
         if has_mount_grant_applicator {
             anyhow::ensure!(
                 applied.namespace_applied,
-                "failed to project child Agent Definition: {}",
+                "failed to project child Agent Process definition: {}",
                 applied
                     .namespace_error
                     .unwrap_or_else(|| "unknown projection error".to_string())
@@ -1979,7 +1258,7 @@ async fn build_child_namespace_assembly_plan(
             .collect::<Vec<_>>();
         if !missing.is_empty() {
             bail!(
-                "Child-agent launch requested unavailable tools: {}",
+                "Child Agent Process launch requested unavailable tools: {}",
                 missing.join(", ")
             );
         }
@@ -3127,7 +2406,7 @@ Body
 
         assert!(
             err.to_string()
-                .contains("Child-agent launches do not support artifact routing yet")
+                .contains("Child Agent Process launches do not support artifact routing yet")
         );
     }
 
@@ -3150,7 +2429,7 @@ Body
 
         assert!(
             err.to_string()
-                .contains("Child-agent launches do not support artifact routing yet")
+                .contains("Child Agent Process launches do not support artifact routing yet")
         );
     }
 
@@ -3617,7 +2896,7 @@ Body
         crate::runtime::ui_surfaces::turn_completed(&launch.environment, false)
             .await
             .unwrap();
-        let controller = ChildRuntimeController {
+        let controller = DelegatedChildRunSupervisor::new(DelegatedChildRunSupervision {
             runtime: None,
             startup_metadata: test_startup_metadata("child-machine", None, false),
             child_run_id: format!("test-child-run-{}", uuid::Uuid::new_v4()),
@@ -3626,7 +2905,7 @@ Body
             process_lifecycle: launch.lifecycle,
             process_environment: launch.environment,
             process_pid: process_pid.clone(),
-        };
+        });
 
         let result = controller.join().await.unwrap();
         assert_eq!(result.status, ChildRuntimeStatus::Completed);
@@ -3693,7 +2972,7 @@ Body
         .unwrap();
         let process_pid = launch.pid.clone();
         let process_environment = launch.environment.clone();
-        let controller = ChildRuntimeController {
+        let controller = DelegatedChildRunSupervisor::new(DelegatedChildRunSupervision {
             runtime: None,
             startup_metadata: test_startup_metadata("child-machine", None, false),
             child_run_id: format!("test-child-run-{}", uuid::Uuid::new_v4()),
@@ -3702,7 +2981,7 @@ Body
             process_lifecycle: launch.lifecycle,
             process_environment: launch.environment,
             process_pid: process_pid.clone(),
-        };
+        });
 
         assert_eq!(process_environment.ui_events_offset().await.unwrap(), 0);
         process_environment
@@ -3818,7 +3097,7 @@ Body
             definition_namespace
                 .lines()
                 .any(|line| line == "/agent-definition ro"),
-            "child Process must receive its target Agent Definition: {definition_namespace:?}"
+            "child Agent Process must receive its target definition: {definition_namespace:?}"
         );
         let applied = launch
             .environment
@@ -3839,7 +3118,7 @@ Body
         .await;
         assert!(
             namespace.lines().any(|line| line == "/mnt/project rw"),
-            "child process namespace should reflect applicator live mounts: {namespace:?}"
+            "child Agent Process namespace should reflect applicator live mounts: {namespace:?}"
         );
     }
 
@@ -4101,7 +3380,7 @@ tool_repeat_limit = 9
         assert!(
             error
                 .to_string()
-                .contains("was not passed by the parent Process")
+                .contains("was not passed to the child Agent Process by the parent Process")
         );
     }
 
@@ -4176,30 +3455,6 @@ model_reasoning_effort = "high"
     }
 
     #[test]
-    fn push_bounded_child_warning_keeps_recent_truncated_warnings() {
-        let mut warnings = Vec::new();
-
-        for index in 0..(MAX_OBSERVED_CHILD_WARNINGS + 2) {
-            push_bounded_child_warning(
-                &mut warnings,
-                format!(
-                    "warning-{index:03}-{}",
-                    "x".repeat(MAX_OBSERVED_CHILD_WARNING_CHARS)
-                ),
-            );
-        }
-
-        assert_eq!(warnings.len(), MAX_OBSERVED_CHILD_WARNINGS);
-        assert!(warnings[0].starts_with("warning-002-"));
-        assert!(
-            warnings
-                .iter()
-                .all(|warning| warning.chars().count() <= MAX_OBSERVED_CHILD_WARNING_CHARS)
-        );
-        assert!(warnings.last().unwrap().ends_with("..."));
-    }
-
-    #[test]
     fn child_launch_contract_rejects_relative_namespace_cwd() {
         let mut spec = launch_spec(PathBuf::from("/tmp/definition"));
         spec.launch.cwd = Some(PathBuf::from("docs"));
@@ -4219,7 +3474,8 @@ model_reasoning_effort = "high"
 
             let err = validate_child_launch_contract(&spec).unwrap_err();
             assert!(
-                err.to_string().contains("Invalid child-agent launch cwd"),
+                err.to_string()
+                    .contains("Invalid child Agent Process launch cwd"),
                 "expected normal-path validation error for {cwd}, got {err:#}"
             );
         }
@@ -4588,25 +3844,6 @@ model_reasoning_effort = "high"
         );
     }
 
-    #[test]
-    fn parse_child_structured_output_reads_last_json_fence() {
-        let text = "Notes before\n```json\n{\"status\":\"completed\",\"summary\":\"first\"}\n```\nMore notes\n```json\n{\"status\":\"completed\",\"summary\":\"second\"}\n```";
-
-        let parsed = parse_child_structured_output(text).unwrap();
-        assert_eq!(parsed["summary"], serde_json::json!("second"));
-    }
-
-    #[test]
-    fn extract_latest_assistant_text_from_rollout_reads_nested_text_parts() {
-        let contents = concat!(
-            "{\"type\":\"message\",\"role\":\"assistant\",\"content\":null,\"message\":{\"parts\":[{\"type\":\"text\",\"text\":\"first\"}]}}\n",
-            "{\"type\":\"message\",\"role\":\"assistant\",\"content\":null,\"message\":{\"parts\":[{\"type\":\"text\",\"text\":\"second\"},{\"type\":\"tool_request\",\"id\":\"ignored\"}]}}\n"
-        );
-
-        let extracted = extract_latest_assistant_text_from_rollout(contents).unwrap();
-        assert_eq!(extracted, "second");
-    }
-
     #[tokio::test]
     async fn child_runtime_join_keeps_running_while_activity_file_is_fresh() {
         let temp = TempDir::new().unwrap();
@@ -4622,8 +3859,8 @@ model_reasoning_effort = "high"
         })
         .await
         .unwrap();
-        child.timeout = Some(Duration::from_millis(200));
-        let environment = child.process_environment.clone();
+        child.set_timeout_for_test(Duration::from_millis(200));
+        let environment = child.process_environment_for_test().clone();
         tokio::spawn(async move {
             for _ in 0..5 {
                 crate::runtime::ui_surfaces::heartbeat(&environment)
@@ -4656,13 +3893,16 @@ model_reasoning_effort = "high"
             Err(err) => err,
         };
 
-        assert!(err.to_string().contains("Child-agent launch cancelled"));
+        assert!(
+            err.to_string()
+                .contains("Child Agent Process launch cancelled")
+        );
     }
 
     #[test]
     fn child_run_status_for_launch_error_maps_cancelled_launches_to_cancelled() {
         let cancelled = anyhow::anyhow!(CHILD_AGENT_LAUNCH_CANCELLED_MESSAGE);
-        let failed = anyhow::anyhow!("Failed to submit initial child-agent turn");
+        let failed = anyhow::anyhow!("Failed to submit initial child Agent Process turn");
 
         assert_eq!(
             child_run_status_for_launch_error(&cancelled),
@@ -4692,8 +3932,8 @@ model_reasoning_effort = "high"
         })
         .await
         .unwrap();
-        let process_environment = child.process_environment.clone();
-        let process_pid = child.process_pid.clone();
+        let process_environment = child.process_environment_for_test().clone();
+        let process_pid = child.process_pid_for_test().to_string();
 
         let started_at = std::time::Instant::now();
         let result = child.join().await.unwrap();

--- a/crates/agent-engine/src/runtime/delegated_child_run.rs
+++ b/crates/agent-engine/src/runtime/delegated_child_run.rs
@@ -10,6 +10,10 @@ use crate::skills::{
 
 use super::child_runs::ChildRunRecord;
 
+mod supervisor;
+
+pub(crate) use supervisor::{DelegatedChildRunSupervision, DelegatedChildRunSupervisor};
+
 pub(super) const MAX_DELEGATED_RESULT_SUMMARY_CHARS: usize = 320;
 pub(super) const MAX_DELEGATED_RESULT_OUTPUT_INLINE_CHARS: usize = 4_000;
 
@@ -119,7 +123,7 @@ impl ChildRuntimeResult {
             }
             ChildRuntimeStatus::Failed => self.failed_delegated_result(
                 format!(
-                    "Delegated runtime failed: {}",
+                    "Delegated Child Run failed: {}",
                     self.error_message
                         .clone()
                         .or_else(|| non_empty_trimmed(&self.output_text))
@@ -129,19 +133,19 @@ impl ChildRuntimeResult {
                 output_reference.as_ref(),
             ),
             ChildRuntimeStatus::TimedOut => self.failed_delegated_result(
-                "Delegated runtime timed out.".to_string(),
+                "Delegated Child Run timed out.".to_string(),
                 "child_timed_out",
                 output_reference.as_ref(),
             ),
             ChildRuntimeStatus::Cancelled => self.failed_delegated_result(
-                "Delegated runtime was cancelled.".to_string(),
+                "Delegated Child Run was cancelled.".to_string(),
                 "child_cancelled",
                 output_reference.as_ref(),
             ),
             ChildRuntimeStatus::Terminated => self.failed_delegated_result(
                 self.error_message
                     .clone()
-                    .unwrap_or_else(|| "Delegated runtime was terminated.".to_string()),
+                    .unwrap_or_else(|| "Delegated Child Run was terminated.".to_string()),
                 "child_terminated",
                 output_reference.as_ref(),
             ),
@@ -249,7 +253,7 @@ impl ChildRuntimeResult {
             .unwrap_or_else(|| ("unknown".to_string(), None));
         let mut delegated = DelegatedSkillResult::failed(
             format!(
-                "Delegated runtime paused for {pause_kind} and cannot continue in v1 delegated execution."
+                "Delegated Child Run paused for {pause_kind} and cannot continue in v1 delegated execution."
             ),
             Some(serde_json::json!({
                 "error_kind": "child_paused",
@@ -300,7 +304,7 @@ impl ChildRuntimeResult {
                 non_empty_trimmed(self.turn_summary.as_deref().unwrap_or_default())
                     .map(|summary| redact_durable_evidence_text(&summary).text)
             })
-            .unwrap_or_else(|| "Delegated runtime completed without textual output.".to_string())
+            .unwrap_or_else(|| "Delegated Child Run completed without textual output.".to_string())
     }
 }
 

--- a/crates/agent-engine/src/runtime/delegated_child_run/supervisor.rs
+++ b/crates/agent-engine/src/runtime/delegated_child_run/supervisor.rs
@@ -1,0 +1,745 @@
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use alan_agent_protocol::YieldKind;
+use anyhow::{Context, Result};
+use tokio_util::sync::CancellationToken;
+
+use super::{ChildRuntimePause, ChildRuntimeResult, ChildRuntimeStatus};
+use crate::runtime::child_runs::ChildRunRegistry;
+use crate::runtime::{
+    AgentProcessLifecycle, ChildRunStatus, ChildRunTerminationMode, ChildRunTerminationRequest,
+    NamespaceRuntimeEnvironment, RuntimeController, RuntimeStartupMetadata,
+};
+
+const MAX_OBSERVED_CHILD_WARNINGS: usize = 32;
+const MAX_OBSERVED_CHILD_WARNING_CHARS: usize = 512;
+const MAX_CHILD_FILE_OBSERVATION_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Inputs retained after a delegated Child Run has been launched and registered.
+pub(crate) struct DelegatedChildRunSupervision {
+    pub(crate) runtime: Option<RuntimeController>,
+    pub(crate) startup_metadata: RuntimeStartupMetadata,
+    pub(crate) child_run_id: String,
+    pub(crate) child_run_registry: ChildRunRegistry,
+    pub(crate) timeout: Option<Duration>,
+    pub(crate) process_lifecycle: Arc<dyn AgentProcessLifecycle>,
+    pub(crate) process_environment: NamespaceRuntimeEnvironment,
+    pub(crate) process_pid: String,
+}
+
+#[derive(Debug)]
+struct ObservedChildTerminalEvent {
+    output_text: String,
+    turn_summary: Option<String>,
+    structured_output: Option<serde_json::Value>,
+    warnings: Vec<String>,
+    error_message: Option<String>,
+    pause: Option<ChildRuntimePause>,
+    status: ChildRuntimeStatus,
+}
+
+enum ChildRuntimeWaitOutcome {
+    Observed(ObservedChildTerminalEvent),
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ChildFileObservation {
+    process_exited: bool,
+    process_exit_code: Option<i32>,
+    output_text: String,
+    process_output_offset: u64,
+    process_io_events_offset: u64,
+    request_ids: Vec<String>,
+    pending_request_id: Option<String>,
+    request_events_offset: u64,
+    action_ids: Vec<String>,
+    action_events_offset: u64,
+    ui_events_offset: u64,
+    terminal_error: Option<String>,
+    activity: alan_agent_protocol::UiActivitySnapshot,
+    notice: alan_agent_protocol::UiNoticeSnapshot,
+}
+
+/// Supervises one delegated Child Run from authoritative Process and AgentFS files.
+pub(crate) struct DelegatedChildRunSupervisor {
+    runtime: Option<RuntimeController>,
+    startup_metadata: RuntimeStartupMetadata,
+    child_run_id: String,
+    child_run_registry: ChildRunRegistry,
+    timeout: Option<Duration>,
+    process_lifecycle: Arc<dyn AgentProcessLifecycle>,
+    process_environment: NamespaceRuntimeEnvironment,
+    process_pid: String,
+}
+
+impl DelegatedChildRunSupervisor {
+    pub(crate) fn new(input: DelegatedChildRunSupervision) -> Self {
+        Self {
+            runtime: input.runtime,
+            startup_metadata: input.startup_metadata,
+            child_run_id: input.child_run_id,
+            child_run_registry: input.child_run_registry,
+            timeout: input.timeout,
+            process_lifecycle: input.process_lifecycle,
+            process_environment: input.process_environment,
+            process_pid: input.process_pid,
+        }
+    }
+
+    async fn observe_files(&self) -> Result<ChildFileObservation> {
+        let environment = &self.process_environment;
+        let pid = self.process_pid.as_str();
+        let timeout = Duration::from_secs(1);
+        let process_exit_code = environment.read_process_exit_code(pid).await?;
+        let (process_output_offset, process_io_events_offset) =
+            environment.read_process_io_offsets(pid).await?;
+        let activity = tokio::time::timeout(timeout, environment.read_ui_activity_snapshot())
+            .await
+            .context("observe child activity timed out")??;
+        let output_text = tokio::time::timeout(timeout, environment.read_assistant_output())
+            .await
+            .context("observe child output timed out")??;
+        let ui_events_offset = tokio::time::timeout(timeout, environment.ui_events_offset())
+            .await
+            .context("observe child UI events offset timed out")??;
+        let notice = tokio::time::timeout(timeout, environment.read_ui_notice_snapshot())
+            .await
+            .context("observe child notice timed out")??;
+        let request_ids = tokio::time::timeout(timeout, environment.request_ids())
+            .await
+            .context("observe child requests timed out")??;
+        let pending_request_id =
+            tokio::time::timeout(timeout, environment.pending_request_id(&request_ids))
+                .await
+                .context("observe child pending request timed out")??;
+        let request_events_offset =
+            tokio::time::timeout(timeout, environment.request_events_offset())
+                .await
+                .context("observe child request stream offset timed out")??;
+        let action_ids = tokio::time::timeout(timeout, environment.action_ids())
+            .await
+            .context("observe child actions timed out")??;
+        let action_events_offset =
+            tokio::time::timeout(timeout, environment.action_events_offset())
+                .await
+                .context("observe child action stream offset timed out")??;
+        Ok(ChildFileObservation {
+            process_exited: process_exit_code.is_some(),
+            process_exit_code,
+            output_text,
+            process_output_offset,
+            process_io_events_offset,
+            request_ids,
+            pending_request_id,
+            request_events_offset,
+            action_ids,
+            action_events_offset,
+            ui_events_offset,
+            terminal_error: if notice.kind == alan_agent_protocol::UiNoticeKind::Error {
+                Some(notice.message.clone())
+            } else {
+                None
+            },
+            activity,
+            notice,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn join(mut self) -> Result<ChildRuntimeResult> {
+        let observed = match self.wait_for_terminal_event(None).await? {
+            ChildRuntimeWaitOutcome::Observed(observed) => observed,
+            ChildRuntimeWaitOutcome::Cancelled => return Ok(self.cancelled_result()),
+        };
+
+        self.finish_after_observed_terminal_event(observed).await
+    }
+
+    pub(crate) async fn join_until_cancelled(
+        mut self,
+        cancel: &CancellationToken,
+    ) -> Result<ChildRuntimeResult> {
+        match self.wait_for_terminal_event(Some(cancel)).await? {
+            ChildRuntimeWaitOutcome::Observed(observed) => {
+                self.finish_after_observed_terminal_event(observed).await
+            }
+            ChildRuntimeWaitOutcome::Cancelled => Ok(self.cancelled_result()),
+        }
+    }
+
+    async fn finish_after_observed_terminal_event(
+        &mut self,
+        observed: ObservedChildTerminalEvent,
+    ) -> Result<ChildRuntimeResult> {
+        let mut warnings = Vec::new();
+        for warning in self
+            .startup_metadata
+            .warnings
+            .iter()
+            .cloned()
+            .chain(observed.warnings)
+        {
+            push_bounded_child_warning(&mut warnings, warning);
+        }
+        self.finish_runtime_and_process(&observed.status).await;
+        let output_text = observed.output_text;
+        let rollout_fallback_text = if output_text.trim().is_empty() {
+            read_latest_assistant_text_from_rollout(self.startup_metadata.rollout_path.as_deref())
+                .await
+        } else {
+            None
+        };
+        let output_text = if output_text.trim().is_empty() {
+            rollout_fallback_text.unwrap_or(output_text)
+        } else {
+            output_text
+        };
+        let structured_output = observed
+            .structured_output
+            .or_else(|| parse_child_structured_output(output_text.as_str()));
+        let child_status = child_run_status_for_runtime_status(observed.status.clone());
+        self.child_run_registry.mark_terminal(
+            &self.child_run_id,
+            child_status,
+            observed.error_message.clone(),
+        );
+
+        Ok(ChildRuntimeResult {
+            status: observed.status,
+            process_path: self.startup_metadata.process_path.clone(),
+            child_run_id: Some(self.child_run_id.clone()),
+            rollout_path: self.startup_metadata.rollout_path.clone(),
+            output_text,
+            turn_summary: observed.turn_summary,
+            structured_output,
+            warnings,
+            error_message: observed.error_message,
+            pause: observed.pause,
+            child_run: self.child_run_registry.get(&self.child_run_id),
+        })
+    }
+
+    fn cancelled_result(&self) -> ChildRuntimeResult {
+        self.child_run_registry
+            .mark_terminal(&self.child_run_id, ChildRunStatus::Cancelled, None);
+        let mut warnings = Vec::new();
+        for warning in self.startup_metadata.warnings.iter().cloned() {
+            push_bounded_child_warning(&mut warnings, warning);
+        }
+        ChildRuntimeResult {
+            status: ChildRuntimeStatus::Cancelled,
+            process_path: self.startup_metadata.process_path.clone(),
+            child_run_id: Some(self.child_run_id.clone()),
+            rollout_path: self.startup_metadata.rollout_path.clone(),
+            output_text: String::new(),
+            turn_summary: None,
+            structured_output: None,
+            warnings,
+            error_message: None,
+            pause: None,
+            child_run: self.child_run_registry.get(&self.child_run_id),
+        }
+    }
+
+    async fn wait_for_terminal_event(
+        &mut self,
+        cancel: Option<&CancellationToken>,
+    ) -> Result<ChildRuntimeWaitOutcome> {
+        if cancel.is_some_and(CancellationToken::is_cancelled) {
+            self.terminate_runtime().await;
+            return Ok(ChildRuntimeWaitOutcome::Cancelled);
+        }
+
+        let mut output_text = String::new();
+        let mut warnings = Vec::new();
+        let mut latest_liveness_at = Instant::now();
+        let started_at = Instant::now();
+        let wall_clock_cap = self.timeout.map(|timeout| timeout.saturating_mul(4));
+        let file_poll_interval = self
+            .timeout
+            .map(|timeout| (timeout / 4).min(MAX_CHILD_FILE_OBSERVATION_POLL_INTERVAL))
+            .unwrap_or(MAX_CHILD_FILE_OBSERVATION_POLL_INTERVAL)
+            .max(Duration::from_millis(10));
+        let mut last_file_observation = None;
+
+        loop {
+            let observation = self.observe_files().await?;
+            if last_file_observation.as_ref() != Some(&observation) {
+                latest_liveness_at = Instant::now();
+                self.child_run_registry.observe_progress(
+                    &self.child_run_id,
+                    "agentfs",
+                    Some(format!(
+                        "process={:?} exit={:?} activity={:?} output={} output_offset={} io_offset={} requests={} request_offset={} actions={} action_offset={} ui_offset={}",
+                        if observation.process_exited { "exited" } else { "running" },
+                        observation.process_exit_code,
+                        observation.activity.state,
+                        observation.output_text.len(),
+                        observation.process_output_offset,
+                        observation.process_io_events_offset,
+                        observation.request_ids.len(),
+                        observation.request_events_offset,
+                        observation.action_ids.len(),
+                        observation.action_events_offset,
+                        observation.ui_events_offset,
+                    )),
+                );
+                if last_file_observation
+                    .as_ref()
+                    .is_none_or(|previous: &ChildFileObservation| {
+                        previous.notice != observation.notice
+                    })
+                    && observation.notice.kind == alan_agent_protocol::UiNoticeKind::Warning
+                    && !observation.notice.message.is_empty()
+                {
+                    push_bounded_child_warning(&mut warnings, observation.notice.message.clone());
+                }
+            }
+            output_text.clone_from(&observation.output_text);
+            if observation.process_exited {
+                let exit_code = observation.process_exit_code.unwrap_or(1);
+                if exit_code == 130 {
+                    return Ok(ChildRuntimeWaitOutcome::Observed(
+                        self.externally_stopped_observed_event(&observation.output_text, &warnings),
+                    ));
+                }
+                return Ok(ChildRuntimeWaitOutcome::Observed(
+                    file_terminal_observation(
+                        observation.output_text,
+                        warnings,
+                        if exit_code == 0 {
+                            ChildRuntimeStatus::Completed
+                        } else {
+                            ChildRuntimeStatus::Failed
+                        },
+                        (exit_code != 0)
+                            .then(|| format!("Child Agent Process exited with code {exit_code}")),
+                        None,
+                    ),
+                ));
+            }
+            if observation.activity.state == alan_agent_protocol::UiActivityState::Paused
+                && let Some(request_id) = observation.pending_request_id.as_ref()
+            {
+                let kind = self
+                    .process_environment
+                    .read_request_kind(request_id)
+                    .await?;
+                let kind = match kind.as_str() {
+                    "confirmation" => YieldKind::Confirmation,
+                    "structured_input" => YieldKind::StructuredInput,
+                    other => YieldKind::Custom(other.to_string()),
+                };
+                return Ok(ChildRuntimeWaitOutcome::Observed(
+                    file_terminal_observation(
+                        observation.output_text,
+                        warnings,
+                        ChildRuntimeStatus::Paused,
+                        None,
+                        Some(ChildRuntimePause {
+                            request_id: request_id.clone(),
+                            kind,
+                        }),
+                    ),
+                ));
+            }
+            if observation.activity.state == alan_agent_protocol::UiActivityState::Idle
+                && observation.ui_events_offset > 0
+            {
+                let status = if observation.terminal_error.is_some() {
+                    ChildRuntimeStatus::Failed
+                } else {
+                    ChildRuntimeStatus::Completed
+                };
+                return Ok(ChildRuntimeWaitOutcome::Observed(
+                    file_terminal_observation(
+                        observation.output_text,
+                        warnings,
+                        status,
+                        observation.terminal_error,
+                        None,
+                    ),
+                ));
+            }
+            last_file_observation = Some(observation);
+
+            if let Some(request) = self
+                .child_run_registry
+                .termination_request(&self.child_run_id)
+            {
+                match request.mode {
+                    ChildRunTerminationMode::Graceful => self.shutdown_runtime_task().await,
+                    ChildRunTerminationMode::Forceful => self.abort_runtime_task().await,
+                }
+                return Ok(ChildRuntimeWaitOutcome::Observed(terminated_observation(
+                    request,
+                    &output_text,
+                    &warnings,
+                )));
+            }
+
+            if let Some(cap) = wall_clock_cap
+                && started_at.elapsed() >= cap
+            {
+                self.abort_runtime_task().await;
+                return Ok(ChildRuntimeWaitOutcome::Observed(timed_out_observation(
+                    "Delegated Child Run wall-clock cap exceeded",
+                    &output_text,
+                    &warnings,
+                )));
+            }
+
+            if let Some(timeout) = self.timeout {
+                let deadline = latest_liveness_at + timeout;
+                let idle_remaining = deadline.saturating_duration_since(Instant::now());
+                if let Some(cancel) = cancel {
+                    tokio::select! {
+                        _ = cancel.cancelled() => {
+                            self.terminate_runtime().await;
+                            return Ok(ChildRuntimeWaitOutcome::Cancelled);
+                        }
+                        _ = tokio::time::sleep(idle_remaining) => {
+                            self.abort_runtime_task().await;
+                            return Ok(ChildRuntimeWaitOutcome::Observed(timed_out_observation(
+                                "Delegated Child Run idle timed out",
+                                &output_text,
+                                &warnings,
+                            )));
+                        }
+                        _ = tokio::time::sleep(file_poll_interval) => continue,
+                    }
+                } else {
+                    tokio::select! {
+                        _ = tokio::time::sleep(idle_remaining) => {
+                            self.abort_runtime_task().await;
+                            return Ok(ChildRuntimeWaitOutcome::Observed(timed_out_observation(
+                                "Delegated Child Run idle timed out",
+                                &output_text,
+                                &warnings,
+                            )));
+                        }
+                        _ = tokio::time::sleep(file_poll_interval) => continue,
+                    }
+                }
+            } else if let Some(cancel) = cancel {
+                tokio::select! {
+                    _ = cancel.cancelled() => {
+                        self.terminate_runtime().await;
+                        return Ok(ChildRuntimeWaitOutcome::Cancelled);
+                    }
+                    _ = tokio::time::sleep(file_poll_interval) => continue,
+                }
+            } else {
+                tokio::time::sleep(file_poll_interval).await;
+            }
+        }
+    }
+
+    async fn terminate_runtime(&mut self) {
+        self.shutdown_runtime_task().await;
+        self.terminate_process_and_reconcile().await;
+    }
+
+    async fn finish_runtime_and_process(&mut self, status: &ChildRuntimeStatus) {
+        self.shutdown_runtime_task().await;
+        self.process_lifecycle
+            .finish(child_runtime_process_exit_code(status))
+            .await;
+        self.reconcile_exited_process().await;
+    }
+
+    async fn shutdown_runtime_task(&mut self) {
+        if let Some(runtime) = self.runtime.take() {
+            let _ = runtime.shutdown().await;
+        }
+    }
+
+    async fn abort_runtime_task(&mut self) {
+        if let Some(runtime) = self.runtime.take() {
+            runtime.abort().await;
+        }
+    }
+
+    async fn terminate_process_and_reconcile(&self) {
+        let environment = &self.process_environment;
+        let pid = self.process_pid.as_str();
+        if let Ok(Some(exit_code)) = environment.read_process_exit_code(pid).await {
+            self.process_lifecycle.finish(exit_code).await;
+            self.child_run_registry
+                .reconcile_process_exit(&self.child_run_id, exit_code);
+            return;
+        }
+        let _ = environment
+            .write_process_control_for_pid(pid, "cancel")
+            .await;
+        let exit_code = environment
+            .read_process_exit_code(pid)
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or(130);
+        self.process_lifecycle.finish(exit_code).await;
+        if let Ok(Some(exit_code)) = environment.read_process_exit_code(pid).await {
+            self.child_run_registry
+                .reconcile_process_exit(&self.child_run_id, exit_code);
+        }
+    }
+
+    async fn reconcile_exited_process(&self) {
+        let environment = &self.process_environment;
+        let pid = self.process_pid.as_str();
+        if let Ok(Some(exit_code)) = environment.read_process_exit_code(pid).await {
+            self.child_run_registry
+                .reconcile_process_exit(&self.child_run_id, exit_code);
+        }
+    }
+
+    fn externally_stopped_observed_event(
+        &self,
+        output_text: &str,
+        warnings: &[String],
+    ) -> ObservedChildTerminalEvent {
+        ObservedChildTerminalEvent {
+            output_text: output_text.to_string(),
+            turn_summary: None,
+            structured_output: parse_child_structured_output(output_text),
+            warnings: warnings.to_vec(),
+            error_message: Some(
+                "Delegated Child Run terminated through external /proc/<pid>/ctl process control"
+                    .to_string(),
+            ),
+            pause: None,
+            status: ChildRuntimeStatus::Terminated,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_timeout_for_test(&mut self, timeout: Duration) {
+        self.timeout = Some(timeout);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn process_environment_for_test(&self) -> &NamespaceRuntimeEnvironment {
+        &self.process_environment
+    }
+
+    #[cfg(test)]
+    pub(crate) fn process_pid_for_test(&self) -> &str {
+        &self.process_pid
+    }
+}
+
+fn push_bounded_child_warning(warnings: &mut Vec<String>, warning: String) {
+    while warnings.len() >= MAX_OBSERVED_CHILD_WARNINGS {
+        warnings.remove(0);
+    }
+    warnings.push(truncate_child_text_with_suffix(
+        &warning,
+        MAX_OBSERVED_CHILD_WARNING_CHARS,
+        "...",
+    ));
+}
+
+fn truncate_child_text_with_suffix(text: &str, max_chars: usize, suffix: &str) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+
+    let suffix_len = suffix.chars().count();
+    if max_chars <= suffix_len {
+        return suffix.chars().take(max_chars).collect();
+    }
+
+    let mut truncated = text
+        .chars()
+        .take(max_chars.saturating_sub(suffix_len))
+        .collect::<String>();
+    truncated.push_str(suffix);
+    truncated
+}
+
+fn parse_child_structured_output(text: &str) -> Option<serde_json::Value> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    serde_json::from_str::<serde_json::Value>(trimmed)
+        .ok()
+        .or_else(|| parse_last_json_fenced_block(trimmed))
+}
+
+fn file_terminal_observation(
+    output_text: String,
+    warnings: Vec<String>,
+    status: ChildRuntimeStatus,
+    error_message: Option<String>,
+    pause: Option<ChildRuntimePause>,
+) -> ObservedChildTerminalEvent {
+    ObservedChildTerminalEvent {
+        structured_output: parse_child_structured_output(&output_text),
+        output_text,
+        turn_summary: None,
+        warnings,
+        error_message,
+        pause,
+        status,
+    }
+}
+
+fn timed_out_observation(
+    message: &str,
+    output_text: &str,
+    warnings: &[String],
+) -> ObservedChildTerminalEvent {
+    ObservedChildTerminalEvent {
+        output_text: output_text.to_string(),
+        turn_summary: None,
+        structured_output: parse_child_structured_output(output_text),
+        warnings: warnings.to_vec(),
+        error_message: Some(message.to_string()),
+        pause: None,
+        status: ChildRuntimeStatus::TimedOut,
+    }
+}
+
+fn terminated_observation(
+    request: ChildRunTerminationRequest,
+    output_text: &str,
+    warnings: &[String],
+) -> ObservedChildTerminalEvent {
+    ObservedChildTerminalEvent {
+        output_text: output_text.to_string(),
+        turn_summary: None,
+        structured_output: parse_child_structured_output(output_text),
+        warnings: warnings.to_vec(),
+        error_message: Some(format!(
+            "Delegated Child Run terminated by {} with {:?} mode: {}",
+            request.actor, request.mode, request.reason
+        )),
+        pause: None,
+        status: ChildRuntimeStatus::Terminated,
+    }
+}
+
+fn child_run_status_for_runtime_status(status: ChildRuntimeStatus) -> ChildRunStatus {
+    match status {
+        ChildRuntimeStatus::Completed => ChildRunStatus::Completed,
+        ChildRuntimeStatus::Paused => ChildRunStatus::Failed,
+        ChildRuntimeStatus::Cancelled => ChildRunStatus::Cancelled,
+        ChildRuntimeStatus::TimedOut => ChildRunStatus::TimedOut,
+        ChildRuntimeStatus::Terminated => ChildRunStatus::Terminated,
+        ChildRuntimeStatus::Failed => ChildRunStatus::Failed,
+    }
+}
+
+fn child_runtime_process_exit_code(status: &ChildRuntimeStatus) -> i32 {
+    match status {
+        ChildRuntimeStatus::Completed => 0,
+        ChildRuntimeStatus::TimedOut => 124,
+        ChildRuntimeStatus::Cancelled | ChildRuntimeStatus::Terminated => 130,
+        ChildRuntimeStatus::Paused | ChildRuntimeStatus::Failed => 1,
+    }
+}
+
+async fn read_latest_assistant_text_from_rollout(rollout_path: Option<&Path>) -> Option<String> {
+    let rollout_path = rollout_path?;
+    let contents = tokio::fs::read_to_string(rollout_path).await.ok()?;
+    extract_latest_assistant_text_from_rollout(contents.as_str())
+}
+
+fn extract_latest_assistant_text_from_rollout(contents: &str) -> Option<String> {
+    let mut last_text = None;
+
+    for line in contents.lines().filter(|line| !line.trim().is_empty()) {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let Some(object) = value.as_object() else {
+            continue;
+        };
+        if object.get("type").and_then(serde_json::Value::as_str) != Some("message") {
+            continue;
+        }
+        if object.get("role").and_then(serde_json::Value::as_str) != Some("assistant") {
+            continue;
+        }
+
+        let direct_content = object
+            .get("content")
+            .and_then(serde_json::Value::as_str)
+            .and_then(non_empty_trimmed);
+        if direct_content.is_some() {
+            last_text = direct_content;
+            continue;
+        }
+
+        let nested_parts = object
+            .get("message")
+            .and_then(|message| message.get("parts"))
+            .and_then(serde_json::Value::as_array)
+            .map(|parts| {
+                parts
+                    .iter()
+                    .filter_map(|part| {
+                        if part.get("type").and_then(serde_json::Value::as_str) == Some("text") {
+                            part.get("text")
+                                .and_then(serde_json::Value::as_str)
+                                .map(str::trim)
+                                .filter(|text| !text.is_empty())
+                                .map(ToOwned::to_owned)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .filter(|parts| !parts.is_empty())
+            .map(|parts| parts.join("\n"));
+        if nested_parts.is_some() {
+            last_text = nested_parts;
+        }
+    }
+
+    last_text
+}
+
+fn non_empty_trimmed(text: &str) -> Option<String> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn parse_last_json_fenced_block(text: &str) -> Option<serde_json::Value> {
+    let mut remainder = text;
+    let mut last_match = None;
+
+    while let Some(start_idx) = remainder.find("```") {
+        let fence_remainder = &remainder[start_idx + 3..];
+        let Some(newline_idx) = fence_remainder.find('\n') else {
+            break;
+        };
+        let info_string = fence_remainder[..newline_idx].trim().to_ascii_lowercase();
+        let content_start = start_idx + 3 + newline_idx + 1;
+        let content_remainder = &remainder[content_start..];
+        let Some(end_idx) = content_remainder.find("```") else {
+            break;
+        };
+        if info_string.is_empty() || info_string == "json" {
+            last_match = Some(content_remainder[..end_idx].trim().to_string());
+        }
+        remainder = &content_remainder[end_idx + 3..];
+    }
+
+    last_match.and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
+}
+
+#[cfg(test)]
+#[path = "supervisor_tests.rs"]
+mod tests;

--- a/crates/agent-engine/src/runtime/delegated_child_run/supervisor_tests.rs
+++ b/crates/agent-engine/src/runtime/delegated_child_run/supervisor_tests.rs
@@ -1,0 +1,140 @@
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Debug)]
+struct RecordingProcessLifecycle {
+    finish_count: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl AgentProcessLifecycle for RecordingProcessLifecycle {
+    async fn finish(&self, _exit_code: i32) {
+        self.finish_count.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+fn test_supervisor(finish_count: Arc<AtomicUsize>) -> DelegatedChildRunSupervisor {
+    let root = alan_ap::InProcessTransport::new(Arc::new(alan_ap::reference::MemFs::new()));
+    DelegatedChildRunSupervisor::new(DelegatedChildRunSupervision {
+        runtime: None,
+        startup_metadata: RuntimeStartupMetadata {
+            process_path: "/proc/42".to_string(),
+            agent_path: "/agent/42".to_string(),
+            rollout_id: None,
+            rollout_path: None,
+            durability: crate::runtime::AgentMachineDurabilityState {
+                durable: false,
+                required: false,
+            },
+            execution_backend: "test".to_string(),
+            request_controls: crate::ResolvedRequestControls::default(),
+            warnings: Vec::new(),
+        },
+        child_run_id: "child-run-1".to_string(),
+        child_run_registry: ChildRunRegistry::default(),
+        timeout: None,
+        process_lifecycle: Arc::new(RecordingProcessLifecycle { finish_count }),
+        process_environment: NamespaceRuntimeEnvironment::new(root, "/agent/42", "default"),
+        process_pid: "42".to_string(),
+    })
+}
+
+#[test]
+fn bounded_warnings_keep_recent_truncated_entries() {
+    let mut warnings = Vec::new();
+
+    for index in 0..(MAX_OBSERVED_CHILD_WARNINGS + 2) {
+        push_bounded_child_warning(
+            &mut warnings,
+            format!(
+                "warning-{index:03}-{}",
+                "x".repeat(MAX_OBSERVED_CHILD_WARNING_CHARS)
+            ),
+        );
+    }
+
+    assert_eq!(warnings.len(), MAX_OBSERVED_CHILD_WARNINGS);
+    assert!(warnings[0].starts_with("warning-002-"));
+    assert!(
+        warnings
+            .iter()
+            .all(|warning| warning.chars().count() <= MAX_OBSERVED_CHILD_WARNING_CHARS)
+    );
+    assert!(warnings.last().unwrap().ends_with("..."));
+}
+
+#[test]
+fn structured_output_reads_last_json_fence() {
+    let text = "Notes before\n```json\n{\"status\":\"completed\",\"summary\":\"first\"}\n```\nMore notes\n```json\n{\"status\":\"completed\",\"summary\":\"second\"}\n```";
+
+    let parsed = parse_child_structured_output(text).unwrap();
+    assert_eq!(parsed["summary"], serde_json::json!("second"));
+}
+
+#[test]
+fn rollout_fallback_reads_latest_nested_assistant_text() {
+    let contents = concat!(
+        "{\"type\":\"message\",\"role\":\"assistant\",\"content\":null,\"message\":{\"parts\":[{\"type\":\"text\",\"text\":\"first\"}]}}\n",
+        "{\"type\":\"message\",\"role\":\"assistant\",\"content\":null,\"message\":{\"parts\":[{\"type\":\"text\",\"text\":\"second\"},{\"type\":\"tool_request\",\"id\":\"ignored\"}]}}\n"
+    );
+
+    assert_eq!(
+        extract_latest_assistant_text_from_rollout(contents).as_deref(),
+        Some("second")
+    );
+}
+
+#[test]
+fn timeout_retains_latest_file_output_and_warnings() {
+    let observed = timed_out_observation(
+        "idle timeout",
+        r#"{"status":"partial"}"#,
+        &["latest warning".to_string()],
+    );
+
+    assert_eq!(observed.status, ChildRuntimeStatus::TimedOut);
+    assert_eq!(observed.output_text, r#"{"status":"partial"}"#);
+    assert_eq!(
+        observed.structured_output,
+        Some(serde_json::json!({"status": "partial"}))
+    );
+    assert_eq!(observed.warnings, vec!["latest warning"]);
+}
+
+#[test]
+fn governed_termination_retains_latest_file_evidence() {
+    let observed = terminated_observation(
+        ChildRunTerminationRequest {
+            actor: "parent".to_string(),
+            reason: "result no longer needed".to_string(),
+            mode: ChildRunTerminationMode::Graceful,
+            requested_at_ms: 42,
+        },
+        "partial child output",
+        &["latest warning".to_string()],
+    );
+
+    assert_eq!(observed.status, ChildRuntimeStatus::Terminated);
+    assert_eq!(observed.output_text, "partial child output");
+    assert_eq!(observed.warnings, vec!["latest warning"]);
+    assert!(
+        observed
+            .error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("parent"))
+    );
+}
+
+#[tokio::test]
+async fn aborting_runtime_task_defers_the_single_process_finish_to_terminal_commit() {
+    let finish_count = Arc::new(AtomicUsize::new(0));
+    let mut supervisor = test_supervisor(finish_count.clone());
+
+    supervisor.abort_runtime_task().await;
+    assert_eq!(finish_count.load(Ordering::Relaxed), 0);
+
+    supervisor
+        .finish_runtime_and_process(&ChildRuntimeStatus::TimedOut)
+        .await;
+    assert_eq!(finish_count.load(Ordering::Relaxed), 1);
+}

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -105,7 +105,12 @@ fn namespace_environment_reaches_capabilities_only_through_files() {
 
 #[test]
 fn child_supervision_has_no_runtime_receiver_fallback() {
-    let source = read_runtime_source("child_agents.rs");
+    let assembly_source = read_runtime_source("child_agents.rs");
+    let assembly_production = assembly_source
+        .split("\n#[cfg(test)]\nmod tests")
+        .next()
+        .unwrap();
+    let supervisor = read_runtime_source("delegated_child_run/supervisor.rs");
     for forbidden in [
         "RuntimeEventEnvelope",
         "RuntimeLivenessEnvelope",
@@ -114,8 +119,8 @@ fn child_supervision_has_no_runtime_receiver_fallback() {
         "broadcast::",
     ] {
         assert!(
-            !source.contains(forbidden),
-            "child path contains {forbidden}"
+            !assembly_production.contains(forbidden) && !supervisor.contains(forbidden),
+            "delegated Child Run path contains {forbidden}"
         );
     }
     for required in [
@@ -126,7 +131,10 @@ fn child_supervision_has_no_runtime_receiver_fallback() {
         "request_events_offset",
         "action_events_offset",
     ] {
-        assert!(source.contains(required), "child path missing {required}");
+        assert!(
+            supervisor.contains(required),
+            "delegated Child Run supervisor missing {required}"
+        );
     }
 }
 

--- a/scripts/rust-source-size-baseline.txt
+++ b/scripts/rust-source-size-baseline.txt
@@ -8,7 +8,7 @@ crates/agent-engine/src/policy.rs 1177
 crates/agent-engine/src/rollout.rs 2266
 crates/agent-engine/src/runtime/agent_loop.rs 2763
 crates/agent-engine/src/runtime/agent_loop/namespace_environment.rs 3747
-crates/agent-engine/src/runtime/child_agents.rs 4829
+crates/agent-engine/src/runtime/child_agents.rs 4069
 crates/agent-engine/src/runtime/compaction.rs 1387
 crates/agent-engine/src/runtime/engine.rs 2816
 crates/agent-engine/src/runtime/memory_promotion.rs 1778


### PR DESCRIPTION
## Summary

- move delegated Child Run supervision from the broad child assembly module into a dedicated deep owner
- observe lifecycle and liveness only through authoritative `/proc` and AgentFS files, with no runtime receiver fallback
- retain latest output and warnings across timeout and governed termination, and commit the Process terminal state exactly once
- ratchet `child_agents.rs` from 4,829 to 4,069 lines; keep the new supervisor and adjacent white-box tests below the 1,000-line target

## Architecture

`child_agents.rs` still owns Agent Runtime Service launch and child Agent Process assembly. `delegated_child_run::supervisor` now owns post-launch observation, cancellation, timeout, termination, reconciliation, and result normalization.

The dependency boundary follows the canonical owner and rejects runtime event or liveness receiver fallback in both assembly and supervision paths.

## Stack

- depends on #664

## Verification

- `cargo test -p alan-agent-engine` (1,199 passed, 1 ignored; dependency boundary 6/6)
- `cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings`
- `just test`
- `just quality`
- `openspec validate refactor-clean-code-architecture-debt --strict`
- `git diff --cached --check`