### PR TITLE
refactor: extract agent machine recovery

### DIFF
--- a/crates/agent-engine/src/agent_machine.rs
+++ b/crates/agent-engine/src/agent_machine.rs
@@ -7,16 +7,18 @@ use tracing::error;
 
 use alan_agent_protocol::{CompactionAttemptSnapshot, MemoryFlushAttemptSnapshot};
 
-use crate::approval::{
-    RUNTIME_CONFIRMATION_CONTROL_SOURCE, RUNTIME_CONFIRMATION_CONTROL_VERSION,
-    is_runtime_confirmation_checkpoint_type, runtime_confirmation_checkpoint_prefix,
-    runtime_confirmation_control_kind,
-};
 use crate::rollout::{
-    CompactedItem, ContextItemRecord, EffectRecord, EventRecord, ReferenceContextSnapshotRecord,
-    RolloutItem, RolloutRecorder, build_durable_tool_payload,
+    CompactedItem, ContextItemRecord, EffectRecord, ReferenceContextSnapshotRecord, RolloutItem,
+    RolloutRecorder, build_durable_tool_payload,
 };
 use crate::tape::{ContextItem, ContextItemsDelta, Tape};
+
+mod recovery;
+mod runtime_control;
+
+pub use recovery::{
+    latest_compaction_attempt_from_rollout_items, latest_memory_flush_attempt_from_rollout_items,
+};
 
 /// Warning emitted when rollback succeeds but remains in-memory only.
 pub const ROLLBACK_NON_DURABLE_WARNING: &str =
@@ -72,240 +74,6 @@ pub struct AgentMachine {
 pub use crate::tape::{Message, MessageRole};
 
 impl AgentMachine {
-    const RESPONSES_CONTINUATION_EVENT_TYPE: &'static str = "responses_continuation";
-
-    fn responses_continuation_from_event_records(
-        event_records: &[EventRecord],
-    ) -> Option<ResponsesContinuationState> {
-        event_records.iter().fold(None, |_, event| {
-            if event.event_type != Self::RESPONSES_CONTINUATION_EVENT_TYPE {
-                return None;
-            }
-
-            if event
-                .payload
-                .get("cleared")
-                .and_then(serde_json::Value::as_bool)
-                == Some(true)
-            {
-                return None;
-            }
-
-            let provider = event
-                .payload
-                .get("provider")
-                .and_then(serde_json::Value::as_str)
-                .map(str::trim)
-                .filter(|value| !value.is_empty())?
-                .to_string();
-            let last_response_id = event
-                .payload
-                .get("last_response_id")
-                .and_then(serde_json::Value::as_str)
-                .map(str::trim)
-                .filter(|value| !value.is_empty())?
-                .to_string();
-            let boundary_message_count = event
-                .payload
-                .get("boundary_message_count")
-                .and_then(serde_json::Value::as_u64)?
-                as usize;
-            let reference_context_revision = event
-                .payload
-                .get("reference_context_revision")
-                .and_then(serde_json::Value::as_u64)?;
-
-            Some(ResponsesContinuationState {
-                provider,
-                last_response_id,
-                boundary_message_count,
-                reference_context_revision,
-            })
-        })
-    }
-
-    fn runtime_confirmation_control_checkpoint(
-        payload: &serde_json::Value,
-    ) -> Option<(&str, &str)> {
-        let checkpoint_id = payload
-            .get("checkpoint_id")
-            .and_then(serde_json::Value::as_str)?;
-        let checkpoint_type = payload
-            .get("checkpoint_type")
-            .and_then(serde_json::Value::as_str)?;
-        let choice = payload.get("choice").and_then(serde_json::Value::as_str)?;
-
-        if !is_runtime_confirmation_checkpoint_type(checkpoint_type) {
-            return None;
-        }
-        if !matches!(choice, "approve" | "reject") {
-            return None;
-        }
-        let prefix = runtime_confirmation_checkpoint_prefix(checkpoint_type)?;
-        if !checkpoint_id.starts_with(prefix) {
-            return None;
-        }
-
-        Some((checkpoint_id, checkpoint_type))
-    }
-
-    fn has_runtime_confirmation_control_kind_and_version(
-        payload: &serde_json::Value,
-        checkpoint_type: &str,
-    ) -> bool {
-        let marker = payload.get("__alan_internal_control");
-        let marker_kind = marker
-            .and_then(|value| value.get("kind"))
-            .and_then(serde_json::Value::as_str);
-        let marker_version = marker
-            .and_then(|value| value.get("version"))
-            .and_then(serde_json::Value::as_u64);
-
-        marker_kind == runtime_confirmation_control_kind(checkpoint_type)
-            && marker_version == Some(RUNTIME_CONFIRMATION_CONTROL_VERSION)
-    }
-
-    fn runtime_confirmation_control_source(payload: &serde_json::Value) -> Option<&str> {
-        payload
-            .get("__alan_internal_control")
-            .and_then(|marker| marker.get("source"))
-            .and_then(serde_json::Value::as_str)
-    }
-
-    fn is_runtime_confirmation_control_payload(payload: &serde_json::Value) -> bool {
-        let Some((_, checkpoint_type)) = Self::runtime_confirmation_control_checkpoint(payload)
-        else {
-            return false;
-        };
-
-        Self::has_runtime_confirmation_control_kind_and_version(payload, checkpoint_type)
-            && Self::runtime_confirmation_control_source(payload)
-                == Some(RUNTIME_CONFIRMATION_CONTROL_SOURCE)
-    }
-
-    fn is_runtime_confirmation_control_parts(parts: &[crate::tape::ContentPart]) -> bool {
-        parts.iter().any(|part| {
-            matches!(
-                part,
-                crate::tape::ContentPart::Structured { data }
-                    if Self::is_runtime_confirmation_control_payload(data)
-            )
-        })
-    }
-
-    fn is_runtime_confirmation_control_message(message: &Message) -> bool {
-        match message {
-            Message::User { parts } => Self::is_runtime_confirmation_control_parts(parts),
-            _ => false,
-        }
-    }
-
-    fn turn_ordinal_from_effect_idempotency_key(key: &str) -> Option<u64> {
-        let tail = key.strip_prefix("machine:turn:")?;
-        let turn_segment = tail.split(':').next()?;
-        turn_segment.parse::<u64>().ok()
-    }
-
-    fn latest_compaction_attempt_from_rollout_items_internal(
-        items: &[RolloutItem],
-    ) -> Option<CompactionAttemptSnapshot> {
-        let mut latest: Option<(usize, CompactionAttemptSnapshot)> = None;
-        let mut pending_tape_mutating_attempts: HashMap<
-            String,
-            (usize, CompactionAttemptSnapshot),
-        > = HashMap::new();
-        for (item_index, item) in items.iter().enumerate() {
-            match item {
-                RolloutItem::CompactionAttempt(attempt) => {
-                    Self::track_compaction_attempt(
-                        &mut latest,
-                        &mut pending_tape_mutating_attempts,
-                        item_index,
-                        attempt.clone(),
-                    );
-                }
-                RolloutItem::Compacted(compacted) => {
-                    if let Some(attempt) = Self::take_completed_compaction_attempt(
-                        &mut pending_tape_mutating_attempts,
-                        compacted,
-                        latest.as_ref().map(|(latest_index, _)| *latest_index),
-                    ) {
-                        latest = Some((item_index, attempt));
-                    }
-                }
-                _ => {}
-            }
-        }
-        latest.map(|(_, attempt)| attempt)
-    }
-
-    fn latest_memory_flush_attempt_from_rollout_items_internal(
-        items: &[RolloutItem],
-    ) -> Option<MemoryFlushAttemptSnapshot> {
-        items.iter().rev().find_map(|item| match item {
-            RolloutItem::MemoryFlushAttempt(attempt) => Some(attempt.clone()),
-            _ => None,
-        })
-    }
-
-    fn track_compaction_attempt(
-        latest: &mut Option<(usize, CompactionAttemptSnapshot)>,
-        pending_tape_mutating_attempts: &mut HashMap<String, (usize, CompactionAttemptSnapshot)>,
-        item_index: usize,
-        attempt: CompactionAttemptSnapshot,
-    ) {
-        if attempt.tape_mutated {
-            pending_tape_mutating_attempts
-                .insert(attempt.attempt_id.clone(), (item_index, attempt));
-        } else {
-            *latest = Some((item_index, attempt));
-        }
-    }
-
-    fn take_completed_compaction_attempt(
-        pending_tape_mutating_attempts: &mut HashMap<String, (usize, CompactionAttemptSnapshot)>,
-        compacted: &CompactedItem,
-        latest_index: Option<usize>,
-    ) -> Option<CompactionAttemptSnapshot> {
-        if let Some(attempt_id) = compacted.attempt_id.as_deref() {
-            let (attempt_index, attempt) = pending_tape_mutating_attempts.remove(attempt_id)?;
-            if latest_index.is_some_and(|latest_index| latest_index > attempt_index) {
-                return None;
-            }
-            return Some(attempt);
-        }
-
-        if pending_tape_mutating_attempts.len() != 1 {
-            return None;
-        }
-
-        let attempt_id = pending_tape_mutating_attempts.keys().next()?.clone();
-        let attempt_index = pending_tape_mutating_attempts
-            .get(&attempt_id)
-            .map(|(item_index, _)| *item_index)?;
-        if latest_index.is_some_and(|latest_index| latest_index > attempt_index) {
-            return None;
-        }
-
-        pending_tape_mutating_attempts
-            .remove(&attempt_id)
-            .map(|(_, attempt)| attempt)
-    }
-
-    fn stabilize_recovered_compacted_item_link(
-        mut compacted: Option<CompactedItem>,
-        latest_attempt: Option<&CompactionAttemptSnapshot>,
-    ) -> Option<CompactedItem> {
-        if let Some(compacted) = compacted.as_mut()
-            && compacted.attempt_id.is_none()
-            && let Some(attempt) = latest_attempt
-            && attempt.tape_mutated
-        {
-            compacted.attempt_id = Some(attempt.attempt_id.clone());
-        }
-        compacted
-    }
-
     /// Create a new machine without persistence
     pub fn new() -> Self {
         Self {
@@ -366,206 +134,6 @@ impl AgentMachine {
         rollouts_dir: &Path,
     ) -> anyhow::Result<Self> {
         Self::new_with_recorder_options(process_path, model, Some(rollouts_dir), None, None).await
-    }
-
-    /// Load a machine from a rollout file
-    pub async fn load_from_rollout(
-        path: &PathBuf,
-        process_path: &str,
-        model: &str,
-    ) -> anyhow::Result<Self> {
-        Self::load_from_rollout_impl(path, process_path, model, None, None, None).await
-    }
-
-    /// Load a machine from a rollout file, writing future persistence to a specific rollouts dir.
-    pub async fn load_from_rollout_in_dir(
-        path: &PathBuf,
-        process_path: &str,
-        model: &str,
-        rollouts_dir: &Path,
-    ) -> anyhow::Result<Self> {
-        Self::load_from_rollout_impl(path, process_path, model, Some(rollouts_dir), None, None)
-            .await
-    }
-
-    pub(crate) async fn load_from_rollout_with_recorder_cwd(
-        path: &PathBuf,
-        process_path: &str,
-        model: &str,
-        rollouts_dir: Option<&Path>,
-        rollout_cwd: Option<&Path>,
-        reasoning_effort: Option<alan_agent_protocol::ReasoningEffort>,
-    ) -> anyhow::Result<Self> {
-        Self::load_from_rollout_impl(
-            path,
-            process_path,
-            model,
-            rollouts_dir,
-            rollout_cwd,
-            reasoning_effort,
-        )
-        .await
-    }
-
-    async fn load_from_rollout_impl(
-        path: &PathBuf,
-        process_path: &str,
-        model: &str,
-        rollouts_dir: Option<&Path>,
-        rollout_cwd: Option<&Path>,
-        reasoning_effort: Option<alan_agent_protocol::ReasoningEffort>,
-    ) -> anyhow::Result<Self> {
-        let items = RolloutRecorder::load_history(path).await?;
-        if !matches!(items.first(), Some(RolloutItem::AgentMachineMeta(_))) {
-            anyhow::bail!("rollout does not begin with current Agent Machine metadata");
-        }
-
-        // Recovery is explicitly scoped to the newly launched Agent Process. The
-        // source rollout is evidence, not a globally addressable execution identity.
-        let mut machine = Self::new_with_recorder_options(
-            process_path,
-            model,
-            rollouts_dir,
-            rollout_cwd,
-            reasoning_effort,
-        )
-        .await?;
-
-        let recovered_latest_compaction_attempt =
-            Self::latest_compaction_attempt_from_rollout_items_internal(&items);
-        let recovered_latest_memory_flush_attempt =
-            Self::latest_memory_flush_attempt_from_rollout_items_internal(&items);
-        let mut context_items: Vec<ContextItem> = Vec::new();
-        let mut compaction_attempt_records: Vec<CompactionAttemptSnapshot> = Vec::new();
-        let mut memory_flush_attempt_records: Vec<MemoryFlushAttemptSnapshot> = Vec::new();
-        let mut recovered_compaction: Option<CompactedItem> = None;
-        let mut effect_records: Vec<EffectRecord> = Vec::new();
-        let mut event_records: Vec<EventRecord> = Vec::new();
-
-        // Replay messages from history
-        for item in items {
-            match item {
-                RolloutItem::Message(msg) => {
-                    let Some(message) = msg.message else {
-                        anyhow::bail!(
-                            "rollout contains a message without the current rich message record"
-                        );
-                    };
-                    if message.is_context() {
-                        continue;
-                    }
-                    if message.is_user() && !Self::is_runtime_confirmation_control_message(&message)
-                    {
-                        machine.user_turn_ordinal = machine.user_turn_ordinal.saturating_add(1);
-                    }
-                    machine.tape.push(message);
-                }
-                RolloutItem::TurnContext(ctx) => {
-                    context_items = ctx
-                        .context_items
-                        .into_iter()
-                        .map(|item| ContextItem {
-                            id: item.id,
-                            kind: item.kind,
-                            title: item.title,
-                            content: item.content,
-                            fingerprint: item.fingerprint,
-                        })
-                        .collect();
-                }
-                RolloutItem::Compacted(compacted) => {
-                    machine.tape.set_summary(compacted.message.clone());
-                    recovered_compaction = Some(compacted);
-                }
-                RolloutItem::CompactionAttempt(attempt) => {
-                    compaction_attempt_records.push(attempt);
-                }
-                RolloutItem::MemoryFlushAttempt(attempt) => {
-                    memory_flush_attempt_records.push(attempt);
-                }
-                RolloutItem::ToolCall(_) => {}
-                RolloutItem::Effect(effect) => effect_records.push(effect),
-                RolloutItem::Event(event) => event_records.push(event),
-                _ => {} // Skip other item types during loading
-            }
-        }
-
-        if !machine.tape.is_empty() {
-            machine.has_active_task = true;
-        }
-
-        if !context_items.is_empty() {
-            let _ = machine.tape.apply_context_items(context_items);
-        }
-        recovered_compaction = Self::stabilize_recovered_compacted_item_link(
-            recovered_compaction,
-            recovered_latest_compaction_attempt.as_ref(),
-        );
-        machine.latest_compaction_attempt = recovered_latest_compaction_attempt;
-        machine.latest_memory_flush_attempt = recovered_latest_memory_flush_attempt;
-        machine.responses_continuation =
-            Self::responses_continuation_from_event_records(&event_records);
-
-        for effect in &effect_records {
-            machine
-                .effect_index
-                .insert(effect.idempotency_key.clone(), effect.clone());
-        }
-        if let Some(max_effect_turn) = effect_records
-            .iter()
-            .filter_map(|effect| {
-                Self::turn_ordinal_from_effect_idempotency_key(&effect.idempotency_key)
-            })
-            .max()
-        {
-            machine.user_turn_ordinal = machine.user_turn_ordinal.max(max_effect_turn);
-        }
-
-        let recovered_messages = machine.tape.messages().to_vec();
-        if (!recovered_messages.is_empty()
-            || recovered_compaction.is_some()
-            || !compaction_attempt_records.is_empty()
-            || !memory_flush_attempt_records.is_empty()
-            || !effect_records.is_empty()
-            || !event_records.is_empty())
-            && let Some(recorder) = machine.recorder.as_ref()
-        {
-            for message in recovered_messages {
-                if let Err(err) = recorder.record_tape_message_nowait(&message) {
-                    error!(error = %err, "Failed to re-persist recovered message");
-                }
-            }
-            for attempt in compaction_attempt_records {
-                if let Err(err) = recorder.record_compaction_attempt_nowait(attempt) {
-                    error!(error = %err, "Failed to re-persist recovered compaction attempt");
-                }
-            }
-            for attempt in memory_flush_attempt_records {
-                if let Err(err) = recorder.record_memory_flush_attempt_nowait(attempt) {
-                    error!(error = %err, "Failed to re-persist recovered memory flush attempt");
-                }
-            }
-            if let Some(compacted) = recovered_compaction
-                && let Err(err) = recorder.record_compacted_item_nowait(compacted)
-            {
-                error!(error = %err, "Failed to re-persist recovered summary");
-            }
-            for effect in effect_records {
-                if let Err(err) = recorder.record_effect_nowait(effect) {
-                    error!(error = %err, "Failed to re-persist recovered effect");
-                }
-            }
-            for event in event_records {
-                if let Err(err) = recorder.record_event_item_nowait(event) {
-                    error!(error = %err, "Failed to re-persist recovered event");
-                }
-            }
-            if let Err(err) = recorder.flush().await {
-                error!(error = %err, "Failed to flush recovered rollout state");
-            }
-        }
-
-        Ok(machine)
     }
 
     /// Add a user message to the machine
@@ -841,7 +409,7 @@ impl AgentMachine {
         };
         self.responses_continuation = Some(state.clone());
         self.record_event(
-            Self::RESPONSES_CONTINUATION_EVENT_TYPE,
+            runtime_control::RESPONSES_CONTINUATION_EVENT_TYPE,
             serde_json::json!({
                 "provider": state.provider,
                 "last_response_id": state.last_response_id,
@@ -857,7 +425,7 @@ impl AgentMachine {
             return;
         };
         self.record_event(
-            Self::RESPONSES_CONTINUATION_EVENT_TYPE,
+            runtime_control::RESPONSES_CONTINUATION_EVENT_TYPE,
             serde_json::json!({
                 "provider": previous.provider,
                 "last_response_id": previous.last_response_id,
@@ -906,7 +474,7 @@ impl AgentMachine {
         for (idx, msg) in messages.iter().enumerate().rev() {
             remove_from = idx;
             if matches!(msg, Message::User { .. })
-                && !Self::is_runtime_confirmation_control_message(msg)
+                && !runtime_control::is_runtime_confirmation_control_message(msg)
             {
                 user_turns_seen += 1;
                 if user_turns_seen >= requested_turns {
@@ -1334,20 +902,6 @@ impl Default for AgentMachine {
     fn default() -> Self {
         Self::new()
     }
-}
-
-/// Recover the latest compaction attempt from current rollout records.
-pub fn latest_compaction_attempt_from_rollout_items(
-    items: &[RolloutItem],
-) -> Option<CompactionAttemptSnapshot> {
-    AgentMachine::latest_compaction_attempt_from_rollout_items_internal(items)
-}
-
-/// Recover the latest memory-flush attempt from rollout items.
-pub fn latest_memory_flush_attempt_from_rollout_items(
-    items: &[RolloutItem],
-) -> Option<MemoryFlushAttemptSnapshot> {
-    AgentMachine::latest_memory_flush_attempt_from_rollout_items_internal(items)
 }
 
 #[cfg(test)]

--- a/crates/agent-engine/src/agent_machine/recovery.rs
+++ b/crates/agent-engine/src/agent_machine/recovery.rs
@@ -1,0 +1,382 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use alan_agent_protocol::{CompactionAttemptSnapshot, MemoryFlushAttemptSnapshot};
+use tracing::error;
+
+use super::{AgentMachine, ResponsesContinuationState, runtime_control};
+use crate::rollout::{CompactedItem, EffectRecord, EventRecord, RolloutItem, RolloutRecorder};
+use crate::tape::ContextItem;
+
+impl AgentMachine {
+    fn responses_continuation_from_event_records(
+        event_records: &[EventRecord],
+    ) -> Option<ResponsesContinuationState> {
+        event_records.iter().fold(None, |_, event| {
+            if event.event_type != runtime_control::RESPONSES_CONTINUATION_EVENT_TYPE {
+                return None;
+            }
+
+            if event
+                .payload
+                .get("cleared")
+                .and_then(serde_json::Value::as_bool)
+                == Some(true)
+            {
+                return None;
+            }
+
+            let provider = event
+                .payload
+                .get("provider")
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())?
+                .to_string();
+            let last_response_id = event
+                .payload
+                .get("last_response_id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())?
+                .to_string();
+            let boundary_message_count = event
+                .payload
+                .get("boundary_message_count")
+                .and_then(serde_json::Value::as_u64)?
+                as usize;
+            let reference_context_revision = event
+                .payload
+                .get("reference_context_revision")
+                .and_then(serde_json::Value::as_u64)?;
+
+            Some(ResponsesContinuationState {
+                provider,
+                last_response_id,
+                boundary_message_count,
+                reference_context_revision,
+            })
+        })
+    }
+
+    fn turn_ordinal_from_effect_idempotency_key(key: &str) -> Option<u64> {
+        let tail = key.strip_prefix("machine:turn:")?;
+        let turn_segment = tail.split(':').next()?;
+        turn_segment.parse::<u64>().ok()
+    }
+
+    fn latest_compaction_attempt_from_rollout_items_internal(
+        items: &[RolloutItem],
+    ) -> Option<CompactionAttemptSnapshot> {
+        let mut latest: Option<(usize, CompactionAttemptSnapshot)> = None;
+        let mut pending_tape_mutating_attempts: HashMap<
+            String,
+            (usize, CompactionAttemptSnapshot),
+        > = HashMap::new();
+        for (item_index, item) in items.iter().enumerate() {
+            match item {
+                RolloutItem::CompactionAttempt(attempt) => {
+                    Self::track_compaction_attempt(
+                        &mut latest,
+                        &mut pending_tape_mutating_attempts,
+                        item_index,
+                        attempt.clone(),
+                    );
+                }
+                RolloutItem::Compacted(compacted) => {
+                    if let Some(attempt) = Self::take_completed_compaction_attempt(
+                        &mut pending_tape_mutating_attempts,
+                        compacted,
+                        latest.as_ref().map(|(latest_index, _)| *latest_index),
+                    ) {
+                        latest = Some((item_index, attempt));
+                    }
+                }
+                _ => {}
+            }
+        }
+        latest.map(|(_, attempt)| attempt)
+    }
+
+    fn latest_memory_flush_attempt_from_rollout_items_internal(
+        items: &[RolloutItem],
+    ) -> Option<MemoryFlushAttemptSnapshot> {
+        items.iter().rev().find_map(|item| match item {
+            RolloutItem::MemoryFlushAttempt(attempt) => Some(attempt.clone()),
+            _ => None,
+        })
+    }
+
+    fn track_compaction_attempt(
+        latest: &mut Option<(usize, CompactionAttemptSnapshot)>,
+        pending_tape_mutating_attempts: &mut HashMap<String, (usize, CompactionAttemptSnapshot)>,
+        item_index: usize,
+        attempt: CompactionAttemptSnapshot,
+    ) {
+        if attempt.tape_mutated {
+            pending_tape_mutating_attempts
+                .insert(attempt.attempt_id.clone(), (item_index, attempt));
+        } else {
+            *latest = Some((item_index, attempt));
+        }
+    }
+
+    fn take_completed_compaction_attempt(
+        pending_tape_mutating_attempts: &mut HashMap<String, (usize, CompactionAttemptSnapshot)>,
+        compacted: &CompactedItem,
+        latest_index: Option<usize>,
+    ) -> Option<CompactionAttemptSnapshot> {
+        if let Some(attempt_id) = compacted.attempt_id.as_deref() {
+            let (attempt_index, attempt) = pending_tape_mutating_attempts.remove(attempt_id)?;
+            if latest_index.is_some_and(|latest_index| latest_index > attempt_index) {
+                return None;
+            }
+            return Some(attempt);
+        }
+
+        if pending_tape_mutating_attempts.len() != 1 {
+            return None;
+        }
+
+        let attempt_id = pending_tape_mutating_attempts.keys().next()?.clone();
+        let attempt_index = pending_tape_mutating_attempts
+            .get(&attempt_id)
+            .map(|(item_index, _)| *item_index)?;
+        if latest_index.is_some_and(|latest_index| latest_index > attempt_index) {
+            return None;
+        }
+
+        pending_tape_mutating_attempts
+            .remove(&attempt_id)
+            .map(|(_, attempt)| attempt)
+    }
+
+    fn stabilize_recovered_compacted_item_link(
+        mut compacted: Option<CompactedItem>,
+        latest_attempt: Option<&CompactionAttemptSnapshot>,
+    ) -> Option<CompactedItem> {
+        if let Some(compacted) = compacted.as_mut()
+            && compacted.attempt_id.is_none()
+            && let Some(attempt) = latest_attempt
+            && attempt.tape_mutated
+        {
+            compacted.attempt_id = Some(attempt.attempt_id.clone());
+        }
+        compacted
+    }
+
+    /// Load a machine from a rollout file
+    pub async fn load_from_rollout(
+        path: &PathBuf,
+        process_path: &str,
+        model: &str,
+    ) -> anyhow::Result<Self> {
+        Self::load_from_rollout_impl(path, process_path, model, None, None, None).await
+    }
+
+    /// Load a machine from a rollout file, writing future persistence to a specific rollouts dir.
+    pub async fn load_from_rollout_in_dir(
+        path: &PathBuf,
+        process_path: &str,
+        model: &str,
+        rollouts_dir: &Path,
+    ) -> anyhow::Result<Self> {
+        Self::load_from_rollout_impl(path, process_path, model, Some(rollouts_dir), None, None)
+            .await
+    }
+
+    pub(crate) async fn load_from_rollout_with_recorder_cwd(
+        path: &PathBuf,
+        process_path: &str,
+        model: &str,
+        rollouts_dir: Option<&Path>,
+        rollout_cwd: Option<&Path>,
+        reasoning_effort: Option<alan_agent_protocol::ReasoningEffort>,
+    ) -> anyhow::Result<Self> {
+        Self::load_from_rollout_impl(
+            path,
+            process_path,
+            model,
+            rollouts_dir,
+            rollout_cwd,
+            reasoning_effort,
+        )
+        .await
+    }
+
+    async fn load_from_rollout_impl(
+        path: &PathBuf,
+        process_path: &str,
+        model: &str,
+        rollouts_dir: Option<&Path>,
+        rollout_cwd: Option<&Path>,
+        reasoning_effort: Option<alan_agent_protocol::ReasoningEffort>,
+    ) -> anyhow::Result<Self> {
+        let items = RolloutRecorder::load_history(path).await?;
+        if !matches!(items.first(), Some(RolloutItem::AgentMachineMeta(_))) {
+            anyhow::bail!("rollout does not begin with current Agent Machine metadata");
+        }
+
+        // Recovery is explicitly scoped to the newly launched Agent Process. The
+        // source rollout is evidence, not a globally addressable execution identity.
+        let mut machine = Self::new_with_recorder_options(
+            process_path,
+            model,
+            rollouts_dir,
+            rollout_cwd,
+            reasoning_effort,
+        )
+        .await?;
+
+        let recovered_latest_compaction_attempt =
+            Self::latest_compaction_attempt_from_rollout_items_internal(&items);
+        let recovered_latest_memory_flush_attempt =
+            Self::latest_memory_flush_attempt_from_rollout_items_internal(&items);
+        let mut context_items: Vec<ContextItem> = Vec::new();
+        let mut compaction_attempt_records: Vec<CompactionAttemptSnapshot> = Vec::new();
+        let mut memory_flush_attempt_records: Vec<MemoryFlushAttemptSnapshot> = Vec::new();
+        let mut recovered_compaction: Option<CompactedItem> = None;
+        let mut effect_records: Vec<EffectRecord> = Vec::new();
+        let mut event_records: Vec<EventRecord> = Vec::new();
+
+        // Replay messages from history
+        for item in items {
+            match item {
+                RolloutItem::Message(msg) => {
+                    let Some(message) = msg.message else {
+                        anyhow::bail!(
+                            "rollout contains a message without the current rich message record"
+                        );
+                    };
+                    if message.is_context() {
+                        continue;
+                    }
+                    if message.is_user()
+                        && !runtime_control::is_runtime_confirmation_control_message(&message)
+                    {
+                        machine.user_turn_ordinal = machine.user_turn_ordinal.saturating_add(1);
+                    }
+                    machine.tape.push(message);
+                }
+                RolloutItem::TurnContext(ctx) => {
+                    context_items = ctx
+                        .context_items
+                        .into_iter()
+                        .map(|item| ContextItem {
+                            id: item.id,
+                            kind: item.kind,
+                            title: item.title,
+                            content: item.content,
+                            fingerprint: item.fingerprint,
+                        })
+                        .collect();
+                }
+                RolloutItem::Compacted(compacted) => {
+                    machine.tape.set_summary(compacted.message.clone());
+                    recovered_compaction = Some(compacted);
+                }
+                RolloutItem::CompactionAttempt(attempt) => {
+                    compaction_attempt_records.push(attempt);
+                }
+                RolloutItem::MemoryFlushAttempt(attempt) => {
+                    memory_flush_attempt_records.push(attempt);
+                }
+                RolloutItem::ToolCall(_) => {}
+                RolloutItem::Effect(effect) => effect_records.push(effect),
+                RolloutItem::Event(event) => event_records.push(event),
+                _ => {} // Skip other item types during loading
+            }
+        }
+
+        if !machine.tape.is_empty() {
+            machine.has_active_task = true;
+        }
+
+        if !context_items.is_empty() {
+            let _ = machine.tape.apply_context_items(context_items);
+        }
+        recovered_compaction = Self::stabilize_recovered_compacted_item_link(
+            recovered_compaction,
+            recovered_latest_compaction_attempt.as_ref(),
+        );
+        machine.latest_compaction_attempt = recovered_latest_compaction_attempt;
+        machine.latest_memory_flush_attempt = recovered_latest_memory_flush_attempt;
+        machine.responses_continuation =
+            Self::responses_continuation_from_event_records(&event_records);
+
+        for effect in &effect_records {
+            machine
+                .effect_index
+                .insert(effect.idempotency_key.clone(), effect.clone());
+        }
+        if let Some(max_effect_turn) = effect_records
+            .iter()
+            .filter_map(|effect| {
+                Self::turn_ordinal_from_effect_idempotency_key(&effect.idempotency_key)
+            })
+            .max()
+        {
+            machine.user_turn_ordinal = machine.user_turn_ordinal.max(max_effect_turn);
+        }
+
+        let recovered_messages = machine.tape.messages().to_vec();
+        if (!recovered_messages.is_empty()
+            || recovered_compaction.is_some()
+            || !compaction_attempt_records.is_empty()
+            || !memory_flush_attempt_records.is_empty()
+            || !effect_records.is_empty()
+            || !event_records.is_empty())
+            && let Some(recorder) = machine.recorder.as_ref()
+        {
+            for message in recovered_messages {
+                if let Err(err) = recorder.record_tape_message_nowait(&message) {
+                    error!(error = %err, "Failed to re-persist recovered message");
+                }
+            }
+            for attempt in compaction_attempt_records {
+                if let Err(err) = recorder.record_compaction_attempt_nowait(attempt) {
+                    error!(error = %err, "Failed to re-persist recovered compaction attempt");
+                }
+            }
+            for attempt in memory_flush_attempt_records {
+                if let Err(err) = recorder.record_memory_flush_attempt_nowait(attempt) {
+                    error!(error = %err, "Failed to re-persist recovered memory flush attempt");
+                }
+            }
+            if let Some(compacted) = recovered_compaction
+                && let Err(err) = recorder.record_compacted_item_nowait(compacted)
+            {
+                error!(error = %err, "Failed to re-persist recovered summary");
+            }
+            for effect in effect_records {
+                if let Err(err) = recorder.record_effect_nowait(effect) {
+                    error!(error = %err, "Failed to re-persist recovered effect");
+                }
+            }
+            for event in event_records {
+                if let Err(err) = recorder.record_event_item_nowait(event) {
+                    error!(error = %err, "Failed to re-persist recovered event");
+                }
+            }
+            if let Err(err) = recorder.flush().await {
+                error!(error = %err, "Failed to flush recovered rollout state");
+            }
+        }
+
+        Ok(machine)
+    }
+}
+
+/// Recover the latest compaction attempt from current rollout records.
+pub fn latest_compaction_attempt_from_rollout_items(
+    items: &[RolloutItem],
+) -> Option<CompactionAttemptSnapshot> {
+    AgentMachine::latest_compaction_attempt_from_rollout_items_internal(items)
+}
+
+/// Recover the latest memory-flush attempt from rollout items.
+pub fn latest_memory_flush_attempt_from_rollout_items(
+    items: &[RolloutItem],
+) -> Option<MemoryFlushAttemptSnapshot> {
+    AgentMachine::latest_memory_flush_attempt_from_rollout_items_internal(items)
+}

--- a/crates/agent-engine/src/agent_machine/runtime_control.rs
+++ b/crates/agent-engine/src/agent_machine/runtime_control.rs
@@ -1,0 +1,80 @@
+use crate::approval::{
+    RUNTIME_CONFIRMATION_CONTROL_SOURCE, RUNTIME_CONFIRMATION_CONTROL_VERSION,
+    is_runtime_confirmation_checkpoint_type, runtime_confirmation_checkpoint_prefix,
+    runtime_confirmation_control_kind,
+};
+use crate::tape::{ContentPart, Message};
+
+pub(super) const RESPONSES_CONTINUATION_EVENT_TYPE: &str = "responses_continuation";
+
+fn runtime_confirmation_control_checkpoint(payload: &serde_json::Value) -> Option<(&str, &str)> {
+    let checkpoint_id = payload
+        .get("checkpoint_id")
+        .and_then(serde_json::Value::as_str)?;
+    let checkpoint_type = payload
+        .get("checkpoint_type")
+        .and_then(serde_json::Value::as_str)?;
+    let choice = payload.get("choice").and_then(serde_json::Value::as_str)?;
+
+    if !is_runtime_confirmation_checkpoint_type(checkpoint_type) {
+        return None;
+    }
+    if !matches!(choice, "approve" | "reject") {
+        return None;
+    }
+    let prefix = runtime_confirmation_checkpoint_prefix(checkpoint_type)?;
+    if !checkpoint_id.starts_with(prefix) {
+        return None;
+    }
+
+    Some((checkpoint_id, checkpoint_type))
+}
+
+fn has_runtime_confirmation_control_kind_and_version(
+    payload: &serde_json::Value,
+    checkpoint_type: &str,
+) -> bool {
+    let marker = payload.get("__alan_internal_control");
+    let marker_kind = marker
+        .and_then(|value| value.get("kind"))
+        .and_then(serde_json::Value::as_str);
+    let marker_version = marker
+        .and_then(|value| value.get("version"))
+        .and_then(serde_json::Value::as_u64);
+
+    marker_kind == runtime_confirmation_control_kind(checkpoint_type)
+        && marker_version == Some(RUNTIME_CONFIRMATION_CONTROL_VERSION)
+}
+
+fn runtime_confirmation_control_source(payload: &serde_json::Value) -> Option<&str> {
+    payload
+        .get("__alan_internal_control")
+        .and_then(|marker| marker.get("source"))
+        .and_then(serde_json::Value::as_str)
+}
+
+fn is_runtime_confirmation_control_payload(payload: &serde_json::Value) -> bool {
+    let Some((_, checkpoint_type)) = runtime_confirmation_control_checkpoint(payload) else {
+        return false;
+    };
+
+    has_runtime_confirmation_control_kind_and_version(payload, checkpoint_type)
+        && runtime_confirmation_control_source(payload) == Some(RUNTIME_CONFIRMATION_CONTROL_SOURCE)
+}
+
+fn is_runtime_confirmation_control_parts(parts: &[ContentPart]) -> bool {
+    parts.iter().any(|part| {
+        matches!(
+            part,
+            ContentPart::Structured { data }
+                if is_runtime_confirmation_control_payload(data)
+        )
+    })
+}
+
+pub(super) fn is_runtime_confirmation_control_message(message: &Message) -> bool {
+    match message {
+        Message::User { parts } => is_runtime_confirmation_control_parts(parts),
+        _ => false,
+    }
+}

--- a/scripts/rust-source-size-baseline.txt
+++ b/scripts/rust-source-size-baseline.txt
@@ -1,7 +1,6 @@
 # Rust source files above the 1,000-line target. Keep sorted by path.
 # A file may only stay equal to this maximum or shrink with this entry tightened.
 crates/agent-engine/skills/swebench/tooling/src/swebench_lite.rs 1389
-crates/agent-engine/src/agent_machine.rs 1355
 crates/agent-engine/src/config.rs 2556
 crates/agent-engine/src/rollout.rs 2266
 crates/agent-engine/src/skills/injector.rs 2490


### PR DESCRIPTION
## Summary
- extract append-only Rollout recovery into a cohesive internal AgentMachine module
- centralize runtime control-message recognition for the live and recovery call paths
- remove AgentMachine from the oversized Rust source baseline

## Impact
- preserves the existing AgentMachine public and crate-visible interface exactly
- reduces agent_machine.rs from 1355 lines to 909 lines
- keeps recovery at 382 lines and runtime control semantics at 80 lines
- changes no product behavior

## Verification
- cargo test -p alan-agent-engine agent_machine::tests
- just quality
- just test
- openspec validate --all --strict

Stacked on #720.