### PR TITLE
refactor: extract sandbox specification

### DIFF
--- a/crates/agent-engine/src/tools/sandbox.rs
+++ b/crates/agent-engine/src/tools/sandbox.rs
@@ -15,7 +15,10 @@ mod command_interpreters;
 mod command_options;
 mod command_wrappers;
 mod path_literals;
+mod sandbox_spec;
 mod shell_syntax;
+
+pub use sandbox_spec::{NetworkPosture, SandboxSpec};
 
 use command_wrappers::{
     shell_wrapper_inline_script, validate_direct_command_shapes, validate_nested_command_evaluators,
@@ -69,142 +72,6 @@ pub struct ExecResult {
     pub stdout: String,
     pub stderr: String,
     pub exit_code: i32,
-}
-
-/// Default network posture for commands run inside a sandbox.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub enum NetworkPosture {
-    #[default]
-    Deny,
-    Allow,
-}
-
-impl NetworkPosture {
-    pub(crate) const fn allows_network(self) -> bool {
-        matches!(self, Self::Allow)
-    }
-}
-
-/// Projected OS-sandbox confinement input.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SandboxSpec {
-    pub host_mounts: Vec<crate::HostMountGrant>,
-    pub readable_roots: Vec<PathBuf>,
-    pub writable_roots: Vec<PathBuf>,
-    pub read_denylist: Vec<PathBuf>,
-    pub network: NetworkPosture,
-}
-
-impl SandboxSpec {
-    /// Build a single writable mount spec for isolated tests and adapters.
-    pub fn seed(root: PathBuf) -> Self {
-        let readable_roots = vec![root.clone()];
-        let writable_roots = vec![root.clone()];
-        let read_denylist = super::sandbox_backend::read_denylist_excluding_writable_roots(
-            &Self::default_sensitive_read_denylist(),
-            &writable_roots,
-        );
-        Self {
-            host_mounts: vec![crate::HostMountGrant {
-                namespace_path: "/mnt/source".to_string(),
-                host_path: root,
-                access: alan_kernel::Access::ReadWrite,
-            }],
-            readable_roots,
-            writable_roots,
-            read_denylist,
-            network: NetworkPosture::Deny,
-        }
-    }
-
-    /// Derive native write authority from the same Host Mount grants used by the namespace.
-    pub fn from_host_mounts(grants: &[crate::HostMountGrant]) -> Self {
-        let host_mounts = grants
-            .iter()
-            .map(|grant| crate::HostMountGrant {
-                namespace_path: grant.namespace_path.clone(),
-                host_path: dunce::canonicalize(&grant.host_path)
-                    .unwrap_or_else(|_| dunce::simplified(&grant.host_path).to_path_buf()),
-                access: grant.access,
-            })
-            .collect::<Vec<_>>();
-        let readable_roots = host_mounts
-            .iter()
-            .map(|grant| grant.host_path.clone())
-            .collect::<Vec<_>>();
-        let writable_roots = grants
-            .iter()
-            .filter(|grant| grant.access == alan_kernel::Access::ReadWrite)
-            .map(|grant| {
-                dunce::canonicalize(&grant.host_path)
-                    .unwrap_or_else(|_| dunce::simplified(&grant.host_path).to_path_buf())
-            })
-            .collect::<Vec<_>>();
-        let read_denylist = super::sandbox_backend::read_denylist_excluding_writable_roots(
-            &Self::default_sensitive_read_denylist(),
-            &readable_roots,
-        );
-        Self {
-            host_mounts,
-            readable_roots,
-            writable_roots,
-            read_denylist,
-            network: NetworkPosture::Deny,
-        }
-    }
-
-    /// Build the default sensitive-read denylist from the current user's home
-    /// directory. If the host home cannot be detected, keep the list empty
-    /// rather than guessing.
-    pub fn default_sensitive_read_denylist() -> Vec<PathBuf> {
-        dirs::home_dir()
-            .map(|home| Self::sensitive_read_denylist_for_home(&home))
-            .unwrap_or_default()
-    }
-
-    /// Derive sensitive read-deny paths from an explicit home directory.
-    pub fn sensitive_read_denylist_for_home(home_dir: &Path) -> Vec<PathBuf> {
-        let mut paths = [".alan", ".alan-dev"]
-            .into_iter()
-            .map(|name| home_dir.join(name))
-            .collect::<Vec<_>>();
-
-        paths.extend(
-            [
-                ".ssh",
-                ".aws",
-                ".azure",
-                ".config/gcloud",
-                ".config/gh",
-                ".docker",
-                ".gnupg",
-                ".kube",
-                ".netrc",
-                ".npmrc",
-                ".pypirc",
-                "Library/Keychains",
-                "Library/Safari",
-                "Library/Application Support/Arc",
-                "Library/Application Support/BraveSoftware",
-                "Library/Application Support/Chromium",
-                "Library/Application Support/Firefox",
-                "Library/Application Support/Google/Chrome",
-                "Library/Application Support/com.apple.Safari",
-            ]
-            .into_iter()
-            .map(|relative| home_dir.join(relative)),
-        );
-
-        paths
-    }
-
-    fn exclude_explicit_mounts_from_read_denylist(mut self) -> Self {
-        self.read_denylist = super::sandbox_backend::read_denylist_excluding_writable_roots(
-            &self.read_denylist,
-            &self.readable_roots,
-        );
-        self
-    }
 }
 
 /// Simple host_mount-only sandbox

--- a/crates/agent-engine/src/tools/sandbox/sandbox_spec.rs
+++ b/crates/agent-engine/src/tools/sandbox/sandbox_spec.rs
@@ -1,0 +1,137 @@
+use std::path::{Path, PathBuf};
+
+/// Default network posture for commands run inside a sandbox.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum NetworkPosture {
+    #[default]
+    Deny,
+    Allow,
+}
+
+impl NetworkPosture {
+    pub(crate) const fn allows_network(self) -> bool {
+        matches!(self, Self::Allow)
+    }
+}
+
+/// Projected OS-sandbox confinement input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxSpec {
+    pub host_mounts: Vec<crate::HostMountGrant>,
+    pub readable_roots: Vec<PathBuf>,
+    pub writable_roots: Vec<PathBuf>,
+    pub read_denylist: Vec<PathBuf>,
+    pub network: NetworkPosture,
+}
+
+impl SandboxSpec {
+    /// Build a single writable mount spec for isolated tests and adapters.
+    pub fn seed(root: PathBuf) -> Self {
+        let readable_roots = vec![root.clone()];
+        let writable_roots = vec![root.clone()];
+        let read_denylist = super::super::sandbox_backend::read_denylist_excluding_writable_roots(
+            &Self::default_sensitive_read_denylist(),
+            &writable_roots,
+        );
+        Self {
+            host_mounts: vec![crate::HostMountGrant {
+                namespace_path: "/mnt/source".to_string(),
+                host_path: root,
+                access: alan_kernel::Access::ReadWrite,
+            }],
+            readable_roots,
+            writable_roots,
+            read_denylist,
+            network: NetworkPosture::Deny,
+        }
+    }
+
+    /// Derive native write authority from the same Host Mount grants used by the namespace.
+    pub fn from_host_mounts(grants: &[crate::HostMountGrant]) -> Self {
+        let host_mounts = grants
+            .iter()
+            .map(|grant| crate::HostMountGrant {
+                namespace_path: grant.namespace_path.clone(),
+                host_path: dunce::canonicalize(&grant.host_path)
+                    .unwrap_or_else(|_| dunce::simplified(&grant.host_path).to_path_buf()),
+                access: grant.access,
+            })
+            .collect::<Vec<_>>();
+        let readable_roots = host_mounts
+            .iter()
+            .map(|grant| grant.host_path.clone())
+            .collect::<Vec<_>>();
+        let writable_roots = grants
+            .iter()
+            .filter(|grant| grant.access == alan_kernel::Access::ReadWrite)
+            .map(|grant| {
+                dunce::canonicalize(&grant.host_path)
+                    .unwrap_or_else(|_| dunce::simplified(&grant.host_path).to_path_buf())
+            })
+            .collect::<Vec<_>>();
+        let read_denylist = super::super::sandbox_backend::read_denylist_excluding_writable_roots(
+            &Self::default_sensitive_read_denylist(),
+            &readable_roots,
+        );
+        Self {
+            host_mounts,
+            readable_roots,
+            writable_roots,
+            read_denylist,
+            network: NetworkPosture::Deny,
+        }
+    }
+
+    /// Build the default sensitive-read denylist from the current user's home
+    /// directory. If the host home cannot be detected, keep the list empty
+    /// rather than guessing.
+    pub fn default_sensitive_read_denylist() -> Vec<PathBuf> {
+        dirs::home_dir()
+            .map(|home| Self::sensitive_read_denylist_for_home(&home))
+            .unwrap_or_default()
+    }
+
+    /// Derive sensitive read-deny paths from an explicit home directory.
+    pub fn sensitive_read_denylist_for_home(home_dir: &Path) -> Vec<PathBuf> {
+        let mut paths = [".alan", ".alan-dev"]
+            .into_iter()
+            .map(|name| home_dir.join(name))
+            .collect::<Vec<_>>();
+
+        paths.extend(
+            [
+                ".ssh",
+                ".aws",
+                ".azure",
+                ".config/gcloud",
+                ".config/gh",
+                ".docker",
+                ".gnupg",
+                ".kube",
+                ".netrc",
+                ".npmrc",
+                ".pypirc",
+                "Library/Keychains",
+                "Library/Safari",
+                "Library/Application Support/Arc",
+                "Library/Application Support/BraveSoftware",
+                "Library/Application Support/Chromium",
+                "Library/Application Support/Firefox",
+                "Library/Application Support/Google/Chrome",
+                "Library/Application Support/com.apple.Safari",
+            ]
+            .into_iter()
+            .map(|relative| home_dir.join(relative)),
+        );
+
+        paths
+    }
+
+    pub(super) fn exclude_explicit_mounts_from_read_denylist(mut self) -> Self {
+        self.read_denylist = super::super::sandbox_backend::read_denylist_excluding_writable_roots(
+            &self.read_denylist,
+            &self.readable_roots,
+        );
+        self
+    }
+}

--- a/scripts/rust-source-size-baseline.txt
+++ b/scripts/rust-source-size-baseline.txt
@@ -1,6 +1,6 @@
 # Rust source files above the 1,000-line target. Keep sorted by path.
 # A file may only stay equal to this maximum or shrink with this entry tightened.
-crates/agent-engine/src/tools/sandbox.rs 1171
+crates/agent-engine/src/tools/sandbox.rs 1038
 crates/agentfs/src/lib.rs 1151
 crates/agentfs/src/root.rs 1191
 crates/alan/src/cli/skill_authoring.rs 1187


### PR DESCRIPTION
## Summary
- extract NetworkPosture and SandboxSpec into a focused sandbox_spec module that owns projected confinement inputs and sensitive read-deny defaults
- re-export both public types from the sandbox module so existing API paths remain unchanged
- preserve the exact production function multiset while reducing sandbox.rs from 1171 to 1038 lines

This is a structural ownership change only; it does not change public APIs or runtime behavior.

## Verification
- cargo test -p alan-agent-engine tools::sandbox::tests -- --quiet (115 passed)
- just quality
- just test
- openspec validate --all --strict (88 passed)
- git diff --check
- exact production function-name multiset hash unchanged