### PR TITLE
refactor: extract sandbox path safety

### DIFF
--- a/crates/agent-engine/src/tools/sandbox.rs
+++ b/crates/agent-engine/src/tools/sandbox.rs
@@ -15,9 +15,11 @@ mod command_interpreters;
 mod command_options;
 mod command_wrappers;
 mod path_literals;
+mod path_safety;
 mod sandbox_spec;
 mod shell_syntax;
 
+pub(crate) use path_safety::protected_path_component;
 pub use sandbox_spec::{NetworkPosture, SandboxSpec};
 
 use command_wrappers::{
@@ -29,6 +31,7 @@ use path_literals::{
     looks_like_bare_protected_subpath_token, looks_like_path_token, path_like_subtokens,
     translate_reified_shell_token,
 };
+use path_safety::{existing_regular_file_has_multiple_links, is_path_guard_reason};
 use shell_syntax::{
     ShellWordToken, normalize_shell_line_continuations, shell_commands, shell_word_tokens,
     shell_word_tokens_with_spans, validate_shell_features,
@@ -36,26 +39,10 @@ use shell_syntax::{
 
 use anyhow::{Result, anyhow};
 use std::ffi::OsString;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SANDBOX_BACKEND_PATH_GUARD: &str = "host_mount_path_guard";
-pub(crate) const PROTECTED_SUBPATHS: [&str; 3] = [".git", ".alan", ".agents"];
-
-pub(crate) fn protected_path_component(path: &Path) -> Option<&'static str> {
-    path.components().find_map(protected_component)
-}
-
-fn protected_component(component: Component<'_>) -> Option<&'static str> {
-    let Component::Normal(name) = component else {
-        return None;
-    };
-    let candidate = name.to_str()?;
-    PROTECTED_SUBPATHS
-        .iter()
-        .copied()
-        .find(|protected| *protected == candidate)
-}
 
 /// How thoroughly to validate command paths. Under an OS sandbox the kernel
 /// enforces host_mount containment, so only protected-subpath writes need the
@@ -722,7 +709,7 @@ impl Sandbox {
             if let Some(component) = root_protected {
                 return Some(component);
             }
-            if let Some(component) = relative.components().find_map(protected_component) {
+            if let Some(component) = protected_path_component(relative) {
                 return Some(component);
             }
         }
@@ -1002,35 +989,6 @@ fn validate_bash_command_shape(cmd: &str) -> Result<()> {
     validate_shell_features(trimmed, Sandbox::backend_name_static())?;
 
     Ok(())
-}
-
-fn is_path_guard_reason(reason: &str) -> bool {
-    reason.contains("outside host_mount")
-}
-
-#[cfg(unix)]
-fn existing_regular_file_has_multiple_links(path: &Path) -> Result<bool> {
-    use std::io::ErrorKind;
-    use std::os::unix::fs::MetadataExt;
-
-    let metadata = match std::fs::metadata(path) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
-        Err(error) => {
-            return Err(anyhow!(
-                "Failed to inspect path link count for {}: {}",
-                path.display(),
-                error
-            ));
-        }
-    };
-
-    Ok(metadata.is_file() && metadata.nlink() > 1)
-}
-
-#[cfg(not(unix))]
-fn existing_regular_file_has_multiple_links(_path: &Path) -> Result<bool> {
-    Ok(false)
 }
 
 #[cfg(test)]

--- a/crates/agent-engine/src/tools/sandbox/path_literals.rs
+++ b/crates/agent-engine/src/tools/sandbox/path_literals.rs
@@ -1,6 +1,6 @@
 use super::super::reified_namespace::ReifiedNamespacePlan;
-use super::PROTECTED_SUBPATHS;
 use super::command_wrappers::is_env_assignment;
+use super::path_safety::PROTECTED_SUBPATHS;
 use super::shell_syntax::{ShellWordToken, shell_word_tokens_with_spans};
 use std::ops::Range;
 use std::path::{Component, Path, PathBuf};

--- a/crates/agent-engine/src/tools/sandbox/path_safety.rs
+++ b/crates/agent-engine/src/tools/sandbox/path_safety.rs
@@ -1,0 +1,48 @@
+use anyhow::{Result, anyhow};
+use std::path::{Component, Path};
+
+pub(crate) const PROTECTED_SUBPATHS: [&str; 3] = [".git", ".alan", ".agents"];
+
+pub(crate) fn protected_path_component(path: &Path) -> Option<&'static str> {
+    path.components().find_map(protected_component)
+}
+
+fn protected_component(component: Component<'_>) -> Option<&'static str> {
+    let Component::Normal(name) = component else {
+        return None;
+    };
+    let candidate = name.to_str()?;
+    PROTECTED_SUBPATHS
+        .iter()
+        .copied()
+        .find(|protected| *protected == candidate)
+}
+
+pub(super) fn is_path_guard_reason(reason: &str) -> bool {
+    reason.contains("outside host_mount")
+}
+
+#[cfg(unix)]
+pub(super) fn existing_regular_file_has_multiple_links(path: &Path) -> Result<bool> {
+    use std::io::ErrorKind;
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = match std::fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(anyhow!(
+                "Failed to inspect path link count for {}: {}",
+                path.display(),
+                error
+            ));
+        }
+    };
+
+    Ok(metadata.is_file() && metadata.nlink() > 1)
+}
+
+#[cfg(not(unix))]
+pub(super) fn existing_regular_file_has_multiple_links(_path: &Path) -> Result<bool> {
+    Ok(false)
+}

--- a/scripts/rust-source-size-baseline.txt
+++ b/scripts/rust-source-size-baseline.txt
@@ -1,6 +1,5 @@
 # Rust source files above the 1,000-line target. Keep sorted by path.
 # A file may only stay equal to this maximum or shrink with this entry tightened.
-crates/agent-engine/src/tools/sandbox.rs 1038
 crates/agentfs/src/lib.rs 1151
 crates/agentfs/src/root.rs 1191
 crates/alan/src/cli/skill_authoring.rs 1187


### PR DESCRIPTION
## Summary

- extract protected-subpath recognition, path-guard reason classification, and hardlink safety checks into path_safety
- preserve the existing protected_path_component module route while allowing the sibling path literal classifier to use the shared protected-name set
- reduce sandbox.rs from 1,038 to 996 lines and remove it from the legacy source-size baseline
- preserve behavior and public API boundaries

## Verification

- focused sandbox tests: 115 passed
- just quality
- just test
- openspec validate --all --strict: 88 passed
- git diff --check
- production function-name multiset hash unchanged: 7ee20411147f5cd87c222f768aab75aeff9a71d167e8bc8495dbd0e1e1dac222

Stacked on #746.