### PR TITLE
refactor: extract seatbelt profile adapter

### DIFF
--- a/crates/agent-engine/src/tools/sandbox_backend.rs
+++ b/crates/agent-engine/src/tools/sandbox_backend.rs
@@ -16,11 +16,18 @@
 //! tooling is present, otherwise the path-guard fallback (under which bash must
 //! not auto-run — the policy escalates it).
 
+mod seatbelt;
+
 use std::fmt;
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::PermissionsExt;
-use std::path::{Component, Path, PathBuf};
+use std::path::Path;
+#[cfg(target_os = "linux")]
+use std::path::PathBuf;
 use std::sync::OnceLock;
+
+pub(crate) use seatbelt::read_denylist_excluding_writable_roots;
+pub use seatbelt::seatbelt_profile;
 
 /// Available sandbox enforcement backends, in order of strength.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -766,95 +773,6 @@ fn landlock_available() -> bool {
     false
 }
 
-/// Generate a macOS Seatbelt (SBPL) profile that confines filesystem writes to
-/// writable roots (plus the temp dir) and denies outbound network.
-///
-/// Uses an allow-by-default base then denies the two effects we care about
-/// (network and out-of-host_mount writes) and re-allows writes to the host_mount
-/// and temp locations. This keeps process exec, dynamic linking, and reads
-/// working while still blocking network and writes that escape writable roots —
-/// which is what the auto-approve boundary relies on.
-pub fn seatbelt_profile(
-    writable_roots: &[PathBuf],
-    read_denylist: &[PathBuf],
-    allow_network: bool,
-) -> String {
-    // sandbox-exec evaluates real (symlink-resolved) paths, so the subpath
-    // rules must use canonical paths (e.g. /var -> /private/var on macOS).
-    let tmpdir = std::env::var("TMPDIR").ok();
-    let mut writable = writable_roots
-        .iter()
-        .map(|root| sbpl_quote(&canonical_string(root)))
-        .collect::<Vec<_>>();
-    writable.extend([
-        sbpl_quote("/tmp"),
-        sbpl_quote("/private/tmp"),
-        sbpl_quote("/private/var/folders"),
-    ]);
-    if let Some(tmpdir) = tmpdir.as_deref().filter(|value| !value.is_empty()) {
-        writable.push(sbpl_quote(
-            canonical_string(Path::new(tmpdir.trim_end_matches('/'))).as_str(),
-        ));
-    }
-    let write_allows = writable
-        .iter()
-        .map(|path| format!("(allow file-write* (subpath {path}))"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let read_denylist = read_denylist_excluding_writable_roots(read_denylist, writable_roots);
-    let read_denies = read_denylist
-        .iter()
-        .map(|path| {
-            let path = sbpl_quote(&canonical_string(path));
-            format!("(deny file-read* (literal {path}) (subpath {path}))\n")
-        })
-        .collect::<String>();
-    // NOTE: we do NOT kernel-deny the protected subpaths (`.git`/`.alan`/
-    // `.agents`). The kernel cannot distinguish a tool's tampering from the
-    // legitimate program-internal writes those dirs are designed for — denying
-    // `.git` breaks `git` itself (init/add/commit all write `.git`), and denying
-    // `.alan` breaks the agent's channel-scoped Memory Store. Protected-subpath
-    // tampering is instead blocked by the path-guard parser (direct +
-    // shell-wrapper-nested path writes), which leaves program-internal writes
-    // (git porcelain, memory) intact.
-    // The OS sandbox's role here is the host_mount + network boundary.
-    let network_rule = if allow_network {
-        ""
-    } else {
-        "(deny network*)\n"
-    };
-    format!(
-        "(version 1)\n\
-         (allow default)\n\
-         {network_rule}\
-         {read_denies}\
-         (deny file-write*)\n\
-         {write_allows}\n\
-         (allow file-write-data (literal \"/dev/null\") (literal \"/dev/stdout\") (literal \"/dev/stderr\") (literal \"/dev/tty\") (literal \"/dev/dtracehelper\"))\n"
-    )
-}
-
-pub(crate) fn read_denylist_excluding_writable_roots(
-    read_denylist: &[PathBuf],
-    writable_roots: &[PathBuf],
-) -> Vec<PathBuf> {
-    read_denylist
-        .iter()
-        .filter(|deny_path| !read_deny_matches_any_writable_root(deny_path, writable_roots))
-        .cloned()
-        .collect()
-}
-
-fn read_deny_matches_any_writable_root(deny_path: &Path, writable_roots: &[PathBuf]) -> bool {
-    let deny_variants = comparable_path_variants(deny_path);
-    writable_roots.iter().any(|writable_root| {
-        let writable_variants = comparable_path_variants(writable_root);
-        deny_variants
-            .iter()
-            .any(|deny| writable_variants.iter().any(|writable| writable == deny))
-    })
-}
-
 /// Apply a Landlock ruleset to the current (child) process: allow reads
 /// everywhere, restrict writes to writable roots and temp directories, and deny
 /// all outbound/listening TCP network access (Landlock ABI v4, best-effort).
@@ -961,45 +879,6 @@ fn landlock_supports_network() -> bool {
 #[cfg(not(target_os = "linux"))]
 fn landlock_supports_network() -> bool {
     false
-}
-
-/// Quote a path for inclusion in an SBPL literal/subpath form.
-fn sbpl_quote(path: &str) -> String {
-    format!("\"{}\"", path.replace('\\', "\\\\").replace('"', "\\\""))
-}
-
-/// Resolve a path to its canonical (symlink-free) string, falling back to the
-/// lexical path when it cannot be canonicalized (e.g. it does not exist yet).
-fn canonical_string(path: &Path) -> String {
-    std::fs::canonicalize(path)
-        .map(|resolved| resolved.display().to_string())
-        .unwrap_or_else(|_| path.display().to_string())
-}
-
-fn comparable_path_variants(path: &Path) -> Vec<PathBuf> {
-    let mut variants = vec![lexically_normalize_path(path)];
-    if let Ok(canonical) = std::fs::canonicalize(path)
-        && !variants.contains(&canonical)
-    {
-        variants.push(canonical);
-    }
-    variants
-}
-
-fn lexically_normalize_path(path: &Path) -> PathBuf {
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
-            Component::RootDir => normalized.push(component.as_os_str()),
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            Component::Normal(part) => normalized.push(part),
-        }
-    }
-    normalized
 }
 
 #[cfg(test)]

--- a/crates/agent-engine/src/tools/sandbox_backend/seatbelt.rs
+++ b/crates/agent-engine/src/tools/sandbox_backend/seatbelt.rs
@@ -1,0 +1,135 @@
+//! macOS Seatbelt profile generation and path projection rules.
+
+use std::path::{Component, Path, PathBuf};
+
+/// Generate a macOS Seatbelt (SBPL) profile that confines filesystem writes to
+/// writable roots (plus the temp dir) and denies outbound network.
+///
+/// Uses an allow-by-default base then denies the two effects we care about
+/// (network and out-of-host_mount writes) and re-allows writes to the host_mount
+/// and temp locations. This keeps process exec, dynamic linking, and reads
+/// working while still blocking network and writes that escape writable roots —
+/// which is what the auto-approve boundary relies on.
+pub fn seatbelt_profile(
+    writable_roots: &[PathBuf],
+    read_denylist: &[PathBuf],
+    allow_network: bool,
+) -> String {
+    // sandbox-exec evaluates real (symlink-resolved) paths, so the subpath
+    // rules must use canonical paths (e.g. /var -> /private/var on macOS).
+    let tmpdir = std::env::var("TMPDIR").ok();
+    let mut writable = writable_roots
+        .iter()
+        .map(|root| sbpl_quote(&canonical_string(root)))
+        .collect::<Vec<_>>();
+    writable.extend([
+        sbpl_quote("/tmp"),
+        sbpl_quote("/private/tmp"),
+        sbpl_quote("/private/var/folders"),
+    ]);
+    if let Some(tmpdir) = tmpdir.as_deref().filter(|value| !value.is_empty()) {
+        writable.push(sbpl_quote(
+            canonical_string(Path::new(tmpdir.trim_end_matches('/'))).as_str(),
+        ));
+    }
+    let write_allows = writable
+        .iter()
+        .map(|path| format!("(allow file-write* (subpath {path}))"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let read_denylist = read_denylist_excluding_writable_roots(read_denylist, writable_roots);
+    let read_denies = read_denylist
+        .iter()
+        .map(|path| {
+            let path = sbpl_quote(&canonical_string(path));
+            format!("(deny file-read* (literal {path}) (subpath {path}))\n")
+        })
+        .collect::<String>();
+    // NOTE: we do NOT kernel-deny the protected subpaths (`.git`/`.alan`/
+    // `.agents`). The kernel cannot distinguish a tool's tampering from the
+    // legitimate program-internal writes those dirs are designed for — denying
+    // `.git` breaks `git` itself (init/add/commit all write `.git`), and denying
+    // `.alan` breaks the agent's channel-scoped Memory Store. Protected-subpath
+    // tampering is instead blocked by the path-guard parser (direct +
+    // shell-wrapper-nested path writes), which leaves program-internal writes
+    // (git porcelain, memory) intact.
+    // The OS sandbox's role here is the host_mount + network boundary.
+    let network_rule = if allow_network {
+        ""
+    } else {
+        "(deny network*)\n"
+    };
+    format!(
+        "(version 1)\n\
+         (allow default)\n\
+         {network_rule}\
+         {read_denies}\
+         (deny file-write*)\n\
+         {write_allows}\n\
+         (allow file-write-data (literal \"/dev/null\") (literal \"/dev/stdout\") (literal \"/dev/stderr\") (literal \"/dev/tty\") (literal \"/dev/dtracehelper\"))\n"
+    )
+}
+
+pub(crate) fn read_denylist_excluding_writable_roots(
+    read_denylist: &[PathBuf],
+    writable_roots: &[PathBuf],
+) -> Vec<PathBuf> {
+    read_denylist
+        .iter()
+        .filter(|deny_path| !read_deny_matches_any_writable_root(deny_path, writable_roots))
+        .cloned()
+        .collect()
+}
+
+fn read_deny_matches_any_writable_root(deny_path: &Path, writable_roots: &[PathBuf]) -> bool {
+    let deny_variants = comparable_path_variants(deny_path);
+    writable_roots.iter().any(|writable_root| {
+        let writable_variants = comparable_path_variants(writable_root);
+        deny_variants
+            .iter()
+            .any(|deny| writable_variants.iter().any(|writable| writable == deny))
+    })
+}
+
+/// Quote a path for inclusion in an SBPL literal/subpath form.
+fn sbpl_quote(path: &str) -> String {
+    format!("\"{}\"", path.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+/// Resolve a path to its canonical (symlink-free) string, falling back to the
+/// lexical path when it cannot be canonicalized (e.g. it does not exist yet).
+fn canonical_string(path: &Path) -> String {
+    std::fs::canonicalize(path)
+        .map(|resolved| resolved.display().to_string())
+        .unwrap_or_else(|_| path.display().to_string())
+}
+
+fn comparable_path_variants(path: &Path) -> Vec<PathBuf> {
+    let mut variants = vec![lexically_normalize_path(path)];
+    if let Ok(canonical) = std::fs::canonicalize(path)
+        && !variants.contains(&canonical)
+    {
+        variants.push(canonical);
+    }
+    variants
+}
+
+fn lexically_normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+    normalized
+}
+
+#[cfg(test)]
+#[path = "seatbelt_tests.rs"]
+mod tests;

--- a/crates/agent-engine/src/tools/sandbox_backend/seatbelt_tests.rs
+++ b/crates/agent-engine/src/tools/sandbox_backend/seatbelt_tests.rs
@@ -1,0 +1,151 @@
+use super::*;
+
+#[test]
+fn seatbelt_profile_confines_writes_and_denies_network() {
+    let writable_roots = vec![PathBuf::from("/work/space")];
+    let profile = seatbelt_profile(&writable_roots, &[], false);
+    assert!(profile.contains("(deny network*)"));
+    assert!(profile.contains("(deny file-write*)"));
+    assert!(profile.contains("(allow file-write* (subpath \"/work/space\"))"));
+}
+
+#[test]
+fn seatbelt_profile_permits_network_when_approved() {
+    // An approved network call runs with network allowed (still fs-confined).
+    let writable_roots = vec![PathBuf::from("/work/space")];
+    let approved = seatbelt_profile(&writable_roots, &[], true);
+    assert!(!approved.contains("(deny network*)"));
+    assert!(approved.contains("(deny file-write*)"));
+}
+
+#[test]
+fn seatbelt_profile_single_root_matches_pre_refactor_profile() {
+    let host_mount_root = PathBuf::from("/work/space");
+    let writable_roots = vec![host_mount_root.clone()];
+    let profile = seatbelt_profile(&writable_roots, &[], false);
+    assert_eq!(
+        profile,
+        pre_refactor_single_host_mount_profile(&host_mount_root, false)
+    );
+    assert!(!profile.contains("(deny file-read*"));
+}
+
+#[test]
+fn seatbelt_profile_emits_read_denies_when_configured() {
+    let writable_roots = vec![PathBuf::from("/work/space")];
+    let read_denylist = vec![PathBuf::from("/secret"), PathBuf::from("/home/me/.netrc")];
+    let profile = seatbelt_profile(&writable_roots, &read_denylist, false);
+    assert!(profile.contains("(deny file-read* (literal \"/secret\") (subpath \"/secret\"))"));
+    assert!(
+        profile.contains(
+            "(deny file-read* (literal \"/home/me/.netrc\") (subpath \"/home/me/.netrc\"))"
+        )
+    );
+}
+
+#[test]
+fn seatbelt_profile_omits_exact_writable_root_read_denies() {
+    let writable_roots = vec![PathBuf::from("/Users/alice/.alan")];
+    let read_denylist = vec![
+        PathBuf::from("/Users/alice"),
+        PathBuf::from("/Users/alice/.alan"),
+        PathBuf::from("/Users/alice/.alan-dev"),
+        PathBuf::from("/Users/alice/.ssh"),
+    ];
+    let profile = seatbelt_profile(&writable_roots, &read_denylist, false);
+
+    assert!(profile.contains("(deny file-read* (literal \"/Users/alice\")"));
+    assert!(!profile.contains("(deny file-read* (literal \"/Users/alice/.alan\")"));
+    assert!(profile.contains("(deny file-read* (literal \"/Users/alice/.alan-dev\")"));
+    assert!(profile.contains("(deny file-read* (literal \"/Users/alice/.ssh\")"));
+}
+
+#[test]
+fn seatbelt_profile_preserves_parent_read_denies_for_nested_writable_roots() {
+    let writable_roots = vec![PathBuf::from("/Users/alice/.ssh/project")];
+    let read_denylist = vec![PathBuf::from("/Users/alice/.ssh")];
+    let profile = seatbelt_profile(&writable_roots, &read_denylist, false);
+
+    assert!(profile.contains("(deny file-read* (literal \"/Users/alice/.ssh\")"));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn seatbelt_enforces_host_mount_write_boundary_on_macos() {
+    if !super::super::seatbelt_available() {
+        return; // sandbox-exec not present; nothing to enforce
+    }
+    let host_mount = tempfile::tempdir().unwrap();
+    let writable_roots = vec![host_mount.path().to_path_buf()];
+    let profile = seatbelt_profile(&writable_roots, &[], false);
+    let canonical_host_mount = std::fs::canonicalize(host_mount.path()).unwrap();
+
+    let run = |script: String| {
+        std::process::Command::new("/usr/bin/sandbox-exec")
+            .arg("-p")
+            .arg(&profile)
+            .arg("sh")
+            .arg("-c")
+            .arg(script)
+            .status()
+            .unwrap()
+    };
+
+    // In-host_mount write succeeds. If it fails, this environment cannot run
+    // `sandbox-exec` (e.g. a restricted CI runner) — skip rather than fail.
+    let inside_file = canonical_host_mount.join("inside.txt");
+    let ok = run(format!("echo hi > {}", inside_file.display()));
+    if !ok.success() || !inside_file.exists() {
+        return;
+    }
+
+    // Out-of-host_mount write (under HOME, outside host_mount and temp roots)
+    // is blocked by the kernel regardless of command syntax.
+    let escape_file =
+        PathBuf::from(std::env::var("HOME").unwrap()).join(".alan_seatbelt_escape_test");
+    let _ = std::fs::remove_file(&escape_file);
+    let blocked = run(format!("echo hi > {}", escape_file.display()));
+    assert!(
+        !blocked.success(),
+        "out-of-host_mount write should be denied"
+    );
+    assert!(
+        !escape_file.exists(),
+        "kernel must prevent the out-of-host_mount file from being created"
+    );
+}
+
+fn pre_refactor_single_host_mount_profile(host_mount_root: &Path, allow_network: bool) -> String {
+    let canonical_root = canonical_string(host_mount_root);
+    let root = sbpl_quote(&canonical_root);
+    let tmpdir = std::env::var("TMPDIR").ok();
+    let mut writable = vec![
+        root,
+        sbpl_quote("/tmp"),
+        sbpl_quote("/private/tmp"),
+        sbpl_quote("/private/var/folders"),
+    ];
+    if let Some(tmpdir) = tmpdir.as_deref().filter(|value| !value.is_empty()) {
+        writable.push(sbpl_quote(
+            canonical_string(Path::new(tmpdir.trim_end_matches('/'))).as_str(),
+        ));
+    }
+    let write_allows = writable
+        .iter()
+        .map(|path| format!("(allow file-write* (subpath {path}))"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let network_rule = if allow_network {
+        ""
+    } else {
+        "(deny network*)\n"
+    };
+    format!(
+        "(version 1)\n\
+         (allow default)\n\
+         {network_rule}\
+         (deny file-write*)\n\
+         {write_allows}\n\
+         (allow file-write-data (literal \"/dev/null\") (literal \"/dev/stdout\") (literal \"/dev/stderr\") (literal \"/dev/tty\") (literal \"/dev/dtracehelper\"))\n"
+    )
+}

--- a/crates/agent-engine/src/tools/sandbox_backend_tests.rs
+++ b/crates/agent-engine/src/tools/sandbox_backend_tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::path::PathBuf;
 
 #[test]
 fn os_backends_are_enforced_and_allow_unattended() {
@@ -52,123 +51,8 @@ fn backend_path_modes_are_stable() {
 }
 
 #[test]
-fn seatbelt_profile_confines_writes_and_denies_network() {
-    let writable_roots = vec![PathBuf::from("/work/space")];
-    let profile = seatbelt_profile(&writable_roots, &[], false);
-    assert!(profile.contains("(deny network*)"));
-    assert!(profile.contains("(deny file-write*)"));
-    assert!(profile.contains("(allow file-write* (subpath \"/work/space\"))"));
-}
-
-#[test]
-fn seatbelt_profile_permits_network_when_approved() {
-    // An approved network call runs with network allowed (still fs-confined).
-    let writable_roots = vec![PathBuf::from("/work/space")];
-    let approved = seatbelt_profile(&writable_roots, &[], true);
-    assert!(!approved.contains("(deny network*)"));
-    assert!(approved.contains("(deny file-write*)"));
-}
-
-#[test]
-fn seatbelt_profile_single_root_matches_pre_refactor_profile() {
-    let host_mount_root = PathBuf::from("/work/space");
-    let writable_roots = vec![host_mount_root.clone()];
-    let profile = seatbelt_profile(&writable_roots, &[], false);
-    assert_eq!(
-        profile,
-        pre_refactor_single_host_mount_profile(&host_mount_root, false)
-    );
-    assert!(!profile.contains("(deny file-read*"));
-}
-
-#[test]
-fn seatbelt_profile_emits_read_denies_when_configured() {
-    let writable_roots = vec![PathBuf::from("/work/space")];
-    let read_denylist = vec![PathBuf::from("/secret"), PathBuf::from("/home/me/.netrc")];
-    let profile = seatbelt_profile(&writable_roots, &read_denylist, false);
-    assert!(profile.contains("(deny file-read* (literal \"/secret\") (subpath \"/secret\"))"));
-    assert!(
-        profile.contains(
-            "(deny file-read* (literal \"/home/me/.netrc\") (subpath \"/home/me/.netrc\"))"
-        )
-    );
-}
-
-#[test]
-fn seatbelt_profile_omits_exact_writable_root_read_denies() {
-    let writable_roots = vec![PathBuf::from("/Users/alice/.alan")];
-    let read_denylist = vec![
-        PathBuf::from("/Users/alice"),
-        PathBuf::from("/Users/alice/.alan"),
-        PathBuf::from("/Users/alice/.alan-dev"),
-        PathBuf::from("/Users/alice/.ssh"),
-    ];
-    let profile = seatbelt_profile(&writable_roots, &read_denylist, false);
-
-    assert!(profile.contains("(deny file-read* (literal \"/Users/alice\")"));
-    assert!(!profile.contains("(deny file-read* (literal \"/Users/alice/.alan\")"));
-    assert!(profile.contains("(deny file-read* (literal \"/Users/alice/.alan-dev\")"));
-    assert!(profile.contains("(deny file-read* (literal \"/Users/alice/.ssh\")"));
-}
-
-#[test]
-fn seatbelt_profile_preserves_parent_read_denies_for_nested_writable_roots() {
-    let writable_roots = vec![PathBuf::from("/Users/alice/.ssh/project")];
-    let read_denylist = vec![PathBuf::from("/Users/alice/.ssh")];
-    let profile = seatbelt_profile(&writable_roots, &read_denylist, false);
-
-    assert!(profile.contains("(deny file-read* (literal \"/Users/alice/.ssh\")"));
-}
-
-#[test]
 fn os_backend_active_matches_detection() {
     assert_eq!(os_backend_active(), detect_backend().is_os_enforced());
-}
-
-#[cfg(target_os = "macos")]
-#[test]
-fn seatbelt_enforces_host_mount_write_boundary_on_macos() {
-    if !super::seatbelt_available() {
-        return; // sandbox-exec not present; nothing to enforce
-    }
-    let host_mount = tempfile::tempdir().unwrap();
-    let writable_roots = vec![host_mount.path().to_path_buf()];
-    let profile = seatbelt_profile(&writable_roots, &[], false);
-    let canonical_host_mount = std::fs::canonicalize(host_mount.path()).unwrap();
-
-    let run = |script: String| {
-        std::process::Command::new("/usr/bin/sandbox-exec")
-            .arg("-p")
-            .arg(&profile)
-            .arg("sh")
-            .arg("-c")
-            .arg(script)
-            .status()
-            .unwrap()
-    };
-
-    // In-host_mount write succeeds. If it fails, this environment cannot run
-    // `sandbox-exec` (e.g. a restricted CI runner) — skip rather than fail.
-    let inside_file = canonical_host_mount.join("inside.txt");
-    let ok = run(format!("echo hi > {}", inside_file.display()));
-    if !ok.success() || !inside_file.exists() {
-        return;
-    }
-
-    // Out-of-host_mount write (under HOME, outside host_mount and temp roots)
-    // is blocked by the kernel regardless of command syntax.
-    let escape_file =
-        std::path::PathBuf::from(std::env::var("HOME").unwrap()).join(".alan_seatbelt_escape_test");
-    let _ = std::fs::remove_file(&escape_file);
-    let blocked = run(format!("echo hi > {}", escape_file.display()));
-    assert!(
-        !blocked.success(),
-        "out-of-host_mount write should be denied"
-    );
-    assert!(
-        !escape_file.exists(),
-        "kernel must prevent the out-of-host_mount file from being created"
-    );
 }
 
 #[cfg(target_os = "linux")]
@@ -493,41 +377,6 @@ fn linux_reification_readiness_audit_names_selected_backend_and_path_mode() {
     )));
     assert!(fields.contains(&("selected_backend", "landlock".to_string())));
     assert!(fields.contains(&("path_mode", "projected_host_paths".to_string())));
-}
-
-fn pre_refactor_single_host_mount_profile(host_mount_root: &Path, allow_network: bool) -> String {
-    let canonical_root = canonical_string(host_mount_root);
-    let root = sbpl_quote(&canonical_root);
-    let tmpdir = std::env::var("TMPDIR").ok();
-    let mut writable = vec![
-        root,
-        sbpl_quote("/tmp"),
-        sbpl_quote("/private/tmp"),
-        sbpl_quote("/private/var/folders"),
-    ];
-    if let Some(tmpdir) = tmpdir.as_deref().filter(|value| !value.is_empty()) {
-        writable.push(sbpl_quote(
-            canonical_string(Path::new(tmpdir.trim_end_matches('/'))).as_str(),
-        ));
-    }
-    let write_allows = writable
-        .iter()
-        .map(|path| format!("(allow file-write* (subpath {path}))"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let network_rule = if allow_network {
-        ""
-    } else {
-        "(deny network*)\n"
-    };
-    format!(
-        "(version 1)\n\
-         (allow default)\n\
-         {network_rule}\
-         (deny file-write*)\n\
-         {write_allows}\n\
-         (allow file-write-data (literal \"/dev/null\") (literal \"/dev/stdout\") (literal \"/dev/stderr\") (literal \"/dev/tty\") (literal \"/dev/dtracehelper\"))\n"
-    )
 }
 
 fn available_capability() -> LinuxReificationCapability {

--- a/scripts/rust-source-size-baseline.txt
+++ b/scripts/rust-source-size-baseline.txt
@@ -1,7 +1,6 @@
 # Rust source files above the 1,000-line target. Keep sorted by path.
 # A file may only stay equal to this maximum or shrink with this entry tightened.
 crates/agent-engine/src/tools/sandbox.rs 3514
-crates/agent-engine/src/tools/sandbox_backend.rs 1007
 crates/agent-engine/src/tools/sandbox_tests.rs 2976
 crates/agentfs/src/lib.rs 1151
 crates/agentfs/src/root.rs 1191


### PR DESCRIPTION
Stacked on #736.

## Summary
- extract macOS Seatbelt profile generation and read-deny path normalization into a dedicated private adapter owner
- move the seven adjacent Seatbelt tests with that owner while preserving the existing sandbox backend facade
- reduce sandbox_backend.rs from 1007 to 886 lines and remove its source-size baseline entry
- preserve the exact 88-function multiset and all 24 sandbox backend tests

## Verification
- cargo test -p alan-agent-engine tools::sandbox_backend -- --quiet
- just quality
- just test
- openspec validate --all --strict