### PR TITLE
refactor: extract steering queue owner

### DIFF
--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -18,6 +18,7 @@ mod memory_recall;
 mod memory_surfaces;
 mod prompt_cache;
 mod response_guardrails;
+mod steering_queue;
 mod submission_handlers;
 mod tool_effect_lifecycle;
 mod tool_orchestrator;

--- a/crates/agent-engine/src/runtime/steering_queue.rs
+++ b/crates/agent-engine/src/runtime/steering_queue.rs
@@ -1,0 +1,111 @@
+use alan_agent_protocol::{Event, InputMode, Op};
+use anyhow::Result;
+use serde_json::json;
+
+use super::agent_loop::{NormalizedToolCall, RuntimeLoopState};
+use super::turn_driver::{MAX_BUFFERED_INBAND_USER_INPUTS, TurnInputBroker};
+use super::turn_support::tool_result_preview;
+
+pub(super) async fn handle_queued_steering_inputs<E, F>(
+    state: &mut RuntimeLoopState,
+    tool_calls: &[NormalizedToolCall],
+    remaining_start_idx: usize,
+    steering_broker: Option<&TurnInputBroker>,
+    emit: &mut E,
+) -> Result<bool>
+where
+    E: FnMut(Event) -> F,
+    F: std::future::Future<Output = ()>,
+{
+    let Some(broker) = steering_broker else {
+        return Ok(false);
+    };
+
+    let mut steering_inputs: Vec<Vec<crate::tape::ContentPart>> = Vec::new();
+    while let Some(submission) = broker.try_recv().await {
+        if let Op::Input {
+            parts,
+            mode: InputMode::Steer,
+        } = &submission.op
+        {
+            steering_inputs.push(parts.clone());
+            continue;
+        }
+
+        if matches!(
+            &submission.op,
+            Op::Input {
+                mode: InputMode::FollowUp,
+                ..
+            }
+        ) && state.turn_state.buffered_inband_user_input_count()
+            >= MAX_BUFFERED_INBAND_USER_INPUTS
+        {
+            emit(Event::Error {
+                message: format!(
+                    "Too many queued in-turn user inputs (limit={MAX_BUFFERED_INBAND_USER_INPUTS}); dropping newest input."
+                ),
+                recoverable: true,
+            })
+            .await;
+            continue;
+        }
+
+        state.turn_state.push_buffered_inband_submission(submission);
+    }
+
+    if steering_inputs.is_empty() {
+        return Ok(false);
+    }
+
+    state.turn_state.note_resumed_user_input();
+    for parts in steering_inputs {
+        state.machine.add_user_message_parts(parts);
+    }
+
+    let remaining = &tool_calls[remaining_start_idx..];
+    if !remaining.is_empty() {
+        emit(Event::Error {
+            message: format!(
+                "Steering input received during tool batch; skipping {} pending tool call(s).",
+                remaining.len()
+            ),
+            recoverable: true,
+        })
+        .await;
+    }
+
+    for skipped in remaining {
+        let skipped_payload = json!({
+            "status": "skipped_due_to_steering",
+            "error": "Skipped due to queued user steering input."
+        });
+        emit(Event::ToolCallStarted {
+            title: None,
+            id: skipped.id.clone(),
+            name: skipped.name.clone(),
+            audit: None,
+        })
+        .await;
+        emit(Event::ToolCallCompleted {
+            presentation: None,
+            id: skipped.id.clone(),
+            name: Some(skipped.name.clone()),
+            success: Some(false),
+            result_preview: tool_result_preview(&skipped_payload),
+            audit: None,
+        })
+        .await;
+        state.machine.record_tool_call(
+            &skipped.name,
+            skipped.arguments.clone(),
+            skipped_payload.clone(),
+            false,
+        );
+        state
+            .machine
+            .add_tool_message(&skipped.id, &skipped.name, skipped_payload);
+    }
+
+    Ok(true)
+}

--- a/crates/agent-engine/src/runtime/tool_orchestrator.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator.rs
@@ -1,6 +1,4 @@
-use alan_agent_protocol::{
-    AdaptivePresentationHint, ConfirmationYieldPayload, Event, InputMode, Op,
-};
+use alan_agent_protocol::{AdaptivePresentationHint, ConfirmationYieldPayload, Event};
 use anyhow::{Context, Result};
 use serde_json::{Value, json};
 use std::time::Instant;
@@ -19,11 +17,12 @@ use crate::evidence::{
 
 use super::agent_loop::{NormalizedToolCall, RuntimeLoopState};
 use super::loop_guard::ToolLoopGuard;
+use super::steering_queue::handle_queued_steering_inputs;
 #[cfg(test)]
 use super::tool_effect_lifecycle::{EffectCategory, build_effect_identity};
 use super::tool_effect_lifecycle::{ToolEffectLifecycle, ToolEffectPlan};
 use super::tool_policy::{ToolPolicyDecision, evaluate_tool_policy};
-use super::turn_driver::{MAX_BUFFERED_INBAND_USER_INPUTS, TurnInputBroker};
+use super::turn_driver::TurnInputBroker;
 use super::turn_support::{check_turn_cancelled, tool_result_preview};
 use super::virtual_tools::{VirtualToolOutcome, try_handle_virtual_tool_call};
 
@@ -989,110 +988,6 @@ where
     }
 
     Ok(ToolBatchOrchestratorOutcome::ContinueTurnLoop { refresh_context })
-}
-
-async fn handle_queued_steering_inputs<E, F>(
-    state: &mut RuntimeLoopState,
-    tool_calls: &[NormalizedToolCall],
-    remaining_start_idx: usize,
-    steering_broker: Option<&TurnInputBroker>,
-    emit: &mut E,
-) -> Result<bool>
-where
-    E: FnMut(Event) -> F,
-    F: std::future::Future<Output = ()>,
-{
-    let Some(broker) = steering_broker else {
-        return Ok(false);
-    };
-
-    let mut steering_inputs: Vec<Vec<crate::tape::ContentPart>> = Vec::new();
-    while let Some(submission) = broker.try_recv().await {
-        if let Op::Input {
-            parts,
-            mode: InputMode::Steer,
-        } = &submission.op
-        {
-            steering_inputs.push(parts.clone());
-            continue;
-        }
-
-        if matches!(
-            &submission.op,
-            Op::Input {
-                mode: InputMode::FollowUp,
-                ..
-            }
-        ) && state.turn_state.buffered_inband_user_input_count()
-            >= MAX_BUFFERED_INBAND_USER_INPUTS
-        {
-            emit(Event::Error {
-                message: format!(
-                    "Too many queued in-turn user inputs (limit={MAX_BUFFERED_INBAND_USER_INPUTS}); dropping newest input."
-                ),
-                recoverable: true,
-            })
-            .await;
-            continue;
-        }
-
-        state.turn_state.push_buffered_inband_submission(submission);
-    }
-
-    if steering_inputs.is_empty() {
-        return Ok(false);
-    }
-
-    state.turn_state.note_resumed_user_input();
-    for parts in steering_inputs {
-        state.machine.add_user_message_parts(parts);
-    }
-
-    let remaining = &tool_calls[remaining_start_idx..];
-    if !remaining.is_empty() {
-        emit(Event::Error {
-            message: format!(
-                "Steering input received during tool batch; skipping {} pending tool call(s).",
-                remaining.len()
-            ),
-            recoverable: true,
-        })
-        .await;
-    }
-
-    for skipped in remaining {
-        let skipped_payload = json!({
-            "status": "skipped_due_to_steering",
-            "error": "Skipped due to queued user steering input."
-        });
-        emit(Event::ToolCallStarted {
-            title: None,
-            id: skipped.id.clone(),
-            name: skipped.name.clone(),
-            audit: None,
-        })
-        .await;
-        emit(Event::ToolCallCompleted {
-            presentation: None,
-            id: skipped.id.clone(),
-            name: Some(skipped.name.clone()),
-            success: Some(false),
-            result_preview: tool_result_preview(&skipped_payload),
-            audit: None,
-        })
-        .await;
-        state.machine.record_tool_call(
-            &skipped.name,
-            skipped.arguments.clone(),
-            skipped_payload.clone(),
-            false,
-        );
-        state
-            .machine
-            .add_tool_message(&skipped.id, &skipped.name, skipped_payload);
-    }
-
-    Ok(true)
 }
 
 #[cfg(test)]

--- a/crates/agent-engine/src/runtime/tool_orchestrator/tests/namespace_and_batch_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator/tests/namespace_and_batch_contract.inc.rs
@@ -1,4 +1,7 @@
 
+    use alan_agent_protocol::{InputMode, Op};
+    use crate::runtime::turn_driver::MAX_BUFFERED_INBAND_USER_INPUTS;
+
     #[tokio::test]
     async fn namespace_tool_call_spawns_bin_executable_and_records_action() {
         let (mut state, shell) = create_namespace_test_state_and_shell();

--- a/scripts/rust-source-size-baseline.txt
+++ b/scripts/rust-source-size-baseline.txt
@@ -5,7 +5,6 @@ crates/agent-engine/src/agent_machine.rs 3661
 crates/agent-engine/src/config.rs 2556
 crates/agent-engine/src/rollout.rs 2266
 crates/agent-engine/src/runtime/engine.rs 2816
-crates/agent-engine/src/runtime/tool_orchestrator.rs 1099
 crates/agent-engine/src/runtime/virtual_tools.rs 2476
 crates/agent-engine/src/runtime/virtual_tools_tests.rs 3331
 crates/agent-engine/src/skills/injector.rs 2490


### PR DESCRIPTION
## Summary

- extract queued in-turn steering and follow-up handling into a dedicated runtime owner
- keep Tool batch orchestration focused on sequencing Tool calls and delegate queue handling explicitly
- remove `tool_orchestrator.rs` from the source-size debt baseline after reducing it from 1,099 to 994 lines
- make the steering contract tests import their protocol and buffer-limit dependencies explicitly

## Verification

- `cargo test -p alan-agent-engine queued_steering`
- `cargo test -p alan-agent-engine runtime::tool_orchestrator::tests`
- `just quality`
- `just test`
- `openspec validate --all --strict`

Stacked on #706.
