### PR TITLE
refactor: isolate child task context assembly

### DIFF
--- a/crates/agent-engine/src/runtime/child_agents.rs
+++ b/crates/agent-engine/src/runtime/child_agents.rs
@@ -1,3 +1,5 @@
+mod task_context;
+
 use super::agent_loop::RuntimeLoopState;
 #[cfg(test)]
 use super::child_runs::ChildRunRegistry;
@@ -15,7 +17,7 @@ use super::engine::{
 };
 #[cfg(test)]
 use crate::llm::LlmClient;
-use crate::tape::{ContentPart, Message};
+use crate::tape::ContentPart;
 use alan_agent_protocol::{
     DelegatedCapabilityDecision, DelegatedCapabilityRecovery, GovernanceConfig, Op, SpawnHandle,
     SpawnSpec, SpawnTarget, Submission,
@@ -38,12 +40,6 @@ use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
 const CHILD_AGENT_LAUNCH_CANCELLED_MESSAGE: &str = "Child Agent Process launch cancelled";
-const MAX_CHILD_CONVERSATION_MESSAGES: usize = 8;
-const MAX_CHILD_CONVERSATION_CHARS: usize = 4_000;
-const MAX_CHILD_PLAN_ITEMS: usize = 16;
-const MAX_CHILD_PLAN_ITEM_CHARS: usize = 240;
-const MAX_CHILD_TOOL_RESULTS: usize = 6;
-const MAX_CHILD_TOOL_RESULT_CHARS: usize = 1_200;
 const ROUTE_MOUNT_PATH: &str = "/mnt/route";
 #[cfg(test)]
 static NEXT_CHILD_NAMESPACE_FID: AtomicU64 = AtomicU64::new(80_000);
@@ -283,7 +279,9 @@ async fn spawn_child_runtime_inner(
     }
     child_run_registry.register(child_run_record);
     let submission = Submission::new(Op::Turn {
-        parts: vec![ContentPart::text(build_child_task_text(parent, &spec))],
+        parts: vec![ContentPart::text(task_context::build_child_task_text(
+            parent, &spec,
+        ))],
         context: None,
     });
     let runtime = match send_initial_child_submission(runtime, submission.clone(), cancel).await {
@@ -1275,149 +1273,6 @@ async fn build_child_namespace_assembly_plan(
         .map(|package| format!("/bin/{}", package.name))
         .collect();
     Ok(plan)
-}
-
-fn build_child_task_text(parent: &RuntimeLoopState, spec: &SpawnSpec) -> String {
-    let mut sections = vec![spec.launch.task.trim().to_string()];
-
-    if let Some(metadata) = render_launch_metadata(spec) {
-        sections.push(metadata);
-    }
-    if spec.has_handle(SpawnHandle::ConversationSnapshot)
-        && let Some(snapshot) = render_conversation_snapshot(parent)
-    {
-        sections.push(snapshot);
-    }
-    if spec.has_handle(SpawnHandle::Plan)
-        && let Some(snapshot) = render_plan_snapshot(parent)
-    {
-        sections.push(snapshot);
-    }
-    if spec.has_handle(SpawnHandle::ToolResults)
-        && let Some(snapshot) = render_tool_results_snapshot(parent)
-    {
-        sections.push(snapshot);
-    }
-
-    sections
-        .into_iter()
-        .filter(|section| !section.trim().is_empty())
-        .collect::<Vec<_>>()
-        .join("\n\n")
-}
-
-fn render_launch_metadata(spec: &SpawnSpec) -> Option<String> {
-    let mut lines = Vec::new();
-    if let Some(cwd) = spec.launch.cwd.as_ref() {
-        lines.push(format!("cwd: {}", cwd.display()));
-    }
-    if let Some(output_dir) = spec.launch.output_dir.as_ref() {
-        lines.push(format!("output_dir: {}", output_dir.display()));
-    }
-
-    (!lines.is_empty()).then(|| format!("Execution Context\n{}", lines.join("\n")))
-}
-
-fn render_conversation_snapshot(parent: &RuntimeLoopState) -> Option<String> {
-    let mut lines = Vec::new();
-    if let Some(summary) = parent.machine.tape.summary() {
-        lines.push("Summary:".to_string());
-        lines.push(truncate_chars(summary.trim(), MAX_CHILD_CONVERSATION_CHARS));
-    }
-
-    let recent_messages = parent
-        .machine
-        .tape
-        .messages()
-        .iter()
-        .rev()
-        .filter(|message| matches!(message, Message::User { .. } | Message::Assistant { .. }))
-        .take(MAX_CHILD_CONVERSATION_MESSAGES)
-        .cloned()
-        .collect::<Vec<_>>();
-
-    if !recent_messages.is_empty() {
-        lines.push("Recent Messages:".to_string());
-        for message in recent_messages.into_iter().rev() {
-            let role = match &message {
-                Message::User { .. } => "user",
-                Message::Assistant { .. } => "assistant",
-                Message::Tool { .. } => unreachable!("tool messages are filtered out above"),
-                Message::System { .. } => "system",
-                Message::Context { .. } => "context",
-            };
-            let text = match &message {
-                Message::Assistant { .. } => message.non_thinking_text_content(),
-                _ => message.text_content(),
-            };
-            if !text.trim().is_empty() {
-                lines.push(format!(
-                    "- {role}: {}",
-                    truncate_chars(text.trim(), MAX_CHILD_CONVERSATION_CHARS / 2)
-                ));
-            }
-        }
-    }
-
-    (!lines.is_empty()).then(|| format!("Parent Conversation Snapshot\n{}", lines.join("\n")))
-}
-
-fn render_plan_snapshot(parent: &RuntimeLoopState) -> Option<String> {
-    let plan_snapshot = parent.turn_state.plan_snapshot()?;
-    let mut lines = Vec::new();
-    if let Some(explanation) = plan_snapshot.explanation.as_deref()
-        && !explanation.trim().is_empty()
-    {
-        lines.push(format!(
-            "Explanation: {}",
-            truncate_chars(explanation.trim(), MAX_CHILD_PLAN_ITEM_CHARS)
-        ));
-    }
-    for item in plan_snapshot.items.iter().take(MAX_CHILD_PLAN_ITEMS) {
-        lines.push(format!(
-            "- [{}] {}",
-            match item.status {
-                alan_agent_protocol::PlanItemStatus::Pending => "pending",
-                alan_agent_protocol::PlanItemStatus::InProgress => "in_progress",
-                alan_agent_protocol::PlanItemStatus::Completed => "completed",
-            },
-            truncate_chars(item.content.trim(), MAX_CHILD_PLAN_ITEM_CHARS)
-        ));
-    }
-
-    (!lines.is_empty()).then(|| format!("Parent Plan Snapshot\n{}", lines.join("\n")))
-}
-
-fn render_tool_results_snapshot(parent: &RuntimeLoopState) -> Option<String> {
-    let mut lines = Vec::new();
-    for message in parent
-        .machine
-        .tape
-        .messages()
-        .iter()
-        .rev()
-        .filter(|message| matches!(message, Message::Tool { .. }))
-        .take(MAX_CHILD_TOOL_RESULTS)
-    {
-        for response in message.tool_responses() {
-            let content =
-                truncate_chars(response.text_content().trim(), MAX_CHILD_TOOL_RESULT_CHARS);
-            if !content.is_empty() {
-                lines.push(format!("- {}: {}", response.id, content));
-            }
-        }
-    }
-    lines.reverse();
-    (!lines.is_empty()).then(|| format!("Parent Tool Results\n{}", lines.join("\n")))
-}
-
-fn truncate_chars(text: &str, limit: usize) -> String {
-    let truncated: String = text.chars().take(limit).collect();
-    if truncated.chars().count() == text.chars().count() {
-        truncated
-    } else {
-        format!("{truncated}...")
-    }
 }
 
 #[cfg(test)]

--- a/crates/agent-engine/src/runtime/child_agents/task_context.rs
+++ b/crates/agent-engine/src/runtime/child_agents/task_context.rs
@@ -1,0 +1,153 @@
+use crate::runtime::agent_loop::RuntimeLoopState;
+use crate::tape::Message;
+use alan_agent_protocol::{SpawnHandle, SpawnSpec};
+
+const MAX_CHILD_CONVERSATION_MESSAGES: usize = 8;
+const MAX_CHILD_CONVERSATION_CHARS: usize = 4_000;
+const MAX_CHILD_PLAN_ITEMS: usize = 16;
+const MAX_CHILD_PLAN_ITEM_CHARS: usize = 240;
+const MAX_CHILD_TOOL_RESULTS: usize = 6;
+const MAX_CHILD_TOOL_RESULT_CHARS: usize = 1_200;
+
+pub(super) fn build_child_task_text(parent: &RuntimeLoopState, spec: &SpawnSpec) -> String {
+    let mut sections = vec![spec.launch.task.trim().to_string()];
+
+    if let Some(metadata) = render_launch_metadata(spec) {
+        sections.push(metadata);
+    }
+    if spec.has_handle(SpawnHandle::ConversationSnapshot)
+        && let Some(snapshot) = render_conversation_snapshot(parent)
+    {
+        sections.push(snapshot);
+    }
+    if spec.has_handle(SpawnHandle::Plan)
+        && let Some(snapshot) = render_plan_snapshot(parent)
+    {
+        sections.push(snapshot);
+    }
+    if spec.has_handle(SpawnHandle::ToolResults)
+        && let Some(snapshot) = render_tool_results_snapshot(parent)
+    {
+        sections.push(snapshot);
+    }
+
+    sections
+        .into_iter()
+        .filter(|section| !section.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn render_launch_metadata(spec: &SpawnSpec) -> Option<String> {
+    let mut lines = Vec::new();
+    if let Some(cwd) = spec.launch.cwd.as_ref() {
+        lines.push(format!("cwd: {}", cwd.display()));
+    }
+    if let Some(output_dir) = spec.launch.output_dir.as_ref() {
+        lines.push(format!("output_dir: {}", output_dir.display()));
+    }
+
+    (!lines.is_empty()).then(|| format!("Execution Context\n{}", lines.join("\n")))
+}
+
+fn render_conversation_snapshot(parent: &RuntimeLoopState) -> Option<String> {
+    let mut lines = Vec::new();
+    if let Some(summary) = parent.machine.tape.summary() {
+        lines.push("Summary:".to_string());
+        lines.push(truncate_chars(summary.trim(), MAX_CHILD_CONVERSATION_CHARS));
+    }
+
+    let recent_messages = parent
+        .machine
+        .tape
+        .messages()
+        .iter()
+        .rev()
+        .filter(|message| matches!(message, Message::User { .. } | Message::Assistant { .. }))
+        .take(MAX_CHILD_CONVERSATION_MESSAGES)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    if !recent_messages.is_empty() {
+        lines.push("Recent Messages:".to_string());
+        for message in recent_messages.into_iter().rev() {
+            let role = match &message {
+                Message::User { .. } => "user",
+                Message::Assistant { .. } => "assistant",
+                Message::Tool { .. } => unreachable!("tool messages are filtered out above"),
+                Message::System { .. } => "system",
+                Message::Context { .. } => "context",
+            };
+            let text = match &message {
+                Message::Assistant { .. } => message.non_thinking_text_content(),
+                _ => message.text_content(),
+            };
+            if !text.trim().is_empty() {
+                lines.push(format!(
+                    "- {role}: {}",
+                    truncate_chars(text.trim(), MAX_CHILD_CONVERSATION_CHARS / 2)
+                ));
+            }
+        }
+    }
+
+    (!lines.is_empty()).then(|| format!("Parent Conversation Snapshot\n{}", lines.join("\n")))
+}
+
+fn render_plan_snapshot(parent: &RuntimeLoopState) -> Option<String> {
+    let plan_snapshot = parent.turn_state.plan_snapshot()?;
+    let mut lines = Vec::new();
+    if let Some(explanation) = plan_snapshot.explanation.as_deref()
+        && !explanation.trim().is_empty()
+    {
+        lines.push(format!(
+            "Explanation: {}",
+            truncate_chars(explanation.trim(), MAX_CHILD_PLAN_ITEM_CHARS)
+        ));
+    }
+    for item in plan_snapshot.items.iter().take(MAX_CHILD_PLAN_ITEMS) {
+        lines.push(format!(
+            "- [{}] {}",
+            match item.status {
+                alan_agent_protocol::PlanItemStatus::Pending => "pending",
+                alan_agent_protocol::PlanItemStatus::InProgress => "in_progress",
+                alan_agent_protocol::PlanItemStatus::Completed => "completed",
+            },
+            truncate_chars(item.content.trim(), MAX_CHILD_PLAN_ITEM_CHARS)
+        ));
+    }
+
+    (!lines.is_empty()).then(|| format!("Parent Plan Snapshot\n{}", lines.join("\n")))
+}
+
+fn render_tool_results_snapshot(parent: &RuntimeLoopState) -> Option<String> {
+    let mut lines = Vec::new();
+    for message in parent
+        .machine
+        .tape
+        .messages()
+        .iter()
+        .rev()
+        .filter(|message| matches!(message, Message::Tool { .. }))
+        .take(MAX_CHILD_TOOL_RESULTS)
+    {
+        for response in message.tool_responses() {
+            let content =
+                truncate_chars(response.text_content().trim(), MAX_CHILD_TOOL_RESULT_CHARS);
+            if !content.is_empty() {
+                lines.push(format!("- {}: {}", response.id, content));
+            }
+        }
+    }
+    lines.reverse();
+    (!lines.is_empty()).then(|| format!("Parent Tool Results\n{}", lines.join("\n")))
+}
+
+fn truncate_chars(text: &str, limit: usize) -> String {
+    let truncated: String = text.chars().take(limit).collect();
+    if truncated.chars().count() == text.chars().count() {
+        truncated
+    } else {
+        format!("{truncated}...")
+    }
+}

--- a/scripts/rust-source-size-baseline.txt
+++ b/scripts/rust-source-size-baseline.txt
@@ -8,7 +8,7 @@ crates/agent-engine/src/policy.rs 1177
 crates/agent-engine/src/rollout.rs 2266
 crates/agent-engine/src/runtime/agent_loop.rs 2763
 crates/agent-engine/src/runtime/agent_loop/namespace_environment.rs 3747
-crates/agent-engine/src/runtime/child_agents.rs 1424
+crates/agent-engine/src/runtime/child_agents.rs 1279
 crates/agent-engine/src/runtime/compaction.rs 1373
 crates/agent-engine/src/runtime/engine.rs 2816
 crates/agent-engine/src/runtime/memory_promotion.rs 1770


### PR DESCRIPTION
## Summary

- give child task/context projection its own production module
- keep conversation, plan, Tool-result, and launch-metadata rendering behind one narrow builder
- leave child Process launch coordination responsible only for consuming the assembled first-turn text
- ratchet `child_agents.rs` from 1424 to 1279 lines

## Boundaries

- no behavior, public API, protocol, or handle-semantics changes
- only explicitly passed `SpawnHandle` values continue to project parent context
- the new owner depends on Agent Machine/tape and turn state, not namespace assembly details

## Mechanical equivalence

- compared the complete moved function bodies and limits against the parent commit
- retained existing conversation/plan/Tool-result integration coverage

## Verification

- `cargo test -p alan-agent-engine runtime::child_agents::tests` (43 passed)
- `just test`
- `just quality`
- `openspec validate --all --strict`
- `git diff --check`

Stacked on #672.
