### PR TITLE
refactor: extract package store

### DIFF
--- a/crates/service-manager/src/package.rs
+++ b/crates/service-manager/src/package.rs
@@ -1,14 +1,13 @@
 //! Package Service (Quartermaster): installed package ownership and lifecycle.
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::fs::{self, File, OpenOptions};
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::collections::BTreeMap;
+use std::fs;
+#[cfg(test)]
+use std::path::Path;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex, Weak};
 
-use alan_agent_engine::skills::{
-    SkillCompatibility, SkillTypedDependency, validate_skill_compatibility,
-};
+use alan_agent_engine::skills::SkillTypedDependency;
 use alan_ap::{ErrorCode, FileServer};
 use alan_hostfs::{HostDirAccess, HostDirFs};
 use anyhow::{Context, Result, bail, ensure};
@@ -16,11 +15,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::flat_fs::{FlatFileService, FlatServiceFs};
 
+mod fs_safety;
 mod materializer;
+mod store;
 
-use materializer::{
-    PackageMaterializer, fingerprint, validate_snapshot, verify_materialized_revision,
-};
+use materializer::{PackageMaterializer, fingerprint, validate_snapshot};
+use store::PackageStore;
 
 const FILES: &[(&str, bool)] = &[
     ("catalog", false),
@@ -162,61 +162,10 @@ struct State {
 /// Channel-scoped installed-package authority.
 pub struct PackageService {
     channel_id: String,
-    store_root: PathBuf,
-    _store_lock: PackageStoreLock,
+    store: PackageStore,
     _temporary_store: Option<tempfile::TempDir>,
     state: Mutex<State>,
     operation: Mutex<()>,
-}
-
-struct PackageStoreLock {
-    file: File,
-}
-
-impl PackageStoreLock {
-    fn acquire(root: &Path) -> Result<Self> {
-        let path = root.join("store.lock");
-        let mut options = OpenOptions::new();
-        options.read(true).write(true).create(true);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt;
-            options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
-        }
-        let file = options
-            .open(&path)
-            .with_context(|| format!("open Package Store lock {}", path.display()))?;
-        #[cfg(unix)]
-        {
-            use std::os::fd::AsRawFd;
-            // SAFETY: file owns a valid descriptor for the lifetime of the lock.
-            let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
-            if result != 0 {
-                let error = std::io::Error::last_os_error();
-                if error
-                    .raw_os_error()
-                    .is_some_and(|code| code == libc::EWOULDBLOCK || code == libc::EAGAIN)
-                {
-                    bail!("Package Store is already owned by another Package Service")
-                }
-                return Err(error).context("acquire Package Store lock");
-            }
-        }
-        Ok(Self { file })
-    }
-}
-
-impl Drop for PackageStoreLock {
-    fn drop(&mut self) {
-        #[cfg(unix)]
-        {
-            use std::os::fd::AsRawFd;
-            // SAFETY: file remains valid until this Drop implementation returns.
-            unsafe {
-                libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
-            }
-        }
-    }
 }
 
 /// An immutable Package Service revision reference retained by a Process context.
@@ -322,59 +271,10 @@ impl PackageService {
             matches!(channel_id.as_str(), "stable" | "dev" | "test"),
             "invalid Package Service channel"
         );
-        ensure_package_store_channel_chain(&store_root)?;
-        match fs::symlink_metadata(&store_root) {
-            Ok(_) => {
-                ensure_owned_directory(&store_root, "Package Store root is not an owned directory")?
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                fs::create_dir_all(&store_root)?;
-            }
-            Err(error) => return Err(error).context("inspect Package Store root"),
-        }
-        ensure_package_store_channel_chain(&store_root)?;
-        fs::create_dir_all(store_root.join("revisions"))?;
-        fs::create_dir_all(store_root.join("staging"))?;
-        ensure_owned_directory(
-            &store_root.join("revisions"),
-            "package revisions store is not an owned directory",
-        )?;
-        ensure_owned_directory(
-            &store_root.join("staging"),
-            "package staging path is not an owned directory",
-        )?;
-        let store_lock = PackageStoreLock::acquire(&store_root)?;
-        let mut catalog = load_catalog(&store_root)?;
-        validate_catalog_structure(&catalog)?;
-        recover_staging(&store_root, &catalog)?;
-        let mut recovered = false;
-        let retiring = catalog
-            .packages
-            .values()
-            .filter(|record| record.state == PackageState::Retiring)
-            .map(|record| record.id.clone())
-            .collect::<Vec<_>>();
-        for package_id in retiring {
-            catalog.packages.remove(&package_id);
-            remove_package_revisions(&store_root, &package_id)?;
-            recovered = true;
-        }
-        for record in catalog.packages.values_mut() {
-            if record.reference_count != 0 {
-                record.reference_count = 0;
-                recovered = true;
-            }
-        }
-        verify_catalog(&store_root, &catalog)?;
-        gc_unreferenced_store_revisions(&store_root, &catalog, &BTreeMap::new())?;
-        if recovered {
-            catalog.generation = catalog.generation.saturating_add(1);
-            persist_catalog(&store_root, &catalog)?;
-        }
+        let (store, catalog) = PackageStore::open(store_root)?;
         Ok(Arc::new(Self {
             channel_id,
-            store_root,
-            _store_lock: store_lock,
+            store,
             _temporary_store: temporary_store,
             state: Mutex::new(State {
                 catalog,
@@ -430,7 +330,7 @@ impl PackageService {
                 "package catalog is full"
             );
         }
-        let materialization = PackageMaterializer::new(&self.store_root)
+        let materialization = PackageMaterializer::new(self.store.root())
             .materialize(package_id, &revision, &snapshot)?;
         let reference_count = existing.as_ref().map_or(0, |record| record.reference_count);
         let now = chrono::Utc::now();
@@ -459,7 +359,7 @@ impl PackageService {
             .filter(|record| record.state == PackageState::Installed)
             .cloned()
             .with_context(|| format!("package `{package_id}` is not installed"))?;
-        verify_revision(&self.store_root, &record)?;
+        self.store.verify_revision(&record)?;
         Ok(record)
     }
 
@@ -473,7 +373,7 @@ impl PackageService {
             .filter(|record| record.state == PackageState::Installed)
             .cloned()
             .with_context(|| format!("package `{package_id}` is not installed"))?;
-        verify_revision(&self.store_root, &record)?;
+        self.store.verify_revision(&record)?;
         let token = state.next_lease_id;
         record.reference_count = record
             .reference_count
@@ -482,7 +382,7 @@ impl PackageService {
         let mut next = state.catalog.clone();
         next.generation = next.generation.saturating_add(1);
         next.packages.insert(package_id.to_string(), record.clone());
-        persist_catalog(&self.store_root, &next)?;
+        self.store.persist_catalog(&next)?;
         state.catalog = next;
         state.next_lease_id = state.next_lease_id.saturating_add(1);
         state
@@ -491,7 +391,9 @@ impl PackageService {
         Ok(Arc::new(PackageReferenceLease {
             service: Arc::downgrade(self),
             token,
-            content_root: revision_root(&self.store_root, package_id, &record.revision)
+            content_root: self
+                .store
+                .revision_root(package_id, &record.revision)
                 .join("content"),
             record,
         }))
@@ -593,7 +495,7 @@ impl PackageService {
             self.catalog().packages.len() < MAX_PACKAGES,
             "package catalog is full"
         );
-        let materialization = PackageMaterializer::new(&self.store_root).materialize(
+        let materialization = PackageMaterializer::new(self.store.root()).materialize(
             &package_id,
             &revision,
             &snapshot,
@@ -657,7 +559,7 @@ impl PackageService {
                 catalog: None,
             });
         }
-        let materialization = PackageMaterializer::new(&self.store_root).materialize(
+        let materialization = PackageMaterializer::new(self.store.root()).materialize(
             &package_id,
             &revision,
             &snapshot,
@@ -706,13 +608,15 @@ impl PackageService {
         let staged_revisions = if retained {
             None
         } else {
-            stage_package_revisions(&self.store_root, &package_id)?
+            self.store.stage_package_revisions(&package_id)?
         };
-        if let Err(error) = persist_catalog(&self.store_root, &next) {
-            rollback_staged_package_revisions(staged_revisions.as_ref(), error)?;
+        if let Err(error) = self.store.persist_catalog(&next) {
+            self.store
+                .rollback_staged_package_revisions(staged_revisions.as_ref(), error)?;
         }
         self.state.lock().expect("package state poisoned").catalog = next;
-        discard_staged_package_revisions(staged_revisions);
+        self.store
+            .discard_staged_package_revisions(staged_revisions);
         Ok(PackageCommandResult {
             request_id,
             success: true,
@@ -746,12 +650,13 @@ impl PackageService {
             next.packages.insert(package_id.clone(), record);
         }
         let staged_revisions = if remove_package {
-            stage_package_revisions(&self.store_root, &package_id)?
+            self.store.stage_package_revisions(&package_id)?
         } else {
             None
         };
-        if let Err(error) = persist_catalog(&self.store_root, &next) {
-            rollback_staged_package_revisions(staged_revisions.as_ref(), error)?;
+        if let Err(error) = self.store.persist_catalog(&next) {
+            self.store
+                .rollback_staged_package_revisions(staged_revisions.as_ref(), error)?;
         }
         state.catalog = next;
         state.leases.remove(&token);
@@ -759,9 +664,10 @@ impl PackageService {
         let leases = state.leases.clone();
         drop(state);
         if remove_package {
-            discard_staged_package_revisions(staged_revisions);
+            self.store
+                .discard_staged_package_revisions(staged_revisions);
         } else {
-            gc_unreferenced_store_revisions(&self.store_root, &catalog, &leases)?;
+            self.store.gc_unreferenced_revisions(&catalog, &leases)?;
         }
         Ok(())
     }
@@ -771,7 +677,8 @@ impl PackageService {
         let catalog = state.catalog.clone();
         let leases = state.leases.clone();
         drop(state);
-        gc_one_package_revisions(&self.store_root, package_id, &catalog, &leases)
+        self.store
+            .gc_package_revisions(package_id, &catalog, &leases)
     }
 
     fn gc_package_revisions_after_commit(&self, package_id: &str, action: &str) {
@@ -793,7 +700,7 @@ impl PackageService {
         );
         next.generation = next.generation.saturating_add(1);
         next.packages.insert(record.id.clone(), record);
-        persist_catalog(&self.store_root, &next)?;
+        self.store.persist_catalog(&next)?;
         self.state.lock().expect("package state poisoned").catalog = next;
         Ok(())
     }
@@ -887,341 +794,6 @@ fn bounded_error_message(error: &anyhow::Error) -> String {
         end -= 1;
     }
     format!("{}…", &message[..end])
-}
-
-fn recover_staging(root: &Path, catalog: &PackageCatalog) -> Result<()> {
-    let staging = root.join("staging");
-    ensure_owned_directory(&staging, "package staging path is not an owned directory")?;
-    for entry in fs::read_dir(&staging)? {
-        let entry = entry?;
-        let name = entry
-            .file_name()
-            .into_string()
-            .map_err(|_| anyhow::anyhow!("package staging entry is not UTF-8"))?;
-        let interrupted_removal = name.strip_prefix("remove-").and_then(|rest| {
-            let (package_id, nonce) = rest.rsplit_once('-')?;
-            uuid::Uuid::parse_str(nonce).ok()?;
-            Some(package_id)
-        });
-        if let Some(package_id) = interrupted_removal
-            && catalog.packages.contains_key(package_id)
-        {
-            validate_package_id(package_id)?;
-            ensure_owned_directory(
-                &entry.path(),
-                "staged package revisions are not an owned directory",
-            )?;
-            let active = root.join("revisions").join(package_id);
-            match fs::symlink_metadata(&active) {
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Ok(_) => bail!("both active and staged package revisions exist"),
-                Err(error) => return Err(error.into()),
-            }
-            fs::rename(entry.path(), active)?;
-        } else {
-            remove_path_without_following(&entry.path())?;
-        }
-    }
-    for entry in fs::read_dir(root)? {
-        let entry = entry?;
-        let name = entry.file_name();
-        if name.to_string_lossy().starts_with("catalog-")
-            && name.to_string_lossy().ends_with(".tmp")
-        {
-            remove_path_without_following(&entry.path())?;
-        }
-    }
-    Ok(())
-}
-
-fn remove_path_without_following(path: &Path) -> Result<()> {
-    let metadata = fs::symlink_metadata(path)?;
-    if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
-        fs::remove_dir_all(path)?;
-    } else {
-        fs::remove_file(path)?;
-    }
-    Ok(())
-}
-
-fn remove_package_revisions(root: &Path, package_id: &str) -> Result<()> {
-    let path = root.join("revisions").join(package_id);
-    if path.exists() {
-        remove_path_without_following(&path)?;
-    }
-    Ok(())
-}
-
-struct StagedPackageRevisions {
-    active: PathBuf,
-    staged: PathBuf,
-}
-
-fn stage_package_revisions(
-    root: &Path,
-    package_id: &str,
-) -> Result<Option<StagedPackageRevisions>> {
-    let active = root.join("revisions").join(package_id);
-    match fs::symlink_metadata(&active) {
-        Ok(metadata) => ensure!(
-            metadata.file_type().is_dir() && !metadata.file_type().is_symlink(),
-            "package revisions path is not an owned directory"
-        ),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => return Err(error.into()),
-    }
-    ensure_owned_directory(
-        &root.join("staging"),
-        "package staging path is not an owned directory",
-    )?;
-    let staged = root.join("staging").join(format!(
-        "remove-{package_id}-{}",
-        uuid::Uuid::new_v4().simple()
-    ));
-    fs::rename(&active, &staged).context("stage package revisions for removal")?;
-    Ok(Some(StagedPackageRevisions { active, staged }))
-}
-
-fn rollback_staged_package_revisions(
-    staged: Option<&StagedPackageRevisions>,
-    catalog_error: anyhow::Error,
-) -> Result<()> {
-    if let Some(staged) = staged
-        && let Err(rollback_error) = fs::rename(&staged.staged, &staged.active)
-    {
-        return Err(catalog_error.context(format!(
-            "rollback staged package revisions failed: {rollback_error}"
-        )));
-    }
-    Err(catalog_error)
-}
-
-fn discard_staged_package_revisions(staged: Option<StagedPackageRevisions>) {
-    if let Some(staged) = staged
-        && let Err(error) = remove_path_without_following(&staged.staged)
-    {
-        tracing::warn!(
-            path = %staged.staged.display(),
-            %error,
-            "staged package revisions remain for startup recovery"
-        );
-    }
-}
-
-fn gc_unreferenced_store_revisions(
-    root: &Path,
-    catalog: &PackageCatalog,
-    leases: &BTreeMap<u64, (String, String)>,
-) -> Result<()> {
-    let revisions = root.join("revisions");
-    for entry in fs::read_dir(&revisions)? {
-        let entry = entry?;
-        let metadata = fs::symlink_metadata(entry.path())?;
-        ensure!(
-            metadata.file_type().is_dir() && !metadata.file_type().is_symlink(),
-            "package revisions store contains an unsupported entry"
-        );
-        let package_id = entry
-            .file_name()
-            .to_str()
-            .context("package revision directory is not UTF-8")?
-            .to_string();
-        if catalog.packages.contains_key(&package_id) {
-            gc_one_package_revisions(root, &package_id, catalog, leases)?;
-        } else {
-            remove_path_without_following(&entry.path())?;
-        }
-    }
-    Ok(())
-}
-
-fn gc_one_package_revisions(
-    root: &Path,
-    package_id: &str,
-    catalog: &PackageCatalog,
-    leases: &BTreeMap<u64, (String, String)>,
-) -> Result<()> {
-    let Some(record) = catalog.packages.get(package_id) else {
-        return remove_package_revisions(root, package_id);
-    };
-    let package_root = root.join("revisions").join(package_id);
-    if !package_root.exists() {
-        return Ok(());
-    }
-    let retained = leases
-        .values()
-        .filter(|(id, _)| id == package_id)
-        .map(|(_, revision)| revision.as_str())
-        .chain(std::iter::once(record.revision.as_str()))
-        .collect::<BTreeSet<_>>();
-    for entry in fs::read_dir(&package_root)? {
-        let entry = entry?;
-        let revision = entry.file_name();
-        let revision = revision
-            .to_str()
-            .context("package revision name is not UTF-8")?;
-        if !retained.contains(revision) {
-            remove_path_without_following(&entry.path())?;
-        }
-    }
-    Ok(())
-}
-
-fn ensure_owned_directory(path: &Path, message: &str) -> Result<()> {
-    let metadata = fs::symlink_metadata(path).with_context(|| format!("inspect {path:?}"))?;
-    ensure!(
-        metadata.file_type().is_dir() && !metadata.file_type().is_symlink(),
-        "{message}"
-    );
-    Ok(())
-}
-
-fn ensure_package_store_channel_chain(store_root: &Path) -> Result<()> {
-    let services_root = store_root
-        .parent()
-        .context("Package Store root has no services parent")?;
-    let channel_root = services_root
-        .parent()
-        .context("Package Store root has no channel parent")?;
-    for (path, message) in [
-        (
-            channel_root,
-            "Package Store channel path contains an unsupported ancestor",
-        ),
-        (
-            services_root,
-            "Package Store channel path contains an unsupported ancestor",
-        ),
-        (store_root, "Package Store root is not an owned directory"),
-    ] {
-        match fs::symlink_metadata(path) {
-            Ok(metadata) => ensure!(
-                metadata.file_type().is_dir() && !metadata.file_type().is_symlink(),
-                "{message}"
-            ),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => return Err(error).context("inspect Package Store channel path"),
-        }
-    }
-    Ok(())
-}
-
-fn ensure_owned_file(path: &Path, message: &str) -> Result<()> {
-    let metadata = fs::symlink_metadata(path).with_context(|| format!("inspect {path:?}"))?;
-    ensure!(
-        metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
-        "{message}"
-    );
-    Ok(())
-}
-
-fn sync_tree(root: &Path) -> Result<()> {
-    let mut pending = vec![root.to_path_buf()];
-    let mut directories = Vec::new();
-    while let Some(directory) = pending.pop() {
-        directories.push(directory.clone());
-        for entry in fs::read_dir(&directory)? {
-            let path = entry?.path();
-            let metadata = fs::symlink_metadata(&path)?;
-            if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
-                pending.push(path);
-            } else if metadata.file_type().is_file() {
-                File::open(path)?.sync_all()?;
-            } else {
-                bail!("package staging contains an unsupported entry");
-            }
-        }
-    }
-    for directory in directories.into_iter().rev() {
-        File::open(directory)?.sync_all()?;
-    }
-    Ok(())
-}
-
-fn load_catalog(root: &Path) -> Result<PackageCatalog> {
-    let path = root.join("catalog.json");
-    if !path.exists() {
-        return Ok(PackageCatalog::default());
-    }
-    let bytes = fs::read(&path)?;
-    serde_json::from_slice(&bytes).context("decode Package Service catalog")
-}
-
-fn persist_catalog(root: &Path, catalog: &PackageCatalog) -> Result<()> {
-    let bytes = serde_json::to_vec_pretty(catalog)?;
-    let temporary = root.join(format!("catalog-{}.tmp", uuid::Uuid::new_v4().simple()));
-    let mut file = File::create(&temporary)?;
-    file.write_all(&bytes)?;
-    file.sync_all()?;
-    fs::rename(&temporary, root.join("catalog.json"))?;
-    File::open(root)?.sync_all()?;
-    Ok(())
-}
-
-fn verify_catalog(root: &Path, catalog: &PackageCatalog) -> Result<()> {
-    validate_catalog_structure(catalog)?;
-    for record in catalog.packages.values() {
-        ensure!(
-            record.materializer_version == MATERIALIZER_VERSION,
-            "catalog references an unsupported materializer version"
-        );
-        verify_revision(root, record)?;
-    }
-    Ok(())
-}
-
-fn validate_catalog_structure(catalog: &PackageCatalog) -> Result<()> {
-    ensure!(
-        catalog.packages.len() <= MAX_PACKAGES,
-        "package catalog exceeds its supported size"
-    );
-    for (package_id, record) in &catalog.packages {
-        ensure!(
-            package_id == &record.id,
-            "package catalog key does not match its record id"
-        );
-        validate_package_id(&record.id)?;
-    }
-    Ok(())
-}
-
-fn verify_revision(root: &Path, record: &PackageRecord) -> Result<()> {
-    ensure!(
-        record.revision.len() == 64
-            && record
-                .revision
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "catalog contains an invalid package revision"
-    );
-    let revision_root = revision_root(root, &record.id, &record.revision);
-    ensure!(
-        revision_root.is_dir(),
-        "catalog references missing package revision"
-    );
-    let manifest = verify_materialized_revision(&revision_root, &record.revision)?;
-    ensure!(
-        manifest.exports == record.exports
-            && manifest.tree_fingerprint == record.materialized_fingerprint,
-        "catalog and materialization manifest disagree"
-    );
-    ensure!(
-        record.state == PackageState::Installed || record.reference_count > 0,
-        "retiring package has an invalid reference state"
-    );
-    for export in &record.exports {
-        validate_skill_compatibility(&SkillCompatibility {
-            dependencies: export.dependencies.clone(),
-            ..SkillCompatibility::default()
-        })
-        .map_err(anyhow::Error::from)
-        .context("catalog contains an invalid typed package dependency")?;
-    }
-    Ok(())
-}
-
-fn revision_root(root: &Path, package_id: &str, revision: &str) -> PathBuf {
-    root.join("revisions").join(package_id).join(revision)
 }
 
 #[cfg(test)]

--- a/crates/service-manager/src/package/fs_safety.rs
+++ b/crates/service-manager/src/package/fs_safety.rs
@@ -1,0 +1,47 @@
+//! Owned-file checks and durable tree synchronization for Package Store content.
+
+use std::fs::{self, File};
+use std::path::Path;
+
+use anyhow::{Context, Result, bail, ensure};
+
+pub(super) fn ensure_owned_directory(path: &Path, message: &str) -> Result<()> {
+    let metadata = fs::symlink_metadata(path).with_context(|| format!("inspect {path:?}"))?;
+    ensure!(
+        metadata.file_type().is_dir() && !metadata.file_type().is_symlink(),
+        "{message}"
+    );
+    Ok(())
+}
+
+pub(super) fn ensure_owned_file(path: &Path, message: &str) -> Result<()> {
+    let metadata = fs::symlink_metadata(path).with_context(|| format!("inspect {path:?}"))?;
+    ensure!(
+        metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
+        "{message}"
+    );
+    Ok(())
+}
+
+pub(super) fn sync_tree(root: &Path) -> Result<()> {
+    let mut pending = vec![root.to_path_buf()];
+    let mut directories = Vec::new();
+    while let Some(directory) = pending.pop() {
+        directories.push(directory.clone());
+        for entry in fs::read_dir(&directory)? {
+            let path = entry?.path();
+            let metadata = fs::symlink_metadata(&path)?;
+            if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
+                pending.push(path);
+            } else if metadata.file_type().is_file() {
+                File::open(path)?.sync_all()?;
+            } else {
+                bail!("package staging contains an unsupported entry");
+            }
+        }
+    }
+    for directory in directories.into_iter().rev() {
+        File::open(directory)?.sync_all()?;
+    }
+    Ok(())
+}

--- a/crates/service-manager/src/package/materializer.rs
+++ b/crates/service-manager/src/package/materializer.rs
@@ -12,9 +12,9 @@ use anyhow::{Context, Result, bail, ensure};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use super::fs_safety::{ensure_owned_directory, ensure_owned_file, sync_tree};
 use super::{
-    MATERIALIZER_VERSION, PackageExport, PackageSnapshot, PackageSnapshotEntry,
-    ensure_owned_directory, ensure_owned_file, revision_root, sync_tree, validate_package_id,
+    MATERIALIZER_VERSION, PackageExport, PackageSnapshot, PackageSnapshotEntry, validate_package_id,
 };
 
 const MAX_SOURCE_FILES: usize = 4_096;
@@ -622,6 +622,10 @@ fn list_relative_files(root: &Path) -> Result<Vec<String>> {
     }
     files.sort();
     Ok(files)
+}
+
+fn revision_root(root: &Path, package_id: &str, revision: &str) -> PathBuf {
+    root.join("revisions").join(package_id).join(revision)
 }
 
 fn copy_tree(source: &Path, target: &Path) -> Result<()> {

--- a/crates/service-manager/src/package/store.rs
+++ b/crates/service-manager/src/package/store.rs
@@ -1,0 +1,488 @@
+//! Durable Package Store ownership, recovery, catalog commits, and revision GC.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use alan_agent_engine::skills::{SkillCompatibility, validate_skill_compatibility};
+use anyhow::{Context, Result, bail, ensure};
+
+use super::fs_safety::ensure_owned_directory;
+use super::materializer::verify_materialized_revision;
+use super::{
+    MATERIALIZER_VERSION, MAX_PACKAGES, PackageCatalog, PackageRecord, PackageState,
+    validate_package_id,
+};
+
+pub(super) struct PackageStore {
+    root: PathBuf,
+    _lock: PackageStoreLock,
+}
+
+impl PackageStore {
+    pub(super) fn open(store_root: PathBuf) -> Result<(Self, PackageCatalog)> {
+        ensure_package_store_channel_chain(&store_root)?;
+        match fs::symlink_metadata(&store_root) {
+            Ok(_) => {
+                ensure_owned_directory(&store_root, "Package Store root is not an owned directory")?
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                fs::create_dir_all(&store_root)?;
+            }
+            Err(error) => return Err(error).context("inspect Package Store root"),
+        }
+        ensure_package_store_channel_chain(&store_root)?;
+        fs::create_dir_all(store_root.join("revisions"))?;
+        fs::create_dir_all(store_root.join("staging"))?;
+        ensure_owned_directory(
+            &store_root.join("revisions"),
+            "package revisions store is not an owned directory",
+        )?;
+        ensure_owned_directory(
+            &store_root.join("staging"),
+            "package staging path is not an owned directory",
+        )?;
+        let store_lock = PackageStoreLock::acquire(&store_root)?;
+        let mut catalog = load_catalog(&store_root)?;
+        validate_catalog_structure(&catalog)?;
+        recover_staging(&store_root, &catalog)?;
+        let mut recovered = false;
+        let retiring = catalog
+            .packages
+            .values()
+            .filter(|record| record.state == PackageState::Retiring)
+            .map(|record| record.id.clone())
+            .collect::<Vec<_>>();
+        for package_id in retiring {
+            catalog.packages.remove(&package_id);
+            remove_package_revisions(&store_root, &package_id)?;
+            recovered = true;
+        }
+        for record in catalog.packages.values_mut() {
+            if record.reference_count != 0 {
+                record.reference_count = 0;
+                recovered = true;
+            }
+        }
+        verify_catalog(&store_root, &catalog)?;
+        gc_unreferenced_store_revisions(&store_root, &catalog, &BTreeMap::new())?;
+        if recovered {
+            catalog.generation = catalog.generation.saturating_add(1);
+            persist_catalog(&store_root, &catalog)?;
+        }
+        Ok((
+            Self {
+                root: store_root,
+                _lock: store_lock,
+            },
+            catalog,
+        ))
+    }
+
+    pub(super) fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub(super) fn persist_catalog(&self, catalog: &PackageCatalog) -> Result<()> {
+        persist_catalog(&self.root, catalog)
+    }
+
+    pub(super) fn verify_revision(&self, record: &PackageRecord) -> Result<()> {
+        verify_revision(&self.root, record)
+    }
+
+    pub(super) fn revision_root(&self, package_id: &str, revision: &str) -> PathBuf {
+        revision_root(&self.root, package_id, revision)
+    }
+
+    pub(super) fn stage_package_revisions(
+        &self,
+        package_id: &str,
+    ) -> Result<Option<StagedPackageRevisions>> {
+        stage_package_revisions(&self.root, package_id)
+    }
+
+    pub(super) fn rollback_staged_package_revisions(
+        &self,
+        staged: Option<&StagedPackageRevisions>,
+        catalog_error: anyhow::Error,
+    ) -> Result<()> {
+        rollback_staged_package_revisions(staged, catalog_error)
+    }
+
+    pub(super) fn discard_staged_package_revisions(&self, staged: Option<StagedPackageRevisions>) {
+        discard_staged_package_revisions(staged);
+    }
+
+    pub(super) fn gc_unreferenced_revisions(
+        &self,
+        catalog: &PackageCatalog,
+        leases: &BTreeMap<u64, (String, String)>,
+    ) -> Result<()> {
+        gc_unreferenced_store_revisions(&self.root, catalog, leases)
+    }
+
+    pub(super) fn gc_package_revisions(
+        &self,
+        package_id: &str,
+        catalog: &PackageCatalog,
+        leases: &BTreeMap<u64, (String, String)>,
+    ) -> Result<()> {
+        gc_one_package_revisions(&self.root, package_id, catalog, leases)
+    }
+}
+
+#[cfg(test)]
+pub(super) fn persist_catalog_at(root: &Path, catalog: &PackageCatalog) -> Result<()> {
+    persist_catalog(root, catalog)
+}
+
+#[cfg(test)]
+pub(super) fn revision_root_at(root: &Path, package_id: &str, revision: &str) -> PathBuf {
+    revision_root(root, package_id, revision)
+}
+
+struct PackageStoreLock {
+    file: File,
+}
+
+impl PackageStoreLock {
+    fn acquire(root: &Path) -> Result<Self> {
+        let path = root.join("store.lock");
+        let mut options = OpenOptions::new();
+        options.read(true).write(true).create(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+        }
+        let file = options
+            .open(&path)
+            .with_context(|| format!("open Package Store lock {}", path.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+            // SAFETY: file owns a valid descriptor for the lifetime of the lock.
+            let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+            if result != 0 {
+                let error = std::io::Error::last_os_error();
+                if error
+                    .raw_os_error()
+                    .is_some_and(|code| code == libc::EWOULDBLOCK || code == libc::EAGAIN)
+                {
+                    bail!("Package Store is already owned by another Package Service")
+                }
+                return Err(error).context("acquire Package Store lock");
+            }
+        }
+        Ok(Self { file })
+    }
+}
+
+impl Drop for PackageStoreLock {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+            // SAFETY: file remains valid until this Drop implementation returns.
+            unsafe {
+                libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
+            }
+        }
+    }
+}
+
+fn recover_staging(root: &Path, catalog: &PackageCatalog) -> Result<()> {
+    let staging = root.join("staging");
+    ensure_owned_directory(&staging, "package staging path is not an owned directory")?;
+    for entry in fs::read_dir(&staging)? {
+        let entry = entry?;
+        let name = entry
+            .file_name()
+            .into_string()
+            .map_err(|_| anyhow::anyhow!("package staging entry is not UTF-8"))?;
+        let interrupted_removal = name.strip_prefix("remove-").and_then(|rest| {
+            let (package_id, nonce) = rest.rsplit_once('-')?;
+            uuid::Uuid::parse_str(nonce).ok()?;
+            Some(package_id)
+        });
+        if let Some(package_id) = interrupted_removal
+            && catalog.packages.contains_key(package_id)
+        {
+            validate_package_id(package_id)?;
+            ensure_owned_directory(
+                &entry.path(),
+                "staged package revisions are not an owned directory",
+            )?;
+            let active = root.join("revisions").join(package_id);
+            match fs::symlink_metadata(&active) {
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Ok(_) => bail!("both active and staged package revisions exist"),
+                Err(error) => return Err(error.into()),
+            }
+            fs::rename(entry.path(), active)?;
+        } else {
+            remove_path_without_following(&entry.path())?;
+        }
+    }
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        if name.to_string_lossy().starts_with("catalog-")
+            && name.to_string_lossy().ends_with(".tmp")
+        {
+            remove_path_without_following(&entry.path())?;
+        }
+    }
+    Ok(())
+}
+
+fn remove_path_without_following(path: &Path) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
+        fs::remove_dir_all(path)?;
+    } else {
+        fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+fn remove_package_revisions(root: &Path, package_id: &str) -> Result<()> {
+    let path = root.join("revisions").join(package_id);
+    if path.exists() {
+        remove_path_without_following(&path)?;
+    }
+    Ok(())
+}
+
+pub(super) struct StagedPackageRevisions {
+    pub(super) active: PathBuf,
+    pub(super) staged: PathBuf,
+}
+
+fn stage_package_revisions(
+    root: &Path,
+    package_id: &str,
+) -> Result<Option<StagedPackageRevisions>> {
+    let active = root.join("revisions").join(package_id);
+    match fs::symlink_metadata(&active) {
+        Ok(metadata) => ensure!(
+            metadata.file_type().is_dir() && !metadata.file_type().is_symlink(),
+            "package revisions path is not an owned directory"
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    }
+    ensure_owned_directory(
+        &root.join("staging"),
+        "package staging path is not an owned directory",
+    )?;
+    let staged = root.join("staging").join(format!(
+        "remove-{package_id}-{}",
+        uuid::Uuid::new_v4().simple()
+    ));
+    fs::rename(&active, &staged).context("stage package revisions for removal")?;
+    Ok(Some(StagedPackageRevisions { active, staged }))
+}
+
+fn rollback_staged_package_revisions(
+    staged: Option<&StagedPackageRevisions>,
+    catalog_error: anyhow::Error,
+) -> Result<()> {
+    if let Some(staged) = staged
+        && let Err(rollback_error) = fs::rename(&staged.staged, &staged.active)
+    {
+        return Err(catalog_error.context(format!(
+            "rollback staged package revisions failed: {rollback_error}"
+        )));
+    }
+    Err(catalog_error)
+}
+
+fn discard_staged_package_revisions(staged: Option<StagedPackageRevisions>) {
+    if let Some(staged) = staged
+        && let Err(error) = remove_path_without_following(&staged.staged)
+    {
+        tracing::warn!(
+            path = %staged.staged.display(),
+            %error,
+            "staged package revisions remain for startup recovery"
+        );
+    }
+}
+
+fn gc_unreferenced_store_revisions(
+    root: &Path,
+    catalog: &PackageCatalog,
+    leases: &BTreeMap<u64, (String, String)>,
+) -> Result<()> {
+    let revisions = root.join("revisions");
+    for entry in fs::read_dir(&revisions)? {
+        let entry = entry?;
+        let metadata = fs::symlink_metadata(entry.path())?;
+        ensure!(
+            metadata.file_type().is_dir() && !metadata.file_type().is_symlink(),
+            "package revisions store contains an unsupported entry"
+        );
+        let package_id = entry
+            .file_name()
+            .to_str()
+            .context("package revision directory is not UTF-8")?
+            .to_string();
+        if catalog.packages.contains_key(&package_id) {
+            gc_one_package_revisions(root, &package_id, catalog, leases)?;
+        } else {
+            remove_path_without_following(&entry.path())?;
+        }
+    }
+    Ok(())
+}
+
+fn gc_one_package_revisions(
+    root: &Path,
+    package_id: &str,
+    catalog: &PackageCatalog,
+    leases: &BTreeMap<u64, (String, String)>,
+) -> Result<()> {
+    let Some(record) = catalog.packages.get(package_id) else {
+        return remove_package_revisions(root, package_id);
+    };
+    let package_root = root.join("revisions").join(package_id);
+    if !package_root.exists() {
+        return Ok(());
+    }
+    let retained = leases
+        .values()
+        .filter(|(id, _)| id == package_id)
+        .map(|(_, revision)| revision.as_str())
+        .chain(std::iter::once(record.revision.as_str()))
+        .collect::<BTreeSet<_>>();
+    for entry in fs::read_dir(&package_root)? {
+        let entry = entry?;
+        let revision = entry.file_name();
+        let revision = revision
+            .to_str()
+            .context("package revision name is not UTF-8")?;
+        if !retained.contains(revision) {
+            remove_path_without_following(&entry.path())?;
+        }
+    }
+    Ok(())
+}
+
+fn ensure_package_store_channel_chain(store_root: &Path) -> Result<()> {
+    let services_root = store_root
+        .parent()
+        .context("Package Store root has no services parent")?;
+    let channel_root = services_root
+        .parent()
+        .context("Package Store root has no channel parent")?;
+    for (path, message) in [
+        (
+            channel_root,
+            "Package Store channel path contains an unsupported ancestor",
+        ),
+        (
+            services_root,
+            "Package Store channel path contains an unsupported ancestor",
+        ),
+        (store_root, "Package Store root is not an owned directory"),
+    ] {
+        match fs::symlink_metadata(path) {
+            Ok(metadata) => ensure!(
+                metadata.file_type().is_dir() && !metadata.file_type().is_symlink(),
+                "{message}"
+            ),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error).context("inspect Package Store channel path"),
+        }
+    }
+    Ok(())
+}
+
+fn load_catalog(root: &Path) -> Result<PackageCatalog> {
+    let path = root.join("catalog.json");
+    if !path.exists() {
+        return Ok(PackageCatalog::default());
+    }
+    let bytes = fs::read(&path)?;
+    serde_json::from_slice(&bytes).context("decode Package Service catalog")
+}
+
+fn persist_catalog(root: &Path, catalog: &PackageCatalog) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(catalog)?;
+    let temporary = root.join(format!("catalog-{}.tmp", uuid::Uuid::new_v4().simple()));
+    let mut file = File::create(&temporary)?;
+    file.write_all(&bytes)?;
+    file.sync_all()?;
+    fs::rename(&temporary, root.join("catalog.json"))?;
+    File::open(root)?.sync_all()?;
+    Ok(())
+}
+
+fn verify_catalog(root: &Path, catalog: &PackageCatalog) -> Result<()> {
+    validate_catalog_structure(catalog)?;
+    for record in catalog.packages.values() {
+        ensure!(
+            record.materializer_version == MATERIALIZER_VERSION,
+            "catalog references an unsupported materializer version"
+        );
+        verify_revision(root, record)?;
+    }
+    Ok(())
+}
+
+fn validate_catalog_structure(catalog: &PackageCatalog) -> Result<()> {
+    ensure!(
+        catalog.packages.len() <= MAX_PACKAGES,
+        "package catalog exceeds its supported size"
+    );
+    for (package_id, record) in &catalog.packages {
+        ensure!(
+            package_id == &record.id,
+            "package catalog key does not match its record id"
+        );
+        validate_package_id(&record.id)?;
+    }
+    Ok(())
+}
+
+fn verify_revision(root: &Path, record: &PackageRecord) -> Result<()> {
+    ensure!(
+        record.revision.len() == 64
+            && record
+                .revision
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+        "catalog contains an invalid package revision"
+    );
+    let revision_root = revision_root(root, &record.id, &record.revision);
+    ensure!(
+        revision_root.is_dir(),
+        "catalog references missing package revision"
+    );
+    let manifest = verify_materialized_revision(&revision_root, &record.revision)?;
+    ensure!(
+        manifest.exports == record.exports
+            && manifest.tree_fingerprint == record.materialized_fingerprint,
+        "catalog and materialization manifest disagree"
+    );
+    ensure!(
+        record.state == PackageState::Installed || record.reference_count > 0,
+        "retiring package has an invalid reference state"
+    );
+    for export in &record.exports {
+        validate_skill_compatibility(&SkillCompatibility {
+            dependencies: export.dependencies.clone(),
+            ..SkillCompatibility::default()
+        })
+        .map_err(anyhow::Error::from)
+        .context("catalog contains an invalid typed package dependency")?;
+    }
+    Ok(())
+}
+
+fn revision_root(root: &Path, package_id: &str, revision: &str) -> PathBuf {
+    root.join("revisions").join(package_id).join(revision)
+}

--- a/crates/service-manager/src/package/tests.rs
+++ b/crates/service-manager/src/package/tests.rs
@@ -1,6 +1,8 @@
 use super::materializer::{MAX_SOURCE_FILE_BYTES, MaterializationManifest};
+use super::store;
 use super::*;
 use alan_agent_engine::skills::{SkillScope, parse_skill_metadata};
+use std::fs::File;
 
 mod file_surface;
 
@@ -101,7 +103,7 @@ fn install_rejects_a_stale_file_at_the_revision_path() {
     let service = PackageService::ephemeral("test").unwrap();
     let snapshot = native_snapshot("stale-file", "body");
     let revision = fingerprint(&snapshot).unwrap();
-    let target = revision_root(&service.store_root, "stale-file-pack", &revision);
+    let target = service.store.revision_root("stale-file-pack", &revision);
     fs::create_dir_all(target.parent().unwrap()).unwrap();
     fs::write(&target, b"stale").unwrap();
 
@@ -124,7 +126,7 @@ fn install_rejects_a_stale_symlink_at_the_revision_path() {
     let service = PackageService::ephemeral("test").unwrap();
     let snapshot = native_snapshot("stale-link", "body");
     let revision = fingerprint(&snapshot).unwrap();
-    let target = revision_root(&service.store_root, "stale-link-pack", &revision);
+    let target = service.store.revision_root("stale-link-pack", &revision);
     fs::create_dir_all(target.parent().unwrap()).unwrap();
     let outside = tempfile::tempdir().unwrap();
     symlink(outside.path(), &target).unwrap();
@@ -152,7 +154,7 @@ fn install_rejects_a_symlinked_package_revision_parent() {
 
     let service = PackageService::ephemeral("test").unwrap();
     let outside = tempfile::tempdir().unwrap();
-    let parent = service.store_root.join("revisions/symlinked-parent-pack");
+    let parent = service.store.root().join("revisions/symlinked-parent-pack");
     symlink(outside.path(), &parent).unwrap();
 
     let result = service.execute(PackageCommand::Install {
@@ -261,7 +263,8 @@ fn install_rejects_case_colliding_snapshot_paths_before_materialization() {
     );
     assert!(
         !service
-            .store_root
+            .store
+            .root()
             .join("revisions/case-collision-pack")
             .exists()
     );
@@ -432,7 +435,7 @@ fn failed_upgrade_keeps_the_current_catalog_and_revision() {
     assert!(!failed.success);
     assert_eq!(service.catalog(), before);
     assert_eq!(
-        fs::read_dir(service.store_root.join("revisions/atomic-pack"))
+        fs::read_dir(service.store.root().join("revisions/atomic-pack"))
             .unwrap()
             .count(),
         1
@@ -454,7 +457,8 @@ fn upgrade_reports_success_when_post_commit_revision_cleanup_fails() {
         .unwrap();
     assert!(installed.success);
     let locked_revision = service
-        .store_root
+        .store
+        .root()
         .join("revisions/cleanup-pack")
         .join("stale-locked-revision");
     fs::create_dir(&locked_revision).unwrap();
@@ -490,7 +494,7 @@ fn failed_uninstall_keeps_the_current_catalog_and_revision() {
         })
         .unwrap();
     let before = service.catalog();
-    let staging = service.store_root.join("staging");
+    let staging = service.store.root().join("staging");
     fs::remove_dir(&staging).unwrap();
     fs::write(&staging, b"block revision staging").unwrap();
 
@@ -506,7 +510,8 @@ fn failed_uninstall_keeps_the_current_catalog_and_revision() {
     assert!(service.resolve("atomic-uninstall-pack").is_ok());
     assert!(
         service
-            .store_root
+            .store
+            .root()
             .join("revisions/atomic-uninstall-pack")
             .is_dir()
     );
@@ -525,7 +530,9 @@ fn restart_rolls_back_revision_removal_when_catalog_is_still_old() {
         })
         .unwrap();
     let record = service.resolve("crash-window-pack").unwrap();
-    let staged = stage_package_revisions(&root, "crash-window-pack")
+    let staged = service
+        .store
+        .stage_package_revisions("crash-window-pack")
         .unwrap()
         .unwrap();
     assert!(staged.staged.is_dir());
@@ -535,7 +542,7 @@ fn restart_rolls_back_revision_removal_when_catalog_is_still_old() {
     let reopened = PackageService::open("dev", root.clone()).unwrap();
 
     assert_eq!(reopened.resolve("crash-window-pack").unwrap(), record);
-    assert!(revision_root(&root, "crash-window-pack", &record.revision).is_dir());
+    assert!(store::revision_root_at(&root, "crash-window-pack", &record.revision).is_dir());
     assert_eq!(fs::read_dir(root.join("staging")).unwrap().count(), 0);
 }
 
@@ -580,7 +587,7 @@ fn live_reference_retains_old_revision_until_retiring_package_is_released() {
     assert!(lease.content_root().is_dir());
     drop(lease);
     assert!(!service.catalog().packages.contains_key("leased-pack"));
-    assert!(!service.store_root.join("revisions/leased-pack").exists());
+    assert!(!service.store.root().join("revisions/leased-pack").exists());
 }
 
 #[test]
@@ -660,7 +667,8 @@ fn restart_fails_closed_when_revision_content_is_tampered() {
         .package
         .unwrap();
     drop(service);
-    let manifest = revision_root(&root, "tamper-pack", &record.revision).join("manifest.json");
+    let manifest =
+        store::revision_root_at(&root, "tamper-pack", &record.revision).join("manifest.json");
     fs::write(manifest, b"{}").unwrap();
     assert!(PackageService::open("dev", root).is_err());
 }
@@ -684,7 +692,8 @@ fn restart_rejects_symlinked_materialized_root() {
         .unwrap();
     drop(service);
 
-    let content = revision_root(&root, "symlinked-content-pack", &record.revision).join("content");
+    let content =
+        store::revision_root_at(&root, "symlinked-content-pack", &record.revision).join("content");
     fs::remove_dir_all(&content).unwrap();
     let victim = directory.path().join("victim");
     fs::create_dir(&victim).unwrap();
@@ -716,7 +725,7 @@ fn restart_rejects_invalid_retiring_package_id_before_removing_revisions() {
     let record = catalog.packages.get_mut("unsafe-recovery-pack").unwrap();
     record.id = victim.to_string_lossy().into_owned();
     record.state = PackageState::Retiring;
-    persist_catalog(&root, &catalog).unwrap();
+    store::persist_catalog_at(&root, &catalog).unwrap();
 
     assert!(PackageService::open("dev", root).is_err());
     assert_eq!(fs::read(victim.join("sentinel")).unwrap(), b"keep");
@@ -858,7 +867,9 @@ fn command_materialization_keeps_unsupported_capability_visible() {
     assert!(content.ends_with("Use WebSearch and TeamCreate for this work."));
     let manifest: MaterializationManifest = serde_json::from_slice(
         &fs::read(
-            revision_root(&service.store_root, "foreign-pack", &record.revision)
+            service
+                .store
+                .revision_root("foreign-pack", &record.revision)
                 .join("manifest.json"),
         )
         .unwrap(),

--- a/scripts/rust-source-size-baseline.txt
+++ b/scripts/rust-source-size-baseline.txt
@@ -1,6 +1,5 @@
 # Rust source files above the 1,000-line target. Keep sorted by path.
 # A file may only stay equal to this maximum or shrink with this entry tightened.
-crates/service-manager/src/package.rs 1228
 crates/service-manager/src/runtime.rs 2243
 crates/shell-core/src/actions.rs 1591
 crates/shell-core/src/control.rs 1183


### PR DESCRIPTION
## Summary

- introduce PackageStore as the durable owner of the store root and exclusive lock
- encapsulate startup recovery, atomic catalog persistence, revision validation, uninstall rollback, and revision GC behind the store owner
- share narrow owned-file and durable-sync primitives with the Package Materializer, reduce package.rs from 1,228 to 800 lines, and remove it from the oversized-source baseline

## Stack

- stacked on #775
- review this PR as the Package Store ownership layer only

## Validation

- cargo test -p alan-service-manager (75 unit tests plus 2 contract suites)
- cargo clippy -p alan-service-manager --all-targets --all-features -- -D warnings
- just quality
- just test
- openspec validate --all --strict (88/88)
- git diff --check