### PR TITLE
refactor(agent-engine): privatize machine state

### DIFF
--- a/crates/agent-engine/src/agent_machine.rs
+++ b/crates/agent-engine/src/agent_machine.rs
@@ -44,15 +44,15 @@ pub struct ResponsesContinuationState {
 
 /// Transition state for one Agent Process.
 #[derive(Debug)]
-pub struct AgentMachine {
+pub(crate) struct AgentMachine {
     /// Conversation history and summary
-    pub tape: Tape,
+    tape: Tape,
     /// Optional recorder for persistence
-    pub recorder: Option<RolloutRecorder>,
+    recorder: Option<RolloutRecorder>,
     /// Per-Process durable-record discriminator used by generated Memory Store paths.
     memory_record_id: String,
     /// Whether a sourcing task has been started in this machine
-    pub has_active_task: bool,
+    has_active_task: bool,
     /// Latest effect record by idempotency key (used for side-effect dedupe).
     effect_index: HashMap<String, EffectRecord>,
     /// Last prompt snapshot fingerprint written to rollout (used to skip duplicates).
@@ -92,6 +92,102 @@ impl AgentMachine {
         }
     }
 
+    pub(crate) fn messages(&self) -> &[Message] {
+        self.tape.messages()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn messages_for_prompt(&self) -> Vec<Message> {
+        self.tape.messages_for_prompt()
+    }
+
+    pub(crate) fn prompt_view(&self) -> crate::tape::PromptContextView {
+        self.tape.prompt_view()
+    }
+
+    pub(crate) fn tape_summary(&self) -> Option<&str> {
+        self.tape.summary()
+    }
+
+    pub(crate) fn tape_len(&self) -> usize {
+        self.tape.len()
+    }
+
+    pub(crate) fn tape_is_empty(&self) -> bool {
+        self.tape.is_empty()
+    }
+
+    pub(crate) fn estimated_prompt_tokens(&self) -> usize {
+        self.tape.estimated_prompt_tokens()
+    }
+
+    pub(crate) fn context_items(&self) -> &[ContextItem] {
+        self.tape.context_items()
+    }
+
+    pub(crate) fn last_context_delta(&self) -> &ContextItemsDelta {
+        self.tape.last_context_delta()
+    }
+
+    pub(crate) fn context_revision(&self) -> u64 {
+        self.tape.context_revision()
+    }
+
+    pub(crate) fn compaction_count(&self) -> usize {
+        self.tape.compaction_count()
+    }
+
+    pub(crate) fn compaction_retention_start(&self, keep_last: usize) -> usize {
+        self.tape.compaction_retention_start(keep_last)
+    }
+
+    pub(crate) fn compact_tape(&mut self, summary: String, keep_last: usize) {
+        self.tape.compact(summary, keep_last);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn push_tape_message(&mut self, message: Message) {
+        self.tape.push(message);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_tape_summary(&mut self, summary: String) {
+        self.tape.set_summary(summary);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn apply_context_items_for_test(&mut self, items: Vec<ContextItem>) {
+        let _ = self.tape.apply_context_items(items);
+    }
+
+    pub(crate) fn activate_task(&mut self) {
+        self.has_active_task = true;
+    }
+
+    pub(crate) fn clear_active_task(&mut self) {
+        self.has_active_task = false;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_active_task(&self) -> bool {
+        self.has_active_task
+    }
+
+    pub(crate) fn rollout_id(&self) -> Option<&str> {
+        self.recorder.as_ref().map(RolloutRecorder::rollout_id)
+    }
+
+    pub(crate) fn is_durable(&self) -> bool {
+        self.recorder.is_some()
+    }
+
+    pub(crate) async fn flush_recorder(&self) -> anyhow::Result<()> {
+        match self.recorder.as_ref() {
+            Some(recorder) => recorder.flush().await,
+            None => Ok(()),
+        }
+    }
+
     pub(crate) async fn new_with_recorder_options(
         process_path: &str,
         model: &str,
@@ -128,6 +224,7 @@ impl AgentMachine {
     }
 
     /// Create a new machine with recorder under a specific rollouts directory.
+    #[cfg(test)]
     pub async fn new_with_recorder_in_dir(
         process_path: &str,
         model: &str,
@@ -137,6 +234,7 @@ impl AgentMachine {
     }
 
     /// Add a user message to the machine
+    #[cfg(test)]
     pub fn add_user_message(&mut self, content: &str) {
         self.add_user_message_parts(vec![crate::tape::ContentPart::text(content)]);
     }
@@ -171,6 +269,7 @@ impl AgentMachine {
     }
 
     /// Add an assistant message to the machine
+    #[cfg(test)]
     pub fn add_assistant_message(&mut self, content: &str, thinking: Option<&str>) {
         self.add_assistant_message_with_reasoning(content, thinking, None, &[]);
     }
@@ -213,22 +312,6 @@ impl AgentMachine {
         {
             error!(error = %err, "Failed to record assistant message");
         }
-    }
-
-    /// Add an assistant message with tool calls to the machine
-    pub fn add_assistant_message_with_tool_calls(
-        &mut self,
-        content: &str,
-        tool_calls: Vec<crate::tape::ToolRequest>,
-        thinking: Option<&str>,
-    ) {
-        self.add_assistant_message_with_tool_calls_and_reasoning(
-            content,
-            tool_calls,
-            thinking,
-            None,
-            &[],
-        );
     }
 
     /// Add an assistant message with tool calls and full reasoning metadata.
@@ -388,6 +471,7 @@ impl AgentMachine {
         self.responses_continuation.as_ref()
     }
 
+    #[cfg(test)]
     pub fn mark_responses_continuation(
         &mut self,
         provider: &str,
@@ -438,6 +522,7 @@ impl AgentMachine {
     }
 
     /// Clear the machine state (but keep the recorder)
+    #[cfg(test)]
     pub fn clear(&mut self) {
         self.tape.clear();
         self.has_active_task = false;
@@ -562,6 +647,7 @@ impl AgentMachine {
     }
 
     /// Count user turns currently present on the tape.
+    #[cfg(test)]
     pub fn user_turn_count(&self) -> usize {
         self.tape
             .messages()
@@ -576,6 +662,7 @@ impl AgentMachine {
     }
 
     /// Latest persisted compaction attempt, if any.
+    #[cfg(test)]
     pub fn latest_compaction_attempt(&self) -> Option<&CompactionAttemptSnapshot> {
         self.latest_compaction_attempt.as_ref()
     }
@@ -607,6 +694,7 @@ impl AgentMachine {
     }
 
     /// Record a checkpoint to persistence (enqueue only; background writer performs IO)
+    #[cfg(test)]
     pub fn record_checkpoint(
         &self,
         checkpoint_id: &str,
@@ -664,6 +752,7 @@ impl AgentMachine {
     }
 
     /// Record a compaction summary to persistence (enqueue only; background writer performs IO)
+    #[cfg(test)]
     pub fn record_summary(&self, summary: &str) {
         self.record_compaction(CompactedItem::new(summary));
     }
@@ -673,6 +762,7 @@ impl AgentMachine {
     /// This low-level API persists only the compacted summary item. For tape-mutating compaction
     /// results, prefer [`AgentMachine::persist_compaction_observation`] so related rollout items are
     /// flushed together.
+    #[cfg(test)]
     pub(crate) fn record_compaction(&self, compacted: CompactedItem) {
         if let Some(recorder) = self.recorder.as_ref()
             && let Err(err) = recorder.record_compacted_item_nowait(compacted)
@@ -721,6 +811,7 @@ impl AgentMachine {
         clippy::too_many_arguments,
         reason = "arguments map directly to the durable turn-context record fields"
     )]
+    #[cfg(test)]
     pub fn record_turn_context(
         &self,
         model: &str,

--- a/crates/agent-engine/src/agent_machine/recovery.rs
+++ b/crates/agent-engine/src/agent_machine/recovery.rs
@@ -165,16 +165,8 @@ impl AgentMachine {
         compacted
     }
 
-    /// Load a machine from a rollout file
-    pub async fn load_from_rollout(
-        path: &PathBuf,
-        process_path: &str,
-        model: &str,
-    ) -> anyhow::Result<Self> {
-        Self::load_from_rollout_impl(path, process_path, model, None, None, None).await
-    }
-
     /// Load a machine from a rollout file, writing future persistence to a specific rollouts dir.
+    #[cfg(test)]
     pub async fn load_from_rollout_in_dir(
         path: &PathBuf,
         process_path: &str,
@@ -288,8 +280,8 @@ impl AgentMachine {
             }
         }
 
-        if !machine.tape.is_empty() {
-            machine.has_active_task = true;
+        if !machine.tape_is_empty() {
+            machine.activate_task();
         }
 
         if !context_items.is_empty() {
@@ -319,7 +311,7 @@ impl AgentMachine {
             machine.user_turn_ordinal = machine.user_turn_ordinal.max(max_effect_turn);
         }
 
-        let recovered_messages = machine.tape.messages().to_vec();
+        let recovered_messages = machine.messages().to_vec();
         if (!recovered_messages.is_empty()
             || recovered_compaction.is_some()
             || !compaction_attempt_records.is_empty()

--- a/crates/agent-engine/src/agent_machine_persistence_tests.rs
+++ b/crates/agent-engine/src/agent_machine_persistence_tests.rs
@@ -5,7 +5,7 @@ fn test_empty_message_content() {
     let mut machine = AgentMachine::new();
     machine.add_user_message("");
 
-    let messages = machine.tape.messages();
+    let messages = machine.messages();
     assert_eq!(messages[0].text_content(), "");
 }
 
@@ -14,7 +14,7 @@ fn test_unicode_message_content() {
     let mut machine = AgentMachine::new();
     machine.add_user_message("你好，世界！🌍");
 
-    let messages = machine.tape.messages();
+    let messages = machine.messages();
     assert_eq!(messages[0].text_content(), "你好，世界！🌍");
 }
 
@@ -78,7 +78,7 @@ async fn test_flush() {
 fn test_add_user_message_with_tool_name() {
     let mut machine = AgentMachine::new();
     machine.add_user_message("Hello");
-    let messages = machine.tape.messages();
+    let messages = machine.messages();
     assert!(messages[0].is_user());
 }
 

--- a/crates/agent-engine/src/agent_machine_recovery_tests.rs
+++ b/crates/agent-engine/src/agent_machine_recovery_tests.rs
@@ -52,8 +52,8 @@ fn test_load_from_rollout_prefers_rich_message_payload_when_available() {
         .await
         .unwrap();
 
-        assert_eq!(machine.tape.messages().len(), 1);
-        let message = &machine.tape.messages()[0];
+        assert_eq!(machine.messages().len(), 1);
+        let message = &machine.messages()[0];
         assert_eq!(
             message.thinking_content().as_deref(),
             Some("internal reasoning")
@@ -106,7 +106,7 @@ fn test_load_from_rollout_recovers_complete_records_before_torn_tail() {
         .await
         .unwrap();
 
-        assert_eq!(machine.tape.messages(), &[Message::user("survives crash")]);
+        assert_eq!(machine.messages(), &[Message::user("survives crash")]);
     });
 }
 

--- a/crates/agent-engine/src/agent_machine_tape_tests.rs
+++ b/crates/agent-engine/src/agent_machine_tape_tests.rs
@@ -3,14 +3,14 @@ use super::*;
 #[test]
 fn test_agent_machine_new() {
     let machine = AgentMachine::new();
-    assert!(machine.tape.messages().is_empty());
-    assert!(machine.recorder.is_none());
+    assert!(machine.messages().is_empty());
+    assert!(!machine.is_durable());
 }
 
 #[test]
 fn test_agent_machine_default() {
     let machine = AgentMachine::default();
-    assert!(machine.tape.messages().is_empty());
+    assert!(machine.messages().is_empty());
 }
 
 #[test]
@@ -18,7 +18,7 @@ fn test_add_user_message() {
     let mut machine = AgentMachine::new();
     machine.add_user_message("Hello, agent!");
 
-    let messages = machine.tape.messages();
+    let messages = machine.messages();
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0].role(), MessageRole::User);
     assert_eq!(messages[0].text_content(), "Hello, agent!");
@@ -62,7 +62,7 @@ fn test_add_assistant_message() {
     let mut machine = AgentMachine::new();
     machine.add_assistant_message("I can help you!", None);
 
-    let messages = machine.tape.messages();
+    let messages = machine.messages();
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0].role(), MessageRole::Assistant);
     assert_eq!(messages[0].text_content(), "I can help you!");
@@ -74,7 +74,7 @@ fn test_add_tool_message() {
     let payload = serde_json::json!({"result": "success"});
     machine.add_tool_message("call_123", "search_tool", payload);
 
-    let messages = machine.tape.messages();
+    let messages = machine.messages();
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0].role(), MessageRole::Tool);
     let responses = messages[0].tool_responses();
@@ -93,7 +93,7 @@ fn test_add_tool_message_accepts_content_parts_payload() {
     });
     machine.add_tool_message("call_123", "capture", payload);
 
-    let messages = machine.tape.messages();
+    let messages = machine.messages();
     assert_eq!(messages.len(), 1);
     let responses = messages[0].tool_responses();
     assert_eq!(responses.len(), 1);
@@ -118,7 +118,7 @@ fn test_add_tool_message_accepts_content_parts_array_payload() {
     ]);
     machine.add_tool_message("call_124", "custom", payload);
 
-    let messages = machine.tape.messages();
+    let messages = machine.messages();
     assert_eq!(messages.len(), 1);
     let responses = messages[0].tool_responses();
     assert_eq!(responses.len(), 1);
@@ -155,7 +155,7 @@ fn test_multiple_messages() {
     machine.add_assistant_message("Second", None);
     machine.add_user_message("Third");
 
-    let messages = machine.tape.messages();
+    let messages = machine.messages();
     assert_eq!(messages.len(), 3);
     assert_eq!(messages[0].role(), MessageRole::User);
     assert_eq!(messages[1].role(), MessageRole::Assistant);
@@ -169,7 +169,7 @@ fn test_clear_machine() {
 
     machine.clear();
 
-    assert!(machine.tape.messages().is_empty());
+    assert!(machine.messages().is_empty());
 }
 
 #[test]
@@ -231,15 +231,15 @@ fn test_machine_rollout_path_without_recorder() {
 #[test]
 fn test_machine_has_active_task_defaults_false() {
     let machine = AgentMachine::new();
-    assert!(!machine.has_active_task);
+    assert!(!machine.has_active_task());
 }
 
 #[test]
 fn test_machine_clear_resets_active_task() {
     let mut machine = AgentMachine::new();
-    machine.has_active_task = true;
+    machine.activate_task();
     machine.clear();
-    assert!(!machine.has_active_task);
+    assert!(!machine.has_active_task());
 }
 
 #[test]
@@ -311,7 +311,7 @@ fn test_add_tool_message_preserves_large_payload_on_tape() {
 
     machine.add_tool_message("call_456", "test_tool", payload);
 
-    let messages = machine.tape.messages();
+    let messages = machine.messages();
     assert_eq!(messages.len(), 1);
     let responses = messages[0].tool_responses();
     assert_eq!(responses.len(), 1);
@@ -452,7 +452,7 @@ fn test_rollback_last_turns_removes_latest_turn_messages() {
 
     assert_eq!(removed.removed_turns, 1);
     assert_eq!(removed.removed_messages, 2);
-    let messages = machine.tape.messages();
+    let messages = machine.messages();
     assert_eq!(messages.len(), 3);
     assert_eq!(messages[0].text_content(), "u1");
     assert_eq!(messages[1].text_content(), "a1");
@@ -464,14 +464,14 @@ fn test_rollback_last_turns_clears_all_when_request_exceeds_history() {
     let mut machine = AgentMachine::new();
     machine.add_user_message("u1");
     machine.add_assistant_message("a1", None);
-    machine.has_active_task = true;
+    machine.activate_task();
 
     let removed = machine.rollback_last_turns(10);
 
     assert_eq!(removed.removed_turns, 1);
     assert_eq!(removed.removed_messages, 2);
-    assert!(machine.tape.messages().is_empty());
-    assert!(!machine.has_active_task);
+    assert!(machine.messages().is_empty());
+    assert!(!machine.has_active_task());
 }
 
 #[test]
@@ -498,7 +498,7 @@ fn test_rollback_last_turns_ignores_control_user_messages_for_turn_boundaries() 
         "rollback should anchor on the real user turn, not synthetic control messages"
     );
     assert_eq!(removed.removed_turns, 1);
-    assert!(machine.tape.messages().is_empty());
+    assert!(machine.messages().is_empty());
 }
 
 #[test]
@@ -525,5 +525,5 @@ fn test_rollback_last_turns_ignores_effect_replay_control_messages_for_turn_boun
         "rollback should ignore effect replay control messages the same way as policy controls"
     );
     assert_eq!(removed.removed_turns, 1);
-    assert!(machine.tape.messages().is_empty());
+    assert!(machine.messages().is_empty());
 }

--- a/crates/agent-engine/src/lib.rs
+++ b/crates/agent-engine/src/lib.rs
@@ -32,7 +32,7 @@ pub mod tools;
 
 pub use agent_definition::ResolvedAgentDefinition;
 pub use agent_machine::{
-    AgentMachine, ROLLBACK_NON_DURABLE_WARNING, latest_compaction_attempt_from_rollout_items,
+    ROLLBACK_NON_DURABLE_WARNING, latest_compaction_attempt_from_rollout_items,
     latest_memory_flush_attempt_from_rollout_items,
 };
 pub use config::{

--- a/crates/agent-engine/src/llm.rs
+++ b/crates/agent-engine/src/llm.rs
@@ -386,7 +386,7 @@ mod tests {
 
         let mut machine = crate::agent_machine::AgentMachine::new();
         machine.add_assistant_message("hi", Some("openrouter thinking"));
-        let messages = machine.tape.messages();
+        let messages = machine.messages();
         let projected = client.project_messages(messages);
         assert_eq!(
             projected[0].thinking.as_deref(),
@@ -423,7 +423,7 @@ mod tests {
         // The Responses path preserves thinking metadata when available.
         let mut machine = crate::agent_machine::AgentMachine::new();
         machine.add_assistant_message("hi", Some("thinking..."));
-        let messages = machine.tape.messages();
+        let messages = machine.messages();
         let projected = client.project_messages(messages);
         assert_eq!(projected[0].thinking.as_deref(), Some("thinking..."));
     }

--- a/crates/agent-engine/src/llm/input_projection_tests.rs
+++ b/crates/agent-engine/src/llm/input_projection_tests.rs
@@ -153,7 +153,7 @@ fn thinking_projection_preserves_or_drops_all_reasoning_metadata() {
         &["ciphertext".to_string()],
     );
 
-    let preserved = project_messages(machine.tape.messages(), true);
+    let preserved = project_messages(machine.messages(), true);
     assert_eq!(preserved[0].thinking.as_deref(), Some("my reasoning"));
     assert_eq!(preserved[0].thinking_signature.as_deref(), Some("sig_123"));
     assert_eq!(
@@ -161,7 +161,7 @@ fn thinking_projection_preserves_or_drops_all_reasoning_metadata() {
         Some(vec!["ciphertext".to_string()])
     );
 
-    let dropped = project_messages(machine.tape.messages(), false);
+    let dropped = project_messages(machine.messages(), false);
     assert_eq!(dropped[0].content, "hello");
     assert_eq!(dropped[0].thinking, None);
     assert_eq!(dropped[0].thinking_signature, None);

--- a/crates/agent-engine/src/runtime/agent_loop.rs
+++ b/crates/agent-engine/src/runtime/agent_loop.rs
@@ -282,7 +282,7 @@ where
                 },
             );
             if activate_task {
-                state.machine.has_active_task = true;
+                state.machine.activate_task();
             }
             Ok(())
         }

--- a/crates/agent-engine/src/runtime/agent_loop/namespace_environment/tests.rs
+++ b/crates/agent-engine/src/runtime/agent_loop/namespace_environment/tests.rs
@@ -426,7 +426,7 @@ async fn answered_request_response_resumes_engine_pending_yield_from_files() {
         questions: Vec::new(),
     });
     let mut state = super::super::RuntimeLoopState {
-        machine: crate::AgentMachine::new(),
+        machine: crate::agent_machine::AgentMachine::new(),
         current_submission_id: None,
         environment,
         core_config: crate::Config::default(),
@@ -460,7 +460,7 @@ async fn answered_request_response_resumes_engine_pending_yield_from_files() {
     );
     assert!(!state.turn_state.has_pending_interaction());
     assert!(events.is_empty());
-    let messages = state.machine.tape.messages();
+    let messages = state.machine.messages();
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0].tool_responses()[0].id, "r0");
     assert_eq!(

--- a/crates/agent-engine/src/runtime/agent_loop/tests.rs
+++ b/crates/agent-engine/src/runtime/agent_loop/tests.rs
@@ -546,7 +546,6 @@ fn memory_flush_json_response() -> String {
 
 fn stateful_messages_snapshot(machine: &AgentMachine) -> Vec<String> {
     machine
-        .tape
         .messages()
         .iter()
         .map(crate::tape::Message::text_content)

--- a/crates/agent-engine/src/runtime/agent_loop/tests/compaction_recovery.rs
+++ b/crates/agent-engine/src/runtime/agent_loop/tests/compaction_recovery.rs
@@ -205,9 +205,7 @@ async fn test_compaction_generation_failure_uses_degraded_fallback_and_audits_it
     }
     assert!(
         state
-            .machine
-            .tape
-            .summary()
+            .machine.tape_summary()
             .is_some_and(|summary| summary.contains("Deterministic fallback summary"))
     );
     assert!(events.iter().any(|event| {
@@ -267,9 +265,7 @@ async fn test_degraded_compaction_rebases_active_turn_start() {
     };
 
     let retention_start = state
-        .machine
-        .tape
-        .compaction_retention_start(state.runtime_config.compaction_keep_last);
+        .machine.compaction_retention_start(state.runtime_config.compaction_keep_last);
     assert!(retention_start > 0);
     state.turn_state.begin_turn(retention_start);
 
@@ -327,7 +323,7 @@ async fn test_compaction_failure_without_fallback_escalates_warning_and_preserve
             .await
             .unwrap();
     for _ in 0..65 {
-        machine.tape.push(crate::tape::Message::assistant(""));
+        machine.push_tape_message(crate::tape::Message::assistant(""));
     }
 
     let original_messages = stateful_messages_snapshot(&machine);
@@ -368,7 +364,7 @@ async fn test_compaction_failure_without_fallback_escalates_warning_and_preserve
         stateful_messages_snapshot(&state.machine),
         original_messages
     );
-    assert!(state.machine.tape.summary().is_none());
+    assert!(state.machine.tape_summary().is_none());
 
     let warning_messages: Vec<&str> = events
         .iter()

--- a/crates/agent-engine/src/runtime/agent_loop/tests/compaction_thresholds.rs
+++ b/crates/agent-engine/src/runtime/agent_loop/tests/compaction_thresholds.rs
@@ -119,15 +119,15 @@ async fn test_maybe_compact_context_triggers_on_estimated_token_budget() {
     .await;
 
     assert!(result.is_ok());
-    assert_eq!(state.machine.tape.len(), 1);
-    let prompt_messages = state.machine.tape.messages_for_prompt();
+    assert_eq!(state.machine.tape_len(), 1);
+    let prompt_messages = state.machine.messages_for_prompt();
     assert!(prompt_messages.iter().any(|m| {
         m.is_context()
             && m.text_content()
                 .contains("Summary from token-triggered compaction")
     }));
     assert_eq!(
-        state.machine.tape.messages()[0].text_content(),
+        state.machine.messages()[0].text_content(),
         "y".repeat(1200)
     );
 }
@@ -172,15 +172,15 @@ async fn test_maybe_compact_context_triggers_immediately_when_ratio_is_zero() {
     .await;
 
     assert!(result.is_ok());
-    assert_eq!(state.machine.tape.len(), 1);
-    let prompt_messages = state.machine.tape.messages_for_prompt();
+    assert_eq!(state.machine.tape_len(), 1);
+    let prompt_messages = state.machine.messages_for_prompt();
     assert!(prompt_messages.iter().any(|m| {
         m.is_context()
             && m.text_content()
                 .contains("Summary from zero-ratio compaction")
     }));
     assert_eq!(
-        state.machine.tape.messages()[0].text_content(),
+        state.machine.messages()[0].text_content(),
         "y".repeat(1200)
     );
 }
@@ -216,7 +216,7 @@ async fn test_maybe_compact_context_skips_when_context_window_budget_has_room() 
         turn_state: TurnState::default(),
     };
 
-    let original_len = state.machine.tape.len();
+    let original_len = state.machine.tape_len();
     let mut emit = |_event: Event| async {};
     let result = maybe_compact_context_for_request(
         &mut state,
@@ -226,8 +226,8 @@ async fn test_maybe_compact_context_skips_when_context_window_budget_has_room() 
     .await;
 
     assert!(result.is_ok());
-    assert_eq!(state.machine.tape.len(), original_len);
-    assert!(state.machine.tape.summary().is_none());
+    assert_eq!(state.machine.tape_len(), original_len);
+    assert!(state.machine.tape_summary().is_none());
 }
 
 #[tokio::test]
@@ -249,7 +249,7 @@ async fn test_auto_pre_turn_soft_compaction_flushes_memory_before_compaction() {
         );
     }
 
-    let estimated_prompt_tokens = machine.tape.estimated_prompt_tokens();
+    let estimated_prompt_tokens = machine.estimated_prompt_tokens();
     let runtime_config = super::RuntimeConfig {
         compaction_trigger_messages: 100,
         compaction_keep_last: 1,
@@ -342,7 +342,7 @@ async fn test_auto_pre_turn_soft_compaction_continues_after_memory_flush_failure
         );
     }
 
-    let estimated_prompt_tokens = machine.tape.estimated_prompt_tokens();
+    let estimated_prompt_tokens = machine.estimated_prompt_tokens();
     let runtime_config = super::RuntimeConfig {
         compaction_trigger_messages: 100,
         compaction_keep_last: 1,
@@ -438,7 +438,7 @@ async fn test_auto_pre_turn_soft_compaction_skips_memory_flush_when_nothing_is_d
         );
     }
 
-    let estimated_prompt_tokens = machine.tape.estimated_prompt_tokens();
+    let estimated_prompt_tokens = machine.estimated_prompt_tokens();
     let runtime_config = super::RuntimeConfig {
         compaction_trigger_messages: 100,
         compaction_keep_last: 1,
@@ -538,7 +538,7 @@ async fn test_auto_pre_turn_soft_compaction_records_already_flushed_cycle_skip()
     }
     machine.note_auto_memory_flush_attempt();
 
-    let estimated_prompt_tokens = machine.tape.estimated_prompt_tokens();
+    let estimated_prompt_tokens = machine.estimated_prompt_tokens();
     let runtime_config = super::RuntimeConfig {
         compaction_trigger_messages: 100,
         compaction_keep_last: 1,
@@ -631,7 +631,7 @@ async fn test_auto_pre_turn_hard_compaction_skips_memory_flush() {
         );
     }
 
-    let estimated_prompt_tokens = machine.tape.estimated_prompt_tokens();
+    let estimated_prompt_tokens = machine.estimated_prompt_tokens();
     let runtime_config = super::RuntimeConfig {
         compaction_trigger_messages: 100,
         compaction_keep_last: 1,
@@ -736,7 +736,7 @@ async fn test_manual_compaction_bypasses_automatic_thresholds_without_memory_flu
             .any(|event| matches!(event, Event::MemoryFlushObserved { .. }))
     );
     assert_eq!(
-        state.machine.tape.summary(),
+        state.machine.tape_summary(),
         Some("Manual compaction below threshold")
     );
 }
@@ -751,7 +751,7 @@ async fn test_maybe_compact_context_allows_mid_turn_emergency_near_hard_limit() 
     let mut machine = AgentMachine::new();
     machine.add_user_message(&"x".repeat(1200));
     machine.add_assistant_message(&"y".repeat(1200), None);
-    let estimated_prompt_tokens = machine.tape.estimated_prompt_tokens();
+    let estimated_prompt_tokens = machine.estimated_prompt_tokens();
 
     let mut runtime_config = super::RuntimeConfig::default();
     runtime_config.compaction_trigger_messages = 100;
@@ -783,7 +783,7 @@ async fn test_maybe_compact_context_allows_mid_turn_emergency_near_hard_limit() 
 
     assert!(matches!(result, Ok(CompactionOutcome::Applied(_))));
     assert_eq!(
-        state.machine.tape.summary(),
+        state.machine.tape_summary(),
         Some("Summary from emergency mid-turn compaction")
     );
 }

--- a/crates/agent-engine/src/runtime/agent_loop/tests/core_behaviors.rs
+++ b/crates/agent-engine/src/runtime/agent_loop/tests/core_behaviors.rs
@@ -167,7 +167,7 @@ async fn test_cancel_current_task() {
         },
     };
     state.machine.add_user_message("existing history");
-    state.machine.has_active_task = true;
+    state.machine.activate_task();
 
     let mut events = vec![];
     let mut emit = |event: Event| {
@@ -179,10 +179,10 @@ async fn test_cancel_current_task() {
 
     assert!(result.is_ok());
     assert!(state.turn_state.pending_confirmation().is_none());
-    assert!(!state.machine.has_active_task);
-    assert_eq!(state.machine.tape.messages().len(), 1);
+    assert!(!state.machine.has_active_task());
+    assert_eq!(state.machine.messages().len(), 1);
     assert_eq!(
-        state.machine.tape.messages()[0].text_content(),
+        state.machine.messages()[0].text_content(),
         "existing history"
     );
 

--- a/crates/agent-engine/src/runtime/agent_loop/tests/submissions.rs
+++ b/crates/agent-engine/src/runtime/agent_loop/tests/submissions.rs
@@ -8,7 +8,7 @@ async fn test_handle_submission_cancel() {
     let config = Config::default();
     let mut machine = AgentMachine::new();
     machine.add_user_message("existing history");
-    machine.has_active_task = true;
+    machine.activate_task();
     let runtime_config = super::RuntimeConfig::default();
 
     let mut state = RuntimeLoopState {
@@ -38,12 +38,12 @@ async fn test_handle_submission_cancel() {
 
     assert!(result.is_ok(), "interrupt should succeed: {result:?}");
     assert_eq!(events.len(), 1);
-    assert_eq!(state.machine.tape.messages().len(), 1);
+    assert_eq!(state.machine.messages().len(), 1);
     assert_eq!(
-        state.machine.tape.messages()[0].text_content(),
+        state.machine.messages()[0].text_content(),
         "existing history"
     );
-    assert!(!state.machine.has_active_task);
+    assert!(!state.machine.has_active_task());
     match &events[0] {
         Event::TurnCompleted { summary } => {
             assert_eq!(summary.as_deref(), Some("Task cancelled by user"));
@@ -64,7 +64,7 @@ async fn test_handle_submission_rollback() {
     machine.add_assistant_message("a1", None);
     machine.add_user_message("u2");
     machine.add_assistant_message("a2", None);
-    machine.has_active_task = true;
+    machine.activate_task();
     let runtime_config = super::RuntimeConfig::default();
 
     let mut state = RuntimeLoopState {
@@ -92,7 +92,7 @@ async fn test_handle_submission_rollback() {
     let result = handle_submission(&mut state, submission, &mut emit).await;
 
     assert!(result.is_ok());
-    assert_eq!(state.machine.tape.messages().len(), 2);
+    assert_eq!(state.machine.messages().len(), 2);
     assert_eq!(events.len(), 3);
     assert!(events.iter().any(|event| matches!(
         event,

--- a/crates/agent-engine/src/runtime/child_agents/task_context.rs
+++ b/crates/agent-engine/src/runtime/child_agents/task_context.rs
@@ -52,14 +52,13 @@ fn render_launch_metadata(spec: &SpawnSpec) -> Option<String> {
 
 fn render_conversation_snapshot(parent: &RuntimeLoopState) -> Option<String> {
     let mut lines = Vec::new();
-    if let Some(summary) = parent.machine.tape.summary() {
+    if let Some(summary) = parent.machine.tape_summary() {
         lines.push("Summary:".to_string());
         lines.push(truncate_chars(summary.trim(), MAX_CHILD_CONVERSATION_CHARS));
     }
 
     let recent_messages = parent
         .machine
-        .tape
         .messages()
         .iter()
         .rev()
@@ -124,7 +123,6 @@ fn render_tool_results_snapshot(parent: &RuntimeLoopState) -> Option<String> {
     let mut lines = Vec::new();
     for message in parent
         .machine
-        .tape
         .messages()
         .iter()
         .rev()

--- a/crates/agent-engine/src/runtime/child_agents/tests.rs
+++ b/crates/agent-engine/src/runtime/child_agents/tests.rs
@@ -488,7 +488,7 @@ fn make_parent_state_with_capability_view(
     let mut core_config = crate::Config::default();
     core_config.memory.store_dir = Some(memory_store.clone());
     core_config.openai_responses_model = "gpt-5.4".to_string();
-    let mut machine = crate::AgentMachine::new();
+    let mut machine = crate::agent_machine::AgentMachine::new();
     machine.add_user_message("Parent user asks for review");
     machine.add_assistant_message("Parent assistant explains the approach", None);
     machine.add_tool_message("tool_call_1", "alpha", json!({"summary": "tool output"}));

--- a/crates/agent-engine/src/runtime/compaction.rs
+++ b/crates/agent-engine/src/runtime/compaction.rs
@@ -404,10 +404,10 @@ where
         error_message,
         started_at,
     } = failure;
-    let reference_context_revision = state.machine.tape.context_revision();
+    let reference_context_revision = state.machine.context_revision();
 
     if let Some(summary) =
-        build_degraded_compaction_summary(sanitized_to_summarize, state.machine.tape.summary())
+        build_degraded_compaction_summary(sanitized_to_summarize, state.machine.tape_summary())
     {
         let attempt_id = uuid::Uuid::new_v4().to_string();
         let failure_streak = state.machine.note_compaction_failure();
@@ -423,11 +423,11 @@ where
         })
         .await;
 
-        let retention_start = state.machine.tape.compaction_retention_start(keep_last);
+        let retention_start = state.machine.compaction_retention_start(keep_last);
         apply_tape_compaction(state, &summary, keep_last, retention_start);
         state.machine.clear_responses_continuation("compaction");
-        let output_prompt_tokens = state.machine.tape.estimated_prompt_tokens();
-        let output_messages = state.machine.tape.len();
+        let output_prompt_tokens = state.machine.estimated_prompt_tokens();
+        let output_messages = state.machine.tape_len();
         let timestamp = chrono::Utc::now().to_rfc3339();
         let duration_ms = duration_ms_since(started_at);
         let attempt = build_compaction_attempt_snapshot(
@@ -448,7 +448,7 @@ where
                 error_message: Some(error_message),
                 failure_streak: Some(failure_streak),
                 reference_context_revision_before: Some(reference_context_revision),
-                reference_context_revision_after: Some(state.machine.tape.context_revision()),
+                reference_context_revision_after: Some(state.machine.context_revision()),
                 timestamp: timestamp.clone(),
             },
         );
@@ -524,7 +524,7 @@ fn apply_tape_compaction(
     keep_last: usize,
     retention_start: usize,
 ) {
-    state.machine.tape.compact(summary.to_string(), keep_last);
+    state.machine.compact_tape(summary.to_string(), keep_last);
     state.turn_state.note_tape_compaction(retention_start);
 }
 
@@ -552,10 +552,9 @@ where
     F: std::future::Future<Output = ()>,
 {
     let keep_last = state.runtime_config.compaction_keep_last;
-    let message_count = state.machine.tape.len();
+    let message_count = state.machine.tape_len();
     let estimated_prompt_tokens = state
         .machine
-        .tape
         .estimated_prompt_tokens()
         .saturating_add(request.additional_prompt_tokens());
     let pressure = evaluate_compaction_pressure(
@@ -583,8 +582,8 @@ where
         ));
     }
 
-    let messages = state.machine.tape.messages().to_vec();
-    let retention_start = state.machine.tape.compaction_retention_start(keep_last);
+    let messages = state.machine.messages().to_vec();
+    let retention_start = state.machine.compaction_retention_start(keep_last);
     let to_summarize = messages[..retention_start].to_vec();
 
     if to_summarize.is_empty() {
@@ -595,7 +594,7 @@ where
         ));
     }
 
-    let compaction_count = state.machine.tape.compaction_count();
+    let compaction_count = state.machine.compaction_count();
     let sanitized_to_summarize = sanitize_messages_for_compaction(&to_summarize);
     let memory_flush_attempt_id = maybe_flush_memory_before_compaction(
         state,
@@ -638,7 +637,7 @@ where
     let started_at = std::time::Instant::now();
     let mut llm_messages = Vec::new();
 
-    if let Some(existing_summary) = state.machine.tape.summary() {
+    if let Some(existing_summary) = state.machine.tape_summary() {
         llm_messages.push(crate::llm::Message::context(format!(
             "[Previous compaction summary (compaction #{})]\n{}",
             compaction_count, existing_summary
@@ -751,16 +750,15 @@ where
 
     let input_prompt_tokens = estimated_prompt_tokens;
     let success_result = compaction_success_result(trimmed_count);
-    let reference_context_revision = state.machine.tape.context_revision();
+    let reference_context_revision = state.machine.context_revision();
     let attempt_id = uuid::Uuid::new_v4().to_string();
     apply_tape_compaction(state, &summary, keep_last, retention_start);
     state.machine.clear_responses_continuation("compaction");
     let output_prompt_tokens = state
         .machine
-        .tape
         .estimated_prompt_tokens()
         .saturating_add(request.additional_prompt_tokens());
-    let output_messages = state.machine.tape.len();
+    let output_messages = state.machine.tape_len();
     let timestamp = chrono::Utc::now().to_rfc3339();
     let duration_ms = duration_ms_since(started_at);
     state.machine.reset_compaction_failure_streak();
@@ -782,7 +780,7 @@ where
             error_message: None,
             failure_streak: None,
             reference_context_revision_before: Some(reference_context_revision),
-            reference_context_revision_after: Some(state.machine.tape.context_revision()),
+            reference_context_revision_after: Some(state.machine.context_revision()),
             timestamp: timestamp.clone(),
         },
     );
@@ -939,7 +937,7 @@ mod tests {
 
         assert!(matches!(outcome, CompactionOutcome::Applied { .. }));
         assert_eq!(
-            state.machine.tape.summary(),
+            state.machine.tape_summary(),
             Some("namespace compaction summary")
         );
         let recorded = requests.lock().unwrap();

--- a/crates/agent-engine/src/runtime/delegated_skill_tool_tests.rs
+++ b/crates/agent-engine/src/runtime/delegated_skill_tool_tests.rs
@@ -93,7 +93,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill() {
         requirements.contains(&alan_agent_protocol::DelegatedCapabilityRequirement::LlmConnection)
     );
 
-    let prompt_view = state.machine.tape.prompt_view();
+    let prompt_view = state.machine.prompt_view();
     let tool_result = prompt_view
         .messages
         .iter()
@@ -334,7 +334,7 @@ Use this skill when asked.
         }
     ));
 
-    let prompt_view = state.machine.tape.prompt_view();
+    let prompt_view = state.machine.prompt_view();
     let tool_result = prompt_view
         .messages
         .iter()
@@ -559,7 +559,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_bounds_preview
     assert!(preview.chars().count() <= 163);
     assert!(preview.ends_with("..."));
 
-    let prompt_view = state.machine.tape.prompt_view();
+    let prompt_view = state.machine.prompt_view();
     let tool_result = prompt_view
         .messages
         .iter()
@@ -648,7 +648,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_honors_interru
         Event::TurnCompleted { summary: Some(summary) } if summary == "Task cancelled by user"
     )));
 
-    let prompt_view = state.machine.tape.prompt_view();
+    let prompt_view = state.machine.prompt_view();
     assert!(!prompt_view.messages.iter().any(|message| matches!(
         message,
         crate::tape::Message::Tool { responses }
@@ -708,7 +708,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_honors_interru
         Event::TurnCompleted { summary: Some(summary) } if summary == "Task cancelled by user"
     )));
 
-    let prompt_view = state.machine.tape.prompt_view();
+    let prompt_view = state.machine.prompt_view();
     assert!(!prompt_view.messages.iter().any(|message| matches!(
         message,
         crate::tape::Message::Tool { responses }
@@ -814,7 +814,7 @@ async fn test_try_handle_virtual_tool_call_rejects_target_mismatch() {
         }
     ));
 
-    let prompt_view = state.machine.tape.prompt_view();
+    let prompt_view = state.machine.prompt_view();
     let tool_result = prompt_view
         .messages
         .iter()

--- a/crates/agent-engine/src/runtime/engine.rs
+++ b/crates/agent-engine/src/runtime/engine.rs
@@ -291,13 +291,10 @@ async fn initialize_agent_machine(
         metadata: RuntimeStartupMetadata::ready(
             launch.process_path.to_string(),
             launch.agent_path.to_string(),
-            machine
-                .recorder
-                .as_ref()
-                .map(|recorder| recorder.rollout_id().to_string()),
+            machine.rollout_id().map(str::to_string),
             machine.rollout_path().cloned(),
             AgentMachineDurabilityState {
-                durable: machine.recorder.is_some(),
+                durable: machine.is_durable(),
                 required: durability_required,
             },
             request_controls,

--- a/crates/agent-engine/src/runtime/engine_runtime_tests.rs
+++ b/crates/agent-engine/src/runtime/engine_runtime_tests.rs
@@ -404,7 +404,7 @@ async fn test_outer_idle_reads_answered_namespace_request_response() {
         questions: Vec::new(),
     });
     let state = RuntimeLoopState {
-        machine: crate::AgentMachine::new(),
+        machine: crate::agent_machine::AgentMachine::new(),
         current_submission_id: None,
         environment: namespace_environment,
         core_config: crate::Config::default(),

--- a/crates/agent-engine/src/runtime/memory_flush.rs
+++ b/crates/agent-engine/src/runtime/memory_flush.rs
@@ -297,7 +297,7 @@ async fn generate_flush_content(
     cancel: &CancellationToken,
 ) -> Result<Option<MemoryFlushContent>> {
     let mut llm_messages = Vec::new();
-    if let Some(existing_summary) = state.machine.tape.summary() {
+    if let Some(existing_summary) = state.machine.tape_summary() {
         llm_messages.push(Message::context(format!(
             "[Current compaction summary]\n{existing_summary}"
         )));
@@ -637,7 +637,7 @@ mod tests {
         state
             .machine
             .add_user_message("remember this namespace fact");
-        let messages = state.machine.tape.messages().to_vec();
+        let messages = state.machine.messages().to_vec();
 
         let content = generate_flush_content(&mut state, &messages, &CancellationToken::new())
             .await

--- a/crates/agent-engine/src/runtime/memory_promotion.rs
+++ b/crates/agent-engine/src/runtime/memory_promotion.rs
@@ -267,7 +267,7 @@ pub(crate) fn build_turn_memory_promotion_job(
 
     let memory_dir = state.core_config.memory.store_dir.clone()?;
     let active_turn_user_messages = active_turn_user_messages(
-        state.machine.tape.messages(),
+        state.machine.messages(),
         state.turn_state.active_turn_message_start(),
     );
     if active_turn_user_messages.is_empty() {
@@ -380,7 +380,7 @@ async fn capture_confirmed_turn_memory_for_test(
     };
 
     let active_turn_user_messages =
-        active_turn_user_messages(machine.tape.messages(), active_turn_start);
+        active_turn_user_messages(machine.messages(), active_turn_start);
     if active_turn_user_messages.is_empty() {
         return Ok(());
     }

--- a/crates/agent-engine/src/runtime/memory_promotion/tests.rs
+++ b/crates/agent-engine/src/runtime/memory_promotion/tests.rs
@@ -480,7 +480,7 @@ async fn generate_memory_promotion_candidates_only_uses_active_turn_user_message
     machine.add_user_message("My name is Bob.");
     machine.add_assistant_message("Noted.", None);
 
-    let active_turn_start = machine.tape.messages().len();
+    let active_turn_start = machine.messages().len();
 
     machine.add_user_message("Please continue with the previous task.");
     let provider = MockLlmProvider::new().with_response(mock_generation_response(
@@ -489,7 +489,7 @@ async fn generate_memory_promotion_candidates_only_uses_active_turn_user_message
     let mut llm_client = LlmClient::new(provider.clone());
 
     let active_turn_user_messages =
-        active_turn_user_messages(machine.tape.messages(), Some(active_turn_start));
+        active_turn_user_messages(machine.messages(), Some(active_turn_start));
     let cancel = CancellationToken::new();
     let drafts = generate_memory_promotion_candidates(
         &mut llm_client,

--- a/crates/agent-engine/src/runtime/memory_surfaces.rs
+++ b/crates/agent-engine/src/runtime/memory_surfaces.rs
@@ -130,7 +130,6 @@ fn render_memory_surfaces(
 fn derive_current_goal(machine: &AgentMachine, turn_state: &TurnState) -> String {
     let source_ref = memory_source_ref(machine);
     let user_messages = machine
-        .tape
         .messages()
         .iter()
         .enumerate()
@@ -182,8 +181,7 @@ fn derive_current_goal(machine: &AgentMachine, turn_state: &TurnState) -> String
     }
 
     if let Some(summary) = machine
-        .tape
-        .summary()
+        .tape_summary()
         .map(str::trim)
         .filter(|summary| !summary.is_empty())
     {
@@ -284,8 +282,8 @@ fn derive_latest_assistant_state(machine: &AgentMachine, turn_state: &TurnState)
     let source_ref = memory_source_ref(machine);
     let messages = turn_state
         .active_turn_message_start()
-        .and_then(|start| machine.tape.messages().get(start..))
-        .unwrap_or_else(|| machine.tape.messages());
+        .and_then(|start| machine.messages().get(start..))
+        .unwrap_or_else(|| machine.messages());
 
     messages
         .iter()
@@ -347,7 +345,6 @@ fn format_plan_status(status: &alan_agent_protocol::PlanItemStatus) -> &'static 
 fn render_recent_messages(machine: &AgentMachine) -> String {
     let source_ref = memory_source_ref(machine);
     let items: Vec<String> = machine
-        .tape
         .messages()
         .iter()
         .filter_map(|message| match message {
@@ -383,8 +380,7 @@ fn render_recent_messages(machine: &AgentMachine) -> String {
 fn render_compaction_summary(machine: &AgentMachine) -> String {
     let source_ref = memory_source_ref(machine);
     machine
-        .tape
-        .summary()
+        .tape_summary()
         .map(str::trim)
         .filter(|summary| !summary.is_empty())
         .map(|summary| truncate_memory_text(summary, MAX_COMPACTION_SUMMARY_CHARS, &source_ref))

--- a/crates/agent-engine/src/runtime/memory_surfaces/tests.rs
+++ b/crates/agent-engine/src/runtime/memory_surfaces/tests.rs
@@ -86,7 +86,7 @@ fn render_memory_surfaces_scopes_latest_assistant_state_to_active_turn() {
     machine.add_assistant_message("Earlier assistant response.", None);
 
     let mut turn_state = TurnState::default();
-    turn_state.begin_turn(machine.tape.messages().len());
+    turn_state.begin_turn(machine.messages().len());
     machine.add_user_message("Current tool-only turn");
 
     let now = DateTime::parse_from_rfc3339("2026-04-15T15:30:00Z")
@@ -154,7 +154,7 @@ fn new_substantive_turn_request_replaces_stale_plan_goal() {
     machine.add_user_message("Finish the old memory task.");
     let mut turn_state = TurnState::default();
     turn_state.set_plan_snapshot(Some("Finish the old memory task.".to_string()), Vec::new());
-    turn_state.begin_turn(machine.tape.messages().len());
+    turn_state.begin_turn(machine.messages().len());
     machine.add_user_message("Rewrite the provider connection documentation.");
 
     assert_eq!(
@@ -167,7 +167,7 @@ fn new_substantive_turn_request_replaces_stale_plan_goal() {
 fn in_turn_plan_update_refines_the_initial_user_goal() {
     let mut machine = AgentMachine::new();
     let mut turn_state = TurnState::default();
-    turn_state.begin_turn(machine.tape.messages().len());
+    turn_state.begin_turn(machine.messages().len());
     machine.add_user_message("Implement the memory contract changes.");
     turn_state.set_plan_snapshot(
         Some("Validate salience and compaction fallback behavior.".to_string()),
@@ -184,7 +184,7 @@ fn in_turn_plan_update_refines_the_initial_user_goal() {
 fn substantive_resume_input_overrides_earlier_active_plan() {
     let mut machine = AgentMachine::new();
     let mut turn_state = TurnState::default();
-    turn_state.begin_turn(machine.tape.messages().len());
+    turn_state.begin_turn(machine.messages().len());
     machine.add_user_message("Implement the old memory contract.");
     turn_state.set_plan_snapshot(
         Some("Finish the old memory contract.".to_string()),
@@ -205,7 +205,7 @@ fn terse_imperative_passes_salience_filter() {
     machine.add_user_message("Prepare the release.");
     let mut turn_state = TurnState::default();
     turn_state.set_plan_snapshot(Some("Prepare the release.".to_string()), Vec::new());
-    turn_state.begin_turn(machine.tape.messages().len());
+    turn_state.begin_turn(machine.messages().len());
     machine.add_user_message("deploy it");
 
     assert_eq!(derive_current_goal(&machine, &turn_state), "deploy it");
@@ -219,9 +219,9 @@ fn active_plan_goal_wins_when_latest_message_is_acknowledgement() {
     turn_state.set_plan_snapshot_at_message_count(
         Some("Validate the namespace-native migration.".to_string()),
         Vec::new(),
-        machine.tape.messages().len(),
+        machine.messages().len(),
     );
-    turn_state.begin_turn(machine.tape.messages().len());
+    turn_state.begin_turn(machine.messages().len());
     machine.add_user_message("ok");
 
     assert_eq!(
@@ -238,7 +238,7 @@ fn later_substantive_goal_wins_before_stale_plan_on_acknowledgement() {
     turn_state.set_plan_snapshot_at_message_count(
         Some("Complete task A plan.".to_string()),
         Vec::new(),
-        machine.tape.messages().len(),
+        machine.messages().len(),
     );
     machine.add_assistant_message("Task A paused.", None);
     machine.add_user_message("Switch to substantive task B.");
@@ -254,7 +254,7 @@ fn later_substantive_goal_wins_before_stale_plan_on_acknowledgement() {
 #[test]
 fn compaction_summary_wins_before_acknowledgement_fallback() {
     let mut machine = AgentMachine::new();
-    machine.tape.set_summary(
+    machine.set_tape_summary(
         "Complete the namespace-native lifecycle migration and verify parent visibility."
             .to_string(),
     );
@@ -421,7 +421,7 @@ async fn refresh_memory_surfaces_needs_no_model_request_or_llm_mount() {
     let memory_dir = temp.path().join(".alan/memory");
     let mut machine = AgentMachine::new();
     machine.add_user_message("Refresh local memory surfaces mechanically.");
-    let message_count = machine.tape.messages().len();
+    let message_count = machine.messages().len();
     let state = RuntimeLoopState {
         machine,
         current_submission_id: None,
@@ -439,7 +439,7 @@ async fn refresh_memory_surfaces_needs_no_model_request_or_llm_mount() {
 
     refresh_turn_memory_surfaces(&state).await.unwrap();
 
-    assert_eq!(state.machine.tape.messages().len(), message_count);
+    assert_eq!(state.machine.messages().len(), message_count);
     let working = tokio::fs::read_to_string(working_memory_path(
         &memory_dir,
         state.machine.memory_record_id(),
@@ -466,12 +466,6 @@ async fn reused_process_path_gets_distinct_durable_memory_paths() {
         working_memory_path(&memory_dir, first.memory_record_id()),
         working_memory_path(&memory_dir, second.memory_record_id())
     );
-    assert_eq!(
-        first.memory_record_id(),
-        first.recorder.as_ref().unwrap().rollout_id()
-    );
-    assert_eq!(
-        second.memory_record_id(),
-        second.recorder.as_ref().unwrap().rollout_id()
-    );
+    assert_eq!(first.memory_record_id(), first.rollout_id().unwrap());
+    assert_eq!(second.memory_record_id(), second.rollout_id().unwrap());
 }

--- a/crates/agent-engine/src/runtime/plan_tool_tests.rs
+++ b/crates/agent-engine/src/runtime/plan_tool_tests.rs
@@ -160,7 +160,7 @@ async fn test_try_handle_virtual_tool_call_update_plan() {
             if explanation.as_deref() == Some("Test plan") && items == &expected_items
     )));
 
-    let prompt_view = state.machine.tape.prompt_view();
+    let prompt_view = state.machine.prompt_view();
     let tool_result = prompt_view
         .messages
         .iter()

--- a/crates/agent-engine/src/runtime/response_guardrails.rs
+++ b/crates/agent-engine/src/runtime/response_guardrails.rs
@@ -146,7 +146,7 @@ fn current_turn_tool_failures(
     state: &RuntimeLoopState,
     tool_packages: &[super::ToolPackageManifest],
 ) -> RecentToolFailureContext {
-    let messages = state.machine.tape.messages();
+    let messages = state.machine.messages();
     let current_turn = active_turn_messages(messages, state.turn_state.active_turn_message_start());
     let tool_capabilities = current_turn_tool_capabilities(state, tool_packages, current_turn);
     let mut failures = RecentToolFailureContext::default();

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/confirmation_and_mount_support.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/confirmation_and_mount_support.inc.rs
@@ -183,9 +183,7 @@
 
     fn tool_result_text_for_call(state: &RuntimeLoopState, call_id: &str) -> String {
         state
-            .machine
-            .tape
-            .messages()
+            .machine.messages()
             .iter()
             .rev()
             .find_map(|message| match message {
@@ -266,9 +264,9 @@
                 let text = alan_agent_protocol::parts_to_text(&user_input.unwrap());
                 assert!(text.contains("test input"));
                 // Turn should preserve existing conversation history.
-                assert_eq!(state.machine.tape.messages().len(), 1);
+                assert_eq!(state.machine.messages().len(), 1);
                 assert_eq!(
-                    state.machine.tape.messages()[0].text_content(),
+                    state.machine.messages()[0].text_content(),
                     "existing message"
                 );
                 assert_eq!(
@@ -430,7 +428,7 @@
         assert!(result.is_ok());
 
         // Tool message should be recorded
-        let messages = state.machine.tape.messages();
+        let messages = state.machine.messages();
         assert!(!messages.is_empty());
         assert!(messages[0].text_content().contains("approve"));
     }
@@ -467,7 +465,7 @@
         assert!(result.is_ok());
 
         // Tool message should contain modifications
-        let messages = state.machine.tape.messages();
+        let messages = state.machine.messages();
         assert!(!messages.is_empty());
         assert!(messages[0].text_content().contains("modify"));
     }

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
@@ -620,7 +620,7 @@
         }
 
         // Verify tool message was recorded
-        assert!(!state.machine.tape.messages().is_empty());
+        assert!(!state.machine.messages().is_empty());
     }
 
     #[tokio::test]

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/runtime_ops_and_replay_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/runtime_ops_and_replay_contract.inc.rs
@@ -71,7 +71,7 @@
         let mut state = create_test_state();
         let (environment, _shell) = namespace_environment_with_live_process_for_test().await;
         state.environment = environment;
-        state.machine.has_active_task = true;
+        state.machine.activate_task();
         let cancel = CancellationToken::new();
 
         let mut events = vec![];
@@ -88,7 +88,7 @@
         match result.unwrap() {
             RuntimeOpAction::NoTurn => {
                 // Task should be cancelled
-                assert!(!state.machine.has_active_task);
+                assert!(!state.machine.has_active_task());
             }
             _ => panic!("Expected NoTurn"),
         }
@@ -371,7 +371,7 @@
         state
             .turn_state
             .set_turn_activity(crate::runtime::turn_state::TurnActivityState::Running);
-        state.machine.has_active_task = true;
+        state.machine.activate_task();
         let cancel = CancellationToken::new();
         let mut events = vec![];
         let mut emit = |event: Event| {
@@ -409,7 +409,7 @@
         let mut state = create_test_state();
         let (environment, _shell) = namespace_environment_with_live_process_for_test().await;
         state.environment = environment;
-        state.machine.has_active_task = true;
+        state.machine.activate_task();
         state
             .turn_state
             .set_turn_activity(crate::runtime::turn_state::TurnActivityState::Running);
@@ -424,7 +424,7 @@
 
         let result = handle_runtime_op_with_cancel(&mut state, op, &mut emit, &cancel).await;
         assert!(result.is_ok());
-        assert!(!state.machine.has_active_task);
+        assert!(!state.machine.has_active_task());
     }
 
     #[tokio::test]
@@ -432,7 +432,7 @@
         let (environment, shell) = namespace_environment_with_live_process_for_test().await;
         let mut state = create_test_state();
         state.environment = environment;
-        state.machine.has_active_task = true;
+        state.machine.activate_task();
         let cancel = CancellationToken::new();
         let mut events = vec![];
         let mut emit = |event: Event| {
@@ -444,7 +444,7 @@
             handle_runtime_op_with_cancel(&mut state, Op::Interrupt, &mut emit, &cancel).await;
 
         assert!(result.is_ok());
-        assert!(!state.machine.has_active_task);
+        assert!(!state.machine.has_active_task());
         assert_eq!(
             String::from_utf8(shell.cat("/proc/1/status").await.unwrap()).unwrap(),
             "running\n"
@@ -550,7 +550,7 @@
             }
         ));
 
-        let messages = state.machine.tape.messages();
+        let messages = state.machine.messages();
         assert_eq!(messages.len(), 1);
         assert!(messages[0].is_user());
         match messages[0].parts().first() {
@@ -596,7 +596,7 @@
             }
         ));
 
-        let messages = state.machine.tape.messages();
+        let messages = state.machine.messages();
         assert_eq!(messages.len(), 1);
         assert!(messages[0].is_user());
         match messages[0].parts().first() {
@@ -642,7 +642,7 @@
             }
         ));
 
-        let messages = state.machine.tape.messages();
+        let messages = state.machine.messages();
         assert_eq!(messages.len(), 1);
         assert!(messages[0].is_tool());
         assert_eq!(messages[0].tool_responses()[0].id, "cp-1");

--- a/crates/agent-engine/src/runtime/tool_effect_lifecycle.rs
+++ b/crates/agent-engine/src/runtime/tool_effect_lifecycle.rs
@@ -178,10 +178,7 @@ impl ToolEffectLifecycle {
         };
         machine.record_effect(record.clone());
 
-        let flush_result = match machine.recorder.as_ref() {
-            Some(recorder) => recorder.flush().await,
-            None => Ok(()),
-        };
+        let flush_result = machine.flush_recorder().await;
         if let Err(error) = flush_result {
             let message = format!("Failed to persist side-effect checkpoint: {error}");
             let payload = json!({

--- a/crates/agent-engine/src/runtime/tool_orchestrator.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator.rs
@@ -460,7 +460,7 @@ where
             // a human. The sandbox + the deterministic red line remain the
             // boundary; the reviewer only decides whether to bother the human.
             let go_human = if matches!(route, super::tool_policy::EscalationRoute::Reviewer) {
-                let transcript = super::guardian::build_transcript(state.machine.tape.messages());
+                let transcript = super::guardian::build_transcript(state.machine.messages());
                 let outcome = {
                     let review_ctx = super::guardian::ReviewContext {
                         policy: super::guardian::DEFAULT_REVIEWER_POLICY,

--- a/crates/agent-engine/src/runtime/tool_orchestrator/tests/namespace_and_batch_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator/tests/namespace_and_batch_contract.inc.rs
@@ -436,12 +436,12 @@
         let mut state = create_test_state();
         state
             .turn_state
-            .begin_turn(state.machine.tape.messages().len());
+            .begin_turn(state.machine.messages().len());
         state.machine.add_user_message("Initial task");
         state.turn_state.set_plan_snapshot_at_message_count(
             Some("Initial plan".to_string()),
             Vec::new(),
-            state.machine.tape.messages().len(),
+            state.machine.messages().len(),
         );
         assert!(state.turn_state.plan_snapshot_is_from_active_turn());
 
@@ -465,7 +465,7 @@
         assert!(handled);
         assert!(!state.turn_state.plan_snapshot_is_from_active_turn());
         assert_eq!(
-            state.machine.tape.messages().last().unwrap().text_content(),
+            state.machine.messages().last().unwrap().text_content(),
             "Steer to the new task"
         );
     }

--- a/crates/agent-engine/src/runtime/tool_orchestrator/tests/replay_and_effect_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator/tests/replay_and_effect_contract.inc.rs
@@ -215,10 +215,8 @@
         tokio::time::sleep(std::time::Duration::from_millis(80)).await;
         let rollout_path = state
             .machine
-            .recorder
-            .as_ref()
+            .rollout_path()
             .expect("recorder should exist")
-            .path()
             .clone();
 
         let recovered_machine =

--- a/crates/agent-engine/src/runtime/turn_driver.rs
+++ b/crates/agent-engine/src/runtime/turn_driver.rs
@@ -496,7 +496,7 @@ mod tests {
         });
 
         let mut state = RuntimeLoopState {
-            machine: crate::AgentMachine::new(),
+            machine: crate::agent_machine::AgentMachine::new(),
             current_submission_id: None,
             environment,
             core_config: crate::Config::default(),

--- a/crates/agent-engine/src/runtime/turn_executor.rs
+++ b/crates/agent-engine/src/runtime/turn_executor.rs
@@ -284,9 +284,7 @@ where
     }
 
     if matches!(turn_kind, TurnRunKind::NewTurn) {
-        state
-            .turn_state
-            .begin_turn(state.machine.tape.messages().len());
+        state.turn_state.begin_turn(state.machine.messages().len());
     } else if user_input.is_some() {
         state.turn_state.note_resumed_user_input();
     }
@@ -339,8 +337,8 @@ where
     )?;
     let model = state.core_config.effective_model().to_string();
     let memory_enabled = state.core_config.memory.enabled;
-    let context_items = state.machine.tape.context_items().to_vec();
-    let context_delta = state.machine.tape.last_context_delta().clone();
+    let context_items = state.machine.context_items().to_vec();
+    let context_delta = state.machine.last_context_delta().clone();
     state.machine.record_turn_context_if_changed(
         &model,
         turn_request_controls.reasoning_effort(),
@@ -376,7 +374,7 @@ where
                 .clear_responses_continuation("provider_capability_unavailable");
         }
 
-        let prompt_view = state.machine.tape.prompt_view();
+        let prompt_view = state.machine.prompt_view();
         let estimated_prompt_tokens =
             prompt_view
                 .estimated_tokens
@@ -695,7 +693,6 @@ where
 
     let estimated_prompt_tokens = state
         .machine
-        .tape
         .estimated_prompt_tokens()
         .saturating_add(additional_prompt_tokens);
     let context_window_tokens = state.runtime_config.context_window_tokens as usize;

--- a/crates/agent-engine/src/runtime/turn_executor/tests/namespace_generation.rs
+++ b/crates/agent-engine/src/runtime/turn_executor/tests/namespace_generation.rs
@@ -438,8 +438,8 @@ async fn test_namespace_turn_omits_provider_local_responses_continuation_fields(
     state.runtime_config.compaction_soft_trigger_ratio = 0.5;
     state.machine.add_user_message("Earlier input");
     state.machine.add_assistant_message("Earlier output", None);
-    let boundary_message_count = state.machine.tape.messages().len();
-    let reference_context_revision = state.machine.tape.context_revision();
+    let boundary_message_count = state.machine.messages().len();
+    let reference_context_revision = state.machine.context_revision();
     state.machine.mark_responses_continuation(
         "openai_responses",
         "resp_prev",
@@ -711,8 +711,8 @@ async fn test_namespace_turn_sends_reference_context_as_neutral_messages() {
     let mut state = create_test_state_with_provider(provider);
     state.machine.add_user_message("Earlier input");
     state.machine.add_assistant_message("Earlier output", None);
-    let boundary_message_count = state.machine.tape.messages().len();
-    let reference_context_revision = state.machine.tape.context_revision();
+    let boundary_message_count = state.machine.messages().len();
+    let reference_context_revision = state.machine.context_revision();
     state.machine.mark_responses_continuation(
         "openai_responses",
         "resp_prev",
@@ -721,8 +721,7 @@ async fn test_namespace_turn_sends_reference_context_as_neutral_messages() {
     );
     state
         .machine
-        .tape
-        .apply_context_items(vec![crate::tape::ContextItem::new(
+        .apply_context_items_for_test(vec![crate::tape::ContextItem::new(
             "ctx_1",
             "domain_note",
             "Domain note",
@@ -789,8 +788,8 @@ async fn test_namespace_turn_does_not_use_provider_managed_compaction() {
     state.runtime_config.compaction_hard_trigger_ratio = 0.0;
     state.machine.add_user_message("Earlier input");
     state.machine.add_assistant_message("Earlier output", None);
-    let boundary_message_count = state.machine.tape.messages().len();
-    let reference_context_revision = state.machine.tape.context_revision();
+    let boundary_message_count = state.machine.messages().len();
+    let reference_context_revision = state.machine.context_revision();
     state.machine.mark_responses_continuation(
         "openai_responses",
         "resp_prev",
@@ -893,8 +892,8 @@ async fn test_namespace_chatgpt_request_omits_provider_local_projection_fields()
     state.runtime_config.compaction_soft_trigger_ratio = 0.5;
     state.machine.add_user_message("Earlier input");
     state.machine.add_assistant_message("Earlier output", None);
-    let boundary_message_count = state.machine.tape.messages().len();
-    let reference_context_revision = state.machine.tape.context_revision();
+    let boundary_message_count = state.machine.messages().len();
+    let reference_context_revision = state.machine.context_revision();
     state.machine.mark_responses_continuation(
         "chatgpt",
         "resp_prev",

--- a/crates/agent-engine/src/runtime/turn_executor/tests/runtime_recall.rs
+++ b/crates/agent-engine/src/runtime/turn_executor/tests/runtime_recall.rs
@@ -209,7 +209,7 @@ async fn test_run_turn_pre_turn_compaction_accounts_for_runtime_recall_budget() 
         estimate_pending_turn_prompt_tokens(Some(&user_input), turn_recall_bundle.as_deref());
     assert!(pending_prompt_tokens > 0);
 
-    let base_prompt_tokens = state.machine.tape.estimated_prompt_tokens();
+    let base_prompt_tokens = state.machine.estimated_prompt_tokens();
     state.runtime_config.context_window_tokens =
         (base_prompt_tokens + pending_prompt_tokens - 1) as u32;
 
@@ -226,7 +226,7 @@ async fn test_run_turn_pre_turn_compaction_accounts_for_runtime_recall_budget() 
     .await;
 
     assert!(result.is_ok());
-    assert_eq!(state.machine.tape.summary(), Some("COMPACTED_FOR_RECALL"));
+    assert_eq!(state.machine.tape_summary(), Some("COMPACTED_FOR_RECALL"));
 
     let system_prompts = seen_system_prompts.lock().unwrap();
     assert_eq!(system_prompts.len(), 2);
@@ -309,7 +309,7 @@ async fn test_maybe_compact_mid_turn_accounts_for_runtime_prompt_overhead() {
         estimate_request_prompt_overhead_tokens(None, Some(pending_guardrail_instruction.as_str()));
     assert!(additional_prompt_tokens > 0);
 
-    let base_prompt_tokens = state.machine.tape.estimated_prompt_tokens();
+    let base_prompt_tokens = state.machine.estimated_prompt_tokens();
     state.runtime_config.context_window_tokens =
         (base_prompt_tokens + additional_prompt_tokens - 1) as u32;
 
@@ -321,7 +321,7 @@ async fn test_maybe_compact_mid_turn_accounts_for_runtime_prompt_overhead() {
 
     assert!(result.is_ok());
     assert_eq!(
-        state.machine.tape.summary(),
+        state.machine.tape_summary(),
         Some("MID_TURN_COMPACTION_SUMMARY")
     );
     assert_eq!(state.turn_state.compactions_this_turn(), 1);

--- a/crates/agent-engine/src/runtime/turn_executor/tests/turn_execution.rs
+++ b/crates/agent-engine/src/runtime/turn_executor/tests/turn_execution.rs
@@ -107,9 +107,8 @@ async fn test_run_turn_keeps_truthful_network_failure_explanation() {
     let mut state = create_test_state_with_provider_and_tools(provider, tools);
     state
         .machine
-        .tape
-        .push(Message::user("how's the weather today?"));
-    state.machine.tape.push(Message::Assistant {
+        .push_tape_message(Message::user("how's the weather today?"));
+    state.machine.push_tape_message(Message::Assistant {
         parts: Vec::new(),
         tool_requests: vec![ToolRequest {
             id: "call_network".to_string(),
@@ -171,7 +170,6 @@ async fn test_run_turn_keeps_truthful_network_failure_explanation() {
 
     let assistant_messages: Vec<_> = state
         .machine
-        .tape
         .messages()
         .iter()
         .filter(|message| matches!(message, Message::Assistant { .. }))
@@ -223,9 +221,8 @@ async fn test_run_turn_recovers_network_claim_after_non_network_timeout() {
     let mut state = create_test_state_with_provider_and_tools(provider, tools);
     state
         .machine
-        .tape
-        .push(Message::user("how's the weather today?"));
-    state.machine.tape.push(Message::Assistant {
+        .push_tape_message(Message::user("how's the weather today?"));
+    state.machine.push_tape_message(Message::Assistant {
         parts: Vec::new(),
         tool_requests: vec![ToolRequest {
             id: "call_local".to_string(),
@@ -311,16 +308,16 @@ async fn test_run_turn_resume_turn_with_steer_keeps_truthful_network_failure_exp
     let mut tools = ToolRegistry::new();
     tools.register(NetworkCapabilityTool);
     let mut state = create_test_state_with_provider_and_tools(provider, tools);
-    state.machine.tape.push(Message::user("earlier turn"));
     state
         .machine
-        .tape
-        .push(Message::assistant("earlier turn completed"));
+        .push_tape_message(Message::user("earlier turn"));
     state
         .machine
-        .tape
-        .push(Message::user("how's the weather today?"));
-    state.machine.tape.push(Message::Assistant {
+        .push_tape_message(Message::assistant("earlier turn completed"));
+    state
+        .machine
+        .push_tape_message(Message::user("how's the weather today?"));
+    state.machine.push_tape_message(Message::Assistant {
         parts: Vec::new(),
         tool_requests: vec![ToolRequest {
             id: "call_network".to_string(),
@@ -418,8 +415,10 @@ async fn test_run_turn_new_turn_ignores_prior_failures_without_completed_assista
     let mut tools = ToolRegistry::new();
     tools.register(NetworkCapabilityTool);
     let mut state = create_test_state_with_provider_and_tools(provider, tools);
-    state.machine.tape.push(Message::user("earlier turn"));
-    state.machine.tape.push(Message::Assistant {
+    state
+        .machine
+        .push_tape_message(Message::user("earlier turn"));
+    state.machine.push_tape_message(Message::Assistant {
         parts: Vec::new(),
         tool_requests: vec![ToolRequest {
             id: "call_network".to_string(),
@@ -514,7 +513,6 @@ async fn test_run_turn_empty_response_fallback() {
 
     let assistant_messages: Vec<_> = state
         .machine
-        .tape
         .messages()
         .iter()
         .filter(|m| matches!(m, crate::agent_machine::Message::Assistant { .. }))
@@ -558,7 +556,6 @@ async fn test_run_turn_empty_content_with_thinking_persists_reasoning() {
 
     let assistant_messages: Vec<_> = state
         .machine
-        .tape
         .messages()
         .iter()
         .filter(|m| matches!(m, crate::agent_machine::Message::Assistant { .. }))
@@ -659,14 +656,13 @@ async fn test_run_turn_performs_mid_turn_compaction_before_follow_up_generation(
     assert!(matches!(result.unwrap(), TurnExecutionOutcome::Finished));
     assert_eq!(generate_calls.load(Ordering::SeqCst), 3);
     assert_eq!(
-        state.machine.tape.summary(),
+        state.machine.tape_summary(),
         Some("Mid-turn compaction summary")
     );
     assert_eq!(state.turn_state.compactions_this_turn(), 1);
     assert!(
         state
             .machine
-            .tape
             .messages()
             .iter()
             .any(|message| message.text_content().contains("Finished after compaction"))
@@ -759,7 +755,7 @@ async fn test_run_turn_resets_mid_turn_compaction_budget_for_new_turns() {
     assert!(matches!(result.unwrap(), TurnExecutionOutcome::Finished));
     assert_eq!(generate_calls.load(Ordering::SeqCst), 3);
     assert_eq!(
-        state.machine.tape.summary(),
+        state.machine.tape_summary(),
         Some("Mid-turn compaction summary")
     );
     assert_eq!(state.turn_state.compactions_this_turn(), 1);

--- a/crates/agent-engine/src/runtime/turn_support.rs
+++ b/crates/agent-engine/src/runtime/turn_support.rs
@@ -19,7 +19,7 @@ where
     // continue the same conversation after an interrupt/cancel.
     state.turn_state.clear();
     state.turn_state.clear_plan_snapshot();
-    state.machine.has_active_task = false;
+    state.machine.clear_active_task();
     super::ui_surfaces::turn_completed(state.namespace_environment(), true).await?;
     emit(Event::TurnCompleted {
         summary: Some("Task cancelled by user".to_string()),

--- a/crates/agent-engine/src/runtime/virtual_tools.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools.rs
@@ -233,7 +233,7 @@ where
                     state.turn_state.set_plan_snapshot_at_message_count(
                         explanation.clone(),
                         items.clone(),
-                        state.machine.tape.messages().len(),
+                        state.machine.messages().len(),
                     );
                     super::ui_surfaces::plan_updated(
                         state.namespace_environment(),

--- a/crates/agent-engine/src/runtime/virtual_tools_tests.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools_tests.rs
@@ -185,7 +185,6 @@ fn tool_result_text_for_call(
 ) -> String {
     state
         .machine
-        .tape
         .prompt_view()
         .messages
         .iter()

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -10,6 +10,32 @@ fn read_crate_source(path: &str) -> String {
         .unwrap_or_else(|error| panic!("read src/{path}: {error}"))
 }
 
+fn read_rust_sources_under(path: &str) -> Vec<(std::path::PathBuf, String)> {
+    fn visit(directory: &std::path::Path, sources: &mut Vec<(std::path::PathBuf, String)>) {
+        for entry in std::fs::read_dir(directory)
+            .unwrap_or_else(|error| panic!("read {}: {error}", directory.display()))
+        {
+            let path = entry.expect("read source entry").path();
+            if path.is_dir() {
+                visit(&path, sources);
+            } else if path.extension().and_then(std::ffi::OsStr::to_str) == Some("rs") {
+                let source = std::fs::read_to_string(&path)
+                    .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+                sources.push((path, source));
+            }
+        }
+    }
+
+    let mut sources = Vec::new();
+    visit(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join(path),
+        &mut sources,
+    );
+    sources
+}
+
 fn rust_item_body<'a>(source: &'a str, marker: &str) -> &'a str {
     let item = &source[source
         .find(marker)
@@ -272,5 +298,41 @@ fn engine_does_not_own_connection_profile_metadata_or_selection() {
             !public_api.contains(forbidden),
             "Agent Execution Engine still exports Connection authority through {forbidden}"
         );
+    }
+}
+
+#[test]
+fn agent_machine_state_is_not_a_public_or_runtime_field_surface() {
+    let public_api = read_crate_source("lib.rs");
+    assert!(
+        !public_api.contains("AgentMachine,"),
+        "AgentMachine must not be a cross-crate integration surface"
+    );
+
+    let machine = read_crate_source("agent_machine.rs");
+    let state = rust_item_body(&machine, "pub(crate) struct AgentMachine");
+    for private_field in ["tape", "recorder", "has_active_task"] {
+        assert!(state.contains(&format!("{private_field}:")));
+        assert!(
+            !state.contains(&format!("pub {private_field}:")),
+            "AgentMachine field {private_field} must remain private"
+        );
+    }
+
+    for (path, source) in read_rust_sources_under("runtime") {
+        for forbidden in [
+            "machine.tape.",
+            "machine.recorder.",
+            "machine.has_active_task =",
+            "state.machine.tape.",
+            "state.machine.recorder.",
+            "state.machine.has_active_task =",
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "{} reaches through AgentMachine via {forbidden}",
+                path.display()
+            );
+        }
     }
 }

--- a/openspec/changes/deepen-agent-machine-transition-module/.openspec.yaml
+++ b/openspec/changes/deepen-agent-machine-transition-module/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-19

--- a/openspec/changes/deepen-agent-machine-transition-module/design.md
+++ b/openspec/changes/deepen-agent-machine-transition-module/design.md
@@ -1,0 +1,124 @@
+## Context
+
+The archived clean-architecture burn-down established the external file-native
+runtime boundary, but the live implementation still distributes transition
+state across `AgentMachine`, `RuntimeLoopState`, and
+`NamespaceRuntimeEnvironment`. `engine.rs` consequently coordinates both
+Process-loop concerns and the details of advancing an accepted submission.
+
+The target ownership is already accepted: Process owns lifecycle and identity;
+Agent Machine owns Tape and transition-local state; AgentFS owns observable
+agent files; rollout and checkpoint files own durable evidence. This change
+deepens that boundary without changing any file or runtime behavior.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give Agent Machine exclusive ownership of Tape and transition-local state.
+- Make the accepted-submission transition a cohesive, testable module boundary.
+- Keep Process-loop control outside the transition owner.
+- Replace broad state/environment reach-through with private state and narrow
+  concrete inputs.
+- Leave a smaller internal API whose ownership can be completed by the
+  subsequent file-native seam change.
+
+**Non-Goals:**
+
+- Change AgentFS, `/proc`, aP, namespace, request, action, Tool, memory,
+  compaction, persistence, recovery, child-process, or renderer behavior.
+- Move Process assembly or Host adapter composition; that belongs to
+  `complete-agent-runtime-file-native-seam`.
+- Add an engine abstraction framework, a transition trait, a factory, or a
+  second Machine representation.
+- Optimize for a new line-count, method-count, or module-count target.
+
+## Decisions
+
+### Decision: Agent Machine owns one private transition state
+
+Agent Machine owns Tape, the current accepted submission, turn state, pending
+Yield, Tool replay state, active-task state, and deferred transition action.
+These fields become private and are changed through semantic operations. A
+private `RuntimeLoopState` may remain if it is the smallest useful
+implementation detail, but it cannot remain a broadly shared field bag.
+
+Agent Machine is not a cross-crate integration surface. Its public re-export and
+direct field access are removed; private behavior is covered by adjacent
+white-box tests, while external contracts are tested through AgentFS, `/proc`,
+rollout, and checkpoint files.
+
+Alternative considered: retain public fields and split callers into more
+extensions. Rejected because it preserves distributed ownership while only
+moving source text.
+
+### Decision: The transition seam starts after submission acceptance
+
+`engine.rs` retains input polling, channel closure, shutdown, cancellation,
+heartbeat, and other Process-loop control. Once a `Submission` is accepted, one
+concrete transition owner advances Agent Machine through generation, Yield,
+Tool replay, completion, and deferred actions, then returns a compact outcome to
+the outer loop.
+
+The transition owner is a concrete module and function boundary, not a trait or
+pluggable strategy. Its outcome contains only what the outer loop needs to
+continue Process control.
+
+Alternative considered: move the entire engine loop into Agent Machine.
+Rejected because input transport and Process lifecycle are not Machine state.
+
+### Decision: One namespace handle enters the transition
+
+The transition boundary receives the existing concrete namespace-backed
+environment. Only that boundary may see the complete transitional environment;
+child modules receive the specific paths, records, handles, or operations they
+need. Namespace construction and cross-crate composition remain unchanged until
+the next change removes their transitional collaborators.
+
+Alternative considered: define narrow traits for every current environment
+operation. Rejected because each would have one implementation and would hide
+the same broad dependency behind boilerplate.
+
+### Decision: Characterize behavior at durable boundaries
+
+Before moving each workflow, focused tests pin its AgentFS, rollout/checkpoint,
+Yield/resume, Tool replay, compaction, and failure behavior. Internal tests may
+exercise private Machine operations, but completion evidence comes from the
+durable file boundaries. No temporary compatibility path is added.
+
+Alternative considered: preserve the old state path until the whole refactor is
+finished. Rejected because dual state ownership would make parity unprovable.
+
+## Risks / Trade-offs
+
+- [Moving state changes ordering around Yield or replay] → Characterize the
+  affected file/evidence sequence first and move one complete workflow at a
+  time.
+- [A nominal transition module remains coupled to the full environment] → Keep
+  full-environment access at one boundary and reject new downstream reach-through
+  in review and architecture checks.
+- [Privacy makes tests harder] → Use adjacent white-box tests for internals and
+  file-boundary tests for supported behavior; do not reopen public fields.
+- [A large one-shot move is difficult to review] → Deliver focused stacked PRs,
+  each deleting the old path before merge.
+
+## Migration Plan
+
+1. Characterize the current accepted-submission, Yield/resume, Tool replay,
+   compaction, persistence, and cancellation boundaries.
+2. Privatize Agent Machine state and move current submission and turn-local
+   state behind semantic Machine operations.
+3. Move accepted-submission advancement into the concrete transition owner and
+   narrow its downstream inputs.
+4. Delete obsolete field access, exports, and forwarding helpers; update the
+   existing architecture gates without adding a new numeric budget.
+5. Run focused engine tests, workspace quality checks, and strict OpenSpec
+   validation. Merge only after CI and Codex Review remain clean on the current
+   HEAD through a follow-up review window.
+
+Rollback is per focused PR. The change has no persisted data migration, so a
+revert restores the prior in-memory ownership without converting user data.
+
+## Open Questions
+
+None.

--- a/openspec/changes/deepen-agent-machine-transition-module/proposal.md
+++ b/openspec/changes/deepen-agent-machine-transition-module/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+The Agent Execution Engine now has the correct file-native external boundary, but
+transition state is still spread across `RuntimeLoopState`, `AgentMachine`, and a
+large environment facade. This obscures the actual Machine owner and makes an
+otherwise local transition change require broad runtime knowledge.
+
+## What Changes
+
+- Make Agent Machine the sole owner of Tape and transition-local state, including
+  the current submission, turn state, pending Yield, Tool replay, and deferred
+  transition action.
+- Separate the outer Process loop (input polling, shutdown, cancellation, and
+  heartbeat) from a cohesive transition module that advances one accepted
+  submission and returns a compact outcome.
+- Keep one concrete namespace handle at the transition boundary and pass narrow
+  values to child modules instead of the entire runtime state or environment.
+- Remove public field-bag access to Agent Machine internals and keep Agent Machine
+  an engine-internal implementation detail.
+- Preserve all AgentFS, `/proc`, aP, file-layout, persistence, recovery,
+  confirmation, compaction, memory, Tool, and child-process behavior.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `agent-namespace-runtime`: Define the internal Agent Machine ownership boundary
+  and the separation between Process-loop control and transition execution.
+
+## Impact
+
+This behavior-preserving refactor affects `crates/agent-engine/src/engine.rs` and
+the runtime modules that currently reach through `RuntimeLoopState`,
+`AgentMachine`, and `NamespaceRuntimeEnvironment`. It introduces no new public
+API, dependency, file surface, compatibility path, or product behavior. It is
+the prerequisite for `complete-agent-runtime-file-native-seam`.

--- a/openspec/changes/deepen-agent-machine-transition-module/specs/agent-namespace-runtime/spec.md
+++ b/openspec/changes/deepen-agent-machine-transition-module/specs/agent-namespace-runtime/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Agent Machine owns transition-local state
+Agent Execution Engine SHALL keep Tape, the current accepted submission, turn
+state, pending Yield, Tool replay state, active-task state, and deferred
+transition action inside one Agent Machine owner. Those values MUST NOT be
+independently mutable through a shared runtime field bag, and Agent Machine
+internals MUST NOT be a public cross-crate integration surface.
+
+#### Scenario: A submission starts a transition
+- **WHEN** the outer Process loop accepts a `Submission`
+- **THEN** Agent Machine records and advances all state local to that transition
+- **AND** sibling runtime modules cannot mutate its Tape or turn state directly
+
+#### Scenario: Engine API visibility is inspected
+- **WHEN** repository validation inspects `alan-agent-engine` exports and field
+  visibility
+- **THEN** Agent Machine state is private to the engine implementation
+- **AND** supported observation remains AgentFS, `/proc`, rollout, and checkpoint
+  files
+
+#### Scenario: A pending transition resumes
+- **WHEN** Agent Runtime Service restores a Yield, Tool replay, or deferred action
+  from durable files
+- **THEN** Agent Machine resumes from that restored transition state
+- **AND** no parallel runtime field bag must be reconciled with it
+
+### Requirement: Process-loop control is separate from transition execution
+Agent Execution Engine SHALL keep input polling, channel closure, shutdown,
+cancellation, and heartbeat control in its outer Process loop. A concrete
+transition module SHALL own execution after a `Submission` is accepted and
+SHALL return only the compact outcome required for the outer loop to continue.
+
+#### Scenario: No submission is available
+- **WHEN** the outer Process loop is polling input or handling heartbeat and
+  shutdown state
+- **THEN** it does not enter or mutate an Agent Machine transition
+
+#### Scenario: An accepted submission completes or yields
+- **WHEN** the transition module advances an accepted submission to completion,
+  Yield, or deferred continuation
+- **THEN** it updates Agent Machine and the owning file surfaces
+- **AND** it returns a compact control outcome rather than transferring Machine
+  state ownership to the outer loop
+
+#### Scenario: A Process is cancelled
+- **WHEN** Process lifecycle control cancels an Agent Process
+- **THEN** the outer loop applies cancellation to the active transition
+- **AND** cancellation does not become a second Agent Machine state owner
+
+### Requirement: Transition dependencies are narrow and concrete
+The accepted-submission transition boundary SHALL receive the one concrete
+namespace-backed runtime environment. Its child modules SHALL receive only the
+specific paths, handles, records, or operations required by their workflow and
+MUST NOT accept the complete runtime environment or a new one-implementation
+abstraction for convenience.
+
+#### Scenario: A transition child operation is added
+- **WHEN** a child module needs a namespace capability during a transition
+- **THEN** the transition owner resolves or passes the narrow concrete input
+  required by that operation
+- **AND** the child module does not gain the complete environment field bag
+
+#### Scenario: The ownership refactor is verified
+- **WHEN** the transition module refactor completes
+- **THEN** existing AgentFS, `/proc`, aP, Tool, Yield, compaction, persistence,
+  recovery, memory, and child-process contract tests remain unchanged in
+  behavior
+- **AND** no compatibility transition path remains

--- a/openspec/changes/deepen-agent-machine-transition-module/tasks.md
+++ b/openspec/changes/deepen-agent-machine-transition-module/tasks.md
@@ -1,0 +1,57 @@
+## 1. Characterize The Transition Boundary
+
+- [x] 1.1 Map every direct `AgentMachine`, `RuntimeLoopState`, and
+  `NamespaceRuntimeEnvironment` access in the accepted-submission path and assign
+  each value to Process-loop control, Agent Machine state, or a narrow
+  transition dependency.
+- [ ] 1.2 Add focused characterization checks for submission acceptance,
+  generation completion, Yield/resume, Tool replay, compaction, deferred
+  actions, persistence/recovery, cancellation, and failure evidence.
+- [ ] 1.3 Confirm current AgentFS, `/proc`, rollout, and checkpoint observations
+  before moving ownership.
+
+## 2. Make Agent Machine The State Owner
+
+- [ ] 2.1 Move current submission, turn state, pending Yield, Tool replay,
+  active-task, and deferred action state behind Agent Machine semantic
+  operations.
+- [ ] 2.2 Make Tape, recorder, flags, and transition state private; remove the
+  public Agent Machine re-export and replace direct field access.
+- [ ] 2.3 Keep or delete the private `RuntimeLoopState` according to whether it
+  still groups cohesive Machine state; do not preserve it as a shared field bag.
+- [ ] 2.4 Add adjacent white-box tests for private Machine transitions and keep
+  supported external tests at file boundaries.
+
+## 3. Extract The Concrete Transition Owner
+
+- [ ] 3.1 Move execution after `Submission` acceptance into one concrete
+  transition module with a compact outcome for the outer loop.
+- [ ] 3.2 Keep input polling, channel closure, shutdown, cancellation, and
+  heartbeat in `engine.rs` and verify they do not become Machine state.
+- [ ] 3.3 Restrict complete namespace-environment access to the transition
+  boundary and pass narrow concrete inputs to generation, Tool, policy, memory,
+  and evidence workflows.
+- [ ] 3.4 Delete displaced forwarding helpers, broad environment parameters,
+  direct Machine field access, and any temporary dual transition path.
+
+## 4. Verify And Deliver The Stack
+
+- [ ] 4.1 Run focused `alan-agent-engine` tests, workspace formatting, Clippy,
+  the canonical repository quality gate, and strict OpenSpec validation.
+- [ ] 4.2 Verify AgentFS, `/proc`, aP, Yield, Tool, compaction, memory,
+  persistence, recovery, and child-process behavior remains unchanged.
+- [ ] 4.3 Deliver focused stacked PRs in dependency order; each PR must move one
+  complete owner and delete its old path rather than add scaffolding or a
+  compatibility layer.
+- [ ] 4.4 For every PR, resolve all actionable Codex Review comments, rerun CI on
+  the current HEAD, wait through a follow-up review window, and merge only when
+  no unresolved or new issue remains.
+
+## 5. Sync And Archive
+
+- [ ] 5.1 After all implementation PRs merge, sync the delta requirement into
+  canonical `agent-namespace-runtime` and run strict OpenSpec validation.
+- [ ] 5.2 Confirm the merged code and canonical spec contain no retired public
+  Machine surface or dual transition owner.
+- [ ] 5.3 Archive the change only after implementation, review, verification,
+  and canonical spec sync are complete.


### PR DESCRIPTION
## Summary

- make AgentMachine crate-private and remove its public re-export
- replace direct Tape, recorder, and active-task field access with semantic operations
- delete unused Machine convenience paths and add an ownership regression gate
- add the deepen-agent-machine-transition-module OpenSpec change and complete its access map

This is the first focused PR in the Agent Machine transition-owner stack. Follow-up PRs will move turn-local state into Machine and extract the accepted-submission transition owner.

## Verification

- repository pre-commit quality gate
- cargo test -p alan-agent-engine (1197 passed, 1 ignored)
- cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings
- cargo test -p alan-agent-engine --test dependency_boundary
- openspec validate deepen-agent-machine-transition-module --strict