### PR TITLE
refactor: complete delegated skill tool ownership

### DIFF
--- a/crates/agent-engine/src/runtime/delegated_skill_tool.rs
+++ b/crates/agent-engine/src/runtime/delegated_skill_tool.rs
@@ -1,6 +1,27 @@
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
+use std::pin::Pin;
+
+use alan_agent_protocol::{
+    DelegatedSpawnContext, Event, SpawnHandle, SpawnLaunchInputs, SpawnRuntimeOverrides, SpawnSpec,
+};
+use anyhow::Result;
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
 
 use crate::llm::ToolDefinition;
+use crate::skills::{DelegatedSkillResult, DelegatedSkillResultStatus};
+
+use super::agent_loop::{NormalizedToolCall, RuntimeLoopState};
+use super::child_agents::spawn_child_runtime_cancellable;
+use super::delegated_child_run::ChildRuntimeResult;
+use super::delegated_skill_evidence::{
+    build_bounded_delegated_invocation_persistence, persist_delegated_child_evidence,
+};
+use super::delegation_capabilities::{
+    DelegatedSpawnRejected, classify_delegated_task_requirements,
+};
+use super::turn_support::{check_turn_cancelled, tool_result_preview};
+use super::virtual_tool::VirtualToolOutcome;
 
 pub(super) const MAX_DELEGATED_SKILL_ID_CHARS: usize = 120;
 pub(super) const MAX_DELEGATED_TARGET_CHARS: usize = 120;
@@ -124,6 +145,425 @@ pub(super) fn invoke_delegated_skill_tool_definition() -> ToolDefinition {
         }),
     }
 }
+
+pub(super) async fn handle_invoke_delegated_skill<E, F>(
+    state: &mut RuntimeLoopState,
+    tool_call: &NormalizedToolCall,
+    tool_arguments: &serde_json::Value,
+    cancel: &CancellationToken,
+    emit: &mut E,
+) -> Result<VirtualToolOutcome>
+where
+    E: FnMut(Event) -> F,
+    F: std::future::Future<Output = ()>,
+{
+    handle_invoke_delegated_skill_with_spawn(
+        state,
+        tool_call,
+        tool_arguments,
+        cancel,
+        emit,
+        |state, spec, cancel| Box::pin(spawn_and_join_delegated_child(state, spec, cancel)),
+    )
+    .await
+}
+
+pub(super) async fn handle_invoke_delegated_skill_with_spawn<E, F, S>(
+    state: &mut RuntimeLoopState,
+    tool_call: &NormalizedToolCall,
+    tool_arguments: &serde_json::Value,
+    cancel: &CancellationToken,
+    emit: &mut E,
+    spawn_child: S,
+) -> Result<VirtualToolOutcome>
+where
+    E: FnMut(Event) -> F,
+    F: std::future::Future<Output = ()>,
+    S: for<'a> FnOnce(
+        &'a RuntimeLoopState,
+        SpawnSpec,
+        &'a CancellationToken,
+    ) -> Pin<
+        Box<dyn std::future::Future<Output = Result<ChildRuntimeResult>> + Send + 'a>,
+    >,
+{
+    emit(Event::ToolCallStarted {
+        title: None,
+        id: tool_call.id.clone(),
+        name: tool_call.name.clone(),
+        audit: None,
+    })
+    .await;
+
+    let Some(request) = parse_delegated_skill_invocation_request(tool_arguments) else {
+        let error_payload = json!({
+            "status": "invalid_request",
+            "error": "Invalid delegated skill invocation payload."
+        });
+        emit(Event::ToolCallCompleted {
+            presentation: None,
+            id: tool_call.id.clone(),
+            name: Some(tool_call.name.clone()),
+            success: Some(false),
+            result_preview: tool_result_preview(&error_payload),
+            audit: None,
+        })
+        .await;
+        state.machine.record_tool_call(
+            &tool_call.name,
+            tool_arguments.clone(),
+            error_payload.clone(),
+            false,
+        );
+        state
+            .machine
+            .add_tool_message(&tool_call.id, &tool_call.name, error_payload.clone());
+        emit(Event::Error {
+            message: "Invalid delegated skill invocation payload.".to_string(),
+            recoverable: true,
+        })
+        .await;
+        return Ok(VirtualToolOutcome::Continue {
+            refresh_context: true,
+        });
+    };
+
+    if !state.prompt_cache.supports_delegated_skill_invocation() {
+        let error_payload = json!({
+            "status": "delegated_invocation_unavailable",
+            "error": "Delegated skill invocation is not available in this runtime."
+        });
+        emit(Event::ToolCallCompleted {
+            presentation: None,
+            id: tool_call.id.clone(),
+            name: Some(tool_call.name.clone()),
+            success: Some(false),
+            result_preview: tool_result_preview(&error_payload),
+            audit: None,
+        })
+        .await;
+        state.machine.record_tool_call(
+            &tool_call.name,
+            tool_arguments.clone(),
+            error_payload.clone(),
+            false,
+        );
+        state
+            .machine
+            .add_tool_message(&tool_call.id, &tool_call.name, error_payload);
+        emit(Event::Error {
+            message: "Delegated skill invocation is not available in this runtime.".to_string(),
+            recoverable: true,
+        })
+        .await;
+        return Ok(VirtualToolOutcome::Continue {
+            refresh_context: true,
+        });
+    }
+
+    let (persisted_request, result, child_run) =
+        match resolve_delegated_skill_invocation(state, &request) {
+            Ok(spec) => {
+                let persisted_request = request.with_effective_launch_inputs(
+                    spec.launch.cwd.clone(),
+                    spec.launch.timeout_secs,
+                );
+                match spawn_child(state, spec, cancel).await {
+                    Ok(mut child_result) => {
+                        if cancel.is_cancelled()
+                            && child_result.is_cancelled()
+                            && check_turn_cancelled(state, emit, cancel).await?
+                        {
+                            return Ok(VirtualToolOutcome::EndTurn);
+                        }
+
+                        let output_reference =
+                            persist_delegated_child_evidence(state, &request, &child_result).await;
+                        if let (Some(child_run_id), Some(reference)) = (
+                            child_result.child_run_id.as_deref(),
+                            output_reference.as_ref(),
+                        ) {
+                            state
+                                .child_run_registry()
+                                .set_state_ref(child_run_id, reference.clone());
+                            child_result.child_run = state.child_run_registry().get(child_run_id);
+                        }
+                        (
+                            persisted_request,
+                            child_result.delegated_result(output_reference),
+                            Some(child_result.reference()),
+                        )
+                    }
+                    Err(err) => {
+                        if cancel.is_cancelled()
+                            && check_turn_cancelled(state, emit, cancel).await?
+                        {
+                            return Ok(VirtualToolOutcome::EndTurn);
+                        }
+
+                        let capability_decision = err
+                            .downcast_ref::<DelegatedSpawnRejected>()
+                            .map(|rejection| rejection.decision.clone());
+                        let error_kind = if capability_decision.is_some() {
+                            "delegated_capability_mismatch"
+                        } else {
+                            "child_launch_failed"
+                        };
+                        let mut result = DelegatedSkillResult::failed(
+                            format!(
+                                "Failed to launch delegated runtime for skill '{}': {err}",
+                                request.skill_id
+                            ),
+                            Some(json!({
+                                "error_kind": error_kind
+                            })),
+                        );
+                        result.error_kind = Some(error_kind.to_string());
+                        result.capability_decision = capability_decision;
+                        (persisted_request, result, None)
+                    }
+                }
+            }
+            Err(result) => (request.clone(), *result, None),
+        };
+
+    let (persisted_arguments, tape_record, rollout_record) =
+        build_bounded_delegated_invocation_persistence(&persisted_request, result, child_run);
+    let preview = tool_result_preview(&json!(tape_record.result.summary.clone()));
+    let tape_payload = serde_json::to_value(&tape_record).unwrap_or_else(|_| {
+        json!({
+            "status": "invalid_result_encoding",
+            "error": "Failed to serialize delegated skill result."
+        })
+    });
+    let rollout_payload =
+        serde_json::to_value(&rollout_record).unwrap_or_else(|_| tape_payload.clone());
+    let invocation_succeeded = matches!(
+        tape_record.result.status,
+        DelegatedSkillResultStatus::Completed
+    );
+    emit(Event::ToolCallCompleted {
+        presentation: None,
+        id: tool_call.id.clone(),
+        name: Some(tool_call.name.clone()),
+        success: Some(invocation_succeeded),
+        result_preview: preview,
+        audit: None,
+    })
+    .await;
+    state.machine.record_tool_call(
+        &tool_call.name,
+        persisted_arguments,
+        rollout_payload,
+        invocation_succeeded,
+    );
+    state
+        .machine
+        .add_tool_message(&tool_call.id, &tool_call.name, tape_payload);
+    Ok(VirtualToolOutcome::Continue {
+        refresh_context: true,
+    })
+}
+
+async fn spawn_and_join_delegated_child(
+    state: &RuntimeLoopState,
+    spec: SpawnSpec,
+    cancel: &CancellationToken,
+) -> Result<ChildRuntimeResult> {
+    if cancel.is_cancelled() {
+        return Ok(ChildRuntimeResult::cancelled_before_launch());
+    }
+
+    let controller = spawn_child_runtime_cancellable(state, spec, cancel).await?;
+    controller.join_until_cancelled(cancel).await
+}
+
+fn resolve_delegated_skill_invocation(
+    state: &mut RuntimeLoopState,
+    request: &DelegatedSkillInvocationRequest,
+) -> DelegatedSkillSpawnResult<SpawnSpec> {
+    let active_skill = state
+        .turn_state
+        .active_skills()
+        .iter()
+        .find(|skill| skill.metadata.id == request.skill_id)
+        .cloned();
+
+    let skill_metadata = if let Some(skill) = active_skill {
+        if !skill.availability.is_available() {
+            return Err(Box::new(DelegatedSkillResult::failed(
+                format!(
+                    "Delegated skill '{}' is {}.",
+                    request.skill_id,
+                    skill.availability.render_label()
+                ),
+                Some(json!({
+                    "error_kind": "skill_unavailable"
+                })),
+            )));
+        }
+        skill.metadata
+    } else {
+        match state
+            .prompt_cache
+            .resolve_listed_skill_metadata(request.skill_id.as_str())
+        {
+            Ok(Some(metadata)) => metadata,
+            Ok(None) => {
+                return Err(Box::new(DelegatedSkillResult::failed(
+                    format!(
+                        "Delegated skill '{}' is not active and is not listed for implicit use in the current runtime.",
+                        request.skill_id
+                    ),
+                    Some(json!({
+                        "error_kind": "skill_not_visible"
+                    })),
+                )));
+            }
+            Err(err) => {
+                return Err(Box::new(DelegatedSkillResult::failed(
+                    format!(
+                        "Failed to resolve delegated skill '{}' from the runtime catalog: {err}",
+                        request.skill_id
+                    ),
+                    Some(json!({
+                        "error_kind": "skill_resolution_failed"
+                    })),
+                )));
+            }
+        }
+    };
+
+    let Some(resolved_target) = skill_metadata.execution.delegate_target() else {
+        return Err(Box::new(DelegatedSkillResult::failed(
+            format!(
+                "Skill '{}' is not resolved for delegated execution.",
+                request.skill_id
+            ),
+            Some(json!({
+                "error_kind": "skill_not_delegated"
+            })),
+        )));
+    };
+
+    if resolved_target != request.target {
+        return Err(Box::new(DelegatedSkillResult::failed(
+            format!(
+                "Delegated skill '{}' resolves to delegated target '{}' rather than '{}'.",
+                request.skill_id, resolved_target, request.target
+            ),
+            Some(json!({
+                "error_kind": "delegate_target_mismatch",
+                "resolved_target": resolved_target
+            })),
+        )));
+    }
+
+    let Some(spawn_target) = skill_metadata.delegated_spawn_target() else {
+        return Err(Box::new(DelegatedSkillResult::failed(
+            format!(
+                "Delegated skill '{}' does not expose a package-local launch target.",
+                request.skill_id
+            ),
+            Some(json!({
+                "error_kind": "delegate_target_missing"
+            })),
+        )));
+    };
+
+    build_delegated_spawn_spec(state, request, spawn_target)
+}
+
+fn build_delegated_spawn_spec(
+    state: &RuntimeLoopState,
+    request: &DelegatedSkillInvocationRequest,
+    target: alan_agent_protocol::SpawnTarget,
+) -> DelegatedSkillSpawnResult<SpawnSpec> {
+    let parent_namespace_cwd = state
+        .namespace_environment()
+        .launch_context()
+        .map(|context| Path::new(&context.cwd));
+    let cwd = request
+        .cwd
+        .as_deref()
+        .map(|path| resolve_delegated_launch_path(path, parent_namespace_cwd, "cwd"))
+        .transpose()?
+        .or_else(|| parent_namespace_cwd.map(lexically_normalize_path));
+    let requirements = classify_delegated_task_requirements(&request.task, cwd.as_deref());
+    let mut handles = vec![SpawnHandle::ApprovalScope];
+    if cwd.as_deref().is_some_and(|cwd| {
+        state
+            .namespace_environment()
+            .launch_context()
+            .is_some_and(|context| {
+                context
+                    .host_mounts
+                    .iter()
+                    .any(|grant| grant.resolve_host_path(&cwd.to_string_lossy()).is_some())
+            })
+    }) {
+        handles.push(SpawnHandle::HostMounts);
+    }
+    Ok(SpawnSpec {
+        target,
+        launch: SpawnLaunchInputs {
+            task: request.task.clone(),
+            cwd,
+            timeout_secs: Some(
+                request
+                    .timeout_secs
+                    .unwrap_or(DEFAULT_DELEGATED_TIMEOUT_SECS),
+            ),
+            output_dir: None,
+        },
+        handles,
+        runtime_overrides: SpawnRuntimeOverrides::default(),
+        delegated: Some(DelegatedSpawnContext { requirements }),
+    })
+}
+
+fn resolve_delegated_launch_path(
+    requested_path: &Path,
+    base: Option<&Path>,
+    field_name: &str,
+) -> DelegatedSkillSpawnResult<PathBuf> {
+    if requested_path.is_absolute() {
+        return Ok(lexically_normalize_path(requested_path));
+    }
+
+    let Some(base) = base else {
+        return Err(Box::new(DelegatedSkillResult::failed(
+            format!(
+                "Delegated skill invocation provided relative {field_name} '{}' but the parent runtime has no base path to resolve it.",
+                requested_path.display()
+            ),
+            Some(json!({
+                "error_kind": "relative_launch_path_unresolvable",
+                "field": field_name
+            })),
+        )));
+    };
+
+    Ok(lexically_normalize_path(&base.join(requested_path)))
+}
+
+fn lexically_normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+    normalized
+}
+
+type DelegatedSkillSpawnResult<T> = std::result::Result<T, Box<DelegatedSkillResult>>;
 
 #[cfg(test)]
 mod tests {

--- a/crates/agent-engine/src/runtime/virtual_tools.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools.rs
@@ -1,49 +1,26 @@
 use alan_agent_protocol::{
-    AdaptivePresentationHint, ConfirmationYieldPayload, DelegatedSpawnContext, Event, SpawnHandle,
-    SpawnLaunchInputs, SpawnRuntimeOverrides, SpawnSpec, StructuredInputKind,
+    AdaptivePresentationHint, ConfirmationYieldPayload, Event, StructuredInputKind,
     StructuredInputOption, StructuredInputQuestion, StructuredInputYieldPayload,
 };
 use anyhow::Result;
 use serde_json::json;
-use std::path::{Component, Path, PathBuf};
-use std::pin::Pin;
 use tokio_util::sync::CancellationToken;
 
 use crate::approval::MOUNT_ESCALATION_CHECKPOINT_TYPE;
 use crate::approval::{PendingConfirmation, append_skill_permission_hints};
 use crate::llm::ToolDefinition;
-use crate::skills::{DelegatedSkillResult, DelegatedSkillResultStatus};
 
 use super::agent_loop::{NormalizedToolCall, RuntimeLoopState};
-use super::child_agents::spawn_child_runtime_cancellable;
 use super::child_run_termination_tool::{
     handle_terminate_child_run, terminate_child_run_tool_definition,
 };
-use super::delegated_child_run::ChildRuntimeResult;
-#[cfg(test)]
-use super::delegated_child_run::{ChildRuntimeStatus, MAX_DELEGATED_RESULT_OUTPUT_INLINE_CHARS};
-use super::delegated_skill_evidence::{
-    build_bounded_delegated_invocation_persistence, persist_delegated_child_evidence,
-};
 use super::delegated_skill_tool::{
-    DEFAULT_DELEGATED_TIMEOUT_SECS, DelegatedSkillInvocationRequest,
-    invoke_delegated_skill_tool_definition, parse_delegated_skill_invocation_request,
+    handle_invoke_delegated_skill, invoke_delegated_skill_tool_definition,
 };
-#[cfg(test)]
-use super::delegated_skill_tool::{
-    MAX_DELEGATED_SKILL_ID_CHARS, MAX_DELEGATED_TARGET_CHARS, MAX_DELEGATED_TASK_CHARS,
-};
-use super::delegation_capabilities::{
-    DelegatedSpawnRejected, classify_delegated_task_requirements,
-};
-#[cfg(test)]
-use super::mount_request_tool::MountRequestAccess;
 pub(super) use super::mount_request_tool::parse_mount_request;
 use super::mount_request_tool::{handle_request_mount, request_mount_tool_definition};
 use super::turn_support::{check_turn_cancelled, tool_result_preview};
 pub(super) use super::virtual_tool::VirtualToolOutcome;
-
-type DelegatedSkillSpawnResult<T> = std::result::Result<T, Box<DelegatedSkillResult>>;
 
 pub(super) fn virtual_tool_definitions(include_delegated_skill: bool) -> Vec<ToolDefinition> {
     let mut defs = vec![
@@ -329,15 +306,7 @@ where
             }
         }
         "invoke_delegated_skill" => {
-            handle_invoke_delegated_skill(
-                state,
-                tool_call,
-                tool_arguments,
-                cancel,
-                emit,
-                |state, spec, cancel| Box::pin(spawn_and_join_delegated_child(state, spec, cancel)),
-            )
-            .await
+            handle_invoke_delegated_skill(state, tool_call, tool_arguments, cancel, emit).await
         }
         "terminate_child_run" => {
             handle_terminate_child_run(
@@ -351,401 +320,6 @@ where
         }
         _ => Ok(VirtualToolOutcome::NotVirtual),
     }
-}
-
-async fn handle_invoke_delegated_skill<E, F, S>(
-    state: &mut RuntimeLoopState,
-    tool_call: &NormalizedToolCall,
-    tool_arguments: &serde_json::Value,
-    cancel: &CancellationToken,
-    emit: &mut E,
-    spawn_child: S,
-) -> Result<VirtualToolOutcome>
-where
-    E: FnMut(Event) -> F,
-    F: std::future::Future<Output = ()>,
-    S: for<'a> FnOnce(
-        &'a RuntimeLoopState,
-        SpawnSpec,
-        &'a CancellationToken,
-    ) -> Pin<
-        Box<dyn std::future::Future<Output = Result<ChildRuntimeResult>> + Send + 'a>,
-    >,
-{
-    emit(Event::ToolCallStarted {
-        title: None,
-        id: tool_call.id.clone(),
-        name: tool_call.name.clone(),
-        audit: None,
-    })
-    .await;
-
-    let Some(request) = parse_delegated_skill_invocation_request(tool_arguments) else {
-        let error_payload = json!({
-            "status": "invalid_request",
-            "error": "Invalid delegated skill invocation payload."
-        });
-        emit(Event::ToolCallCompleted {
-            presentation: None,
-            id: tool_call.id.clone(),
-            name: Some(tool_call.name.clone()),
-            success: Some(false),
-            result_preview: tool_result_preview(&error_payload),
-            audit: None,
-        })
-        .await;
-        state.machine.record_tool_call(
-            &tool_call.name,
-            tool_arguments.clone(),
-            error_payload.clone(),
-            false,
-        );
-        state
-            .machine
-            .add_tool_message(&tool_call.id, &tool_call.name, error_payload.clone());
-        emit(Event::Error {
-            message: "Invalid delegated skill invocation payload.".to_string(),
-            recoverable: true,
-        })
-        .await;
-        return Ok(VirtualToolOutcome::Continue {
-            refresh_context: true,
-        });
-    };
-
-    if !state.prompt_cache.supports_delegated_skill_invocation() {
-        let error_payload = json!({
-            "status": "delegated_invocation_unavailable",
-            "error": "Delegated skill invocation is not available in this runtime."
-        });
-        emit(Event::ToolCallCompleted {
-            presentation: None,
-            id: tool_call.id.clone(),
-            name: Some(tool_call.name.clone()),
-            success: Some(false),
-            result_preview: tool_result_preview(&error_payload),
-            audit: None,
-        })
-        .await;
-        state.machine.record_tool_call(
-            &tool_call.name,
-            tool_arguments.clone(),
-            error_payload.clone(),
-            false,
-        );
-        state
-            .machine
-            .add_tool_message(&tool_call.id, &tool_call.name, error_payload);
-        emit(Event::Error {
-            message: "Delegated skill invocation is not available in this runtime.".to_string(),
-            recoverable: true,
-        })
-        .await;
-        return Ok(VirtualToolOutcome::Continue {
-            refresh_context: true,
-        });
-    }
-
-    let (persisted_request, result, child_run) =
-        match resolve_delegated_skill_invocation(state, &request) {
-            Ok(spec) => {
-                let persisted_request = request.with_effective_launch_inputs(
-                    spec.launch.cwd.clone(),
-                    spec.launch.timeout_secs,
-                );
-                match spawn_child(state, spec, cancel).await {
-                    Ok(mut child_result) => {
-                        if cancel.is_cancelled()
-                            && child_result.is_cancelled()
-                            && check_turn_cancelled(state, emit, cancel).await?
-                        {
-                            return Ok(VirtualToolOutcome::EndTurn);
-                        }
-
-                        let output_reference =
-                            persist_delegated_child_evidence(state, &request, &child_result).await;
-                        if let (Some(child_run_id), Some(reference)) = (
-                            child_result.child_run_id.as_deref(),
-                            output_reference.as_ref(),
-                        ) {
-                            state
-                                .child_run_registry()
-                                .set_state_ref(child_run_id, reference.clone());
-                            child_result.child_run = state.child_run_registry().get(child_run_id);
-                        }
-                        (
-                            persisted_request,
-                            child_result.delegated_result(output_reference),
-                            Some(child_result.reference()),
-                        )
-                    }
-                    Err(err) => {
-                        if cancel.is_cancelled()
-                            && check_turn_cancelled(state, emit, cancel).await?
-                        {
-                            return Ok(VirtualToolOutcome::EndTurn);
-                        }
-
-                        let capability_decision = err
-                            .downcast_ref::<DelegatedSpawnRejected>()
-                            .map(|rejection| rejection.decision.clone());
-                        let error_kind = if capability_decision.is_some() {
-                            "delegated_capability_mismatch"
-                        } else {
-                            "child_launch_failed"
-                        };
-                        let mut result = DelegatedSkillResult::failed(
-                            format!(
-                                "Failed to launch delegated runtime for skill '{}': {err}",
-                                request.skill_id
-                            ),
-                            Some(json!({
-                                "error_kind": error_kind
-                            })),
-                        );
-                        result.error_kind = Some(error_kind.to_string());
-                        result.capability_decision = capability_decision;
-                        (persisted_request, result, None)
-                    }
-                }
-            }
-            Err(result) => (request.clone(), *result, None),
-        };
-
-    let (persisted_arguments, tape_record, rollout_record) =
-        build_bounded_delegated_invocation_persistence(&persisted_request, result, child_run);
-    let preview = tool_result_preview(&json!(tape_record.result.summary.clone()));
-    let tape_payload = serde_json::to_value(&tape_record).unwrap_or_else(|_| {
-        json!({
-            "status": "invalid_result_encoding",
-            "error": "Failed to serialize delegated skill result."
-        })
-    });
-    let rollout_payload =
-        serde_json::to_value(&rollout_record).unwrap_or_else(|_| tape_payload.clone());
-    let invocation_succeeded = matches!(
-        tape_record.result.status,
-        DelegatedSkillResultStatus::Completed
-    );
-    emit(Event::ToolCallCompleted {
-        presentation: None,
-        id: tool_call.id.clone(),
-        name: Some(tool_call.name.clone()),
-        success: Some(invocation_succeeded),
-        result_preview: preview,
-        audit: None,
-    })
-    .await;
-    state.machine.record_tool_call(
-        &tool_call.name,
-        persisted_arguments,
-        rollout_payload,
-        invocation_succeeded,
-    );
-    state
-        .machine
-        .add_tool_message(&tool_call.id, &tool_call.name, tape_payload);
-    Ok(VirtualToolOutcome::Continue {
-        refresh_context: true,
-    })
-}
-
-async fn spawn_and_join_delegated_child(
-    state: &RuntimeLoopState,
-    spec: SpawnSpec,
-    cancel: &CancellationToken,
-) -> Result<ChildRuntimeResult> {
-    if cancel.is_cancelled() {
-        return Ok(ChildRuntimeResult::cancelled_before_launch());
-    }
-
-    let controller = spawn_child_runtime_cancellable(state, spec, cancel).await?;
-    controller.join_until_cancelled(cancel).await
-}
-
-fn resolve_delegated_skill_invocation(
-    state: &mut RuntimeLoopState,
-    request: &DelegatedSkillInvocationRequest,
-) -> DelegatedSkillSpawnResult<SpawnSpec> {
-    let active_skill = state
-        .turn_state
-        .active_skills()
-        .iter()
-        .find(|skill| skill.metadata.id == request.skill_id)
-        .cloned();
-
-    let skill_metadata = if let Some(skill) = active_skill {
-        if !skill.availability.is_available() {
-            return Err(Box::new(DelegatedSkillResult::failed(
-                format!(
-                    "Delegated skill '{}' is {}.",
-                    request.skill_id,
-                    skill.availability.render_label()
-                ),
-                Some(json!({
-                    "error_kind": "skill_unavailable"
-                })),
-            )));
-        }
-        skill.metadata
-    } else {
-        match state
-            .prompt_cache
-            .resolve_listed_skill_metadata(request.skill_id.as_str())
-        {
-            Ok(Some(metadata)) => metadata,
-            Ok(None) => {
-                return Err(Box::new(DelegatedSkillResult::failed(
-                    format!(
-                        "Delegated skill '{}' is not active and is not listed for implicit use in the current runtime.",
-                        request.skill_id
-                    ),
-                    Some(json!({
-                        "error_kind": "skill_not_visible"
-                    })),
-                )));
-            }
-            Err(err) => {
-                return Err(Box::new(DelegatedSkillResult::failed(
-                    format!(
-                        "Failed to resolve delegated skill '{}' from the runtime catalog: {err}",
-                        request.skill_id
-                    ),
-                    Some(json!({
-                        "error_kind": "skill_resolution_failed"
-                    })),
-                )));
-            }
-        }
-    };
-
-    let Some(resolved_target) = skill_metadata.execution.delegate_target() else {
-        return Err(Box::new(DelegatedSkillResult::failed(
-            format!(
-                "Skill '{}' is not resolved for delegated execution.",
-                request.skill_id
-            ),
-            Some(json!({
-                "error_kind": "skill_not_delegated"
-            })),
-        )));
-    };
-
-    if resolved_target != request.target {
-        return Err(Box::new(DelegatedSkillResult::failed(
-            format!(
-                "Delegated skill '{}' resolves to delegated target '{}' rather than '{}'.",
-                request.skill_id, resolved_target, request.target
-            ),
-            Some(json!({
-                "error_kind": "delegate_target_mismatch",
-                "resolved_target": resolved_target
-            })),
-        )));
-    }
-
-    let Some(spawn_target) = skill_metadata.delegated_spawn_target() else {
-        return Err(Box::new(DelegatedSkillResult::failed(
-            format!(
-                "Delegated skill '{}' does not expose a package-local launch target.",
-                request.skill_id
-            ),
-            Some(json!({
-                "error_kind": "delegate_target_missing"
-            })),
-        )));
-    };
-
-    build_delegated_spawn_spec(state, request, spawn_target)
-}
-
-fn build_delegated_spawn_spec(
-    state: &RuntimeLoopState,
-    request: &DelegatedSkillInvocationRequest,
-    target: alan_agent_protocol::SpawnTarget,
-) -> DelegatedSkillSpawnResult<SpawnSpec> {
-    let parent_namespace_cwd = state
-        .namespace_environment()
-        .launch_context()
-        .map(|context| Path::new(&context.cwd));
-    let cwd = request
-        .cwd
-        .as_deref()
-        .map(|path| resolve_delegated_launch_path(path, parent_namespace_cwd, "cwd"))
-        .transpose()?
-        .or_else(|| parent_namespace_cwd.map(lexically_normalize_path));
-    let requirements = classify_delegated_task_requirements(&request.task, cwd.as_deref());
-    let mut handles = vec![SpawnHandle::ApprovalScope];
-    if cwd.as_deref().is_some_and(|cwd| {
-        state
-            .namespace_environment()
-            .launch_context()
-            .is_some_and(|context| {
-                context
-                    .host_mounts
-                    .iter()
-                    .any(|grant| grant.resolve_host_path(&cwd.to_string_lossy()).is_some())
-            })
-    }) {
-        handles.push(SpawnHandle::HostMounts);
-    }
-    Ok(SpawnSpec {
-        target,
-        launch: SpawnLaunchInputs {
-            task: request.task.clone(),
-            cwd,
-            timeout_secs: Some(
-                request
-                    .timeout_secs
-                    .unwrap_or(DEFAULT_DELEGATED_TIMEOUT_SECS),
-            ),
-            output_dir: None,
-        },
-        handles,
-        runtime_overrides: SpawnRuntimeOverrides::default(),
-        delegated: Some(DelegatedSpawnContext { requirements }),
-    })
-}
-
-fn resolve_delegated_launch_path(
-    requested_path: &Path,
-    base: Option<&Path>,
-    field_name: &str,
-) -> DelegatedSkillSpawnResult<PathBuf> {
-    if requested_path.is_absolute() {
-        return Ok(lexically_normalize_path(requested_path));
-    }
-
-    let Some(base) = base else {
-        return Err(Box::new(DelegatedSkillResult::failed(
-            format!(
-                "Delegated skill invocation provided relative {field_name} '{}' but the parent runtime has no base path to resolve it.",
-                requested_path.display()
-            ),
-            Some(json!({
-                "error_kind": "relative_launch_path_unresolvable",
-                "field": field_name
-            })),
-        )));
-    };
-
-    Ok(lexically_normalize_path(&base.join(requested_path)))
-}
-
-fn lexically_normalize_path(path: &Path) -> PathBuf {
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
-            Component::RootDir => normalized.push(component.as_os_str()),
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            Component::Normal(part) => normalized.push(part),
-        }
-    }
-    normalized
 }
 
 pub(super) fn parse_confirmation_request(
@@ -1229,6 +803,51 @@ fn update_plan_tool_definition() -> ToolDefinition {
             },
             "required": ["items"]
         }),
+    }
+}
+
+#[cfg(test)]
+mod definition_tests {
+    use super::*;
+
+    #[test]
+    fn definitions_exclude_optional_delegation_tools_by_default() {
+        let defs = virtual_tool_definitions(false);
+        assert_eq!(defs.len(), 4);
+        assert!(
+            defs.iter()
+                .any(|definition| definition.name == "request_confirmation")
+        );
+        assert!(
+            defs.iter()
+                .any(|definition| definition.name == "request_mount")
+        );
+        assert!(
+            defs.iter()
+                .any(|definition| definition.name == "request_user_input")
+        );
+        assert!(
+            defs.iter()
+                .any(|definition| definition.name == "update_plan")
+        );
+        assert!(
+            !defs
+                .iter()
+                .any(|definition| definition.name == "invoke_delegated_skill")
+        );
+    }
+
+    #[test]
+    fn definitions_include_delegation_tools_when_supported() {
+        let defs = virtual_tool_definitions(true);
+        assert!(
+            defs.iter()
+                .any(|definition| definition.name == "invoke_delegated_skill")
+        );
+        assert!(
+            defs.iter()
+                .any(|definition| definition.name == "terminate_child_run")
+        );
     }
 }
 

--- a/crates/agent-engine/src/runtime/virtual_tools_tests.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools_tests.rs
@@ -5,7 +5,19 @@ use crate::{
     rollout::{RolloutItem, RolloutRecorder},
     runtime::{
         ChildRunRecord, ChildRunStatus, NamespaceRuntimeEnvironment, RuntimeConfig, TurnState,
-        agent_loop::NamespaceActionRecord, delegated_child_run::MAX_DELEGATED_RESULT_SUMMARY_CHARS,
+        agent_loop::NamespaceActionRecord,
+        delegated_child_run::{
+            ChildRuntimeResult, ChildRuntimeStatus, MAX_DELEGATED_RESULT_OUTPUT_INLINE_CHARS,
+            MAX_DELEGATED_RESULT_SUMMARY_CHARS,
+        },
+        delegated_skill_evidence::persist_delegated_child_evidence,
+        delegated_skill_tool::{
+            DEFAULT_DELEGATED_TIMEOUT_SECS, DelegatedSkillInvocationRequest,
+            MAX_DELEGATED_SKILL_ID_CHARS, MAX_DELEGATED_TARGET_CHARS, MAX_DELEGATED_TASK_CHARS,
+            handle_invoke_delegated_skill_with_spawn,
+        },
+        delegation_capabilities::DelegatedSpawnRejected,
+        mount_request_tool::MountRequestAccess,
         turn_state::TurnActivityState,
     },
     skills::{
@@ -15,6 +27,7 @@ use crate::{
     },
     tools::ToolRegistry,
 };
+use alan_agent_protocol::SpawnHandle;
 use alan_agentfs::AgentFs;
 use alan_ap::InProcessTransport;
 use alan_kernel::{Access, MountFs, Namespace};
@@ -197,24 +210,6 @@ where
 {
     let cancel = CancellationToken::new();
     try_handle_virtual_tool_call(state, tool_call, &tool_call.arguments, &cancel, false, emit).await
-}
-
-#[test]
-fn test_virtual_tool_definitions_include_all_runtime_virtual_tools() {
-    let defs = virtual_tool_definitions(false);
-    assert_eq!(defs.len(), 4);
-    assert!(defs.iter().any(|d| d.name == "request_confirmation"));
-    assert!(defs.iter().any(|d| d.name == "request_mount"));
-    assert!(defs.iter().any(|d| d.name == "request_user_input"));
-    assert!(defs.iter().any(|d| d.name == "update_plan"));
-    assert!(!defs.iter().any(|d| d.name == "invoke_delegated_skill"));
-}
-
-#[test]
-fn test_virtual_tool_definitions_can_include_delegated_skill() {
-    let defs = virtual_tool_definitions(true);
-    assert!(defs.iter().any(|d| d.name == "invoke_delegated_skill"));
-    assert!(defs.iter().any(|d| d.name == "terminate_child_run"));
 }
 
 #[test]
@@ -1920,7 +1915,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill() {
     let captured_spec = Arc::new(Mutex::new(None));
     let captured_spec_for_spawn = Arc::clone(&captured_spec);
     let cancel = CancellationToken::new();
-    let result = handle_invoke_delegated_skill(
+    let result = handle_invoke_delegated_skill_with_spawn(
         &mut state,
         &tool_call,
         &tool_call.arguments,
@@ -2032,7 +2027,7 @@ async fn test_delegated_capability_rejection_is_recorded_on_parent_tape() {
     let cancel = CancellationToken::new();
     let mut emit = |_event: Event| async {};
 
-    handle_invoke_delegated_skill(
+    handle_invoke_delegated_skill_with_spawn(
         &mut state,
         &tool_call,
         &tool_call.arguments,
@@ -2103,7 +2098,7 @@ Use this skill when asked.
     let captured_spec_for_spawn = Arc::clone(&captured_spec);
     let cancel = CancellationToken::new();
     let mut emit = |_event: Event| async {};
-    let result = handle_invoke_delegated_skill(
+    let result = handle_invoke_delegated_skill_with_spawn(
         &mut state,
         &tool_call,
         &tool_call.arguments,
@@ -2191,7 +2186,7 @@ Use this skill when asked.
 
     let mut emit = |_event: Event| async {};
     let cancel = CancellationToken::new();
-    let result = handle_invoke_delegated_skill(
+    let result = handle_invoke_delegated_skill_with_spawn(
         &mut state,
         &tool_call,
         &tool_call.arguments,
@@ -2266,7 +2261,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_records_succes
 
     let mut emit = |_event: Event| async {};
     let cancel = CancellationToken::new();
-    let result = handle_invoke_delegated_skill(
+    let result = handle_invoke_delegated_skill_with_spawn(
         &mut state,
         &tool_call,
         &tool_call.arguments,
@@ -2334,7 +2329,7 @@ async fn test_try_handle_virtual_tool_call_records_normalized_namespace_cwd() {
 
     let mut emit = |_event: Event| async {};
     let cancel = CancellationToken::new();
-    let result = handle_invoke_delegated_skill(
+    let result = handle_invoke_delegated_skill_with_spawn(
         &mut state,
         &tool_call,
         &tool_call.arguments,
@@ -2408,7 +2403,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_bounds_preview
     };
 
     let cancel = CancellationToken::new();
-    let result = handle_invoke_delegated_skill(
+    let result = handle_invoke_delegated_skill_with_spawn(
         &mut state,
         &tool_call,
         &tool_call.arguments,
@@ -2498,7 +2493,7 @@ async fn long_delegated_output_uses_parent_resolvable_namespace_reference() {
     let mut emit = |_event: Event| async {};
 
     let output_len = (1 << 20) + 1_024;
-    handle_invoke_delegated_skill(
+    handle_invoke_delegated_skill_with_spawn(
         &mut state,
         &tool_call,
         &tool_call.arguments,
@@ -2712,7 +2707,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_honors_interru
 
     let cancel = CancellationToken::new();
     let cancel_for_task = cancel.clone();
-    let result = handle_invoke_delegated_skill(
+    let result = handle_invoke_delegated_skill_with_spawn(
         &mut state,
         &tool_call,
         &tool_call.arguments,
@@ -2784,7 +2779,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_honors_interru
 
     let cancel = CancellationToken::new();
     let cancel_for_task = cancel.clone();
-    let result = handle_invoke_delegated_skill(
+    let result = handle_invoke_delegated_skill_with_spawn(
         &mut state,
         &tool_call,
         &tool_call.arguments,
@@ -2877,7 +2872,7 @@ async fn test_try_handle_virtual_tool_call_rejects_target_mismatch() {
     };
 
     let cancel = CancellationToken::new();
-    let result = handle_invoke_delegated_skill(
+    let result = handle_invoke_delegated_skill_with_spawn(
         &mut state,
         &tool_call,
         &tool_call.arguments,

--- a/scripts/rust-source-size-baseline.txt
+++ b/scripts/rust-source-size-baseline.txt
@@ -5,8 +5,7 @@ crates/agent-engine/src/agent_machine.rs 3661
 crates/agent-engine/src/config.rs 2556
 crates/agent-engine/src/rollout.rs 2266
 crates/agent-engine/src/runtime/engine.rs 2816
-crates/agent-engine/src/runtime/virtual_tools.rs 1237
-crates/agent-engine/src/runtime/virtual_tools_tests.rs 2979
+crates/agent-engine/src/runtime/virtual_tools_tests.rs 2974
 crates/agent-engine/src/skills/injector.rs 2490
 crates/agent-engine/src/skills/types.rs 3013
 crates/agent-engine/src/tools/reified_namespace.rs 2756


### PR DESCRIPTION
## Summary

- move delegated-skill invocation handling, runtime launch, child join, and spawn-spec resolution into the dedicated Tool owner
- keep `virtual_tools.rs` as a thin dispatcher for delegated invocation
- make handler-test dependencies explicit and move small definition tests beside the dispatcher

## Architecture impact

- `virtual_tools.rs`: 1237 -> 856 lines and removed from the source-size debt baseline
- `delegated_skill_tool.rs`: 235 -> 675 lines, remaining below the 1000-line target
- delegated launch policy, package target resolution, namespace cwd normalization, handles, cancellation, and result recording now share one owner
- `virtual_tools_tests.rs`: 2979 -> 2974 lines, so its debt baseline continues to tighten

## Verification

- `cargo test -p alan-agent-engine delegated`
- `cargo test -p alan-agent-engine runtime::virtual_tools`
- `just quality`
- `just test`
- `openspec validate --all --strict`

Stacked on #710.
