### PR TITLE
test: wait for restart transcript persistence

### DIFF
--- a/clients/apple/scripts/test-shell-ui-smoke.sh
+++ b/clients/apple/scripts/test-shell-ui-smoke.sh
@@ -885,6 +885,11 @@ run_restart_restore_step() {
     fi
     require_control_applied "$terminal_result" "restart restore terminal.send_text before quit"
 
+    wait_for_json_transcript_text \
+        "$manifest_path" \
+        "$before_token" \
+        "persisted restart transcript token before quit"
+
     sleep 1
     capture_step restart-before-quit
 


### PR DESCRIPTION
## Summary\n\n- wait for the restart transcript token to reach the workspace manifest before quitting\n- remove the race where the quit-confirm fallback could terminate Alan Dev before durable transcript capture\n- keep the restore assertion meaningful by proving the pre-quit durability boundary\n\n## Verification\n\n- bash -n clients/apple/scripts/test-shell-ui-smoke.sh\n- just quality\n- just apple-shell-ui-smoke (two consecutive passing runs after the fix)\n- reproduced the pre-fix failure: timed out waiting for persisted restart transcript token\n- git diff --check