### PR TITLE
refactor: extract runtime controller

### DIFF
--- a/crates/agent-engine/src/runtime/child_agents/runtime_startup.rs
+++ b/crates/agent-engine/src/runtime/child_agents/runtime_startup.rs
@@ -1,6 +1,6 @@
 use crate::runtime::AgentProcessLifecycle;
 use crate::runtime::child_runs::ChildRunStatus;
-use crate::runtime::engine::{RuntimeController, RuntimeStartupMetadata};
+use crate::runtime::controller::{RuntimeController, RuntimeStartupMetadata};
 use alan_agent_protocol::Submission;
 use anyhow::{Context, Result, bail};
 use std::sync::Arc;

--- a/crates/agent-engine/src/runtime/child_agents/tests.rs
+++ b/crates/agent-engine/src/runtime/child_agents/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::llm::{GenerationRequest, GenerationResponse, StreamChunk, TokenUsage};
-use crate::runtime::engine::RuntimeStartupMetadata;
+use crate::runtime::controller::RuntimeStartupMetadata;
 use crate::runtime::{
     ApprovedMountGrant, ApprovedMountGrantAccess, MountGrantApplicator,
     MountGrantApplicatorFactory, NamespaceRuntimeEnvironment, RuntimeConfig,
@@ -29,7 +29,7 @@ fn test_startup_metadata(
         agent_path: "/agent/test".to_string(),
         rollout_id: None,
         rollout_path,
-        durability: super::super::engine::AgentMachineDurabilityState {
+        durability: super::super::controller::AgentMachineDurabilityState {
             durable,
             required: false,
         },

--- a/crates/agent-engine/src/runtime/controller.rs
+++ b/crates/agent-engine/src/runtime/controller.rs
@@ -1,0 +1,228 @@
+//! Runtime readiness, control, and shutdown ownership.
+
+use alan_agent_protocol::Submission;
+use anyhow::Result;
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
+
+/// Effective durability state for a runtime machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AgentMachineDurabilityState {
+    /// Whether the active machine has a persistent recorder attached.
+    pub durable: bool,
+    /// Whether startup required durability instead of allowing in-memory fallback.
+    pub required: bool,
+}
+
+/// Metadata produced once runtime startup completes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeStartupMetadata {
+    /// Authoritative lifecycle path of the launched Agent Process.
+    pub process_path: String,
+    /// AgentFS projection path of the launched Agent Process.
+    pub agent_path: String,
+    /// Identity of the fresh rollout produced by this process, when durable.
+    pub rollout_id: Option<String>,
+    /// Host-owned rollout file used for durable execution evidence, when available.
+    pub rollout_path: Option<PathBuf>,
+    /// Effective durability state of the Agent Machine.
+    pub durability: AgentMachineDurabilityState,
+    /// Active Tool execution backend name.
+    pub execution_backend: String,
+    /// Request controls resolved for this Agent Machine.
+    pub request_controls: crate::ResolvedRequestControls,
+    /// Non-fatal startup diagnostics.
+    pub warnings: Vec<String>,
+}
+
+impl RuntimeStartupMetadata {
+    pub(super) fn ready(
+        process_path: String,
+        agent_path: String,
+        rollout_id: Option<String>,
+        rollout_path: Option<PathBuf>,
+        durability: AgentMachineDurabilityState,
+        request_controls: crate::ResolvedRequestControls,
+        warnings: Vec<String>,
+    ) -> Self {
+        Self {
+            process_path,
+            agent_path,
+            rollout_id,
+            rollout_path,
+            durability,
+            execution_backend: crate::tools::active_backend_name().to_string(),
+            request_controls,
+            warnings,
+        }
+    }
+
+    fn already_ready_fallback() -> Self {
+        Self::ready(
+            String::new(),
+            String::new(),
+            None,
+            None,
+            AgentMachineDurabilityState {
+                durable: true,
+                required: false,
+            },
+            crate::ResolvedRequestControls::default(),
+            Vec::new(),
+        )
+    }
+}
+
+/// Handle for communicating with an agent runtime.
+#[derive(Clone)]
+pub struct RuntimeHandle {
+    /// Submission channel for runtime input and control operations.
+    pub submission_tx: mpsc::Sender<Submission>,
+    /// Shutdown signal sender for graceful shutdown.
+    shutdown_tx: Option<mpsc::Sender<()>>,
+}
+
+impl RuntimeHandle {
+    fn new(submission_tx: mpsc::Sender<Submission>, shutdown_tx: Option<mpsc::Sender<()>>) -> Self {
+        Self {
+            submission_tx,
+            shutdown_tx,
+        }
+    }
+
+    /// Request graceful shutdown of the runtime.
+    pub async fn shutdown(&self) -> Result<()> {
+        if let Some(ref tx) = self.shutdown_tx {
+            tx.send(()).await.map_err(|_| {
+                anyhow::anyhow!("Failed to send shutdown signal - runtime may already be stopped")
+            })?;
+            info!("Shutdown signal sent to runtime");
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("Shutdown channel not available"))
+        }
+    }
+}
+
+/// Runtime controller for managing a spawned agent runtime.
+pub struct RuntimeController {
+    /// Handle for communicating with the runtime.
+    pub handle: RuntimeHandle,
+    /// Join handle for the main runtime task (Option to allow take on abort).
+    task_handle: Option<JoinHandle<()>>,
+    /// Runtime readiness channel.
+    ready_rx: Option<oneshot::Receiver<std::result::Result<RuntimeStartupMetadata, String>>>,
+    /// Cached startup metadata for repeated readiness checks and child-launch introspection.
+    startup_metadata: Option<RuntimeStartupMetadata>,
+}
+
+impl RuntimeController {
+    pub(super) fn spawned(
+        submission_tx: mpsc::Sender<Submission>,
+        shutdown_tx: mpsc::Sender<()>,
+        task_handle: JoinHandle<()>,
+        ready_rx: oneshot::Receiver<std::result::Result<RuntimeStartupMetadata, String>>,
+    ) -> Self {
+        Self {
+            handle: RuntimeHandle::new(submission_tx, Some(shutdown_tx)),
+            task_handle: Some(task_handle),
+            ready_rx: Some(ready_rx),
+            startup_metadata: None,
+        }
+    }
+
+    /// Returns true if the runtime task has already exited.
+    pub fn is_finished(&self) -> bool {
+        self.task_handle
+            .as_ref()
+            .map(tokio::task::JoinHandle::is_finished)
+            .unwrap_or(true)
+    }
+
+    /// Wait until the runtime has completed startup.
+    pub async fn wait_until_ready(&mut self) -> Result<RuntimeStartupMetadata> {
+        if let Some(metadata) = self.startup_metadata.clone() {
+            return Ok(metadata);
+        }
+
+        let Some(ready_rx) = self.ready_rx.take() else {
+            return Ok(RuntimeStartupMetadata::already_ready_fallback());
+        };
+
+        match ready_rx.await {
+            Ok(Ok(metadata)) => {
+                self.startup_metadata = Some(metadata.clone());
+                Ok(metadata)
+            }
+            Ok(Err(message)) => Err(anyhow::anyhow!(message)),
+            Err(_) => Err(anyhow::anyhow!(
+                "Runtime stopped before signaling startup readiness"
+            )),
+        }
+    }
+
+    /// Shutdown the runtime gracefully and wait for it to complete.
+    ///
+    /// First sends shutdown signal, then waits up to 10s for graceful shutdown.
+    /// If timeout occurs, the task is explicitly aborted and awaited to ensure
+    /// the runtime is truly stopped.
+    pub async fn shutdown(mut self) -> Result<()> {
+        self.ready_rx.take();
+
+        if let Some(ref tx) = self.handle.shutdown_tx
+            && tx.send(()).await.is_err()
+        {
+            warn!("Shutdown channel closed - runtime may already be stopped");
+        }
+
+        drop(self.handle.submission_tx);
+
+        let timeout = tokio::time::Duration::from_secs(10);
+        if let Some(ref mut handle) = self.task_handle {
+            match tokio::time::timeout(timeout, &mut *handle).await {
+                Ok(Ok(())) => {
+                    info!("Runtime task completed gracefully");
+                    Ok(())
+                }
+                Ok(Err(err)) => Err(anyhow::anyhow!("Runtime task panicked: {}", err)),
+                Err(_) => {
+                    warn!("Runtime shutdown timeout, aborting task");
+                    handle.abort();
+                    match tokio::time::timeout(Duration::from_secs(5), handle).await {
+                        Ok(_) => {
+                            info!("Runtime task aborted successfully");
+                            Ok(())
+                        }
+                        Err(_) => Err(anyhow::anyhow!("Runtime shutdown timeout and abort failed")),
+                    }
+                }
+            }
+        } else {
+            Err(anyhow::anyhow!("Task handle not available"))
+        }
+    }
+
+    /// Abort the runtime immediately without waiting for graceful shutdown.
+    ///
+    /// This takes ownership of the task handles and aborts them immediately.
+    /// Use this when you need to guarantee the runtime stops.
+    pub async fn abort(mut self) {
+        self.ready_rx.take();
+
+        if let Some(ref tx) = self.handle.shutdown_tx {
+            let _ = tx.try_send(());
+        }
+
+        if let Some(handle) = self.task_handle.take() {
+            handle.abort();
+            let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "controller_tests.rs"]
+mod tests;

--- a/crates/agent-engine/src/runtime/controller_tests.rs
+++ b/crates/agent-engine/src/runtime/controller_tests.rs
@@ -1,0 +1,39 @@
+use super::*;
+
+#[test]
+fn runtime_handle_is_cloneable() {
+    let (submission_tx, _submission_rx) = mpsc::channel(10);
+    let handle = RuntimeHandle::new(submission_tx, None);
+
+    let cloned = handle.clone();
+
+    drop(cloned);
+    drop(handle);
+}
+
+#[test]
+fn runtime_handle_exposes_submission_channel() {
+    let (submission_tx, _submission_rx) = mpsc::channel::<Submission>(10);
+    let handle = RuntimeHandle::new(submission_tx, None);
+
+    assert!(!handle.submission_tx.is_closed());
+}
+
+#[tokio::test]
+async fn runtime_handle_shutdown_requires_channel() {
+    let (submission_tx, _submission_rx) = mpsc::channel::<Submission>(10);
+    let handle = RuntimeHandle::new(submission_tx, None);
+
+    assert!(handle.shutdown().await.is_err());
+}
+
+#[tokio::test]
+async fn runtime_handle_shutdown_signals_channel() {
+    let (submission_tx, _submission_rx) = mpsc::channel::<Submission>(10);
+    let (shutdown_tx, mut shutdown_rx) = mpsc::channel::<()>(1);
+    let handle = RuntimeHandle::new(submission_tx, Some(shutdown_tx));
+
+    handle.shutdown().await.unwrap();
+
+    assert!(shutdown_rx.recv().await.is_some());
+}

--- a/crates/agent-engine/src/runtime/engine.rs
+++ b/crates/agent-engine/src/runtime/engine.rs
@@ -4,6 +4,7 @@ use super::agent_loop::{
     DeferredRuntimeActionExit, handle_submission_with_cancel,
     run_deferred_runtime_action_with_cancel,
 };
+use super::controller::{AgentMachineDurabilityState, RuntimeController, RuntimeStartupMetadata};
 use super::launch_config::AgentProcessConfig;
 use super::turn_driver::{
     NAMESPACE_PENDING_RESPONSE_POLL_INTERVAL, TurnInputBroker, drive_turn_submission_with_cancel,
@@ -15,10 +16,8 @@ use crate::agent_machine::AgentMachine;
 use alan_agent_protocol::{Event, InputMode, Submission};
 use anyhow::Result;
 use std::collections::VecDeque;
-use std::path::PathBuf;
 use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
-use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
@@ -137,31 +136,6 @@ impl RuntimeSubmissionQueues {
     }
 }
 
-/// Effective durability state for a runtime machine.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct AgentMachineDurabilityState {
-    /// Whether the active machine has a persistent recorder attached.
-    pub durable: bool,
-    /// Whether startup required durability instead of allowing in-memory fallback.
-    pub required: bool,
-}
-
-/// Metadata produced once runtime startup completes.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RuntimeStartupMetadata {
-    /// Authoritative lifecycle path of the launched Agent Process.
-    pub process_path: String,
-    /// AgentFS projection path of the launched Agent Process.
-    pub agent_path: String,
-    /// Identity of the fresh rollout produced by this process, when durable.
-    pub rollout_id: Option<String>,
-    pub rollout_path: Option<PathBuf>,
-    pub durability: AgentMachineDurabilityState,
-    pub execution_backend: String,
-    pub request_controls: crate::ResolvedRequestControls,
-    pub warnings: Vec<String>,
-}
-
 struct AgentMachineStartupOutcome {
     machine: AgentMachine,
     metadata: RuntimeStartupMetadata,
@@ -169,10 +143,6 @@ struct AgentMachineStartupOutcome {
 
 fn best_effort_durability_warning(err: &anyhow::Error) -> String {
     format!("AgentMachine is running without persistent recorder; using in-memory mode: {err}")
-}
-
-fn current_execution_backend() -> String {
-    crate::tools::active_backend_name().to_string()
 }
 
 #[cfg(test)]
@@ -318,176 +288,23 @@ async fn initialize_agent_machine(
     };
 
     Ok(AgentMachineStartupOutcome {
-        metadata: RuntimeStartupMetadata {
-            process_path: launch.process_path.to_string(),
-            agent_path: launch.agent_path.to_string(),
-            rollout_id: machine
+        metadata: RuntimeStartupMetadata::ready(
+            launch.process_path.to_string(),
+            launch.agent_path.to_string(),
+            machine
                 .recorder
                 .as_ref()
                 .map(|recorder| recorder.rollout_id().to_string()),
-            rollout_path: machine.rollout_path().cloned(),
-            durability: AgentMachineDurabilityState {
+            machine.rollout_path().cloned(),
+            AgentMachineDurabilityState {
                 durable: machine.recorder.is_some(),
                 required: durability_required,
             },
-            execution_backend: current_execution_backend(),
             request_controls,
             warnings,
-        },
+        ),
         machine,
     })
-}
-
-/// Handle for communicating with an agent runtime
-#[derive(Clone)]
-pub struct RuntimeHandle {
-    pub submission_tx: mpsc::Sender<Submission>,
-    /// Shutdown signal sender for graceful shutdown
-    shutdown_tx: Option<mpsc::Sender<()>>,
-}
-
-impl RuntimeHandle {
-    /// Request graceful shutdown of the runtime
-    pub async fn shutdown(&self) -> Result<()> {
-        if let Some(ref tx) = self.shutdown_tx {
-            tx.send(()).await.map_err(|_| {
-                anyhow::anyhow!("Failed to send shutdown signal - runtime may already be stopped")
-            })?;
-            info!("Shutdown signal sent to runtime");
-            Ok(())
-        } else {
-            Err(anyhow::anyhow!("Shutdown channel not available"))
-        }
-    }
-}
-
-/// Runtime controller for managing a spawned agent runtime
-pub struct RuntimeController {
-    /// Handle for communicating with the runtime
-    pub handle: RuntimeHandle,
-    /// Join handle for the main runtime task (Option to allow take on abort)
-    task_handle: Option<JoinHandle<()>>,
-    /// Runtime readiness channel
-    ready_rx: Option<oneshot::Receiver<std::result::Result<RuntimeStartupMetadata, String>>>,
-    /// Cached startup metadata for repeated readiness checks and child-launch introspection.
-    startup_metadata: Option<RuntimeStartupMetadata>,
-}
-
-impl RuntimeController {
-    /// Returns true if the runtime task has already exited.
-    pub fn is_finished(&self) -> bool {
-        self.task_handle
-            .as_ref()
-            .map(tokio::task::JoinHandle::is_finished)
-            .unwrap_or(true)
-    }
-
-    /// Wait until the runtime has completed startup.
-    pub async fn wait_until_ready(&mut self) -> Result<RuntimeStartupMetadata> {
-        if let Some(metadata) = self.startup_metadata.clone() {
-            return Ok(metadata);
-        }
-
-        let Some(ready_rx) = self.ready_rx.take() else {
-            return Ok(RuntimeStartupMetadata {
-                process_path: String::new(),
-                agent_path: String::new(),
-                rollout_id: None,
-                rollout_path: None,
-                durability: AgentMachineDurabilityState {
-                    durable: true,
-                    required: false,
-                },
-                execution_backend: current_execution_backend(),
-                request_controls: crate::ResolvedRequestControls::default(),
-                warnings: Vec::new(),
-            });
-        };
-
-        match ready_rx.await {
-            Ok(Ok(metadata)) => {
-                self.startup_metadata = Some(metadata.clone());
-                Ok(metadata)
-            }
-            Ok(Err(message)) => Err(anyhow::anyhow!(message)),
-            Err(_) => Err(anyhow::anyhow!(
-                "Runtime stopped before signaling startup readiness"
-            )),
-        }
-    }
-
-    /// Shutdown the runtime gracefully and wait for it to complete
-    ///
-    /// First sends shutdown signal, then waits up to 10s for graceful shutdown.
-    /// If timeout occurs, the task is explicitly aborted and awaited to ensure
-    /// the runtime is truly stopped.
-    pub async fn shutdown(mut self) -> Result<()> {
-        // No longer need readiness signal once shutdown starts.
-        self.ready_rx.take();
-
-        // Send shutdown signal
-        if let Some(ref tx) = self.handle.shutdown_tx
-            && tx.send(()).await.is_err()
-        {
-            warn!("Shutdown channel closed - runtime may already be stopped");
-        }
-
-        // Close submission channel to stop accepting new work
-        drop(self.handle.submission_tx);
-
-        // Wait for the main task to complete with timeout
-        let timeout = tokio::time::Duration::from_secs(10);
-
-        // Use &mut handle so we don't consume it on timeout
-        if let Some(ref mut handle) = self.task_handle {
-            match tokio::time::timeout(timeout, &mut *handle).await {
-                Ok(Ok(())) => {
-                    info!("Runtime task completed gracefully");
-                    Ok(())
-                }
-                Ok(Err(e)) => {
-                    // Task panicked
-                    Err(anyhow::anyhow!("Runtime task panicked: {}", e))
-                }
-                Err(_) => {
-                    // Timeout - explicitly abort the task
-                    warn!("Runtime shutdown timeout, aborting task");
-                    handle.abort();
-                    // Wait for the aborted task to complete
-                    match tokio::time::timeout(Duration::from_secs(5), handle).await {
-                        Ok(_) => {
-                            info!("Runtime task aborted successfully");
-                            Ok(())
-                        }
-                        Err(_) => Err(anyhow::anyhow!("Runtime shutdown timeout and abort failed")),
-                    }
-                }
-            }
-        } else {
-            Err(anyhow::anyhow!("Task handle not available"))
-        }
-    }
-
-    /// Abort the runtime immediately without waiting for graceful shutdown
-    ///
-    /// This takes ownership of the task handles and aborts them immediately.
-    /// Use this when you need to guarantee the runtime stops.
-    pub async fn abort(mut self) {
-        // No longer need readiness signal once abort starts.
-        self.ready_rx.take();
-
-        // Send shutdown signal first (best effort)
-        if let Some(ref tx) = self.handle.shutdown_tx {
-            let _ = tx.try_send(());
-        }
-
-        // Take and abort the runtime task.
-        if let Some(handle) = self.task_handle.take() {
-            handle.abort();
-            // Wait for the task to actually stop
-            let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
-        }
-    }
 }
 
 /// Start Agent Execution Engine over an already-assembled Process namespace.
@@ -1005,15 +822,12 @@ fn spawn_with_prepared_runtime_environment(
         state.machine.flush().await;
     });
 
-    Ok(RuntimeController {
-        handle: RuntimeHandle {
-            submission_tx: sub_tx,
-            shutdown_tx: Some(shutdown_tx),
-        },
-        task_handle: Some(task_handle),
-        ready_rx: Some(ready_rx),
-        startup_metadata: None,
-    })
+    Ok(RuntimeController::spawned(
+        sub_tx,
+        shutdown_tx,
+        task_handle,
+        ready_rx,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/agent-engine/src/runtime/engine_startup_tests.rs
+++ b/crates/agent-engine/src/runtime/engine_startup_tests.rs
@@ -45,65 +45,6 @@ fn test_runtime_host_capabilities_include_host_path_executables() {
     assert!(capabilities.supports_required_tool("demo"));
 }
 
-#[test]
-fn test_agent_runtime_handle_clone() {
-    let (sub_tx, _sub_rx) = mpsc::channel(10);
-
-    let handle = RuntimeHandle {
-        submission_tx: sub_tx,
-        shutdown_tx: None,
-    };
-
-    let cloned = handle.clone();
-    // Both handles should share the same channels
-    drop(cloned);
-    drop(handle);
-}
-
-#[test]
-fn test_agent_runtime_handle_fields() {
-    let (sub_tx, _sub_rx) = mpsc::channel::<Submission>(10);
-
-    let handle = RuntimeHandle {
-        submission_tx: sub_tx,
-        shutdown_tx: None,
-    };
-
-    // Verify handle can be created
-    assert!(!handle.submission_tx.is_closed());
-}
-
-#[tokio::test]
-async fn test_agent_runtime_handle_shutdown_without_channel() {
-    let (sub_tx, _sub_rx) = mpsc::channel::<Submission>(10);
-    let handle = RuntimeHandle {
-        submission_tx: sub_tx,
-        shutdown_tx: None,
-    };
-
-    let result = handle.shutdown().await;
-    assert!(result.is_err());
-}
-
-#[tokio::test]
-async fn test_agent_runtime_handle_shutdown_with_channel() {
-    let (sub_tx, _sub_rx) = mpsc::channel::<Submission>(10);
-    let (shutdown_tx, mut shutdown_rx) = mpsc::channel::<()>(1);
-
-    let handle = RuntimeHandle {
-        submission_tx: sub_tx,
-        shutdown_tx: Some(shutdown_tx),
-    };
-
-    // Shutdown should send signal
-    let result = handle.shutdown().await;
-    assert!(result.is_ok());
-
-    // Verify shutdown signal was sent
-    let signal = shutdown_rx.recv().await;
-    assert!(signal.is_some());
-}
-
 #[tokio::test]
 async fn test_initialize_agent_machine_from_rollout_preserves_current_process_cwd() {
     let temp = TempDir::new().unwrap();

--- a/crates/agent-engine/src/runtime/engine_tests.rs
+++ b/crates/agent-engine/src/runtime/engine_tests.rs
@@ -430,7 +430,7 @@ fn test_should_drive_turn_submission() {
     }));
 }
 
-#[path = "engine_config_tests.rs"]
-mod config;
 #[path = "engine_runtime_tests.rs"]
 mod runtime;
+#[path = "engine_startup_tests.rs"]
+mod startup;

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -8,6 +8,7 @@ mod child_agents;
 mod child_run_termination_tool;
 mod child_runs;
 mod compaction;
+mod controller;
 mod delegated_child_run;
 mod delegated_skill_evidence;
 mod delegated_skill_tool;
@@ -52,10 +53,10 @@ pub use child_runs::{
     ChildRunRecord, ChildRunRegistryError, ChildRunStatus, ChildRunTerminationMode,
     ChildRunTerminationRequest,
 };
-pub use engine::{
+pub use controller::{
     AgentMachineDurabilityState, RuntimeController, RuntimeHandle, RuntimeStartupMetadata,
-    spawn_with_namespace_environment,
 };
+pub use engine::spawn_with_namespace_environment;
 pub use launch_config::{
     AgentConfig, AgentProcessConfig, configure_runtime_tool_execution_binding,
     effective_core_config_for_runtime,

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -38,8 +38,9 @@ fn runtime_state_and_handles_have_no_parallel_capability_or_event_authority() {
     assert!(state.contains("pub environment: NamespaceRuntimeEnvironment"));
 
     let engine_source = read_runtime_source("engine.rs");
-    let handle = rust_item_body(&engine_source, "pub struct RuntimeHandle");
-    let controller = rust_item_body(&engine_source, "pub struct RuntimeController");
+    let controller_source = read_runtime_source("controller.rs");
+    let handle = rust_item_body(&controller_source, "pub struct RuntimeHandle");
+    let controller = rust_item_body(&controller_source, "pub struct RuntimeController");
     let spawn = rust_item_body(&engine_source, "fn spawn_with_prepared_runtime_environment");
 
     for (owner, source) in [

--- a/scripts/rust-source-size-baseline.txt
+++ b/scripts/rust-source-size-baseline.txt
@@ -4,7 +4,6 @@ crates/agent-engine/skills/swebench/tooling/src/swebench_lite.rs 1389
 crates/agent-engine/src/agent_machine.rs 3661
 crates/agent-engine/src/config.rs 2556
 crates/agent-engine/src/rollout.rs 2266
-crates/agent-engine/src/runtime/engine.rs 1021
 crates/agent-engine/src/skills/injector.rs 2490
 crates/agent-engine/src/skills/types.rs 3013
 crates/agent-engine/src/tools/reified_namespace.rs 2756


### PR DESCRIPTION
## Summary
- move runtime readiness metadata, handles, and controller lifecycle into a dedicated controller owner
- encapsulate spawned channel and task construction behind RuntimeController
- move handle white-box tests and retarget the architecture guard to the durable owner

## Impact
- reduces runtime engine.rs from 1021 to 835 lines
- removes runtime engine.rs from the oversized Rust source baseline
- keeps the public runtime control API and product behavior unchanged

## Verification
- cargo test -p alan-agent-engine runtime::controller::tests
- cargo test -p alan-agent-engine runtime::engine::tests
- cargo test -p alan-agent-engine runtime::child_agents
- cargo test -p alan-agent-engine runtime::delegated_child_run
- cargo test -p alan-agent-engine --test dependency_boundary
- just quality
- just test
- openspec validate --all --strict

Stacked on #718.