### PR TITLE
refactor(macos): split Ghostty platform adapters

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -42,7 +42,8 @@ Xcode target.
 | `Views/Shell/Terminal/ShellTerminalOverlayViews.swift` | 128 | SwiftUI; macOS gates | Pane-scoped Find interaction and passive inactive-pane dimming | `Views/Shell/Terminal/` |
 | `Views/Shell/Content/ShellBoundedContentViews.swift` | 647 | Foundation, SwiftUI; macOS gates | Bounded Agent and Markdown content renderers plus unavailable-content presentation | `Views/Shell/Content/` |
 | `TerminalHostView.swift` | 1911 | AppKit, Carbon, QuartzCore, GhosttyKit; macOS gates | AppKit terminal host bridge, focus, overlay composition, runtime attachment, and collaborator wiring | `Views/Shell/Terminal/` plus terminal collaborators |
-| `GhosttyLiveHost.swift` | 1227 | Foundation, AppKit, GhosttyKit, OSLog, QuartzCore; macOS/Ghostty gates | Ghostty canvas bridge and wakeup/occlusion integration | `Services/Terminal/` or `Support/TerminalBridge/` |
+| `GhosttyLiveHost.swift` | 1179 | Foundation, AppKit, GhosttyKit, OSLog, QuartzCore; macOS/Ghostty gates | Ghostty app/surface lifecycle, callbacks, and renderer coordination | `Services/Terminal/` |
+| `Services/Terminal/GhosttyPlatformAdapters.swift` | 104 | Foundation, AppKit, GhosttyKit; macOS/Ghostty gates | Ghostty key-code, clipboard, app-focus, canvas, and display adapters | `Services/Terminal/` |
 | `TerminalHostRuntime.swift` | 1406 | CoreGraphics, Foundation; macOS gates | Terminal launch resolution, boot profiles, runtime protocols, and fallback runtime state | `Services/Terminal/` |
 | `Services/Terminal/TerminalHostRuntimeReporter.swift` | 47 | Foundation; macOS gates | Runtime snapshot deduplication and main-queue publication for terminal host updates | `Services/Terminal/` |
 | `Services/Terminal/TerminalHostWindowObserver.swift` | 55 | AppKit; macOS gates | Terminal host window key, screen, and occlusion notification ownership | `Services/Terminal/` |
@@ -321,13 +322,13 @@ device support was not required for this validation.
 ## Remaining Architecture Debt
 
 `check-architecture-maintainability.sh` currently completes in report mode.
-6 known large-file / bridge-boundary warnings remain after the first eleven Apple
+5 known large-file / bridge-boundary warnings remain after the first twelve Apple
 ownership slices removed the `ShellHostController.swift` bridge warning and
 split control projection, observation commands, root-controller
 responsibilities, shell presentation models, settings models, snapshot DTO
 families, shell/platform value families, sidebar and settings presentation,
 pane-tree/content rendering, and pane title/overlay presentation into focused
-owners. These warnings
+owners, then isolated Ghostty's macOS platform adapters from its live host. These warnings
 are telemetry for the cleanup, not the cleanup
 definition. The real debt is any Swift production source that still carries a
 Rust-owned shell-domain implementation, fixture, or fallback after shell-core
@@ -424,6 +425,13 @@ overlay presentation into focused owners under `Views/Shell/Terminal/`, and
 deleted the unreferenced runtime, boot, Ghostty, binding, action, chip, and info
 card presentation chain. `TerminalPaneView.swift` falls from 1,337 to 229 lines
 and exits the large-file ledger, lowering the warning count from 7 to 6.
+
+The twelfth ownership slice moved Ghostty physical key codes, clipboard access,
+application-focus observation, the transparent canvas view, and display lookup
+behind `Services/Terminal/GhosttyPlatformAdapters.swift`. `GhosttyLiveHost.swift`
+retains app/surface lifecycle, callback assembly, and renderer coordination,
+falls from 1,258 to 1,179 lines, and exits the large-file ledger, lowering the
+warning count from 6 to 5.
 
 Rust-owned Swift legacy cleanup targets at this baseline:
 

--- a/clients/apple/README.md
+++ b/clients/apple/README.md
@@ -37,7 +37,8 @@ recorded in [`ARCHITECTURE.md`](./ARCHITECTURE.md).
   file polling, event store, diagnostics, and command-execution services that
   keep runtime metadata and IO out of the observable host
 - `Services/Terminal/`: terminal host runtime reporting, window observation,
-  agent-activity projection, and terminal runtime service collaborators
+  Ghostty platform adapters, agent-activity projection, and terminal runtime
+  service collaborators
 - `TerminalPaneView.swift` / `TerminalHostView.swift`: current terminal pane and host surfaces;
   settings, bounded content, pane-tree, terminal-leaf, title-bar, and overlay
   presentation live under `Views/Shell/`

--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		A12300000000000000000003 /* Views/Shell/Content/ShellBoundedContentViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12300000000000000000103 /* Views/Shell/Content/ShellBoundedContentViews.swift */; };
 		A12400000000000000000001 /* Views/Shell/Terminal/ShellPaneTitleBarViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12400000000000000000101 /* Views/Shell/Terminal/ShellPaneTitleBarViews.swift */; };
 		A12400000000000000000002 /* Views/Shell/Terminal/ShellTerminalOverlayViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12400000000000000000102 /* Views/Shell/Terminal/ShellTerminalOverlayViews.swift */; };
+		A12500000000000000000001 /* Services/Terminal/GhosttyPlatformAdapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12500000000000000000101 /* Services/Terminal/GhosttyPlatformAdapters.swift */; };
 		AA1B2C3D4E5F6A7B8C9D0E1F /* Views/Shell/Controls/ShellFormControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2C3D4E5F6A7B8C9D0E1F2A /* Views/Shell/Controls/ShellFormControls.swift */; };
 		0000000000000000000000F0 /* Views/Shell/ShellSpaceCreationForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000000000000000001F0 /* Views/Shell/ShellSpaceCreationForm.swift */; };
 		00000000000000000000001B /* Views/Shell/ShellWorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000011B /* Views/Shell/ShellWorkspaceView.swift */; };
@@ -220,6 +221,7 @@
 		A12300000000000000000103 /* Views/Shell/Content/ShellBoundedContentViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/Shell/Content/ShellBoundedContentViews.swift; sourceTree = "<group>"; };
 		A12400000000000000000101 /* Views/Shell/Terminal/ShellPaneTitleBarViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/Shell/Terminal/ShellPaneTitleBarViews.swift; sourceTree = "<group>"; };
 		A12400000000000000000102 /* Views/Shell/Terminal/ShellTerminalOverlayViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/Shell/Terminal/ShellTerminalOverlayViews.swift; sourceTree = "<group>"; };
+		A12500000000000000000101 /* Services/Terminal/GhosttyPlatformAdapters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/GhosttyPlatformAdapters.swift; sourceTree = "<group>"; };
 		BB2C3D4E5F6A7B8C9D0E1F2A /* Views/Shell/Controls/ShellFormControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Views/Shell/Controls/ShellFormControls.swift"; sourceTree = "<group>"; };
 		0000000000000000000001F0 /* Views/Shell/ShellSpaceCreationForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/Shell/ShellSpaceCreationForm.swift; sourceTree = "<group>"; };
 		00000000000000000000011B /* Views/Shell/ShellWorkspaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/Shell/ShellWorkspaceView.swift; sourceTree = "<group>"; };
@@ -550,6 +552,7 @@
 		00000000000000000000030D /* Services/Terminal */ = {
 			isa = PBXGroup;
 			children = (
+				A12500000000000000000101 /* Services/Terminal/GhosttyPlatformAdapters.swift */,
 				A12000000000000000000108 /* Services/Terminal/TerminalAgentActivityAdapter.swift */,
 				000000000000000000000127 /* Services/Terminal/TerminalHostRuntimeReporter.swift */,
 				000000000000000000000128 /* Services/Terminal/TerminalHostWindowObserver.swift */,
@@ -805,6 +808,7 @@
 				A12300000000000000000003 /* Views/Shell/Content/ShellBoundedContentViews.swift in Sources */,
 				A12400000000000000000001 /* Views/Shell/Terminal/ShellPaneTitleBarViews.swift in Sources */,
 				A12400000000000000000002 /* Views/Shell/Terminal/ShellTerminalOverlayViews.swift in Sources */,
+				A12500000000000000000001 /* Services/Terminal/GhosttyPlatformAdapters.swift in Sources */,
 				AA1B2C3D4E5F6A7B8C9D0E1F /* Views/Shell/Controls/ShellFormControls.swift in Sources */,
 				0000000000000000000000F0 /* Views/Shell/ShellSpaceCreationForm.swift in Sources */,
 				00000000000000000000001B /* Views/Shell/ShellWorkspaceView.swift in Sources */,

--- a/clients/apple/alan-macos/GhosttyLiveHost.swift
+++ b/clients/apple/alan-macos/GhosttyLiveHost.swift
@@ -27,7 +27,7 @@ final class AlanGhosttyLiveHost: NSObject {
     private var envStorage: [(UnsafeMutablePointer<CChar>, UnsafeMutablePointer<CChar>)] = []
     private let tickScheduleLock = NSLock()
     private var tickScheduled = false
-    private var appObservers: [NSObjectProtocol] = []
+    private let appFocusObserver = AlanGhosttyAppFocusObserver()
     private var didEmitFirstRefresh = false
     private var diagnostics = TerminalRendererSnapshot.placeholder
     private var metadata = TerminalPaneMetadataSnapshot.placeholder
@@ -36,13 +36,6 @@ final class AlanGhosttyLiveHost: NSObject {
     private var didEmitNonConfirmingCloseRequest = false
     private var foregroundCommandStartedAt: Date?
     private var queuedForegroundCommandSubmissions = 0
-
-    private enum KeyCode {
-        static let d: UInt32 = 2
-        static let c: UInt32 = 8
-        static let returnKey: UInt32 = 36
-        static let keypadEnter: UInt32 = 76
-    }
 
     func attach(
         to canvasView: AlanGhosttyCanvasView,
@@ -178,13 +171,13 @@ final class AlanGhosttyLiveHost: NSObject {
         let mods: ghostty_input_mods_e
         switch key {
         case .interrupt:
-            keycode = KeyCode.c
+            keycode = AlanGhosttyKeyCode.c
             mods = GHOSTTY_MODS_CTRL
         case .endOfTransmission:
-            keycode = KeyCode.d
+            keycode = AlanGhosttyKeyCode.d
             mods = GHOSTTY_MODS_CTRL
         case .returnKey:
-            keycode = KeyCode.returnKey
+            keycode = AlanGhosttyKeyCode.returnKey
             mods = GHOSTTY_MODS_NONE
         }
 
@@ -346,7 +339,7 @@ final class AlanGhosttyLiveHost: NSObject {
 
     func teardown() {
         teardownSurface()
-        removeAppObservers()
+        appFocusObserver.remove()
         if let app {
             ghostty_app_free(app)
             self.app = nil
@@ -386,7 +379,7 @@ final class AlanGhosttyLiveHost: NSObject {
                   let surface = host.surface
             else { return false }
 
-            let text = AlanGhosttyLiveHost.readClipboardText(location: location) ?? ""
+            let text = AlanGhosttyClipboard.readText(location: location) ?? ""
             text.withCString { cString in
                 ghostty_surface_complete_clipboard_request(surface, cString, state, false)
             }
@@ -399,7 +392,11 @@ final class AlanGhosttyLiveHost: NSObject {
             ghostty_surface_complete_clipboard_request(surface, string, state, true)
         }
         runtimeConfig.write_clipboard_cb = { _, location, content, len, _ in
-            AlanGhosttyLiveHost.writeClipboard(location: location, content: content, len: len)
+            AlanGhosttyClipboard.write(
+                location: location,
+                content: content,
+                len: len
+            )
         }
         runtimeConfig.close_surface_cb = { userdata, processAlive in
             AlanGhosttyLiveHost.from(userdata)?
@@ -420,7 +417,7 @@ final class AlanGhosttyLiveHost: NSObject {
         if let created = ghostty_app_new(&runtimeConfig, primaryConfig) {
             self.app = created
             self.config = primaryConfig
-            installAppObservers()
+            appFocusObserver.install(for: created)
             ghostty_app_set_focus(created, NSApp.isActive)
             transition(
                 kind: .ghosttyLive,
@@ -462,7 +459,7 @@ final class AlanGhosttyLiveHost: NSObject {
 
         self.app = created
         self.config = fallbackConfig
-        installAppObservers()
+        appFocusObserver.install(for: created)
         ghostty_app_set_focus(created, NSApp.isActive)
         transition(
             kind: .ghosttyLive,
@@ -515,7 +512,7 @@ final class AlanGhosttyLiveHost: NSObject {
                 ?? 2
         )
         surfaceConfig.context = GHOSTTY_SURFACE_CONTEXT_WINDOW
-        if let displayID = (canvasView.window?.screen ?? NSScreen.main)?.displayID,
+        if let displayID = (canvasView.window?.screen ?? NSScreen.main)?.alanGhosttyDisplayID,
            displayID != 0
         {
             surfaceConfig.initial_macos_display_id = displayID
@@ -601,7 +598,7 @@ final class AlanGhosttyLiveHost: NSObject {
             UInt32(max(1, Int(floor(backingSize.height))))
         )
 
-        if let displayID = (window.screen ?? NSScreen.main)?.displayID, displayID != 0 {
+        if let displayID = (window.screen ?? NSScreen.main)?.alanGhosttyDisplayID, displayID != 0 {
             ghostty_surface_set_display_id(surface, displayID)
         }
     }
@@ -1074,7 +1071,10 @@ final class AlanGhosttyLiveHost: NSObject {
 
     private func isCommandSubmissionKey(_ keyEvent: ghostty_input_key_s) -> Bool {
         keyEvent.action == GHOSTTY_ACTION_PRESS
-            && (keyEvent.keycode == KeyCode.returnKey || keyEvent.keycode == KeyCode.keypadEnter)
+            && (
+                keyEvent.keycode == AlanGhosttyKeyCode.returnKey
+                    || keyEvent.keycode == AlanGhosttyKeyCode.keypadEnter
+            )
     }
 
     private func isCommandSubmissionText(_ text: String) -> Bool {
@@ -1145,69 +1145,9 @@ final class AlanGhosttyLiveHost: NSObject {
         }
     }
 
-    private func installAppObservers() {
-        removeAppObservers()
-        guard let app else { return }
-        let center = NotificationCenter.default
-        appObservers = [
-            center.addObserver(
-                forName: NSApplication.didBecomeActiveNotification,
-                object: nil,
-                queue: .main
-            ) { _ in
-                ghostty_app_set_focus(app, true)
-            },
-            center.addObserver(
-                forName: NSApplication.didResignActiveNotification,
-                object: nil,
-                queue: .main
-            ) { _ in
-                ghostty_app_set_focus(app, false)
-            },
-        ]
-    }
-
-    private func removeAppObservers() {
-        appObservers.forEach(NotificationCenter.default.removeObserver)
-        appObservers.removeAll()
-    }
-
     private static func from(_ userdata: UnsafeMutableRawPointer?) -> AlanGhosttyLiveHost? {
         guard let userdata else { return nil }
         return Unmanaged<AlanGhosttyLiveHost>.fromOpaque(userdata).takeUnretainedValue()
-    }
-
-    private static func readClipboardText(location: ghostty_clipboard_e) -> String? {
-        let pasteboard: NSPasteboard?
-        switch location {
-        case GHOSTTY_CLIPBOARD_STANDARD:
-            pasteboard = .general
-        default:
-            pasteboard = nil
-        }
-
-        return pasteboard?.string(forType: .string)
-    }
-
-    private static func writeClipboard(
-        location: ghostty_clipboard_e,
-        content: UnsafePointer<ghostty_clipboard_content_s>?,
-        len: Int
-    ) {
-        guard location == GHOSTTY_CLIPBOARD_STANDARD,
-              let content,
-              len > 0
-        else { return }
-
-        let buffer = UnsafeBufferPointer(start: content, count: len)
-        guard let first = buffer.first,
-              let data = first.data
-        else { return }
-
-        let text = String(cString: data)
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
     }
 }
 
@@ -1236,23 +1176,4 @@ extension AlanGhosttyLiveHost: TerminalRenderCoordinatedHost {
     }
 }
 
-final class AlanGhosttyCanvasView: NSView {
-    override var mouseDownCanMoveWindow: Bool { false }
-
-    override func hitTest(_ point: NSPoint) -> NSView? { nil }
-
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) is not supported")
-    }
-}
-
-extension NSScreen {
-    var displayID: UInt32? {
-        (deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber).map { $0.uint32Value }
-    }
-}
 #endif

--- a/clients/apple/alan-macos/Services/Terminal/GhosttyPlatformAdapters.swift
+++ b/clients/apple/alan-macos/Services/Terminal/GhosttyPlatformAdapters.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+#if os(macOS) && canImport(GhosttyKit)
+import AppKit
+import GhosttyKit
+
+enum AlanGhosttyKeyCode {
+    static let d: UInt32 = 2
+    static let c: UInt32 = 8
+    static let returnKey: UInt32 = 36
+    static let keypadEnter: UInt32 = 76
+}
+
+enum AlanGhosttyClipboard {
+    static func readText(location: ghostty_clipboard_e) -> String? {
+        let pasteboard: NSPasteboard?
+        switch location {
+        case GHOSTTY_CLIPBOARD_STANDARD:
+            pasteboard = .general
+        default:
+            pasteboard = nil
+        }
+
+        return pasteboard?.string(forType: .string)
+    }
+
+    static func write(
+        location: ghostty_clipboard_e,
+        content: UnsafePointer<ghostty_clipboard_content_s>?,
+        len: Int
+    ) {
+        guard location == GHOSTTY_CLIPBOARD_STANDARD,
+              let content,
+              len > 0
+        else { return }
+
+        let buffer = UnsafeBufferPointer(start: content, count: len)
+        guard let first = buffer.first,
+              let data = first.data
+        else { return }
+
+        let text = String(cString: data)
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+    }
+}
+
+final class AlanGhosttyAppFocusObserver {
+    private var observers: [NSObjectProtocol] = []
+
+    func install(for app: ghostty_app_t) {
+        remove()
+        let center = NotificationCenter.default
+        observers = [
+            center.addObserver(
+                forName: NSApplication.didBecomeActiveNotification,
+                object: nil,
+                queue: .main
+            ) { _ in
+                ghostty_app_set_focus(app, true)
+            },
+            center.addObserver(
+                forName: NSApplication.didResignActiveNotification,
+                object: nil,
+                queue: .main
+            ) { _ in
+                ghostty_app_set_focus(app, false)
+            },
+        ]
+    }
+
+    func remove() {
+        observers.forEach(NotificationCenter.default.removeObserver)
+        observers.removeAll()
+    }
+
+    deinit {
+        remove()
+    }
+}
+
+final class AlanGhosttyCanvasView: NSView {
+    override var mouseDownCanMoveWindow: Bool { false }
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+}
+
+extension NSScreen {
+    var alanGhosttyDisplayID: UInt32? {
+        (deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber).map {
+            $0.uint32Value
+        }
+    }
+}
+#endif

--- a/clients/apple/scripts/architecture-warning-baseline.txt
+++ b/clients/apple/scripts/architecture-warning-baseline.txt
@@ -1,6 +1,5 @@
 # Exact Apple architecture-warning debt. Keep entries sorted.
 # large entries include their current line ceiling; every reduction tightens it.
-large|GhosttyLiveHost.swift|1258
 large|Services/Shell/AlanPrivilegedHelperXPC.swift|2117
 large|TerminalHostRuntime.swift|1552
 large|TerminalHostView.swift|2010

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -2293,12 +2293,12 @@ require_pattern \
     "fallback terminal canvas views must be transparent to AppKit hit-testing"
 
 require_pattern \
-    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
+    "clients/apple/alan-macos/Services/Terminal/GhosttyPlatformAdapters.swift" \
     "override var mouseDownCanMoveWindow: Bool \\{ false \\}" \
     "Ghostty canvas views must not allow terminal pane clicks to drag the shell window"
 
 require_pattern \
-    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
+    "clients/apple/alan-macos/Services/Terminal/GhosttyPlatformAdapters.swift" \
     "override func hitTest\\(_ point: NSPoint\\) -> NSView\\? \\{ nil \\}" \
     "Ghostty canvas views must be transparent to AppKit hit-testing"
 


### PR DESCRIPTION
## Summary
- move macOS-specific Ghostty key codes, clipboard access, app-focus observation, transparent canvas ownership, and display lookup into Services/Terminal/GhosttyPlatformAdapters.swift
- keep AlanGhosttyLiveHost focused on Ghostty app and surface lifecycle, callback assembly, and renderer coordination
- reduce GhosttyLiveHost.swift from 1,258 to 1,179 lines and ratchet the Apple architecture warning ledger from 6 to 5

## Validation
- just quality
- just test
- just apple-shell-focused-tests
- openspec validate --all --strict
- just install-dev
- codesign --verify --deep --strict --verbose=4 ~/Applications/Alan\ Dev.app
- just apple-shell-ui-smoke
- visually inspected launch, split-pane, terminal input, and restart-restore screenshots

The inherited direct check-shell-contracts.sh failure remains limited to the already tracked optional shell-core FFI fallback debt for OpenSpec 4.4; the canonical quality gate passes.

## Stack
- base: #806
- OpenSpec: refactor-clean-code-architecture-debt, first 4.3 terminal-host ownership slice