### PR TITLE
refactor(agent-engine): move turn state into machine

### DIFF
--- a/crates/agent-engine/src/agent_machine.rs
+++ b/crates/agent-engine/src/agent_machine.rs
@@ -15,6 +15,14 @@ use crate::tape::{ContextItem, ContextItemsDelta, Tape};
 
 mod recovery;
 mod runtime_control;
+mod transition_state;
+
+use runtime_control::{ResponsesContinuationState, RollbackOutcome};
+use transition_state::MachineTransitionState;
+pub(crate) use transition_state::{
+    DeferredRuntimeAction, NormalizedToolCall, PendingYield, TurnActivityState,
+    is_auto_mid_turn_compaction_emergency,
+};
 
 pub use recovery::{
     latest_compaction_attempt_from_rollout_items, latest_memory_flush_attempt_from_rollout_items,
@@ -23,24 +31,6 @@ pub use recovery::{
 /// Warning emitted when rollback succeeds but remains in-memory only.
 pub const ROLLBACK_NON_DURABLE_WARNING: &str =
     "Rollback is in-memory only and will not survive runtime restart.";
-
-/// Structured outcome for an in-memory rollback request.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct RollbackOutcome {
-    /// Number of logical user turns actually removed.
-    pub removed_turns: u32,
-    /// Number of tape messages removed by the rollback.
-    pub removed_messages: usize,
-}
-
-/// Server-managed continuation state for Responses-compatible providers.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ResponsesContinuationState {
-    pub provider: String,
-    pub last_response_id: String,
-    pub boundary_message_count: usize,
-    pub reference_context_revision: u64,
-}
 
 /// Transition state for one Agent Process.
 #[derive(Debug)]
@@ -53,6 +43,8 @@ pub(crate) struct AgentMachine {
     memory_record_id: String,
     /// Whether a sourcing task has been started in this machine
     has_active_task: bool,
+    /// All in-memory state local to an accepted submission and logical turn.
+    transition_state: MachineTransitionState,
     /// Latest effect record by idempotency key (used for side-effect dedupe).
     effect_index: HashMap<String, EffectRecord>,
     /// Last prompt snapshot fingerprint written to rollout (used to skip duplicates).
@@ -81,6 +73,7 @@ impl AgentMachine {
             recorder: None,
             memory_record_id: uuid::Uuid::new_v4().to_string(),
             has_active_task: false,
+            transition_state: MachineTransitionState::default(),
             effect_index: HashMap::new(),
             last_turn_context_snapshot_fingerprint: None,
             user_turn_ordinal: 0,
@@ -212,6 +205,7 @@ impl AgentMachine {
             recorder: Some(recorder),
             memory_record_id,
             has_active_task: false,
+            transition_state: MachineTransitionState::default(),
             effect_index: HashMap::new(),
             last_turn_context_snapshot_fingerprint: None,
             user_turn_ordinal: 0,

--- a/crates/agent-engine/src/agent_machine/runtime_control.rs
+++ b/crates/agent-engine/src/agent_machine/runtime_control.rs
@@ -5,6 +5,24 @@ use crate::approval::{
 };
 use crate::tape::{ContentPart, Message};
 
+/// Structured outcome for an in-memory rollback request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RollbackOutcome {
+    /// Number of logical user turns actually removed.
+    pub(crate) removed_turns: u32,
+    /// Number of tape messages removed by the rollback.
+    pub(crate) removed_messages: usize,
+}
+
+/// Server-managed continuation state for Responses-compatible providers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResponsesContinuationState {
+    pub(crate) provider: String,
+    pub(crate) last_response_id: String,
+    pub(crate) boundary_message_count: usize,
+    pub(crate) reference_context_revision: u64,
+}
+
 pub(super) const RESPONSES_CONTINUATION_EVENT_TYPE: &str = "responses_continuation";
 
 fn runtime_confirmation_control_checkpoint(payload: &serde_json::Value) -> Option<(&str, &str)> {

--- a/crates/agent-engine/src/agent_machine/transition_state.rs
+++ b/crates/agent-engine/src/agent_machine/transition_state.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, VecDeque};
 
-use super::agent_loop::{DeferredRuntimeAction, NormalizedToolCall};
+use super::AgentMachine;
 use crate::approval::{PendingConfirmation, PendingStructuredInputRequest};
 use crate::skills::ActiveSkillEnvelope;
 use crate::tape::ContentPart;
@@ -10,7 +10,7 @@ const MAX_QUEUED_NEXT_TURN_INPUTS: usize = 16;
 const AUTO_MID_TURN_COMPACTION_LIMIT: u32 = 2;
 const AUTO_MID_TURN_COMPACTION_MIN_GROWTH_TOKENS: usize = 256;
 
-pub(super) fn is_auto_mid_turn_compaction_emergency(
+pub(crate) fn is_auto_mid_turn_compaction_emergency(
     estimated_prompt_tokens: usize,
     context_window_tokens: usize,
 ) -> bool {
@@ -20,7 +20,7 @@ pub(super) fn is_auto_mid_turn_compaction_emergency(
 }
 
 #[derive(Debug, Clone)]
-pub(super) enum PendingYield {
+pub(crate) enum PendingYield {
     Confirmation(PendingConfirmation),
     StructuredInput(PendingStructuredInputRequest),
 }
@@ -39,8 +39,24 @@ pub(crate) struct PlanSnapshot {
     pub items: Vec<PlanItem>,
 }
 
+/// Tool call normalized at the Machine transition boundary.
+#[derive(Debug, Clone)]
+pub(crate) struct NormalizedToolCall {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) arguments: serde_json::Value,
+}
+
+/// Best-effort work retained by Machine until the outer Process loop can run it.
+#[derive(Debug, Clone)]
+pub(crate) enum DeferredRuntimeAction {
+    TurnMemoryPromotion(crate::runtime::TurnMemoryPromotionJob),
+}
+
 #[derive(Debug, Clone, Default)]
-pub(crate) struct TurnState {
+pub(super) struct MachineTransitionState {
+    /// Identifier of the submission currently accepted by this Machine.
+    current_submission_id: Option<String>,
     pending: HashMap<String, PendingYield>,
     pending_tool_replay_batches: HashMap<String, Vec<NormalizedToolCall>>,
     /// Insertion order tracking for all pending items
@@ -80,70 +96,95 @@ const GUARDIAN_MAX_CONSECUTIVE_DENIALS: u32 = 3;
 const GUARDIAN_DENIAL_WINDOW: usize = 50;
 const GUARDIAN_MAX_DENIALS_IN_WINDOW: usize = 10;
 
-impl TurnState {
+impl AgentMachine {
+    pub(crate) fn accept_submission(&mut self, submission_id: impl Into<String>) {
+        self.transition_state.current_submission_id = Some(submission_id.into());
+    }
+
+    pub(crate) fn finish_submission(&mut self) {
+        self.transition_state.current_submission_id = None;
+    }
+
+    pub(crate) fn current_submission_id(&self) -> Option<&str> {
+        self.transition_state.current_submission_id.as_deref()
+    }
+
     /// Record a guardian review outcome (true = denied). Returns true when the
     /// rejection circuit breaker trips (≥3 consecutive, or ≥10 denials within
     /// the last 50 reviews this turn). A non-denial resets the consecutive count.
     pub(crate) fn record_guardian_review(&mut self, denied: bool) -> bool {
         if denied {
-            self.guardian_consecutive_denials = self.guardian_consecutive_denials.saturating_add(1);
+            self.transition_state.guardian_consecutive_denials = self
+                .transition_state
+                .guardian_consecutive_denials
+                .saturating_add(1);
         } else {
-            self.guardian_consecutive_denials = 0;
+            self.transition_state.guardian_consecutive_denials = 0;
         }
-        self.guardian_recent_reviews.push_back(denied);
-        while self.guardian_recent_reviews.len() > GUARDIAN_DENIAL_WINDOW {
-            self.guardian_recent_reviews.pop_front();
+        self.transition_state
+            .guardian_recent_reviews
+            .push_back(denied);
+        while self.transition_state.guardian_recent_reviews.len() > GUARDIAN_DENIAL_WINDOW {
+            self.transition_state.guardian_recent_reviews.pop_front();
         }
-        let denials_in_window = self.guardian_recent_reviews.iter().filter(|d| **d).count();
-        self.guardian_consecutive_denials >= GUARDIAN_MAX_CONSECUTIVE_DENIALS
+        let denials_in_window = self
+            .transition_state
+            .guardian_recent_reviews
+            .iter()
+            .filter(|d| **d)
+            .count();
+        self.transition_state.guardian_consecutive_denials >= GUARDIAN_MAX_CONSECUTIVE_DENIALS
             || denials_in_window >= GUARDIAN_MAX_DENIALS_IN_WINDOW
     }
 
     pub(crate) fn has_pending_interaction(&self) -> bool {
-        !self.pending.is_empty()
+        !self.transition_state.pending.is_empty()
     }
 
     pub(crate) fn pending_request_ids(&self) -> Vec<String> {
-        self.pending_order.clone()
+        self.transition_state.pending_order.clone()
     }
 
-    pub(crate) fn clear(&mut self) {
-        self.pending.clear();
-        self.pending_tool_replay_batches.clear();
-        self.pending_order.clear();
-        self.turn_activity = TurnActivityState::Idle;
-        self.buffered_inband_submissions.clear();
-        self.active_turn_message_start = None;
-        self.active_skills.clear();
-        self.active_turn_request_control_intent = crate::RequestControlIntent::default();
+    pub(crate) fn reset_turn(&mut self) {
+        self.transition_state.pending.clear();
+        self.transition_state.pending_tool_replay_batches.clear();
+        self.transition_state.pending_order.clear();
+        self.transition_state.turn_activity = TurnActivityState::Idle;
+        self.transition_state.buffered_inband_submissions.clear();
+        self.transition_state.active_turn_message_start = None;
+        self.transition_state.active_skills.clear();
+        self.transition_state.active_turn_request_control_intent =
+            crate::RequestControlIntent::default();
         self.reset_auto_mid_turn_compaction_state();
-        self.guardian_consecutive_denials = 0;
-        self.guardian_recent_reviews.clear();
+        self.transition_state.guardian_consecutive_denials = 0;
+        self.transition_state.guardian_recent_reviews.clear();
     }
 
     pub(crate) fn clear_plan_snapshot(&mut self) {
-        self.plan_snapshot = None;
-        self.plan_snapshot_turn_start = None;
-        self.plan_snapshot_message_count = None;
+        self.transition_state.plan_snapshot = None;
+        self.transition_state.plan_snapshot_turn_start = None;
+        self.transition_state.plan_snapshot_message_count = None;
     }
 
     pub(crate) fn reset_auto_mid_turn_compaction_state(&mut self) {
-        self.compactions_this_turn = 0;
-        self.last_compaction_prompt_tokens = None;
+        self.transition_state.compactions_this_turn = 0;
+        self.transition_state.last_compaction_prompt_tokens = None;
     }
 
     /// Queue `next_turn` input parts. Returns `Some(new_len)` on success, `None` on overflow.
     pub(crate) fn queue_next_turn_input(&mut self, parts: Vec<ContentPart>) -> Option<usize> {
-        if self.queued_next_turn_inputs.len() >= MAX_QUEUED_NEXT_TURN_INPUTS {
+        if self.transition_state.queued_next_turn_inputs.len() >= MAX_QUEUED_NEXT_TURN_INPUTS {
             return None;
         }
-        self.queued_next_turn_inputs.push_back(parts);
-        Some(self.queued_next_turn_inputs.len())
+        self.transition_state
+            .queued_next_turn_inputs
+            .push_back(parts);
+        Some(self.transition_state.queued_next_turn_inputs.len())
     }
 
     /// Drain queued `next_turn` input parts in FIFO order.
     pub(crate) fn drain_next_turn_inputs(&mut self) -> VecDeque<Vec<ContentPart>> {
-        std::mem::take(&mut self.queued_next_turn_inputs)
+        std::mem::take(&mut self.transition_state.queued_next_turn_inputs)
     }
 
     /// Number of queued `next_turn` payloads.
@@ -155,27 +196,32 @@ impl TurnState {
         )
     )]
     pub(crate) fn queued_next_turn_input_count(&self) -> usize {
-        self.queued_next_turn_inputs.len()
+        self.transition_state.queued_next_turn_inputs.len()
     }
 
     /// Drain all buffered inband submissions.
     pub(crate) fn drain_buffered_inband_submissions(&mut self) -> VecDeque<Submission> {
-        std::mem::take(&mut self.buffered_inband_submissions)
+        std::mem::take(&mut self.transition_state.buffered_inband_submissions)
     }
 
     /// Push a submission to the buffered inband submissions queue.
     pub(crate) fn push_buffered_inband_submission(&mut self, submission: Submission) {
-        self.buffered_inband_submissions.push_back(submission);
+        self.transition_state
+            .buffered_inband_submissions
+            .push_back(submission);
     }
 
     /// Pop a submission from the buffered inband submissions queue.
     pub(crate) fn pop_buffered_inband_submission(&mut self) -> Option<Submission> {
-        self.buffered_inband_submissions.pop_front()
+        self.transition_state
+            .buffered_inband_submissions
+            .pop_front()
     }
 
     /// Count user input submissions in the buffered queue
     pub(crate) fn buffered_inband_user_input_count(&self) -> usize {
-        self.buffered_inband_submissions
+        self.transition_state
+            .buffered_inband_submissions
             .iter()
             .filter(|submission| matches!(submission.op, alan_agent_protocol::Op::Input { .. }))
             .count()
@@ -183,8 +229,8 @@ impl TurnState {
 
     /// Clear buffered inband submissions and return the count
     pub(crate) fn clear_buffered_inband_submissions(&mut self) -> usize {
-        let count = self.buffered_inband_submissions.len();
-        self.buffered_inband_submissions.clear();
+        let count = self.transition_state.buffered_inband_submissions.len();
+        self.transition_state.buffered_inband_submissions.clear();
         count
     }
 
@@ -197,11 +243,11 @@ impl TurnState {
         )
     )]
     pub(crate) fn latest_pending_key(&self) -> Option<String> {
-        self.pending_order.last().cloned()
+        self.transition_state.pending_order.last().cloned()
     }
 
     pub(crate) fn set_turn_activity(&mut self, activity: TurnActivityState) {
-        self.turn_activity = activity;
+        self.transition_state.turn_activity = activity;
     }
 
     #[cfg_attr(
@@ -212,70 +258,79 @@ impl TurnState {
         )
     )]
     pub(crate) fn turn_activity(&self) -> TurnActivityState {
-        self.turn_activity
+        self.transition_state.turn_activity
     }
 
     pub(crate) fn is_turn_active(&self) -> bool {
-        !matches!(self.turn_activity, TurnActivityState::Idle)
+        !matches!(self.transition_state.turn_activity, TurnActivityState::Idle)
     }
 
     pub(crate) fn begin_turn(&mut self, tape_message_count: usize) {
-        self.active_turn_message_start = Some(tape_message_count);
+        self.transition_state.active_turn_message_start = Some(tape_message_count);
     }
 
     pub(crate) fn active_turn_message_start(&self) -> Option<usize> {
-        self.active_turn_message_start
+        self.transition_state.active_turn_message_start
     }
 
     pub(crate) fn set_active_turn_request_control_intent(
         &mut self,
         intent: crate::RequestControlIntent,
     ) {
-        self.active_turn_request_control_intent = intent;
+        self.transition_state.active_turn_request_control_intent = intent;
     }
 
     pub(crate) fn active_turn_request_control_intent(&self) -> crate::RequestControlIntent {
-        self.active_turn_request_control_intent
+        self.transition_state.active_turn_request_control_intent
     }
 
     pub(crate) fn note_tape_compaction(&mut self, retention_start: usize) {
-        if let Some(active_turn_message_start) = &mut self.active_turn_message_start {
+        if let Some(active_turn_message_start) =
+            &mut self.transition_state.active_turn_message_start
+        {
             *active_turn_message_start = active_turn_message_start.saturating_sub(retention_start);
         }
         if self
+            .transition_state
             .plan_snapshot_turn_start
             .is_some_and(|start| start < retention_start)
         {
-            self.plan_snapshot_turn_start = None;
-        } else if let Some(plan_snapshot_turn_start) = &mut self.plan_snapshot_turn_start {
+            self.transition_state.plan_snapshot_turn_start = None;
+        } else if let Some(plan_snapshot_turn_start) =
+            &mut self.transition_state.plan_snapshot_turn_start
+        {
             *plan_snapshot_turn_start -= retention_start;
         }
         if self
+            .transition_state
             .plan_snapshot_message_count
             .is_some_and(|count| count < retention_start)
         {
-            self.plan_snapshot_message_count = None;
-        } else if let Some(plan_snapshot_message_count) = &mut self.plan_snapshot_message_count {
+            self.transition_state.plan_snapshot_message_count = None;
+        } else if let Some(plan_snapshot_message_count) =
+            &mut self.transition_state.plan_snapshot_message_count
+        {
             *plan_snapshot_message_count -= retention_start;
         }
     }
 
     pub(crate) fn note_resumed_user_input(&mut self) {
-        self.plan_snapshot_turn_start = None;
+        self.transition_state.plan_snapshot_turn_start = None;
     }
 
     pub(crate) fn set_active_skills(&mut self, active_skills: Vec<ActiveSkillEnvelope>) {
-        self.active_skills = active_skills;
+        self.transition_state.active_skills = active_skills;
     }
 
     pub(crate) fn active_skills(&self) -> &[ActiveSkillEnvelope] {
-        &self.active_skills
+        &self.transition_state.active_skills
     }
 
     pub(crate) fn set_plan_snapshot(&mut self, explanation: Option<String>, items: Vec<PlanItem>) {
-        self.plan_snapshot = Some(PlanSnapshot { explanation, items });
-        self.plan_snapshot_turn_start = self.active_turn_message_start;
-        self.plan_snapshot_message_count = None;
+        self.transition_state.plan_snapshot = Some(PlanSnapshot { explanation, items });
+        self.transition_state.plan_snapshot_turn_start =
+            self.transition_state.active_turn_message_start;
+        self.transition_state.plan_snapshot_message_count = None;
     }
 
     pub(crate) fn set_plan_snapshot_at_message_count(
@@ -285,29 +340,33 @@ impl TurnState {
         tape_message_count: usize,
     ) {
         self.set_plan_snapshot(explanation, items);
-        self.plan_snapshot_message_count = Some(tape_message_count);
+        self.transition_state.plan_snapshot_message_count = Some(tape_message_count);
     }
 
     pub(crate) fn plan_snapshot(&self) -> Option<&PlanSnapshot> {
-        self.plan_snapshot.as_ref()
+        self.transition_state.plan_snapshot.as_ref()
     }
 
     pub(crate) fn plan_snapshot_is_from_active_turn(&self) -> bool {
-        self.active_turn_message_start.is_some()
-            && self.plan_snapshot_turn_start == self.active_turn_message_start
+        self.transition_state.active_turn_message_start.is_some()
+            && self.transition_state.plan_snapshot_turn_start
+                == self.transition_state.active_turn_message_start
     }
 
     pub(crate) fn plan_snapshot_postdates_message(&self, message_index: usize) -> bool {
-        self.plan_snapshot_message_count
+        self.transition_state
+            .plan_snapshot_message_count
             .is_some_and(|count| count > message_index)
     }
 
     pub(crate) fn push_deferred_runtime_action(&mut self, action: DeferredRuntimeAction) {
-        self.deferred_runtime_actions.push_back(action);
+        self.transition_state
+            .deferred_runtime_actions
+            .push_back(action);
     }
 
     pub(crate) fn drain_deferred_runtime_actions(&mut self) -> VecDeque<DeferredRuntimeAction> {
-        std::mem::take(&mut self.deferred_runtime_actions)
+        std::mem::take(&mut self.transition_state.deferred_runtime_actions)
     }
 
     pub(crate) fn can_auto_mid_turn_compact(
@@ -319,11 +378,11 @@ impl TurnState {
             return true;
         }
 
-        if self.compactions_this_turn >= AUTO_MID_TURN_COMPACTION_LIMIT {
+        if self.transition_state.compactions_this_turn >= AUTO_MID_TURN_COMPACTION_LIMIT {
             return false;
         }
 
-        if let Some(last_prompt_tokens) = self.last_compaction_prompt_tokens
+        if let Some(last_prompt_tokens) = self.transition_state.last_compaction_prompt_tokens
             && estimated_prompt_tokens
                 <= last_prompt_tokens.saturating_add(AUTO_MID_TURN_COMPACTION_MIN_GROWTH_TOKENS)
         {
@@ -334,8 +393,11 @@ impl TurnState {
     }
 
     pub(crate) fn record_auto_mid_turn_compaction(&mut self, output_prompt_tokens: usize) {
-        self.compactions_this_turn = self.compactions_this_turn.saturating_add(1);
-        self.last_compaction_prompt_tokens = Some(output_prompt_tokens);
+        self.transition_state.compactions_this_turn = self
+            .transition_state
+            .compactions_this_turn
+            .saturating_add(1);
+        self.transition_state.last_compaction_prompt_tokens = Some(output_prompt_tokens);
     }
 
     #[cfg_attr(
@@ -346,7 +408,7 @@ impl TurnState {
         )
     )]
     pub(crate) fn compactions_this_turn(&self) -> u32 {
-        self.compactions_this_turn
+        self.transition_state.compactions_this_turn
     }
 
     #[cfg_attr(
@@ -366,16 +428,18 @@ impl TurnState {
         pending: PendingConfirmation,
     ) {
         let key = request_id.into();
-        self.pending
+        self.transition_state
+            .pending
             .insert(key.clone(), PendingYield::Confirmation(pending));
-        push_latest_key(&mut self.pending_order, key);
+        push_latest_key(&mut self.transition_state.pending_order, key);
     }
 
     pub(crate) fn pending_confirmation(&self) -> Option<PendingConfirmation> {
-        self.pending_order
+        self.transition_state
+            .pending_order
             .iter()
             .rev()
-            .find_map(|key| match self.pending.get(key) {
+            .find_map(|key| match self.transition_state.pending.get(key) {
                 Some(PendingYield::Confirmation(value)) => Some(value.clone()),
                 _ => None,
             })
@@ -386,7 +450,8 @@ impl TurnState {
         checkpoint_id: impl Into<String>,
         tool_calls: Vec<NormalizedToolCall>,
     ) {
-        self.pending_tool_replay_batches
+        self.transition_state
+            .pending_tool_replay_batches
             .insert(checkpoint_id.into(), tool_calls);
     }
 
@@ -394,7 +459,9 @@ impl TurnState {
         &mut self,
         checkpoint_id: &str,
     ) -> Option<Vec<NormalizedToolCall>> {
-        self.pending_tool_replay_batches.remove(checkpoint_id)
+        self.transition_state
+            .pending_tool_replay_batches
+            .remove(checkpoint_id)
     }
 
     #[cfg_attr(
@@ -414,15 +481,16 @@ impl TurnState {
         pending: PendingStructuredInputRequest,
     ) {
         let key = request_id.into();
-        self.pending
+        self.transition_state
+            .pending
             .insert(key.clone(), PendingYield::StructuredInput(pending));
-        push_latest_key(&mut self.pending_order, key);
+        push_latest_key(&mut self.transition_state.pending_order, key);
     }
 
     /// Unified lookup: take any pending item by request_id.
-    pub(super) fn take_pending(&mut self, request_id: &str) -> Option<PendingYield> {
-        let item = self.pending.remove(request_id)?;
-        remove_key(&mut self.pending_order, request_id);
+    pub(crate) fn take_pending(&mut self, request_id: &str) -> Option<PendingYield> {
+        let item = self.transition_state.pending.remove(request_id)?;
+        remove_key(&mut self.transition_state.pending_order, request_id);
         Some(item)
     }
 }
@@ -444,8 +512,20 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    fn accepted_submission_identity_is_machine_owned() {
+        let mut machine = AgentMachine::new();
+        assert_eq!(machine.current_submission_id(), None);
+
+        machine.accept_submission("sub-1");
+        assert_eq!(machine.current_submission_id(), Some("sub-1"));
+
+        machine.finish_submission();
+        assert_eq!(machine.current_submission_id(), None);
+    }
+
+    #[test]
     fn guardian_breaker_trips_on_three_consecutive_denials() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         assert!(!state.record_guardian_review(true));
         assert!(!state.record_guardian_review(true));
         assert!(state.record_guardian_review(true)); // third consecutive trips
@@ -453,7 +533,7 @@ mod tests {
 
     #[test]
     fn guardian_breaker_resets_on_allow() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         assert!(!state.record_guardian_review(true));
         assert!(!state.record_guardian_review(true));
         assert!(!state.record_guardian_review(false)); // reset
@@ -464,7 +544,7 @@ mod tests {
 
     #[test]
     fn guardian_breaker_trips_on_ten_denials_in_window() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         // Interleave allow/deny so it never hits 3 consecutive, but reaches 10
         // denials within the rolling window.
         let mut tripped = false;
@@ -477,7 +557,7 @@ mod tests {
 
     #[test]
     fn test_confirmation_set_and_pending() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         state.set_confirmation(PendingConfirmation {
             checkpoint_id: "cp-1".to_string(),
             checkpoint_type: "tool_escalation".to_string(),
@@ -497,7 +577,7 @@ mod tests {
 
     #[test]
     fn test_clear_resets_pending_interactions() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         state.set_confirmation(PendingConfirmation {
             checkpoint_id: "cp".to_string(),
             checkpoint_type: "tool_escalation".to_string(),
@@ -505,7 +585,7 @@ mod tests {
             details: json!({}),
             options: vec!["approve".to_string()],
         });
-        state.clear();
+        state.reset_turn();
         assert!(state.pending_confirmation().is_none());
         assert!(!state.has_pending_interaction());
         assert!(matches!(state.turn_activity(), TurnActivityState::Idle));
@@ -513,7 +593,7 @@ mod tests {
 
     #[test]
     fn test_turn_activity_state_roundtrip_and_clear() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         assert!(matches!(state.turn_activity(), TurnActivityState::Idle));
 
         state.set_turn_activity(TurnActivityState::Running);
@@ -522,14 +602,14 @@ mod tests {
         state.set_turn_activity(TurnActivityState::Paused);
         assert!(matches!(state.turn_activity(), TurnActivityState::Paused));
 
-        state.clear();
+        state.reset_turn();
         assert!(matches!(state.turn_activity(), TurnActivityState::Idle));
         assert_eq!(state.compactions_this_turn(), 0);
     }
 
     #[test]
     fn test_clear_preserves_plan_snapshot() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         state.set_plan_snapshot(
             Some("Keep the current plan".to_string()),
             vec![PlanItem {
@@ -539,7 +619,7 @@ mod tests {
             }],
         );
 
-        state.clear();
+        state.reset_turn();
 
         let snapshot = state.plan_snapshot().expect("plan snapshot should persist");
         assert_eq!(
@@ -551,7 +631,7 @@ mod tests {
 
     #[test]
     fn test_clear_plan_snapshot_removes_latest_plan() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         state.set_plan_snapshot(
             Some("Drop the current plan".to_string()),
             vec![PlanItem {
@@ -568,7 +648,7 @@ mod tests {
 
     #[test]
     fn test_active_skills_roundtrip_and_clear() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         state.set_active_skills(vec![crate::skills::ActiveSkillEnvelope::available(
             crate::skills::SkillMetadata {
                 id: "deploy".to_string(),
@@ -600,13 +680,13 @@ mod tests {
         assert_eq!(state.active_skills().len(), 1);
         assert_eq!(state.active_skills()[0].metadata.id, "deploy");
 
-        state.clear();
+        state.reset_turn();
         assert!(state.active_skills().is_empty());
     }
 
     #[test]
     fn test_active_turn_message_start_tracks_turn_start_and_compaction() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         assert_eq!(state.active_turn_message_start(), None);
 
         state.begin_turn(5);
@@ -618,13 +698,13 @@ mod tests {
         state.note_tape_compaction(10);
         assert_eq!(state.active_turn_message_start(), Some(0));
 
-        state.clear();
+        state.reset_turn();
         assert_eq!(state.active_turn_message_start(), None);
     }
 
     #[test]
     fn dropped_plan_boundary_does_not_become_active_after_compaction() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         state.begin_turn(2);
         state.set_plan_snapshot(Some("old plan".to_string()), Vec::new());
         state.begin_turn(5);
@@ -637,7 +717,7 @@ mod tests {
 
     #[test]
     fn test_auto_mid_turn_compaction_budget_and_growth_guard() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         assert!(state.can_auto_mid_turn_compact(4_000, 8_192));
 
         state.record_auto_mid_turn_compaction(3_200);
@@ -650,7 +730,7 @@ mod tests {
         assert!(!state.can_auto_mid_turn_compact(3_700, 8_192));
         assert!(state.can_auto_mid_turn_compact(7_980, 8_192));
 
-        state.clear();
+        state.reset_turn();
         assert!(state.can_auto_mid_turn_compact(4_000, 8_192));
     }
 
@@ -663,7 +743,7 @@ mod tests {
 
     #[test]
     fn test_latest_pending_key_tracks_cross_type_insertion_order() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         state.set_confirmation(PendingConfirmation {
             checkpoint_id: "cp-1".to_string(),
             checkpoint_type: "manual".to_string(),
@@ -687,7 +767,7 @@ mod tests {
 
     #[test]
     fn test_turn_state_buffers_inband_submissions_fifo() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         state.push_buffered_inband_submission(Submission {
             id: "s1".to_string(),
             op: alan_agent_protocol::Op::Input {
@@ -725,7 +805,7 @@ mod tests {
 
     #[test]
     fn test_turn_state_drain_buffered_inband_submissions_preserves_order() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         state.push_buffered_inband_submission(Submission {
             id: "s1".to_string(),
             op: alan_agent_protocol::Op::Input {
@@ -752,7 +832,7 @@ mod tests {
 
     #[test]
     fn test_clear_buffered_inband_submissions_returns_count() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         state.push_buffered_inband_submission(Submission {
             id: "s1".to_string(),
             op: alan_agent_protocol::Op::Input {
@@ -775,7 +855,7 @@ mod tests {
 
     #[test]
     fn test_queue_next_turn_inputs_fifo_and_drain() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         assert_eq!(
             state.queue_next_turn_input(vec![ContentPart::text("ctx-1")]),
             Some(1)
@@ -795,7 +875,7 @@ mod tests {
 
     #[test]
     fn test_queue_next_turn_inputs_overflow_is_rejected() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         for _ in 0..MAX_QUEUED_NEXT_TURN_INPUTS {
             assert!(
                 state
@@ -812,7 +892,7 @@ mod tests {
 
     #[test]
     fn test_tool_replay_batch_roundtrip() {
-        let mut state = TurnState::default();
+        let mut state = AgentMachine::new();
         let tool_calls = vec![
             NormalizedToolCall {
                 id: "call-1".to_string(),

--- a/crates/agent-engine/src/runtime/agent_loop.rs
+++ b/crates/agent-engine/src/runtime/agent_loop.rs
@@ -18,7 +18,14 @@ use anyhow::Result;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
-use crate::{agent_machine::AgentMachine, config::Config, retry, runtime::RuntimeConfig};
+#[cfg(test)]
+use crate::agent_machine::NormalizedToolCall;
+use crate::{
+    agent_machine::{AgentMachine, DeferredRuntimeAction, TurnActivityState},
+    config::Config,
+    retry,
+    runtime::RuntimeConfig,
+};
 
 use super::submission_handlers::{RuntimeOpAction, handle_runtime_op_with_cancel};
 use super::tool_orchestrator::{
@@ -28,7 +35,6 @@ use super::tool_orchestrator::{
 use super::turn_driver::TurnInputBroker;
 pub(super) use super::turn_executor::run_turn_with_cancel;
 use super::turn_executor::{TurnExecutionOutcome, TurnRunKind};
-use super::turn_state::{TurnActivityState, TurnState};
 #[allow(
     unused_imports,
     reason = "these helpers are imported here for the adjacent white-box test module"
@@ -36,19 +42,6 @@ use super::turn_state::{TurnActivityState, TurnState};
 use super::turn_support::{
     cancel_current_task, emit_streaming_chunks, normalize_tool_calls, split_text_for_typing,
 };
-/// Normalized tool call with guaranteed ID
-#[derive(Debug, Clone)]
-pub struct NormalizedToolCall {
-    pub id: String,
-    pub name: String,
-    pub arguments: serde_json::Value,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) enum DeferredRuntimeAction {
-    TurnMemoryPromotion(super::memory_promotion::TurnMemoryPromotionJob),
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum DeferredRuntimeActionExit {
     Completed,
@@ -56,15 +49,13 @@ pub(super) enum DeferredRuntimeActionExit {
 }
 
 /// Agent state for the execution loop
-pub struct RuntimeLoopState {
-    pub machine: AgentMachine,
-    pub current_submission_id: Option<String>,
-    pub environment: NamespaceRuntimeEnvironment,
-    pub core_config: Config,
-    pub runtime_config: RuntimeConfig,
-    pub definition_persona_dirs: Vec<std::path::PathBuf>,
-    pub prompt_cache: super::prompt_cache::PromptAssemblyCache,
-    pub turn_state: TurnState,
+pub(crate) struct RuntimeLoopState {
+    pub(crate) machine: AgentMachine,
+    pub(crate) environment: NamespaceRuntimeEnvironment,
+    pub(crate) core_config: Config,
+    pub(crate) runtime_config: RuntimeConfig,
+    pub(crate) definition_persona_dirs: Vec<std::path::PathBuf>,
+    pub(crate) prompt_cache: super::prompt_cache::PromptAssemblyCache,
 }
 
 impl RuntimeLoopState {
@@ -255,9 +246,7 @@ where
             user_input,
             activate_task,
         } => {
-            state
-                .turn_state
-                .set_turn_activity(TurnActivityState::Running);
+            state.machine.set_turn_activity(TurnActivityState::Running);
             let turn_outcome = match run_turn_with_cancel(
                 state,
                 turn_kind,
@@ -270,11 +259,11 @@ where
             {
                 Ok(outcome) => outcome,
                 Err(err) => {
-                    state.turn_state.set_turn_activity(TurnActivityState::Idle);
+                    state.machine.set_turn_activity(TurnActivityState::Idle);
                     return Err(err);
                 }
             };
-            state.turn_state.set_turn_activity(
+            state.machine.set_turn_activity(
                 if matches!(turn_outcome, TurnExecutionOutcome::Paused) {
                     TurnActivityState::Paused
                 } else {
@@ -291,9 +280,7 @@ where
             approved_unknown_effect_call_id,
             approved_tool_escalation_call_id,
         } => {
-            state
-                .turn_state
-                .set_turn_activity(TurnActivityState::Running);
+            state.machine.set_turn_activity(TurnActivityState::Running);
             match replay_approved_tool_call_with_cancel(
                 state,
                 &tool_call,
@@ -321,11 +308,11 @@ where
                         {
                             Ok(outcome) => outcome,
                             Err(err) => {
-                                state.turn_state.set_turn_activity(TurnActivityState::Idle);
+                                state.machine.set_turn_activity(TurnActivityState::Idle);
                                 return Err(err);
                             }
                         };
-                        state.turn_state.set_turn_activity(
+                        state.machine.set_turn_activity(
                             if matches!(turn_outcome, TurnExecutionOutcome::Paused) {
                                 TurnActivityState::Paused
                             } else {
@@ -334,9 +321,7 @@ where
                         );
                     }
                     ToolBatchOrchestratorOutcome::PauseTurn => {
-                        state
-                            .turn_state
-                            .set_turn_activity(TurnActivityState::Paused);
+                        state.machine.set_turn_activity(TurnActivityState::Paused);
                     }
                     ToolBatchOrchestratorOutcome::EndTurn { surfaces_refreshed } => {
                         finalize_replayed_tool_end_turn_best_effort(
@@ -350,7 +335,7 @@ where
                     }
                 },
                 Err(err) => {
-                    state.turn_state.set_turn_activity(TurnActivityState::Idle);
+                    state.machine.set_turn_activity(TurnActivityState::Idle);
                     return Err(err);
                 }
             };
@@ -361,9 +346,7 @@ where
             approved_unknown_effect_call_id,
             approved_tool_escalation_call_id,
         } => {
-            state
-                .turn_state
-                .set_turn_activity(TurnActivityState::Running);
+            state.machine.set_turn_activity(TurnActivityState::Running);
             match replay_approved_tool_batch_with_cancel(
                 state,
                 &tool_calls,
@@ -391,11 +374,11 @@ where
                         {
                             Ok(outcome) => outcome,
                             Err(err) => {
-                                state.turn_state.set_turn_activity(TurnActivityState::Idle);
+                                state.machine.set_turn_activity(TurnActivityState::Idle);
                                 return Err(err);
                             }
                         };
-                        state.turn_state.set_turn_activity(
+                        state.machine.set_turn_activity(
                             if matches!(turn_outcome, TurnExecutionOutcome::Paused) {
                                 TurnActivityState::Paused
                             } else {
@@ -404,9 +387,7 @@ where
                         );
                     }
                     ToolBatchOrchestratorOutcome::PauseTurn => {
-                        state
-                            .turn_state
-                            .set_turn_activity(TurnActivityState::Paused);
+                        state.machine.set_turn_activity(TurnActivityState::Paused);
                     }
                     ToolBatchOrchestratorOutcome::EndTurn { surfaces_refreshed } => {
                         finalize_replayed_tool_end_turn_best_effort(
@@ -420,7 +401,7 @@ where
                     }
                 },
                 Err(err) => {
-                    state.turn_state.set_turn_activity(TurnActivityState::Idle);
+                    state.machine.set_turn_activity(TurnActivityState::Idle);
                     return Err(err);
                 }
             };
@@ -448,12 +429,12 @@ async fn finalize_replayed_tool_end_turn_best_effort(
             super::memory_promotion::build_turn_memory_promotion_job(state, promotion_context)
         {
             state
-                .turn_state
+                .machine
                 .push_deferred_runtime_action(DeferredRuntimeAction::TurnMemoryPromotion(job));
         }
     }
 
-    state.turn_state.set_turn_activity(TurnActivityState::Idle);
+    state.machine.set_turn_activity(TurnActivityState::Idle);
 }
 
 pub(super) async fn run_deferred_runtime_action_with_cancel(

--- a/crates/agent-engine/src/runtime/agent_loop/namespace_environment/tests.rs
+++ b/crates/agent-engine/src/runtime/agent_loop/namespace_environment/tests.rs
@@ -418,22 +418,20 @@ async fn answered_request_response_resumes_engine_pending_yield_from_files() {
         other => panic!("expected Op::Resume, got {other:?}"),
     }
 
-    let mut turn_state = super::super::super::turn_state::TurnState::default();
-    turn_state.set_structured_input(crate::approval::PendingStructuredInputRequest {
+    let mut machine = crate::agent_machine::AgentMachine::new();
+    machine.set_structured_input(crate::approval::PendingStructuredInputRequest {
         request_id,
         title: "Missing detail".to_string(),
         prompt: "Provide the missing detail".to_string(),
         questions: Vec::new(),
     });
     let mut state = super::super::RuntimeLoopState {
-        machine: crate::agent_machine::AgentMachine::new(),
-        current_submission_id: None,
+        machine,
         environment,
         core_config: crate::Config::default(),
         runtime_config: super::super::super::RuntimeConfig::default(),
         definition_persona_dirs: Vec::new(),
         prompt_cache: super::super::super::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state,
     };
     let cancel = tokio_util::sync::CancellationToken::new();
     let mut events = Vec::new();
@@ -458,7 +456,7 @@ async fn answered_request_response_resumes_engine_pending_yield_from_files() {
         ),
         "resume should re-enter the turn path: {action:?}"
     );
-    assert!(!state.turn_state.has_pending_interaction());
+    assert!(!state.machine.has_pending_interaction());
     assert!(events.is_empty());
     let messages = state.machine.messages();
     assert_eq!(messages.len(), 1);

--- a/crates/agent-engine/src/runtime/agent_loop/tests.rs
+++ b/crates/agent-engine/src/runtime/agent_loop/tests.rs
@@ -118,13 +118,11 @@ fn runtime_state_with_provider(provider: impl LlmProvider + 'static) -> RuntimeL
 fn runtime_state_with_environment(environment: NamespaceRuntimeEnvironment) -> RuntimeLoopState {
     RuntimeLoopState {
         machine: AgentMachine::new(),
-        current_submission_id: None,
         environment,
         core_config: Config::default(),
         runtime_config: super::RuntimeConfig::default(),
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     }
 }
 
@@ -307,12 +305,10 @@ impl LlmProvider for TimeoutThenSucceedStreamProvider {
 
 fn create_replay_memory_test_state(
     memory_dir: std::path::PathBuf,
-    turn_state: TurnState,
     machine: AgentMachine,
 ) -> RuntimeLoopState {
     RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(DelayedMockProvider::new(
             tokio::time::Duration::from_millis(0),
             "",
@@ -326,13 +322,12 @@ fn create_replay_memory_test_state(
         runtime_config: super::RuntimeConfig::default(),
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state,
     }
 }
 
 async fn run_deferred_runtime_actions(state: &mut RuntimeLoopState) -> usize {
     let cancel = CancellationToken::new();
-    let actions = state.turn_state.drain_deferred_runtime_actions();
+    let actions = state.machine.drain_deferred_runtime_actions();
     let count = actions.len();
     for action in actions {
         assert_eq!(

--- a/crates/agent-engine/src/runtime/agent_loop/tests/compaction_recovery.rs
+++ b/crates/agent-engine/src/runtime/agent_loop/tests/compaction_recovery.rs
@@ -9,13 +9,13 @@ async fn test_manual_compaction_records_audit_fields() {
     for i in 0..65 {
         machine.add_user_message(&format!("Message {}", i));
     }
+    machine.accept_submission("sub-compact");
 
     let rollout_path = machine.rollout_path().unwrap().clone();
     let runtime_config = super::RuntimeConfig::default();
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: Some("sub-compact".to_string()),
         environment: namespace_environment_with_provider(DelayedMockProvider::new(
             tokio::time::Duration::from_millis(0),
             "Manual compaction summary",
@@ -24,7 +24,6 @@ async fn test_manual_compaction_records_audit_fields() {
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let mut events = vec![];
@@ -105,7 +104,6 @@ async fn test_compaction_retry_result_is_audited_when_trimming_succeeds() {
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(FailThenSucceedMockProvider::new(
             1,
             "Compaction summary after retry",
@@ -114,7 +112,6 @@ async fn test_compaction_retry_result_is_audited_when_trimming_succeeds() {
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let mut emit = |_event: Event| async {};
@@ -172,7 +169,6 @@ async fn test_compaction_generation_failure_uses_degraded_fallback_and_audits_it
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(ErrorMockProvider::new(
             "synthetic compaction failure",
         )),
@@ -180,7 +176,6 @@ async fn test_compaction_generation_failure_uses_degraded_fallback_and_audits_it
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let mut events = vec![];
@@ -253,7 +248,6 @@ async fn test_degraded_compaction_rebases_active_turn_start() {
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(ErrorMockProvider::new(
             "synthetic compaction failure",
         )),
@@ -261,13 +255,12 @@ async fn test_degraded_compaction_rebases_active_turn_start() {
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let retention_start = state
         .machine.compaction_retention_start(state.runtime_config.compaction_keep_last);
     assert!(retention_start > 0);
-    state.turn_state.begin_turn(retention_start);
+    state.machine.begin_turn(retention_start);
 
     let mut emit = |_event: Event| async {};
     let outcome =
@@ -282,7 +275,7 @@ async fn test_degraded_compaction_rebases_active_turn_start() {
         _ => panic!("expected degraded compaction to apply"),
     }
 
-    assert_eq!(state.turn_state.active_turn_message_start(), Some(0));
+    assert_eq!(state.machine.active_turn_message_start(), Some(0));
 }
 
 #[test]
@@ -332,7 +325,6 @@ async fn test_compaction_failure_without_fallback_escalates_warning_and_preserve
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(ErrorMockProvider::new(
             "synthetic compaction failure",
         )),
@@ -340,7 +332,6 @@ async fn test_compaction_failure_without_fallback_escalates_warning_and_preserve
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let mut events = vec![];

--- a/crates/agent-engine/src/runtime/agent_loop/tests/compaction_thresholds.rs
+++ b/crates/agent-engine/src/runtime/agent_loop/tests/compaction_thresholds.rs
@@ -6,7 +6,6 @@ async fn test_maybe_compact_context_no_compaction_needed() {
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(DelayedMockProvider::new(
             tokio::time::Duration::from_millis(0),
             "",
@@ -15,7 +14,6 @@ async fn test_maybe_compact_context_no_compaction_needed() {
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let mut events = vec![];
@@ -50,7 +48,6 @@ async fn test_maybe_compact_context_with_mock_llm() {
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(DelayedMockProvider::new(
             tokio::time::Duration::from_millis(0),
             "Summary",
@@ -59,7 +56,6 @@ async fn test_maybe_compact_context_with_mock_llm() {
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let mut events = vec![];
@@ -98,7 +94,6 @@ async fn test_maybe_compact_context_triggers_on_estimated_token_budget() {
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(DelayedMockProvider::new(
             tokio::time::Duration::from_millis(0),
             "Summary from token-triggered compaction",
@@ -107,7 +102,6 @@ async fn test_maybe_compact_context_triggers_on_estimated_token_budget() {
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let mut emit = |_event: Event| async {};
@@ -151,7 +145,6 @@ async fn test_maybe_compact_context_triggers_immediately_when_ratio_is_zero() {
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(DelayedMockProvider::new(
             tokio::time::Duration::from_millis(0),
             "Summary from zero-ratio compaction",
@@ -160,7 +153,6 @@ async fn test_maybe_compact_context_triggers_immediately_when_ratio_is_zero() {
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let mut emit = |_event: Event| async {};
@@ -204,7 +196,6 @@ async fn test_maybe_compact_context_skips_when_context_window_budget_has_room() 
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(DelayedMockProvider::new(
             tokio::time::Duration::from_millis(0),
             "Should not compact",
@@ -213,7 +204,6 @@ async fn test_maybe_compact_context_skips_when_context_window_budget_has_room() 
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let original_len = state.machine.tape_len();
@@ -261,7 +251,6 @@ async fn test_auto_pre_turn_soft_compaction_flushes_memory_before_compaction() {
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(SequencedMockProvider::new(vec![
             SequencedStep::Success(memory_flush_json_response()),
             SequencedStep::Success("Summary after soft-threshold compaction".to_string()),
@@ -270,7 +259,6 @@ async fn test_auto_pre_turn_soft_compaction_flushes_memory_before_compaction() {
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let mut events = vec![];
@@ -354,7 +342,6 @@ async fn test_auto_pre_turn_soft_compaction_continues_after_memory_flush_failure
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(SequencedMockProvider::new(vec![
             SequencedStep::Error("synthetic memory flush failure".to_string()),
             SequencedStep::Success("Summary after failed memory flush".to_string()),
@@ -363,7 +350,6 @@ async fn test_auto_pre_turn_soft_compaction_continues_after_memory_flush_failure
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let mut events = vec![];
@@ -450,7 +436,6 @@ async fn test_auto_pre_turn_soft_compaction_skips_memory_flush_when_nothing_is_d
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(SequencedMockProvider::new(vec![
             SequencedStep::Success(
                 "{\"why\":\"\",\"key_decisions\":[],\"constraints\":[],\"next_steps\":[],\"important_refs\":[]}"
@@ -462,7 +447,6 @@ async fn test_auto_pre_turn_soft_compaction_skips_memory_flush_when_nothing_is_d
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let mut events = vec![];
@@ -550,7 +534,6 @@ async fn test_auto_pre_turn_soft_compaction_records_already_flushed_cycle_skip()
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(SequencedMockProvider::new(vec![
             SequencedStep::Success("Summary after already-flushed-cycle skip".to_string()),
         ])),
@@ -558,7 +541,6 @@ async fn test_auto_pre_turn_soft_compaction_records_already_flushed_cycle_skip()
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let mut events = vec![];
@@ -643,7 +625,6 @@ async fn test_auto_pre_turn_hard_compaction_skips_memory_flush() {
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(SequencedMockProvider::new(vec![
             SequencedStep::Success("Summary at hard threshold".to_string()),
         ])),
@@ -651,7 +632,6 @@ async fn test_auto_pre_turn_hard_compaction_skips_memory_flush() {
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let mut events = vec![];
@@ -706,7 +686,6 @@ async fn test_manual_compaction_bypasses_automatic_thresholds_without_memory_flu
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(DelayedMockProvider::new(
             tokio::time::Duration::from_millis(0),
             "Manual compaction below threshold",
@@ -715,7 +694,6 @@ async fn test_manual_compaction_bypasses_automatic_thresholds_without_memory_flu
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let mut events = vec![];
@@ -761,7 +739,6 @@ async fn test_maybe_compact_context_allows_mid_turn_emergency_near_hard_limit() 
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(DelayedMockProvider::new(
             tokio::time::Duration::from_millis(0),
             "Summary from emergency mid-turn compaction",
@@ -770,7 +747,6 @@ async fn test_maybe_compact_context_allows_mid_turn_emergency_near_hard_limit() 
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let mut emit = |_event: Event| async {};

--- a/crates/agent-engine/src/runtime/agent_loop/tests/core_behaviors.rs
+++ b/crates/agent-engine/src/runtime/agent_loop/tests/core_behaviors.rs
@@ -140,12 +140,18 @@ fn test_split_text_for_typing_long_text_chunks_preserve_content() {
 #[tokio::test]
 async fn test_cancel_current_task() {
     let config = Config::default();
-    let machine = AgentMachine::new();
+    let mut machine = AgentMachine::new();
+    machine.set_confirmation(PendingConfirmation {
+        checkpoint_id: "cp_123".to_string(),
+        checkpoint_type: "test_checkpoint".to_string(),
+        summary: "Test".to_string(),
+        details: json!({}),
+        options: vec!["approve".to_string()],
+    });
     let runtime_config = super::RuntimeConfig::default();
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(DelayedMockProvider::new(
             tokio::time::Duration::from_millis(0),
             "",
@@ -154,17 +160,6 @@ async fn test_cancel_current_task() {
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: {
-            let mut turn_state = TurnState::default();
-            turn_state.set_confirmation(PendingConfirmation {
-                checkpoint_id: "cp_123".to_string(),
-                checkpoint_type: "test_checkpoint".to_string(),
-                summary: "Test".to_string(),
-                details: json!({}),
-                options: vec!["approve".to_string()],
-            });
-            turn_state
-        },
     };
     state.machine.add_user_message("existing history");
     state.machine.activate_task();
@@ -178,7 +173,7 @@ async fn test_cancel_current_task() {
     let result = cancel_current_task(&mut state, &mut emit).await;
 
     assert!(result.is_ok());
-    assert!(state.turn_state.pending_confirmation().is_none());
+    assert!(state.machine.pending_confirmation().is_none());
     assert!(!state.machine.has_active_task());
     assert_eq!(state.machine.messages().len(), 1);
     assert_eq!(
@@ -205,9 +200,8 @@ async fn test_handle_submission_promotes_direct_user_fact_when_replayed_tool_cal
     let mut machine = AgentMachine::new();
     machine.add_user_message("My name is Morris.");
 
-    let mut turn_state = TurnState::default();
-    turn_state.begin_turn(0);
-    turn_state.set_confirmation(PendingConfirmation {
+    machine.begin_turn(0);
+    machine.set_confirmation(PendingConfirmation {
         checkpoint_id: checkpoint_id.to_string(),
         checkpoint_type: TOOL_ESCALATION_CHECKPOINT_TYPE.to_string(),
         summary: "Replay tool call".to_string(),
@@ -221,7 +215,7 @@ async fn test_handle_submission_promotes_direct_user_fact_when_replayed_tool_cal
         options: vec!["approve".to_string(), "reject".to_string()],
     });
 
-    let mut state = create_replay_memory_test_state(memory_dir.clone(), turn_state, machine);
+    let mut state = create_replay_memory_test_state(memory_dir.clone(), machine);
     let cancel = CancellationToken::new();
     let mut emit = |_event: Event| async {};
 
@@ -239,7 +233,7 @@ async fn test_handle_submission_promotes_direct_user_fact_when_replayed_tool_cal
     .await;
 
     assert!(result.is_ok());
-    assert_eq!(state.turn_state.turn_activity(), TurnActivityState::Idle);
+    assert_eq!(state.machine.turn_activity(), TurnActivityState::Idle);
     assert_eq!(run_deferred_runtime_actions(&mut state).await, 1);
 
     let user_memory = std::fs::read_to_string(memory_dir.join("USER.md")).unwrap();
@@ -255,16 +249,15 @@ async fn test_handle_submission_promotes_direct_user_fact_when_replayed_tool_bat
     let mut machine = AgentMachine::new();
     machine.add_user_message("My name is Morris.");
 
-    let mut turn_state = TurnState::default();
-    turn_state.begin_turn(0);
-    turn_state.set_confirmation(PendingConfirmation {
+    machine.begin_turn(0);
+    machine.set_confirmation(PendingConfirmation {
         checkpoint_id: checkpoint_id.to_string(),
         checkpoint_type: TOOL_ESCALATION_CHECKPOINT_TYPE.to_string(),
         summary: "Replay tool batch".to_string(),
         details: json!({}),
         options: vec!["approve".to_string(), "reject".to_string()],
     });
-    turn_state.set_tool_replay_batch(
+    machine.set_tool_replay_batch(
         checkpoint_id,
         vec![NormalizedToolCall {
             id: "call-1".to_string(),
@@ -273,7 +266,7 @@ async fn test_handle_submission_promotes_direct_user_fact_when_replayed_tool_bat
         }],
     );
 
-    let mut state = create_replay_memory_test_state(memory_dir.clone(), turn_state, machine);
+    let mut state = create_replay_memory_test_state(memory_dir.clone(), machine);
     let cancel = CancellationToken::new();
     let mut emit = |_event: Event| async {};
 
@@ -291,7 +284,7 @@ async fn test_handle_submission_promotes_direct_user_fact_when_replayed_tool_bat
     .await;
 
     assert!(result.is_ok());
-    assert_eq!(state.turn_state.turn_activity(), TurnActivityState::Idle);
+    assert_eq!(state.machine.turn_activity(), TurnActivityState::Idle);
     assert_eq!(run_deferred_runtime_actions(&mut state).await, 1);
 
     let user_memory = std::fs::read_to_string(memory_dir.join("USER.md")).unwrap();
@@ -336,7 +329,6 @@ fn test_agent_loop_state_creation() {
 
     let state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(DelayedMockProvider::new(
             tokio::time::Duration::from_millis(0),
             "",
@@ -345,10 +337,9 @@ fn test_agent_loop_state_creation() {
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
-    assert!(state.turn_state.pending_confirmation().is_none());
+    assert!(state.machine.pending_confirmation().is_none());
 }
 
 #[test]

--- a/crates/agent-engine/src/runtime/agent_loop/tests/submissions.rs
+++ b/crates/agent-engine/src/runtime/agent_loop/tests/submissions.rs
@@ -13,7 +13,6 @@ async fn test_handle_submission_cancel() {
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_live_process(DelayedMockProvider::new(
             tokio::time::Duration::from_millis(0),
             "",
@@ -23,7 +22,6 @@ async fn test_handle_submission_cancel() {
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let mut events = vec![];
@@ -69,7 +67,6 @@ async fn test_handle_submission_rollback() {
 
     let mut state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_with_provider(DelayedMockProvider::new(
             tokio::time::Duration::from_millis(0),
             "",
@@ -78,7 +75,6 @@ async fn test_handle_submission_rollback() {
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     let mut events = vec![];

--- a/crates/agent-engine/src/runtime/child_agents/task_context.rs
+++ b/crates/agent-engine/src/runtime/child_agents/task_context.rs
@@ -94,7 +94,7 @@ fn render_conversation_snapshot(parent: &RuntimeLoopState) -> Option<String> {
 }
 
 fn render_plan_snapshot(parent: &RuntimeLoopState) -> Option<String> {
-    let plan_snapshot = parent.turn_state.plan_snapshot()?;
+    let plan_snapshot = parent.machine.plan_snapshot()?;
     let mut lines = Vec::new();
     if let Some(explanation) = plan_snapshot.explanation.as_deref()
         && !explanation.trim().is_empty()

--- a/crates/agent-engine/src/runtime/child_agents/tests.rs
+++ b/crates/agent-engine/src/runtime/child_agents/tests.rs
@@ -493,8 +493,7 @@ fn make_parent_state_with_capability_view(
     machine.add_assistant_message("Parent assistant explains the approach", None);
     machine.add_tool_message("tool_call_1", "alpha", json!({"summary": "tool output"}));
 
-    let mut turn_state = super::super::TurnState::default();
-    turn_state.set_plan_snapshot(
+    machine.set_plan_snapshot(
         Some("Finish the delegated check".to_string()),
         vec![alan_agent_protocol::PlanItem {
             id: "plan-1".to_string(),
@@ -511,7 +510,6 @@ fn make_parent_state_with_capability_view(
 
     RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_for_parent_test_with_services(
             Arc::new(alan_routefs::RouteFs::new()),
             llmfs,
@@ -529,7 +527,6 @@ fn make_parent_state_with_capability_view(
             Vec::new(),
             SkillHostCapabilities::with_tools(["alpha", "beta"]),
         ),
-        turn_state,
     }
 }
 

--- a/crates/agent-engine/src/runtime/child_run_termination_tool.rs
+++ b/crates/agent-engine/src/runtime/child_run_termination_tool.rs
@@ -8,11 +8,12 @@ use crate::approval::{
 };
 use crate::llm::ToolDefinition;
 
-use super::agent_loop::{NormalizedToolCall, RuntimeLoopState};
+use super::agent_loop::RuntimeLoopState;
 use super::child_runs::{ChildRunRegistryError, ChildRunTerminationMode};
 use super::tool_policy::{ToolPolicyDecision, evaluate_tool_policy};
 use super::turn_support::tool_result_preview;
 use super::virtual_tool::VirtualToolOutcome;
+use crate::agent_machine::NormalizedToolCall;
 
 pub(super) async fn handle_terminate_child_run<E, F>(
     state: &mut RuntimeLoopState,
@@ -210,7 +211,7 @@ where
                 "tool_name": tool_call.name,
                 "arguments": tool_arguments,
             });
-            details = append_skill_permission_hints(details, state.turn_state.active_skills());
+            details = append_skill_permission_hints(details, state.machine.active_skills());
             let pending = PendingConfirmation {
                 checkpoint_id: format!("{TOOL_ESCALATION_CHECKPOINT_PREFIX}{}", tool_call.id),
                 checkpoint_type: TOOL_ESCALATION_CHECKPOINT_TYPE.to_string(),
@@ -230,7 +231,7 @@ where
                 .await?
                 .unwrap_or_else(|| pending.checkpoint_id.clone());
             state
-                .turn_state
+                .machine
                 .set_confirmation_for_request(request_id.clone(), pending.clone());
             super::ui_surfaces::paused(state.namespace_environment()).await?;
             emit(Event::Yield {

--- a/crates/agent-engine/src/runtime/child_run_termination_tool_tests.rs
+++ b/crates/agent-engine/src/runtime/child_run_termination_tool_tests.rs
@@ -205,7 +205,7 @@ async fn test_try_handle_virtual_tool_call_terminate_child_run_escalates_under_e
     let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(result.unwrap(), VirtualToolOutcome::PauseTurn));
-    assert!(state.turn_state.pending_confirmation().is_some());
+    assert!(state.machine.pending_confirmation().is_some());
     assert!(events.iter().any(|event| matches!(
         event,
         Event::Yield { kind: alan_agent_protocol::YieldKind::Confirmation, payload, .. }

--- a/crates/agent-engine/src/runtime/compaction.rs
+++ b/crates/agent-engine/src/runtime/compaction.rs
@@ -270,7 +270,7 @@ fn compaction_submission_id(
     request: &CompactionRequest,
 ) -> Option<String> {
     matches!(request.mode(), CompactionMode::Manual)
-        .then(|| state.current_submission_id.clone())
+        .then(|| state.machine.current_submission_id().map(str::to_owned))
         .flatten()
 }
 
@@ -525,7 +525,7 @@ fn apply_tape_compaction(
     retention_start: usize,
 ) {
     state.machine.compact_tape(summary.to_string(), keep_last);
-    state.turn_state.note_tape_compaction(retention_start);
+    state.machine.note_tape_compaction(retention_start);
 }
 
 pub(crate) async fn maybe_compact_context_for_request<E, F>(
@@ -827,7 +827,7 @@ mod tests {
         agent_machine::AgentMachine,
         config::Config,
         runtime::{
-            NamespaceRuntimeEnvironment, RuntimeConfig, RuntimeLoopState, TurnState,
+            NamespaceRuntimeEnvironment, RuntimeConfig, RuntimeLoopState,
             prompt_cache::PromptAssemblyCache,
         },
     };
@@ -893,7 +893,6 @@ mod tests {
 
         RuntimeLoopState {
             machine: AgentMachine::new(),
-            current_submission_id: None,
             environment: NamespaceRuntimeEnvironment::new(root, "/agent/1", "default"),
             core_config: Config::default(),
             runtime_config: RuntimeConfig {
@@ -903,7 +902,6 @@ mod tests {
             },
             definition_persona_dirs: Vec::new(),
             prompt_cache: PromptAssemblyCache::new(Vec::new()),
-            turn_state: TurnState::default(),
         }
     }
 

--- a/crates/agent-engine/src/runtime/compaction/pressure.rs
+++ b/crates/agent-engine/src/runtime/compaction/pressure.rs
@@ -68,7 +68,7 @@ pub(super) fn evaluate_compaction_pressure(
     let over_soft_token_threshold =
         context_window_tokens > 0 && estimated_prompt_tokens >= soft_token_trigger_threshold;
     let emergency_mid_turn_compaction = matches!(request.mode(), CompactionMode::AutoMidTurn)
-        && super::super::turn_state::is_auto_mid_turn_compaction_emergency(
+        && crate::agent_machine::is_auto_mid_turn_compaction_emergency(
             estimated_prompt_tokens,
             context_window_tokens,
         );

--- a/crates/agent-engine/src/runtime/delegated_skill_tool.rs
+++ b/crates/agent-engine/src/runtime/delegated_skill_tool.rs
@@ -11,7 +11,7 @@ use tokio_util::sync::CancellationToken;
 use crate::llm::ToolDefinition;
 use crate::skills::{DelegatedSkillResult, DelegatedSkillResultStatus};
 
-use super::agent_loop::{NormalizedToolCall, RuntimeLoopState};
+use super::agent_loop::RuntimeLoopState;
 use super::child_agents::spawn_child_runtime_cancellable;
 use super::delegated_child_run::ChildRuntimeResult;
 use super::delegated_skill_evidence::{
@@ -22,6 +22,7 @@ use super::delegation_capabilities::{
 };
 use super::turn_support::{check_turn_cancelled, tool_result_preview};
 use super::virtual_tool::VirtualToolOutcome;
+use crate::agent_machine::NormalizedToolCall;
 
 pub(super) const MAX_DELEGATED_SKILL_ID_CHARS: usize = 120;
 pub(super) const MAX_DELEGATED_TARGET_CHARS: usize = 120;
@@ -383,7 +384,7 @@ fn resolve_delegated_skill_invocation(
     request: &DelegatedSkillInvocationRequest,
 ) -> DelegatedSkillSpawnResult<SpawnSpec> {
     let active_skill = state
-        .turn_state
+        .machine
         .active_skills()
         .iter()
         .find(|skill| skill.metadata.id == request.skill_id)

--- a/crates/agent-engine/src/runtime/delegated_skill_tool_tests.rs
+++ b/crates/agent-engine/src/runtime/delegated_skill_tool_tests.rs
@@ -589,9 +589,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_bounds_preview
 async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_honors_interrupt() {
     let mut state = create_test_agent_loop_state();
     activate_test_delegated_skill(&mut state, "repo-review", "reviewer");
-    state
-        .turn_state
-        .set_turn_activity(TurnActivityState::Running);
+    state.machine.set_turn_activity(TurnActivityState::Running);
 
     let tool_call = NormalizedToolCall {
         id: "call_1".to_string(),
@@ -661,9 +659,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_honors_interru
 {
     let mut state = create_test_agent_loop_state();
     activate_test_delegated_skill(&mut state, "repo-review", "reviewer");
-    state
-        .turn_state
-        .set_turn_activity(TurnActivityState::Running);
+    state.machine.set_turn_activity(TurnActivityState::Running);
 
     let tool_call = NormalizedToolCall {
         id: "call_1".to_string(),

--- a/crates/agent-engine/src/runtime/engine.rs
+++ b/crates/agent-engine/src/runtime/engine.rs
@@ -10,7 +10,6 @@ use super::turn_driver::{
     NAMESPACE_PENDING_RESPONSE_POLL_INTERVAL, TurnInputBroker, drive_turn_submission_with_cancel,
     is_turn_inband_submission, namespace_pending_resume_submission, should_drive_turn_submission,
 };
-use super::turn_state::TurnState;
 use super::{NamespaceRuntimeEnvironment, RuntimeLoopState};
 use crate::agent_machine::AgentMachine;
 use alan_agent_protocol::{Event, InputMode, Submission};
@@ -28,11 +27,11 @@ use tracing::{debug, error, info, warn};
 /// Requeue leftover inband submissions from turn state and broker to the outer queue.
 async fn requeue_leftover_inband_submissions(
     broker: &TurnInputBroker,
-    turn_state: &mut TurnState,
+    machine: &mut AgentMachine,
     queued_submissions: &mut VecDeque<QueuedRuntimeItem>,
 ) -> usize {
     let broker_drained = broker.drain().await;
-    let turn_drained = turn_state.drain_buffered_inband_submissions();
+    let turn_drained = machine.drain_buffered_inband_submissions();
     let count = broker_drained.len() + turn_drained.len();
     for submission in turn_drained {
         push_submission_ahead_of_deferred(queued_submissions, submission);
@@ -47,7 +46,7 @@ async fn requeue_leftover_inband_submissions(
 /// 2. The `active_turn_broker` - channel for in-turn submissions during active turn execution.
 enum QueuedRuntimeItem {
     Submission(Submission),
-    Deferred(super::agent_loop::DeferredRuntimeAction),
+    Deferred(crate::agent_machine::DeferredRuntimeAction),
 }
 
 fn push_submission_ahead_of_deferred(
@@ -75,7 +74,7 @@ fn preserves_paused_terminal_state(result: &Result<()>, has_pending_interaction:
 async fn read_pending_namespace_resume_submission(
     state: &RuntimeLoopState,
 ) -> Option<Result<Submission>> {
-    if !state.turn_state.has_pending_interaction() {
+    if !state.machine.has_pending_interaction() {
         return None;
     }
 
@@ -121,15 +120,15 @@ impl RuntimeSubmissionQueues {
         push_submission_ahead_of_deferred(&mut self.outer_queue, submission);
     }
 
-    fn push_outer_deferred(&mut self, action: super::agent_loop::DeferredRuntimeAction) {
+    fn push_outer_deferred(&mut self, action: crate::agent_machine::DeferredRuntimeAction) {
         self.outer_queue
             .push_back(QueuedRuntimeItem::Deferred(action));
     }
 
-    async fn requeue_active_turn_leftovers(&mut self, turn_state: &mut TurnState) -> usize {
+    async fn requeue_active_turn_leftovers(&mut self, machine: &mut AgentMachine) -> usize {
         requeue_leftover_inband_submissions(
             &self.active_turn_broker,
-            turn_state,
+            machine,
             &mut self.outer_queue,
         )
         .await
@@ -431,13 +430,11 @@ fn spawn_with_prepared_runtime_environment(
         // Build agent loop state
         let mut state = RuntimeLoopState {
             machine,
-            current_submission_id: None,
             environment,
             core_config,
             runtime_config,
             definition_persona_dirs: prompt_cache_persona_dirs.clone(),
             prompt_cache,
-            turn_state: super::TurnState::default(),
         };
         match super::ui_surfaces::initialize(state.namespace_environment()).await {
             Ok(()) => {}
@@ -507,7 +504,7 @@ fn spawn_with_prepared_runtime_environment(
                 None
             } else {
                 let namespace_control = state.namespace_environment().clone();
-                let poll_pending_namespace_response = state.turn_state.has_pending_interaction();
+                let poll_pending_namespace_response = state.machine.has_pending_interaction();
                 tokio::select! {
                     submission = sub_rx.recv() => submission.map(QueuedRuntimeItem::Submission),
                     namespace_submission = namespace_input_rx.recv() => {
@@ -571,7 +568,7 @@ fn spawn_with_prepared_runtime_environment(
                 QueuedRuntimeItem::Submission(submission) => {
                     debug!(?submission.id, "Received submission");
                     let drive_as_turn_submission = should_drive_turn_submission(&submission.op);
-                    state.current_submission_id = Some(submission.id.clone());
+                    state.machine.accept_submission(submission.id.clone());
 
                     let cancel = CancellationToken::new();
                     let mut emit = |_event: Event| async {};
@@ -604,7 +601,7 @@ fn spawn_with_prepared_runtime_environment(
                                 let terminal_ui_result = match &result {
                                     Ok(()) if preserves_paused_terminal_state(
                                         &result,
-                                        state.turn_state.has_pending_interaction(),
+                                        state.machine.has_pending_interaction(),
                                     ) => Ok(()),
                                     Ok(()) => super::ui_surfaces::turn_completed(
                                         &namespace_heartbeat,
@@ -622,7 +619,7 @@ fn spawn_with_prepared_runtime_environment(
                                 }
                                 if drive_as_turn_submission {
                                     let _ = queues
-                                        .requeue_active_turn_leftovers(&mut state.turn_state)
+                                        .requeue_active_turn_leftovers(&mut state.machine)
                                         .await;
                                 }
                                 if let Err(e) = result {
@@ -631,12 +628,12 @@ fn spawn_with_prepared_runtime_environment(
                                 }
                                 queues.outer_queue.extend(
                                     state
-                                        .turn_state
+                                        .machine
                                         .drain_deferred_runtime_actions()
                                         .into_iter()
                                         .map(QueuedRuntimeItem::Deferred),
                                 );
-                                state.current_submission_id = None;
+                                state.machine.finish_submission();
                                 break;
                             }
                             incoming = sub_rx.recv(), if !submissions_closed => {

--- a/crates/agent-engine/src/runtime/engine_runtime_tests.rs
+++ b/crates/agent-engine/src/runtime/engine_runtime_tests.rs
@@ -38,15 +38,15 @@ async fn test_requeue_active_turn_leftovers_inserts_before_existing_deferred_act
     let mut queues = RuntimeSubmissionQueues::default();
     queues.push_outer_deferred(make_deferred_action_for_test());
 
-    let mut turn_state = TurnState::default();
+    let mut machine = AgentMachine::new();
     let buffered_submission = Submission::new(Op::Input {
         parts: vec![alan_agent_protocol::ContentPart::text("follow up")],
         mode: alan_agent_protocol::InputMode::FollowUp,
     });
     let buffered_submission_id = buffered_submission.id.clone();
-    turn_state.push_buffered_inband_submission(buffered_submission);
+    machine.push_buffered_inband_submission(buffered_submission);
 
-    let requeued = queues.requeue_active_turn_leftovers(&mut turn_state).await;
+    let requeued = queues.requeue_active_turn_leftovers(&mut machine).await;
 
     assert_eq!(requeued, 1);
     assert_eq!(
@@ -396,22 +396,20 @@ async fn test_outer_idle_reads_answered_namespace_request_response() {
         ))
         .await
         .unwrap();
-    let mut turn_state = TurnState::default();
-    turn_state.set_structured_input(crate::approval::PendingStructuredInputRequest {
+    let mut machine = AgentMachine::new();
+    machine.set_structured_input(crate::approval::PendingStructuredInputRequest {
         request_id: request_id.clone(),
         title: "Missing value".to_string(),
         prompt: "Provide the missing value".to_string(),
         questions: Vec::new(),
     });
     let state = RuntimeLoopState {
-        machine: crate::agent_machine::AgentMachine::new(),
-        current_submission_id: None,
+        machine,
         environment: namespace_environment,
         core_config: crate::Config::default(),
         runtime_config: RuntimeConfig::default(),
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state,
     };
 
     assert!(

--- a/crates/agent-engine/src/runtime/engine_tests.rs
+++ b/crates/agent-engine/src/runtime/engine_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
-use crate::runtime::{RuntimeConfig, agent_loop::DeferredRuntimeAction, memory_promotion};
+use crate::agent_machine::DeferredRuntimeAction;
+use crate::runtime::{RuntimeConfig, memory_promotion};
 use alan_agent_protocol::{ContentPart, Op};
 use alan_ap::InProcessTransport;
 use alan_llm::{
@@ -56,8 +57,7 @@ fn make_deferred_action_for_test() -> DeferredRuntimeAction {
     let mut machine = AgentMachine::new();
     machine.add_user_message("My name is Morris.");
 
-    let mut turn_state = TurnState::default();
-    turn_state.begin_turn(0);
+    machine.begin_turn(0);
 
     let mut core_config = crate::Config::default();
     core_config.memory.enabled = true;
@@ -66,13 +66,11 @@ fn make_deferred_action_for_test() -> DeferredRuntimeAction {
 
     let state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_for_test(),
         core_config,
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state,
     };
 
     memory_promotion::build_turn_memory_promotion_job(&state, "queue ordering test")

--- a/crates/agent-engine/src/runtime/interaction_tool_tests.rs
+++ b/crates/agent-engine/src/runtime/interaction_tool_tests.rs
@@ -384,7 +384,7 @@ async fn test_try_handle_virtual_tool_call_request_confirmation() {
     assert!(matches!(result.unwrap(), VirtualToolOutcome::PauseTurn));
 
     // Verify confirmation was set
-    assert!(state.turn_state.pending_confirmation().is_some());
+    assert!(state.machine.pending_confirmation().is_some());
 }
 
 #[tokio::test]
@@ -412,16 +412,9 @@ async fn namespace_request_confirmation_writes_request_file_and_waits_on_file_id
         .await
         .unwrap();
     assert!(matches!(result, VirtualToolOutcome::PauseTurn));
+    assert_eq!(state.machine.pending_request_ids(), vec!["r0".to_string()]);
     assert_eq!(
-        state.turn_state.pending_request_ids(),
-        vec!["r0".to_string()]
-    );
-    assert_eq!(
-        state
-            .turn_state
-            .pending_confirmation()
-            .unwrap()
-            .checkpoint_id,
+        state.machine.pending_confirmation().unwrap().checkpoint_id,
         "call_1"
     );
     assert_eq!(
@@ -498,7 +491,7 @@ async fn test_try_handle_virtual_tool_call_request_user_input() {
     assert!(matches!(result.unwrap(), VirtualToolOutcome::PauseTurn));
 
     // Verify structured input was set
-    assert!(state.turn_state.has_pending_interaction());
+    assert!(state.machine.has_pending_interaction());
 }
 
 #[tokio::test]
@@ -525,10 +518,7 @@ async fn namespace_request_user_input_writes_request_file_and_waits_on_file_id()
         .await
         .unwrap();
     assert!(matches!(result, VirtualToolOutcome::PauseTurn));
-    assert_eq!(
-        state.turn_state.pending_request_ids(),
-        vec!["r0".to_string()]
-    );
+    assert_eq!(state.machine.pending_request_ids(), vec!["r0".to_string()]);
     assert_eq!(
         read_shell_utf8(&shell, "/agent/1/requests/r0/kind").await,
         "structured_input"

--- a/crates/agent-engine/src/runtime/memory_flush.rs
+++ b/crates/agent-engine/src/runtime/memory_flush.rs
@@ -549,7 +549,7 @@ mod tests {
         agent_machine::AgentMachine,
         config::Config,
         runtime::{
-            NamespaceRuntimeEnvironment, RuntimeConfig, RuntimeLoopState, TurnState,
+            NamespaceRuntimeEnvironment, RuntimeConfig, RuntimeLoopState,
             prompt_cache::PromptAssemblyCache,
         },
     };
@@ -616,13 +616,11 @@ mod tests {
 
         RuntimeLoopState {
             machine: AgentMachine::new(),
-            current_submission_id: None,
             environment: NamespaceRuntimeEnvironment::new(root, "/agent/1", "default"),
             core_config: Config::default(),
             runtime_config: RuntimeConfig::default(),
             definition_persona_dirs: Vec::new(),
             prompt_cache: PromptAssemblyCache::new(Vec::new()),
-            turn_state: TurnState::default(),
         }
     }
 

--- a/crates/agent-engine/src/runtime/memory_promotion.rs
+++ b/crates/agent-engine/src/runtime/memory_promotion.rs
@@ -268,7 +268,7 @@ pub(crate) fn build_turn_memory_promotion_job(
     let memory_dir = state.core_config.memory.store_dir.clone()?;
     let active_turn_user_messages = active_turn_user_messages(
         state.machine.messages(),
-        state.turn_state.active_turn_message_start(),
+        state.machine.active_turn_message_start(),
     );
     if active_turn_user_messages.is_empty() {
         return None;

--- a/crates/agent-engine/src/runtime/memory_promotion/tests.rs
+++ b/crates/agent-engine/src/runtime/memory_promotion/tests.rs
@@ -13,7 +13,7 @@ use tempfile::TempDir;
 use crate::{
     config::Config,
     runtime::{
-        NamespaceRuntimeEnvironment, RuntimeConfig, RuntimeLoopState, TurnState,
+        NamespaceRuntimeEnvironment, RuntimeConfig, RuntimeLoopState,
         prompt_cache::PromptAssemblyCache,
     },
 };
@@ -430,13 +430,11 @@ async fn deferred_memory_promotion_uses_namespace_llmfs() {
     let root = InProcessTransport::new(Arc::new(MountFs::new(namespace)));
     let mut state = RuntimeLoopState {
         machine: AgentMachine::new(),
-        current_submission_id: None,
         environment: NamespaceRuntimeEnvironment::new(root, "/agent/1", "default"),
         core_config: Config::default(),
         runtime_config: RuntimeConfig::default(),
         definition_persona_dirs: Vec::new(),
         prompt_cache: PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
     let job = TurnMemoryPromotionJob {
         memory_dir: memory_dir.clone(),

--- a/crates/agent-engine/src/runtime/memory_surfaces.rs
+++ b/crates/agent-engine/src/runtime/memory_surfaces.rs
@@ -9,7 +9,6 @@ use crate::agent_machine::AgentMachine;
 use crate::tape::Message;
 
 use super::agent_loop::RuntimeLoopState;
-use super::turn_state::TurnState;
 
 const MAX_INLINE_TEXT_CHARS: usize = 280;
 const MAX_RECENT_MESSAGE_ITEMS: usize = 6;
@@ -43,13 +42,7 @@ pub(crate) async fn refresh_turn_memory_surfaces(state: &RuntimeLoopState) -> Re
     let now = Utc::now();
     let process_path = state.process_path();
     let memory_record_id = state.machine.memory_record_id();
-    let rendered = render_memory_surfaces(
-        &state.machine,
-        &state.turn_state,
-        &process_path,
-        memory_record_id,
-        now,
-    );
+    let rendered = render_memory_surfaces(&state.machine, &process_path, memory_record_id, now);
 
     write_text_file(
         &working_memory_path(memory_dir, memory_record_id),
@@ -80,7 +73,7 @@ pub(crate) async fn refresh_active_turn_memory_surfaces_best_effort(
     state: &RuntimeLoopState,
     context: &'static str,
 ) {
-    if state.turn_state.active_turn_message_start().is_none() {
+    if state.machine.active_turn_message_start().is_none() {
         return;
     }
 
@@ -89,15 +82,14 @@ pub(crate) async fn refresh_active_turn_memory_surfaces_best_effort(
 
 fn render_memory_surfaces(
     machine: &AgentMachine,
-    turn_state: &TurnState,
     process_path: &str,
     memory_record_id: &str,
     now: DateTime<Utc>,
 ) -> RenderedMemorySurfaces {
-    let current_goal = derive_current_goal(machine, turn_state);
-    let latest_assistant_state = derive_latest_assistant_state(machine, turn_state);
-    let active_plan_items = render_plan_items(turn_state, &["in_progress", "pending"]);
-    let completed_plan_items = render_plan_items(turn_state, &["completed"]);
+    let current_goal = derive_current_goal(machine);
+    let latest_assistant_state = derive_latest_assistant_state(machine);
+    let active_plan_items = render_plan_items(machine, &["in_progress", "pending"]);
+    let completed_plan_items = render_plan_items(machine, &["completed"]);
     let recent_messages = render_recent_messages(machine);
     let compaction_summary = render_compaction_summary(machine);
     let latest_memory_flush = render_latest_memory_flush(machine);
@@ -127,7 +119,7 @@ fn render_memory_surfaces(
     }
 }
 
-fn derive_current_goal(machine: &AgentMachine, turn_state: &TurnState) -> String {
+fn derive_current_goal(machine: &AgentMachine) -> String {
     let source_ref = memory_source_ref(machine);
     let user_messages = machine
         .messages()
@@ -145,11 +137,11 @@ fn derive_current_goal(machine: &AgentMachine, turn_state: &TurnState) -> String
         .map(|(_, text)| is_substantive_goal_message(text))
         .unwrap_or(false);
     let latest_is_current_turn = latest_user
-        .zip(turn_state.active_turn_message_start())
+        .zip(machine.active_turn_message_start())
         .is_some_and(|((index, _), start)| *index >= start);
 
-    if turn_state.plan_snapshot_is_from_active_turn()
-        && let Some(plan_goal) = derive_active_plan_goal(turn_state)
+    if machine.plan_snapshot_is_from_active_turn()
+        && let Some(plan_goal) = derive_active_plan_goal(machine)
     {
         return plan_goal;
     }
@@ -167,8 +159,8 @@ fn derive_current_goal(machine: &AgentMachine, turn_state: &TurnState) -> String
         .rev()
         .find(|(_, text)| is_substantive_goal_message(text))
     {
-        if turn_state.plan_snapshot_postdates_message(*index)
-            && let Some(plan_goal) = derive_active_plan_goal(turn_state)
+        if machine.plan_snapshot_postdates_message(*index)
+            && let Some(plan_goal) = derive_active_plan_goal(machine)
         {
             return mark_carried_goal_if_needed(plan_goal, latest_user, latest_is_substantive);
         }
@@ -176,7 +168,7 @@ fn derive_current_goal(machine: &AgentMachine, turn_state: &TurnState) -> String
         return mark_carried_goal_if_needed(goal, latest_user, latest_is_substantive);
     }
 
-    if let Some(plan_goal) = derive_active_plan_goal(turn_state) {
+    if let Some(plan_goal) = derive_active_plan_goal(machine) {
         return mark_carried_goal_if_needed(plan_goal, latest_user, latest_is_substantive);
     }
 
@@ -195,8 +187,8 @@ fn derive_current_goal(machine: &AgentMachine, turn_state: &TurnState) -> String
         .unwrap_or_else(|| "No current goal recorded.".to_string())
 }
 
-fn derive_active_plan_goal(turn_state: &TurnState) -> Option<String> {
-    let snapshot = turn_state.plan_snapshot()?;
+fn derive_active_plan_goal(machine: &AgentMachine) -> Option<String> {
+    let snapshot = machine.plan_snapshot()?;
     snapshot
         .explanation
         .as_deref()
@@ -278,9 +270,9 @@ fn is_acknowledgement_class_fragment(text: &str) -> bool {
         })
 }
 
-fn derive_latest_assistant_state(machine: &AgentMachine, turn_state: &TurnState) -> String {
+fn derive_latest_assistant_state(machine: &AgentMachine) -> String {
     let source_ref = memory_source_ref(machine);
-    let messages = turn_state
+    let messages = machine
         .active_turn_message_start()
         .and_then(|start| machine.messages().get(start..))
         .unwrap_or_else(|| machine.messages());
@@ -293,7 +285,7 @@ fn derive_latest_assistant_state(machine: &AgentMachine, turn_state: &TurnState)
         .map(|text| truncate_memory_text(text.trim(), MAX_INLINE_TEXT_CHARS, &source_ref))
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| {
-            if turn_state.active_turn_message_start().is_some() {
+            if machine.active_turn_message_start().is_some() {
                 "This turn completed without a new assistant response.".to_string()
             } else {
                 "No assistant response recorded yet.".to_string()
@@ -301,8 +293,8 @@ fn derive_latest_assistant_state(machine: &AgentMachine, turn_state: &TurnState)
         })
 }
 
-fn render_plan_items(turn_state: &TurnState, statuses: &[&str]) -> String {
-    let Some(snapshot) = turn_state.plan_snapshot() else {
+fn render_plan_items(machine: &AgentMachine, statuses: &[&str]) -> String {
+    let Some(snapshot) = machine.plan_snapshot() else {
         return "- None recorded.\n".to_string();
     };
 

--- a/crates/agent-engine/src/runtime/memory_surfaces/tests.rs
+++ b/crates/agent-engine/src/runtime/memory_surfaces/tests.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::agent_machine::AgentMachine;
-use crate::runtime::turn_state::TurnState;
 use std::sync::Arc;
 
 fn namespace_environment_for_test() -> crate::runtime::NamespaceRuntimeEnvironment {
@@ -16,8 +15,7 @@ fn render_memory_surfaces_follow_pure_text_layout_and_content() {
     machine.add_user_message("Finish the pure-text memory slice.");
     machine.add_assistant_message("Added scaffolding and prompt bootstrap.", None);
 
-    let mut turn_state = TurnState::default();
-    turn_state.set_plan_snapshot(
+    machine.set_plan_snapshot(
         Some("Finish the pure-text memory slice.".to_string()),
         vec![
             alan_agent_protocol::PlanItem {
@@ -36,13 +34,7 @@ fn render_memory_surfaces_follow_pure_text_layout_and_content() {
     let now = DateTime::parse_from_rfc3339("2026-04-15T15:30:00Z")
         .unwrap()
         .with_timezone(&Utc);
-    let rendered = render_memory_surfaces(
-        &machine,
-        &turn_state,
-        "/proc/1",
-        machine.memory_record_id(),
-        now,
-    );
+    let rendered = render_memory_surfaces(&machine, "/proc/1", machine.memory_record_id(), now);
 
     assert!(rendered.working_memory.contains("# Working Memory"));
     assert!(rendered.handoff.contains("# Latest Handoff"));
@@ -85,20 +77,13 @@ fn render_memory_surfaces_scopes_latest_assistant_state_to_active_turn() {
     machine.add_user_message("Earlier task");
     machine.add_assistant_message("Earlier assistant response.", None);
 
-    let mut turn_state = TurnState::default();
-    turn_state.begin_turn(machine.messages().len());
+    machine.begin_turn(machine.messages().len());
     machine.add_user_message("Current tool-only turn");
 
     let now = DateTime::parse_from_rfc3339("2026-04-15T15:30:00Z")
         .unwrap()
         .with_timezone(&Utc);
-    let rendered = render_memory_surfaces(
-        &machine,
-        &turn_state,
-        "/proc/1",
-        machine.memory_record_id(),
-        now,
-    );
+    let rendered = render_memory_surfaces(&machine, "/proc/1", machine.memory_record_id(), now);
 
     assert!(
         rendered
@@ -117,7 +102,7 @@ fn one_letter_follow_up_carries_prior_substantive_goal() {
     machine.add_assistant_message("Ready for confirmation.", None);
     machine.add_user_message("y");
 
-    let goal = derive_current_goal(&machine, &TurnState::default());
+    let goal = derive_current_goal(&machine);
 
     assert_eq!(
         goal,
@@ -143,7 +128,7 @@ fn request_response_control_message_does_not_replace_goal() {
     )]);
 
     assert_eq!(
-        derive_current_goal(&machine, &TurnState::default()),
+        derive_current_goal(&machine),
         "Remove the obsolete compatibility endpoints."
     );
 }
@@ -152,13 +137,12 @@ fn request_response_control_message_does_not_replace_goal() {
 fn new_substantive_turn_request_replaces_stale_plan_goal() {
     let mut machine = AgentMachine::new();
     machine.add_user_message("Finish the old memory task.");
-    let mut turn_state = TurnState::default();
-    turn_state.set_plan_snapshot(Some("Finish the old memory task.".to_string()), Vec::new());
-    turn_state.begin_turn(machine.messages().len());
+    machine.set_plan_snapshot(Some("Finish the old memory task.".to_string()), Vec::new());
+    machine.begin_turn(machine.messages().len());
     machine.add_user_message("Rewrite the provider connection documentation.");
 
     assert_eq!(
-        derive_current_goal(&machine, &turn_state),
+        derive_current_goal(&machine),
         "Rewrite the provider connection documentation."
     );
 }
@@ -166,16 +150,15 @@ fn new_substantive_turn_request_replaces_stale_plan_goal() {
 #[test]
 fn in_turn_plan_update_refines_the_initial_user_goal() {
     let mut machine = AgentMachine::new();
-    let mut turn_state = TurnState::default();
-    turn_state.begin_turn(machine.messages().len());
+    machine.begin_turn(machine.messages().len());
     machine.add_user_message("Implement the memory contract changes.");
-    turn_state.set_plan_snapshot(
+    machine.set_plan_snapshot(
         Some("Validate salience and compaction fallback behavior.".to_string()),
         Vec::new(),
     );
 
     assert_eq!(
-        derive_current_goal(&machine, &turn_state),
+        derive_current_goal(&machine),
         "Validate salience and compaction fallback behavior."
     );
 }
@@ -183,18 +166,17 @@ fn in_turn_plan_update_refines_the_initial_user_goal() {
 #[test]
 fn substantive_resume_input_overrides_earlier_active_plan() {
     let mut machine = AgentMachine::new();
-    let mut turn_state = TurnState::default();
-    turn_state.begin_turn(machine.messages().len());
+    machine.begin_turn(machine.messages().len());
     machine.add_user_message("Implement the old memory contract.");
-    turn_state.set_plan_snapshot(
+    machine.set_plan_snapshot(
         Some("Finish the old memory contract.".to_string()),
         Vec::new(),
     );
-    turn_state.note_resumed_user_input();
+    machine.note_resumed_user_input();
     machine.add_user_message("Switch to the provider connection contract.");
 
     assert_eq!(
-        derive_current_goal(&machine, &turn_state),
+        derive_current_goal(&machine),
         "Switch to the provider connection contract."
     );
 }
@@ -203,29 +185,27 @@ fn substantive_resume_input_overrides_earlier_active_plan() {
 fn terse_imperative_passes_salience_filter() {
     let mut machine = AgentMachine::new();
     machine.add_user_message("Prepare the release.");
-    let mut turn_state = TurnState::default();
-    turn_state.set_plan_snapshot(Some("Prepare the release.".to_string()), Vec::new());
-    turn_state.begin_turn(machine.messages().len());
+    machine.set_plan_snapshot(Some("Prepare the release.".to_string()), Vec::new());
+    machine.begin_turn(machine.messages().len());
     machine.add_user_message("deploy it");
 
-    assert_eq!(derive_current_goal(&machine, &turn_state), "deploy it");
+    assert_eq!(derive_current_goal(&machine), "deploy it");
 }
 
 #[test]
 fn active_plan_goal_wins_when_latest_message_is_acknowledgement() {
     let mut machine = AgentMachine::new();
     machine.add_user_message("Complete the broader migration.");
-    let mut turn_state = TurnState::default();
-    turn_state.set_plan_snapshot_at_message_count(
+    machine.set_plan_snapshot_at_message_count(
         Some("Validate the namespace-native migration.".to_string()),
         Vec::new(),
         machine.messages().len(),
     );
-    turn_state.begin_turn(machine.messages().len());
+    machine.begin_turn(machine.messages().len());
     machine.add_user_message("ok");
 
     assert_eq!(
-        derive_current_goal(&machine, &turn_state),
+        derive_current_goal(&machine),
         "[carried forward] Validate the namespace-native migration."
     );
 }
@@ -234,8 +214,7 @@ fn active_plan_goal_wins_when_latest_message_is_acknowledgement() {
 fn later_substantive_goal_wins_before_stale_plan_on_acknowledgement() {
     let mut machine = AgentMachine::new();
     machine.add_user_message("Finish task A.");
-    let mut turn_state = TurnState::default();
-    turn_state.set_plan_snapshot_at_message_count(
+    machine.set_plan_snapshot_at_message_count(
         Some("Complete task A plan.".to_string()),
         Vec::new(),
         machine.messages().len(),
@@ -246,7 +225,7 @@ fn later_substantive_goal_wins_before_stale_plan_on_acknowledgement() {
     machine.add_user_message("ok");
 
     assert_eq!(
-        derive_current_goal(&machine, &turn_state),
+        derive_current_goal(&machine),
         "[carried forward] Switch to substantive task B."
     );
 }
@@ -261,7 +240,7 @@ fn compaction_summary_wins_before_acknowledgement_fallback() {
     machine.add_user_message("ok");
 
     assert_eq!(
-        derive_current_goal(&machine, &TurnState::default()),
+        derive_current_goal(&machine),
         "[carried forward] Complete the namespace-native lifecycle migration and verify parent visibility."
     );
 }
@@ -274,7 +253,7 @@ fn acknowledgement_token_sequences_and_emoji_modifiers_do_not_replace_goal() {
         machine.add_user_message(acknowledgement);
 
         assert_eq!(
-            derive_current_goal(&machine, &TurnState::default()),
+            derive_current_goal(&machine),
             "[carried forward] Archive the completed Alan OS contract changes.",
             "acknowledgement {acknowledgement:?} must not become the goal"
         );
@@ -283,8 +262,8 @@ fn acknowledgement_token_sequences_and_emoji_modifiers_do_not_replace_goal() {
 
 #[test]
 fn active_plan_goal_prefers_in_progress_before_pending_order() {
-    let mut turn_state = TurnState::default();
-    turn_state.set_plan_snapshot(
+    let mut machine = AgentMachine::new();
+    machine.set_plan_snapshot(
         None,
         vec![
             alan_agent_protocol::PlanItem {
@@ -301,7 +280,7 @@ fn active_plan_goal_prefers_in_progress_before_pending_order() {
     );
 
     assert_eq!(
-        derive_active_plan_goal(&turn_state).as_deref(),
+        derive_active_plan_goal(&machine).as_deref(),
         Some("Verify the current contract.")
     );
 }
@@ -311,7 +290,7 @@ fn acknowledgement_is_used_verbatim_when_no_better_context_exists() {
     let mut machine = AgentMachine::new();
     machine.add_user_message("ok");
 
-    assert_eq!(derive_current_goal(&machine, &TurnState::default()), "ok");
+    assert_eq!(derive_current_goal(&machine), "ok");
 }
 
 #[test]
@@ -372,8 +351,7 @@ async fn refresh_turn_memory_surfaces_writes_expected_files() {
     machine.add_user_message("Keep the latest handoff fresh.");
     machine.add_assistant_message("Wrote the memory surfaces.", None);
 
-    let mut turn_state = TurnState::default();
-    turn_state.set_plan_snapshot(
+    machine.set_plan_snapshot(
         Some("Keep the latest handoff fresh.".to_string()),
         vec![alan_agent_protocol::PlanItem {
             id: "p1".to_string(),
@@ -384,7 +362,6 @@ async fn refresh_turn_memory_surfaces_writes_expected_files() {
 
     let state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_for_test(),
         core_config: {
             let mut config = crate::Config::default();
@@ -394,7 +371,6 @@ async fn refresh_turn_memory_surfaces_writes_expected_files() {
         runtime_config: super::super::RuntimeConfig::default(),
         definition_persona_dirs: Vec::new(),
         prompt_cache: super::super::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state,
     };
 
     refresh_turn_memory_surfaces(&state).await.unwrap();
@@ -424,7 +400,6 @@ async fn refresh_memory_surfaces_needs_no_model_request_or_llm_mount() {
     let message_count = machine.messages().len();
     let state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_for_test(),
         core_config: {
             let mut config = crate::Config::default();
@@ -434,7 +409,6 @@ async fn refresh_memory_surfaces_needs_no_model_request_or_llm_mount() {
         runtime_config: super::super::RuntimeConfig::default(),
         definition_persona_dirs: Vec::new(),
         prompt_cache: super::super::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
 
     refresh_turn_memory_surfaces(&state).await.unwrap();

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -33,7 +33,6 @@ mod tool_policy;
 mod tool_presentation;
 mod turn_driver;
 mod turn_executor;
-mod turn_state;
 mod turn_support;
 mod ui_surfaces;
 mod virtual_tool;
@@ -64,8 +63,8 @@ pub use launch_config::{
 
 // Re-export agent loop types for internal use
 pub(crate) use agent_loop::RuntimeLoopState;
+pub(crate) use memory_promotion::TurnMemoryPromotionJob;
 pub use tool_packages::ToolPackageManifest;
-pub(crate) use turn_state::TurnState;
 
 /// Configuration for the agent runtime
 #[derive(Debug, Clone)]

--- a/crates/agent-engine/src/runtime/mount_request_tool.rs
+++ b/crates/agent-engine/src/runtime/mount_request_tool.rs
@@ -10,10 +10,11 @@ use crate::approval::{
 };
 use crate::llm::ToolDefinition;
 
-use super::agent_loop::{NormalizedToolCall, RuntimeLoopState};
+use super::agent_loop::RuntimeLoopState;
 use super::tool_policy::{ToolPolicyDecision, evaluate_tool_policy};
 use super::turn_support::tool_result_preview;
 use super::virtual_tool::VirtualToolOutcome;
+use crate::agent_machine::NormalizedToolCall;
 
 const RESERVED_MOUNT_NAMESPACE_ROOTS: &[&str] = &["llm", "mem", "route"];
 
@@ -233,7 +234,7 @@ where
         },
         "live_applied": false,
     });
-    details = append_skill_permission_hints(details, state.turn_state.active_skills());
+    details = append_skill_permission_hints(details, state.machine.active_skills());
 
     let pending = PendingConfirmation {
         checkpoint_id: format!("{MOUNT_ESCALATION_CHECKPOINT_PREFIX}{}", tool_call.id),
@@ -274,7 +275,7 @@ where
         Some(escalation_audit),
     );
     state
-        .turn_state
+        .machine
         .set_confirmation_for_request(request_id.clone(), pending.clone());
     super::ui_surfaces::paused(state.namespace_environment()).await?;
     emit(Event::Yield {

--- a/crates/agent-engine/src/runtime/mount_request_tool_tests.rs
+++ b/crates/agent-engine/src/runtime/mount_request_tool_tests.rs
@@ -227,7 +227,7 @@ async fn test_try_handle_virtual_tool_call_request_mount_escalates_even_when_all
     assert!(matches!(result.unwrap(), VirtualToolOutcome::PauseTurn));
 
     let pending = state
-        .turn_state
+        .machine
         .pending_confirmation()
         .expect("mount request should pause for confirmation");
     assert_eq!(
@@ -304,7 +304,7 @@ async fn test_try_handle_virtual_tool_call_request_mount_does_not_probe_host_exi
     assert!(matches!(result.unwrap(), VirtualToolOutcome::PauseTurn));
 
     let pending = state
-        .turn_state
+        .machine
         .pending_confirmation()
         .expect("syntactically valid mount request should pause for confirmation");
     assert_eq!(
@@ -351,7 +351,7 @@ async fn test_try_handle_virtual_tool_call_request_mount_denied_by_policy() {
             refresh_context: false
         }
     ));
-    assert!(state.turn_state.pending_confirmation().is_none());
+    assert!(state.machine.pending_confirmation().is_none());
     assert!(!events.iter().any(|event| matches!(
         event,
         Event::Yield {
@@ -421,7 +421,7 @@ default_action: allow
             refresh_context: false
         }
     ));
-    assert!(state.turn_state.pending_confirmation().is_none());
+    assert!(state.machine.pending_confirmation().is_none());
     assert!(events.iter().any(|event| matches!(
         event,
         Event::ToolCallCompleted { success: Some(false), audit: Some(audit), .. }
@@ -486,7 +486,7 @@ default_action: allow
             refresh_context: false
         }
     ));
-    assert!(state.turn_state.pending_confirmation().is_none());
+    assert!(state.machine.pending_confirmation().is_none());
     assert!(events.iter().any(|event| matches!(
         event,
         Event::ToolCallCompleted { success: Some(false), audit: Some(audit), .. }
@@ -529,7 +529,7 @@ async fn test_try_handle_virtual_tool_call_request_mount_rejects_invalid_request
             refresh_context: true
         }
     ));
-    assert!(state.turn_state.pending_confirmation().is_none());
+    assert!(state.machine.pending_confirmation().is_none());
     assert!(!events.iter().any(|event| matches!(
         event,
         Event::Yield {

--- a/crates/agent-engine/src/runtime/response_guardrails.rs
+++ b/crates/agent-engine/src/runtime/response_guardrails.rs
@@ -147,7 +147,7 @@ fn current_turn_tool_failures(
     tool_packages: &[super::ToolPackageManifest],
 ) -> RecentToolFailureContext {
     let messages = state.machine.messages();
-    let current_turn = active_turn_messages(messages, state.turn_state.active_turn_message_start());
+    let current_turn = active_turn_messages(messages, state.machine.active_turn_message_start());
     let tool_capabilities = current_turn_tool_capabilities(state, tool_packages, current_turn);
     let mut failures = RecentToolFailureContext::default();
 

--- a/crates/agent-engine/src/runtime/steering_queue.rs
+++ b/crates/agent-engine/src/runtime/steering_queue.rs
@@ -2,9 +2,10 @@ use alan_agent_protocol::{Event, InputMode, Op};
 use anyhow::Result;
 use serde_json::json;
 
-use super::agent_loop::{NormalizedToolCall, RuntimeLoopState};
+use super::agent_loop::RuntimeLoopState;
 use super::turn_driver::{MAX_BUFFERED_INBAND_USER_INPUTS, TurnInputBroker};
 use super::turn_support::tool_result_preview;
+use crate::agent_machine::NormalizedToolCall;
 
 pub(super) async fn handle_queued_steering_inputs<E, F>(
     state: &mut RuntimeLoopState,
@@ -38,8 +39,7 @@ where
                 mode: InputMode::FollowUp,
                 ..
             }
-        ) && state.turn_state.buffered_inband_user_input_count()
-            >= MAX_BUFFERED_INBAND_USER_INPUTS
+        ) && state.machine.buffered_inband_user_input_count() >= MAX_BUFFERED_INBAND_USER_INPUTS
         {
             emit(Event::Error {
                 message: format!(
@@ -51,14 +51,14 @@ where
             continue;
         }
 
-        state.turn_state.push_buffered_inband_submission(submission);
+        state.machine.push_buffered_inband_submission(submission);
     }
 
     if steering_inputs.is_empty() {
         return Ok(false);
     }
 
-    state.turn_state.note_resumed_user_input();
+    state.machine.note_resumed_user_input();
     for parts in steering_inputs {
         state.machine.add_user_message_parts(parts);
     }

--- a/crates/agent-engine/src/runtime/submission_handlers.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers.rs
@@ -12,13 +12,12 @@ use crate::approval::{
 use crate::tape::ContentPart;
 
 use super::agent_loop::{
-    ApprovedMountGrant, ApprovedMountGrantAccess, NamespaceMountApplication, NormalizedToolCall,
-    RuntimeLoopState,
+    ApprovedMountGrant, ApprovedMountGrantAccess, NamespaceMountApplication, RuntimeLoopState,
 };
 use super::compaction::{CompactionRequest, maybe_compact_context_for_request};
 use super::turn_executor::TurnRunKind;
-use super::turn_state::PendingYield;
 use super::turn_support::cancel_current_task;
+use crate::agent_machine::{NormalizedToolCall, PendingYield};
 
 #[derive(Debug, Clone)]
 pub(super) enum RuntimeOpAction {
@@ -65,7 +64,7 @@ where
                 return Ok(RuntimeOpAction::NoTurn);
             }
             let rollback = state.machine.rollback_last_turns(turns);
-            state.turn_state.clear_plan_snapshot();
+            state.machine.clear_plan_snapshot();
             super::ui_surfaces::plan_updated(state.namespace_environment(), None, Vec::new())
                 .await?;
             super::ui_surfaces::rollback(state.namespace_environment(), rollback.removed_turns)
@@ -111,7 +110,7 @@ where
         Op::Turn { parts, context } => {
             let reasoning_effort = context.as_ref().and_then(|c| c.reasoning_effort);
 
-            let queued_next_turn_inputs = state.turn_state.drain_next_turn_inputs();
+            let queued_next_turn_inputs = state.machine.drain_next_turn_inputs();
             let queued_next_turn_count = queued_next_turn_inputs.len();
             let mut merged_parts = Vec::new();
             for queued_parts in queued_next_turn_inputs {
@@ -119,8 +118,8 @@ where
             }
             merged_parts.extend(parts);
 
-            state.turn_state.clear();
-            state.turn_state.set_active_turn_request_control_intent(
+            state.machine.reset_turn();
+            state.machine.set_active_turn_request_control_intent(
                 crate::RequestControlIntent::reasoning_effort(reasoning_effort),
             );
 
@@ -142,8 +141,7 @@ where
         Op::Input { parts, mode } => {
             match mode {
                 InputMode::Steer => {
-                    if !(state.turn_state.is_turn_active()
-                        || state.turn_state.has_pending_interaction())
+                    if !(state.machine.is_turn_active() || state.machine.has_pending_interaction())
                     {
                         emit(Event::Error {
                             message: "Input(mode=steer) requires an active or pending turn. Use Op::Turn to start a new turn.".to_string(),
@@ -160,13 +158,11 @@ where
                     });
                 }
                 InputMode::FollowUp => {
-                    if state.turn_state.is_turn_active()
-                        || state.turn_state.has_pending_interaction()
-                    {
+                    if state.machine.is_turn_active() || state.machine.has_pending_interaction() {
                         // In normal runtime flow this path should be handled by in-band queueing in
                         // turn_driver. Keep this as a safe fallback.
                         state
-                            .turn_state
+                            .machine
                             .push_buffered_inband_submission(Submission::new(Op::Input {
                                 parts,
                                 mode: InputMode::FollowUp,
@@ -179,7 +175,7 @@ where
                         return Ok(RuntimeOpAction::NoTurn);
                     }
 
-                    state.turn_state.clear();
+                    state.machine.reset_turn();
                     return Ok(RuntimeOpAction::RunTurn {
                         turn_kind: TurnRunKind::NewTurn,
                         user_input: Some(parts),
@@ -187,7 +183,7 @@ where
                     });
                 }
                 InputMode::NextTurn => {
-                    let queued_size = state.turn_state.queue_next_turn_input(parts);
+                    let queued_size = state.machine.queue_next_turn_input(parts);
                     match queued_size {
                         Some(size) => {
                             let message = format!(
@@ -219,7 +215,7 @@ where
             content,
         } => {
             let result = resume_content_to_value(&content);
-            match state.turn_state.take_pending(&request_id) {
+            match state.machine.take_pending(&request_id) {
                 Some(PendingYield::Confirmation(pending)) => {
                     let choice = result
                         .get("choice")
@@ -368,9 +364,7 @@ async fn handle_confirmation_resolution(
     modifications: Option<String>,
 ) -> Result<RuntimeOpAction> {
     let replay_tool_batch = if replays_tool_calls(&pending.checkpoint_type) {
-        state
-            .turn_state
-            .take_tool_replay_batch(&pending.checkpoint_id)
+        state.machine.take_tool_replay_batch(&pending.checkpoint_id)
     } else {
         None
     };

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/confirmation_and_mount_support.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/confirmation_and_mount_support.inc.rs
@@ -5,7 +5,7 @@
         agent_machine::AgentMachine,
         config::Config,
         rollout::{RolloutItem, RolloutRecorder},
-        runtime::{MountGrantApplicator, NamespaceRuntimeEnvironment, RuntimeConfig, TurnState},
+        runtime::{MountGrantApplicator, NamespaceRuntimeEnvironment, RuntimeConfig},
         tape::ContentPart,
         tools::ToolRegistry,
     };
@@ -120,13 +120,11 @@
 
         RuntimeLoopState {
             machine,
-            current_submission_id: None,
             environment: namespace_environment_for_test(),
             core_config: config,
             runtime_config,
             definition_persona_dirs: Vec::new(),
             prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-            turn_state: TurnState::default(),
         }
     }
 
@@ -271,7 +269,7 @@
                 );
                 assert_eq!(
                     state
-                        .turn_state
+                        .machine
                         .active_turn_request_control_intent()
                         .reasoning_effort,
                     Some(alan_agent_protocol::ReasoningEffort::High)
@@ -358,7 +356,7 @@
     async fn test_handle_confirm_wrong_checkpoint() {
         let mut state = create_test_state();
         state
-            .turn_state
+            .machine
             .set_confirmation(crate::approval::PendingConfirmation {
                 checkpoint_id: "other_checkpoint".to_string(),
                 checkpoint_type: "test".to_string(),
@@ -397,7 +395,7 @@
     async fn test_handle_confirm_approve() {
         let mut state = create_test_state();
         state
-            .turn_state
+            .machine
             .set_confirmation(crate::approval::PendingConfirmation {
                 checkpoint_id: "chk_123".to_string(),
                 checkpoint_type: "test".to_string(),
@@ -437,7 +435,7 @@
     async fn test_handle_confirm_with_modifications() {
         let mut state = create_test_state();
         state
-            .turn_state
+            .machine
             .set_confirmation(crate::approval::PendingConfirmation {
                 checkpoint_id: "chk_123".to_string(),
                 checkpoint_type: "test".to_string(),
@@ -494,7 +492,7 @@
             .await
             .unwrap();
         state
-            .turn_state
+            .machine
             .set_confirmation(crate::approval::PendingConfirmation {
                 checkpoint_id: "tool_escalation_call_123".to_string(),
                 checkpoint_type: crate::approval::TOOL_ESCALATION_CHECKPOINT_TYPE.to_string(),
@@ -560,7 +558,7 @@
         let root = InProcessTransport::new(Arc::new(MountFs::new(Namespace::new())));
         state.environment = NamespaceRuntimeEnvironment::new(root, "/agent/1", "default");
         state
-            .turn_state
+            .machine
             .set_confirmation(crate::approval::PendingConfirmation {
                 checkpoint_id: "tool_escalation_call_456".to_string(),
                 checkpoint_type: crate::approval::TOOL_ESCALATION_CHECKPOINT_TYPE.to_string(),
@@ -616,7 +614,7 @@
                 .unwrap();
         bind_test_source_mount(&mut state, host_mount_root.path());
         state
-            .turn_state
+            .machine
             .set_confirmation(mount_escalation_pending_confirmation_with(
                 approved_host.path().to_str().unwrap(),
                 "read_write",
@@ -703,7 +701,7 @@
             namespace_environment_with_mount_applicator_for_test(applicator.clone());
         bind_test_source_mount(&mut state, host_mount_root.path());
         state
-            .turn_state
+            .machine
             .set_confirmation(mount_escalation_pending_confirmation_with(
                 approved_host.path().to_str().unwrap(),
                 "read_write",

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
@@ -15,7 +15,7 @@
             metadata: system_store.path().join("metadata"),
         });
         state
-            .turn_state
+            .machine
             .set_confirmation(mount_escalation_pending_confirmation_with(
                 approved_host.path().to_str().unwrap(),
                 "read_write",
@@ -93,7 +93,7 @@
             namespace_environment_with_mount_applicator_for_test(applicator.clone());
         bind_test_source_mount(&mut state, host_mount_root.path());
         state
-            .turn_state
+            .machine
             .set_confirmation(mount_escalation_pending_confirmation_with(
                 approved_host.path().to_str().unwrap(),
                 "read_only",
@@ -137,7 +137,7 @@
             namespace_environment_with_mount_applicator_for_test(applicator.clone());
         bind_test_source_mount(&mut state, host_mount_root.path());
         state
-            .turn_state
+            .machine
             .set_confirmation(mount_escalation_pending_confirmation_with(
                 approved_host.path().to_str().unwrap(),
                 "read_write",
@@ -184,7 +184,7 @@
 
         for _ in 0..2 {
             state
-                .turn_state
+                .machine
                 .set_confirmation(mount_escalation_pending_confirmation_with(
                     approved_host.path().to_str().unwrap(),
                     "read_write",
@@ -230,7 +230,7 @@
 
         for host in [first_host.path(), replacement_host.path()] {
             state
-                .turn_state
+                .machine
                 .set_confirmation(mount_escalation_pending_confirmation_with(
                     host.to_str().unwrap(),
                     "read_write",
@@ -278,7 +278,7 @@
         state.environment = namespace_environment_with_mount_applicator_for_test(applicator);
         bind_test_source_mount(&mut state, host_mount_root.path());
         state
-            .turn_state
+            .machine
             .set_confirmation(mount_escalation_pending_confirmation_with(
                 approved_host.path().to_str().unwrap(),
                 "read_only",
@@ -321,7 +321,7 @@
                 .unwrap();
         bind_test_source_mount(&mut state, host_mount_root.path());
         state
-            .turn_state
+            .machine
             .set_confirmation(mount_escalation_pending_confirmation_with(
                 approved_host.path().to_str().unwrap(),
                 "read_write",
@@ -379,7 +379,7 @@
         let host_path = std::fs::canonicalize(std::env::current_dir().unwrap()).unwrap();
         let host_path = host_path.display().to_string();
         state
-            .turn_state
+            .machine
             .set_confirmation(mount_escalation_pending_confirmation_with(
                 &host_path,
                 "read_write",
@@ -426,7 +426,7 @@
                 .await
                 .unwrap();
         state
-            .turn_state
+            .machine
             .set_confirmation(crate::approval::PendingConfirmation {
                 checkpoint_id: "forged_mount".to_string(),
                 checkpoint_type: crate::approval::MOUNT_ESCALATION_CHECKPOINT_TYPE.to_string(),
@@ -543,7 +543,7 @@
     async fn test_handle_structured_user_input_wrong_id() {
         let mut state = create_test_state();
         state
-            .turn_state
+            .machine
             .set_structured_input(crate::approval::PendingStructuredInputRequest {
                 request_id: "other_id".to_string(),
                 title: "Test".to_string(),
@@ -581,7 +581,7 @@
     async fn test_handle_structured_user_input_success() {
         let mut state = create_test_state();
         state
-            .turn_state
+            .machine
             .set_structured_input(crate::approval::PendingStructuredInputRequest {
                 request_id: "req_123".to_string(),
                 title: "Test".to_string(),

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/runtime_ops_and_replay_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/runtime_ops_and_replay_contract.inc.rs
@@ -45,7 +45,7 @@
         let mut state = create_test_state();
         state.machine.add_user_message("u1");
         state.machine.add_assistant_message("a1", None);
-        state.turn_state.set_plan_snapshot(
+        state.machine.set_plan_snapshot(
             Some("Stale plan".to_string()),
             vec![alan_agent_protocol::PlanItem {
                 id: "plan-1".to_string(),
@@ -63,7 +63,7 @@
         let result = handle_runtime_op_with_cancel(&mut state, op, &mut emit, &cancel).await;
         assert!(result.is_ok());
         assert!(matches!(result.unwrap(), RuntimeOpAction::NoTurn));
-        assert!(state.turn_state.plan_snapshot().is_none());
+        assert!(state.machine.plan_snapshot().is_none());
     }
 
     #[tokio::test]
@@ -233,7 +233,7 @@
     #[tokio::test]
     async fn test_handle_follow_up_without_active_turn_starts_new_turn() {
         let mut state = create_test_state();
-        state.turn_state.set_active_turn_request_control_intent(
+        state.machine.set_active_turn_request_control_intent(
             crate::RequestControlIntent::reasoning_effort(Some(
                 alan_agent_protocol::ReasoningEffort::High,
             )),
@@ -267,7 +267,7 @@
                 assert!(activate_task);
                 assert!(
                     state
-                        .turn_state
+                        .machine
                         .active_turn_request_control_intent()
                         .is_empty()
                 );
@@ -294,7 +294,7 @@
             handle_runtime_op_with_cancel(&mut state, queue_op, &mut emit, &cancel).await;
         assert!(queue_result.is_ok());
         assert!(matches!(queue_result.unwrap(), RuntimeOpAction::NoTurn));
-        assert_eq!(state.turn_state.queued_next_turn_input_count(), 1);
+        assert_eq!(state.machine.queued_next_turn_input_count(), 1);
 
         let turn_op = Op::Turn {
             parts: vec![ContentPart::text("explicit turn")],
@@ -318,7 +318,7 @@
             }
             _ => panic!("Expected RunTurn"),
         }
-        assert_eq!(state.turn_state.queued_next_turn_input_count(), 0);
+        assert_eq!(state.machine.queued_next_turn_input_count(), 0);
     }
 
     #[tokio::test]
@@ -369,8 +369,8 @@
     async fn test_handle_input_op_during_active_turn_uses_resume_turn() {
         let mut state = create_test_state();
         state
-            .turn_state
-            .set_turn_activity(crate::runtime::turn_state::TurnActivityState::Running);
+            .machine
+            .set_turn_activity(crate::agent_machine::TurnActivityState::Running);
         state.machine.activate_task();
         let cancel = CancellationToken::new();
         let mut events = vec![];
@@ -411,8 +411,8 @@
         state.environment = environment;
         state.machine.activate_task();
         state
-            .turn_state
-            .set_turn_activity(crate::runtime::turn_state::TurnActivityState::Running);
+            .machine
+            .set_turn_activity(crate::agent_machine::TurnActivityState::Running);
         let cancel = CancellationToken::new();
         let mut events = vec![];
         let mut emit = |event: Event| {
@@ -489,7 +489,7 @@
         use crate::approval::PendingConfirmation;
 
         let mut state = create_test_state();
-        state.turn_state.set_confirmation(PendingConfirmation {
+        state.machine.set_confirmation(PendingConfirmation {
             checkpoint_id: "cp-1".to_string(),
             checkpoint_type: "review".to_string(),
             summary: "Review this".to_string(),
@@ -525,7 +525,7 @@
         use crate::approval::PendingConfirmation;
 
         let mut state = create_test_state();
-        state.turn_state.set_confirmation(PendingConfirmation {
+        state.machine.set_confirmation(PendingConfirmation {
             checkpoint_id: "tool_escalation_tool_123".to_string(),
             checkpoint_type: "tool_escalation".to_string(),
             summary: "Approve?".to_string(),
@@ -571,7 +571,7 @@
         use crate::approval::PendingConfirmation;
 
         let mut state = create_test_state();
-        state.turn_state.set_confirmation(PendingConfirmation {
+        state.machine.set_confirmation(PendingConfirmation {
             checkpoint_id: "effect_replay_call-123".to_string(),
             checkpoint_type: "effect_replay_confirmation".to_string(),
             summary: "Replay side effect?".to_string(),
@@ -617,7 +617,7 @@
         use crate::approval::PendingConfirmation;
 
         let mut state = create_test_state();
-        state.turn_state.set_confirmation(PendingConfirmation {
+        state.machine.set_confirmation(PendingConfirmation {
             checkpoint_id: "cp-1".to_string(),
             checkpoint_type: "review".to_string(),
             summary: "Review?".to_string(),
@@ -653,7 +653,7 @@
         use crate::approval::PendingConfirmation;
 
         let mut state = create_test_state();
-        state.turn_state.set_confirmation(PendingConfirmation {
+        state.machine.set_confirmation(PendingConfirmation {
             checkpoint_id: "tool_escalation_call-1".to_string(),
             checkpoint_type: "tool_escalation".to_string(),
             summary: "Approve policy escalation".to_string(),
@@ -667,7 +667,7 @@
             }),
             options: vec!["approve".to_string(), "reject".to_string()],
         });
-        state.turn_state.set_tool_replay_batch(
+        state.machine.set_tool_replay_batch(
             "tool_escalation_call-1",
             vec![NormalizedToolCall {
                 id: "call-1".to_string(),
@@ -708,7 +708,7 @@
         use crate::approval::PendingConfirmation;
 
         let mut state = create_test_state();
-        state.turn_state.set_confirmation(PendingConfirmation {
+        state.machine.set_confirmation(PendingConfirmation {
             checkpoint_id: "effect_replay_call-1".to_string(),
             checkpoint_type: "effect_replay_confirmation".to_string(),
             summary: "Approve unknown-effect replay".to_string(),
@@ -722,7 +722,7 @@
             }),
             options: vec!["approve".to_string(), "reject".to_string()],
         });
-        state.turn_state.set_tool_replay_batch(
+        state.machine.set_tool_replay_batch(
             "effect_replay_call-1",
             vec![NormalizedToolCall {
                 id: "call-1".to_string(),

--- a/crates/agent-engine/src/runtime/tool_orchestrator.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator.rs
@@ -15,7 +15,7 @@ use crate::evidence::{
     redaction_markers_in_text,
 };
 
-use super::agent_loop::{NormalizedToolCall, RuntimeLoopState};
+use super::agent_loop::RuntimeLoopState;
 use super::loop_guard::ToolLoopGuard;
 use super::steering_queue::handle_queued_steering_inputs;
 #[cfg(test)]
@@ -25,6 +25,7 @@ use super::tool_policy::{ToolPolicyDecision, evaluate_tool_policy};
 use super::turn_driver::TurnInputBroker;
 use super::turn_support::{check_turn_cancelled, tool_result_preview};
 use super::virtual_tools::{VirtualToolOutcome, try_handle_virtual_tool_call};
+use crate::agent_machine::NormalizedToolCall;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ToolOrchestratorOutcome {
@@ -454,7 +455,7 @@ where
                 "tool_name": tool_call.name,
                 "arguments": tool_arguments,
             });
-            details = append_skill_permission_hints(details, state.turn_state.active_skills());
+            details = append_skill_permission_hints(details, state.machine.active_skills());
 
             // Reviewer-routed escalations consult the guardian before pausing for
             // a human. The sandbox + the deterministic red line remain the
@@ -480,11 +481,11 @@ where
                 };
                 match outcome {
                     super::guardian::ReviewOutcome::Allow => {
-                        state.turn_state.record_guardian_review(false);
+                        state.machine.record_guardian_review(false);
                         false
                     }
                     super::guardian::ReviewOutcome::Deny { rationale } => {
-                        let tripped = state.turn_state.record_guardian_review(true);
+                        let tripped = state.machine.record_guardian_review(true);
                         let message = format!("auto-review denied: {rationale}");
                         super::ui_surfaces::warning(state.namespace_environment(), message.clone())
                             .await?;
@@ -563,7 +564,7 @@ where
                     Some(audit),
                 );
                 state
-                    .turn_state
+                    .machine
                     .set_confirmation_for_request(request_id.clone(), pending.clone());
                 super::ui_surfaces::paused(state.namespace_environment()).await?;
                 emit(Event::Yield {
@@ -659,7 +660,7 @@ where
                         "arguments": tool_arguments,
                     }
                 }),
-                state.turn_state.active_skills(),
+                state.machine.active_skills(),
             ),
             options: vec!["approve".to_string(), "reject".to_string()],
         };
@@ -681,7 +682,7 @@ where
             tool_audit.clone(),
         );
         state
-            .turn_state
+            .machine
             .set_confirmation_for_request(request_id.clone(), pending.clone());
         super::ui_surfaces::paused(state.namespace_environment()).await?;
         emit(Event::Yield {
@@ -945,11 +946,11 @@ where
                 }
             }
             ToolOrchestratorOutcome::PauseTurn => {
-                if let Some(pending) = state.turn_state.pending_confirmation()
+                if let Some(pending) = state.machine.pending_confirmation()
                     && replays_tool_calls(&pending.checkpoint_type)
                 {
                     state
-                        .turn_state
+                        .machine
                         .set_tool_replay_batch(pending.checkpoint_id, tool_calls[idx..].to_vec());
                 }
                 return Ok(ToolBatchOrchestratorOutcome::PauseTurn);

--- a/crates/agent-engine/src/runtime/tool_orchestrator/tests/namespace_and_batch_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator/tests/namespace_and_batch_contract.inc.rs
@@ -392,7 +392,7 @@
         let mut state = create_test_state();
         for idx in 0..MAX_BUFFERED_INBAND_USER_INPUTS {
             state
-                .turn_state
+                .machine
                 .push_buffered_inband_submission(alan_agent_protocol::Submission::new(Op::Input {
                     parts: vec![alan_agent_protocol::ContentPart::text(format!(
                         "buffered-{idx}"
@@ -421,7 +421,7 @@
             .unwrap();
         assert!(!handled);
         assert_eq!(
-            state.turn_state.buffered_inband_user_input_count(),
+            state.machine.buffered_inband_user_input_count(),
             MAX_BUFFERED_INBAND_USER_INPUTS
         );
         assert!(events.iter().any(|event| matches!(
@@ -435,15 +435,15 @@
     async fn queued_steering_input_invalidates_earlier_active_plan() {
         let mut state = create_test_state();
         state
-            .turn_state
+            .machine
             .begin_turn(state.machine.messages().len());
         state.machine.add_user_message("Initial task");
-        state.turn_state.set_plan_snapshot_at_message_count(
+        state.machine.set_plan_snapshot_at_message_count(
             Some("Initial plan".to_string()),
             Vec::new(),
             state.machine.messages().len(),
         );
-        assert!(state.turn_state.plan_snapshot_is_from_active_turn());
+        assert!(state.machine.plan_snapshot_is_from_active_turn());
 
         let broker = TurnInputBroker::default();
         assert!(
@@ -463,7 +463,7 @@
             .unwrap();
 
         assert!(handled);
-        assert!(!state.turn_state.plan_snapshot_is_from_active_turn());
+        assert!(!state.machine.plan_snapshot_is_from_active_turn());
         assert_eq!(
             state.machine.messages().last().unwrap().text_content(),
             "Steer to the new task"

--- a/crates/agent-engine/src/runtime/tool_orchestrator/tests/replay_and_effect_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator/tests/replay_and_effect_contract.inc.rs
@@ -40,10 +40,10 @@
     #[tokio::test]
     async fn test_orchestrate_tool_batch_with_cancel() {
         let mut state = create_test_state();
-        state.turn_state.begin_turn(0);
+        state.machine.begin_turn(0);
         state
-            .turn_state
-            .set_turn_activity(crate::runtime::turn_state::TurnActivityState::Running);
+            .machine
+            .set_turn_activity(crate::agent_machine::TurnActivityState::Running);
         let mut orchestrator = ToolTurnOrchestrator::new(None, 4);
         let cancel = CancellationToken::new();
 

--- a/crates/agent-engine/src/runtime/tool_orchestrator/tests/support_and_namespace_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator/tests/support_and_namespace_contract.inc.rs
@@ -2,7 +2,7 @@
     use crate::{
         agent_machine::AgentMachine,
         config::Config,
-        runtime::{NamespaceRuntimeEnvironment, TurnState},
+        runtime::NamespaceRuntimeEnvironment,
         tools::{Tool, ToolContext, ToolRegistry, ToolResult},
     };
     use alan_agent_protocol::ToolCapability;
@@ -372,13 +372,11 @@
 
         RuntimeLoopState {
             machine,
-            current_submission_id: None,
             environment: NamespaceRuntimeEnvironment::new(root, "/agent/1", "default"),
             core_config: config,
             runtime_config,
             definition_persona_dirs: Vec::new(),
             prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-            turn_state: TurnState::default(),
         }
     }
 
@@ -460,13 +458,11 @@
         let shell = Shell::new(root.clone());
         let state = RuntimeLoopState {
             machine: AgentMachine::new(),
-            current_submission_id: None,
             environment: NamespaceRuntimeEnvironment::new(root, "/agent/1", "default"),
             core_config: Config::default(),
             runtime_config: super::super::RuntimeConfig::default(),
             definition_persona_dirs: Vec::new(),
             prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-            turn_state: TurnState::default(),
         };
         (state, shell)
     }
@@ -648,7 +644,6 @@
         };
         RuntimeLoopState {
             machine,
-            current_submission_id: None,
             environment: NamespaceRuntimeEnvironment::new(root, agent_path, "default")
                 .with_launch_context(launch_context)
                 .with_tool_process_context(alan_kernel::Pid(1), tool_runner),
@@ -656,7 +651,6 @@
             runtime_config: super::super::RuntimeConfig::default(),
             definition_persona_dirs: Vec::new(),
             prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-            turn_state: TurnState::default(),
         }
     }
 

--- a/crates/agent-engine/src/runtime/turn_driver.rs
+++ b/crates/agent-engine/src/runtime/turn_driver.rs
@@ -6,8 +6,8 @@ use tokio::sync::{Mutex, Notify};
 use tokio_util::sync::CancellationToken;
 
 use super::agent_loop::{RuntimeLoopState, handle_submission_with_cancel_and_steering};
-use super::turn_state::TurnState;
 use super::turn_support::cancel_current_task;
+use crate::agent_machine::AgentMachine;
 
 const MAX_BROKERED_INBAND_USER_INPUTS: usize = 16;
 pub(super) const MAX_BUFFERED_INBAND_USER_INPUTS: usize = 16;
@@ -123,8 +123,10 @@ where
     F: std::future::Future<Output = ()>,
 {
     broker.clear().await;
-    let _ = state.turn_state.clear_buffered_inband_submissions();
-    state.current_submission_id = Some(initial_submission.id.clone());
+    let _ = state.machine.clear_buffered_inband_submissions();
+    state
+        .machine
+        .accept_submission(initial_submission.id.clone());
 
     handle_submission_with_cancel_and_steering(
         state,
@@ -136,9 +138,9 @@ where
     .await?;
 
     loop {
-        let next_submission = if state.turn_state.has_pending_interaction() {
+        let next_submission = if state.machine.has_pending_interaction() {
             next_pending_interaction_submission(state, broker, emit, cancel).await?
-        } else if let Some(buffered) = state.turn_state.pop_buffered_inband_submission() {
+        } else if let Some(buffered) = state.machine.pop_buffered_inband_submission() {
             Some(buffered)
         } else {
             broker.try_recv().await
@@ -147,7 +149,7 @@ where
         let Some(next_submission) = next_submission else {
             break;
         };
-        state.current_submission_id = Some(next_submission.id.clone());
+        state.machine.accept_submission(next_submission.id.clone());
 
         handle_submission_with_cancel_and_steering(
             state,
@@ -180,14 +182,14 @@ where
         tokio::select! {
             incoming = broker.recv(cancel) => {
                 let Some(incoming) = incoming else {
-                    if cancel.is_cancelled() && state.turn_state.has_pending_interaction() {
+                    if cancel.is_cancelled() && state.machine.has_pending_interaction() {
                         // Report and clear buffered in-turn submissions before cancel_current_task
-                        // clears turn_state, otherwise the drop count under-reports.
-                        emit_dropped_in_turn_submissions(emit, &mut state.turn_state, broker).await;
+                        // resets Machine turn state, otherwise the drop count under-reports.
+                        emit_dropped_in_turn_submissions(emit, &mut state.machine, broker).await;
                         cancel_current_task(state, emit).await?;
                         return Ok(None);
                     }
-                    emit_dropped_in_turn_submissions(emit, &mut state.turn_state, broker).await;
+                    emit_dropped_in_turn_submissions(emit, &mut state.machine, broker).await;
                     return Ok(None);
                 };
 
@@ -196,7 +198,7 @@ where
                 }
 
                 if is_brokered_input(&incoming.op)
-                    && state.turn_state.buffered_inband_user_input_count()
+                    && state.machine.buffered_inband_user_input_count()
                         >= MAX_BUFFERED_INBAND_USER_INPUTS
                 {
                     emit(Event::Error {
@@ -208,7 +210,7 @@ where
                     .await;
                     continue;
                 }
-                state.turn_state.push_buffered_inband_submission(incoming);
+                state.machine.push_buffered_inband_submission(incoming);
             }
             _ = tokio::time::sleep(NAMESPACE_PENDING_RESPONSE_POLL_INTERVAL) => {}
         }
@@ -220,7 +222,7 @@ pub(super) async fn namespace_pending_resume_submission(
 ) -> Result<Option<Submission>> {
     let namespace = state.namespace_environment();
 
-    for request_id in state.turn_state.pending_request_ids() {
+    for request_id in state.machine.pending_request_ids() {
         if let Some(submission) = namespace
             .resume_submission_from_answered_request(&request_id)
             .await?
@@ -234,13 +236,13 @@ pub(super) async fn namespace_pending_resume_submission(
 
 async fn emit_dropped_in_turn_submissions<E, F>(
     emit: &mut E,
-    turn_state: &mut TurnState,
+    machine: &mut AgentMachine,
     broker: &TurnInputBroker,
 ) where
     E: FnMut(Event) -> F,
     F: std::future::Future<Output = ()>,
 {
-    let dropped_buffered = turn_state.clear_buffered_inband_submissions();
+    let dropped_buffered = machine.clear_buffered_inband_submissions();
     let dropped_brokered = broker.drain().await.len();
     let dropped_total = dropped_buffered + dropped_brokered;
     if dropped_total > 0 {
@@ -427,8 +429,8 @@ mod tests {
     #[tokio::test]
     async fn test_emit_dropped_in_turn_submissions_reports_count() {
         let broker = TurnInputBroker::default();
-        let mut turn_state = TurnState::default();
-        turn_state.push_buffered_inband_submission(Submission {
+        let mut machine = AgentMachine::new();
+        machine.push_buffered_inband_submission(Submission {
             id: "u-1".to_string(),
             op: Op::Input {
                 parts: vec![alan_agent_protocol::ContentPart::text("queued")],
@@ -455,9 +457,9 @@ mod tests {
             async {}
         };
 
-        emit_dropped_in_turn_submissions(&mut emit, &mut turn_state, &broker).await;
+        emit_dropped_in_turn_submissions(&mut emit, &mut machine, &broker).await;
 
-        assert_eq!(turn_state.clear_buffered_inband_submissions(), 0);
+        assert_eq!(machine.clear_buffered_inband_submissions(), 0);
         assert!(broker.try_recv().await.is_none());
         assert!(events.iter().any(|event| matches!(
             event,
@@ -487,8 +489,8 @@ mod tests {
             ))
             .await
             .unwrap();
-        let mut turn_state = TurnState::default();
-        turn_state.set_structured_input(crate::approval::PendingStructuredInputRequest {
+        let mut machine = AgentMachine::new();
+        machine.set_structured_input(crate::approval::PendingStructuredInputRequest {
             request_id: request_id.clone(),
             title: "Missing value".to_string(),
             prompt: "Provide the missing value".to_string(),
@@ -496,14 +498,12 @@ mod tests {
         });
 
         let mut state = RuntimeLoopState {
-            machine: crate::agent_machine::AgentMachine::new(),
-            current_submission_id: None,
+            machine,
             environment,
             core_config: crate::Config::default(),
             runtime_config: super::super::RuntimeConfig::default(),
             definition_persona_dirs: Vec::new(),
             prompt_cache: super::super::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-            turn_state,
         };
         let broker = TurnInputBroker::default();
         let cancel = CancellationToken::new();

--- a/crates/agent-engine/src/runtime/turn_executor.rs
+++ b/crates/agent-engine/src/runtime/turn_executor.rs
@@ -6,7 +6,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::llm::build_generation_request;
 
-use super::agent_loop::{DeferredRuntimeAction, RuntimeLoopState};
+use super::agent_loop::RuntimeLoopState;
 use super::compaction::{CompactionRequest, maybe_compact_context_with_cancel};
 use super::response_guardrails::{
     AssistantDraft, GuardrailDecision, ResponseGuardrailContext, ResponseGuardrails,
@@ -20,6 +20,7 @@ use super::turn_support::{
     normalize_tool_calls,
 };
 use super::virtual_tools::virtual_tool_definitions;
+use crate::agent_machine::DeferredRuntimeAction;
 
 mod namespace_generation;
 
@@ -96,7 +97,7 @@ async fn finalize_turn_memory_best_effort(
         super::memory_promotion::build_turn_memory_promotion_job(state, promotion_context)
     {
         state
-            .turn_state
+            .machine
             .push_deferred_runtime_action(DeferredRuntimeAction::TurnMemoryPromotion(job));
     }
 }
@@ -218,7 +219,7 @@ where
     F: std::future::Future<Output = ()>,
 {
     if matches!(turn_kind, TurnRunKind::NewTurn) {
-        state.turn_state.reset_auto_mid_turn_compaction_state();
+        state.machine.reset_auto_mid_turn_compaction_state();
         super::ui_surfaces::turn_started(state.namespace_environment())
             .await
             .context("write turn-start UI state")?;
@@ -284,9 +285,9 @@ where
     }
 
     if matches!(turn_kind, TurnRunKind::NewTurn) {
-        state.turn_state.begin_turn(state.machine.messages().len());
+        state.machine.begin_turn(state.machine.messages().len());
     } else if user_input.is_some() {
-        state.turn_state.note_resumed_user_input();
+        state.machine.note_resumed_user_input();
     }
     if let Some(user_input) = user_input {
         state.machine.add_user_message_parts(user_input);
@@ -295,7 +296,7 @@ where
     // Resume turns keep the same active skill envelopes for the logical turn.
     // Current user input can still add new skills via prompt assembly merge logic.
     let resumed_active_skills = matches!(turn_kind, TurnRunKind::ResumeTurn)
-        .then(|| state.turn_state.active_skills().to_vec())
+        .then(|| state.machine.active_skills().to_vec())
         .filter(|active_skills| !active_skills.is_empty());
     let prompt_build = build_domain_prompt_with_skills(
         state,
@@ -312,7 +313,7 @@ where
         "Prepared prompt assembly inputs"
     );
     state
-        .turn_state
+        .machine
         .set_active_skills(prompt_build.active_skills.clone());
     let active_skill_ids = prompt_build
         .active_skills
@@ -333,7 +334,7 @@ where
         &state.core_config,
         initial_provider_capabilities,
         state.runtime_config.request_control_intent,
-        state.turn_state.active_turn_request_control_intent(),
+        state.machine.active_turn_request_control_intent(),
     )?;
     let model = state.core_config.effective_model().to_string();
     let memory_enabled = state.core_config.memory.enabled;
@@ -697,7 +698,7 @@ where
         .saturating_add(additional_prompt_tokens);
     let context_window_tokens = state.runtime_config.context_window_tokens as usize;
     if !state
-        .turn_state
+        .machine
         .can_auto_mid_turn_compact(estimated_prompt_tokens, context_window_tokens)
     {
         return Ok(());
@@ -716,7 +717,7 @@ where
     match compaction.result {
         Ok(CompactionOutcome::Applied(outcome)) => {
             state
-                .turn_state
+                .machine
                 .record_auto_mid_turn_compaction(outcome.output_prompt_tokens);
         }
         Ok(CompactionOutcome::Skipped(_)) => {}

--- a/crates/agent-engine/src/runtime/turn_executor/tests.rs
+++ b/crates/agent-engine/src/runtime/turn_executor/tests.rs
@@ -1,10 +1,9 @@
 use super::*;
-use crate::runtime::turn_state::TurnActivityState;
 use crate::{
-    agent_machine::AgentMachine,
+    agent_machine::{AgentMachine, TurnActivityState},
     config::Config,
     rollout::{RolloutItem, RolloutRecorder},
-    runtime::{NamespaceRuntimeEnvironment, RuntimeConfig, TurnState},
+    runtime::{NamespaceRuntimeEnvironment, RuntimeConfig},
     skills::{ResolvedCapabilityView, ScopedPackageDir, SkillScope},
     tape::{ContentPart, Message, ToolRequest},
     tools::{Tool, ToolContext, ToolRegistry, ToolResult},
@@ -930,14 +929,12 @@ fn create_test_state_with_provider_and_tools_and_shell<P: LlmProvider + 'static>
 
     let state = RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: NamespaceRuntimeEnvironment::new(root.clone(), "/agent/1", "default")
             .with_launch_context(launch_context),
         core_config: config,
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
-        turn_state: TurnState::default(),
     };
     (state, alan_shell::Shell::new(root))
 }

--- a/crates/agent-engine/src/runtime/turn_executor/tests/active_skill_context.rs
+++ b/crates/agent-engine/src/runtime/turn_executor/tests/active_skill_context.rs
@@ -46,9 +46,7 @@ runtime:
     let prior_prompt = state.prompt_cache.build(Some(&[ContentPart::text(
         "please use $release-check for this task",
     )]));
-    state
-        .turn_state
-        .set_active_skills(prior_prompt.active_skills);
+    state.machine.set_active_skills(prior_prompt.active_skills);
     state
         .machine
         .add_user_message("continue the prior approval flow");
@@ -145,9 +143,7 @@ runtime:
     let prior_prompt = state.prompt_cache.build(Some(&[ContentPart::text(
         "please use $release-check for this task",
     )]));
-    state
-        .turn_state
-        .set_active_skills(prior_prompt.active_skills);
+    state.machine.set_active_skills(prior_prompt.active_skills);
 
     let cancel = CancellationToken::new();
     let mut events = vec![];
@@ -359,9 +355,7 @@ runtime:
     let prior_prompt = state.prompt_cache.build(Some(&[ContentPart::text(
         "please use $release-check for this task",
     )]));
-    state
-        .turn_state
-        .set_active_skills(prior_prompt.active_skills);
+    state.machine.set_active_skills(prior_prompt.active_skills);
 
     let cancel = CancellationToken::new();
     let mut events = vec![];

--- a/crates/agent-engine/src/runtime/turn_executor/tests/memory_surfaces.rs
+++ b/crates/agent-engine/src/runtime/turn_executor/tests/memory_surfaces.rs
@@ -14,9 +14,7 @@ async fn test_run_turn_refreshes_memory_surfaces_when_tool_batch_ends_turn() {
         "",
     ));
     state.core_config.memory.store_dir = Some(memory_dir.clone());
-    state
-        .turn_state
-        .set_turn_activity(TurnActivityState::Running);
+    state.machine.set_turn_activity(TurnActivityState::Running);
 
     let cancel = CancellationToken::new();
     let mut events = vec![];
@@ -66,9 +64,7 @@ async fn test_run_turn_promotes_direct_user_fact_when_tool_batch_ends_turn() {
     ));
     state.core_config.memory.store_dir = Some(memory_dir.clone());
     state.core_config.memory.enabled = true;
-    state
-        .turn_state
-        .set_turn_activity(TurnActivityState::Running);
+    state.machine.set_turn_activity(TurnActivityState::Running);
 
     let cancel = CancellationToken::new();
     let mut emit = |_event: Event| async {};
@@ -128,7 +124,7 @@ async fn test_run_turn_defers_memory_promotion_until_after_completion() {
             .iter()
             .any(|event| matches!(event, Event::TurnCompleted { .. }))
     );
-    assert_eq!(state.turn_state.drain_deferred_runtime_actions().len(), 1);
+    assert_eq!(state.machine.drain_deferred_runtime_actions().len(), 1);
 }
 
 struct SlowTool {
@@ -181,9 +177,7 @@ async fn test_run_turn_cancelled_tool_batch_does_not_refresh_memory_surfaces() {
         tools,
     );
     state.core_config.memory.store_dir = Some(memory_dir.clone());
-    state
-        .turn_state
-        .set_turn_activity(TurnActivityState::Running);
+    state.machine.set_turn_activity(TurnActivityState::Running);
 
     let cancel = CancellationToken::new();
     let cancel_for_task = cancel.clone();
@@ -305,6 +299,6 @@ async fn test_run_turn_tool_loop_guard_refreshes_memory_surfaces_before_completi
     assert!(result.is_ok());
     assert!(matches!(result.unwrap(), TurnExecutionOutcome::Finished));
     assert_eq!(generate_calls.load(Ordering::SeqCst), 2);
-    assert_eq!(state.turn_state.drain_deferred_runtime_actions().len(), 1);
+    assert_eq!(state.machine.drain_deferred_runtime_actions().len(), 1);
     assert!(saw_handoff_before_completion);
 }

--- a/crates/agent-engine/src/runtime/turn_executor/tests/namespace_generation.rs
+++ b/crates/agent-engine/src/runtime/turn_executor/tests/namespace_generation.rs
@@ -558,7 +558,7 @@ async fn test_run_turn_uses_turn_reasoning_effort_before_runtime_effort() {
     state.runtime_config.request_control_intent = crate::RequestControlIntent::reasoning_effort(
         Some(alan_agent_protocol::ReasoningEffort::High),
     );
-    state.turn_state.set_active_turn_request_control_intent(
+    state.machine.set_active_turn_request_control_intent(
         crate::RequestControlIntent::reasoning_effort(Some(
             alan_agent_protocol::ReasoningEffort::Low,
         )),

--- a/crates/agent-engine/src/runtime/turn_executor/tests/runtime_recall.rs
+++ b/crates/agent-engine/src/runtime/turn_executor/tests/runtime_recall.rs
@@ -236,7 +236,7 @@ async fn test_run_turn_pre_turn_compaction_accounts_for_runtime_recall_budget() 
         .expect("expected runtime recall bundle prompt");
     assert!(request_prompt.contains("## Runtime Recall Bundle"));
     assert!(request_prompt.contains("ALAN_PRETURN_RECALL"));
-    assert_eq!(state.turn_state.drain_deferred_runtime_actions().len(), 1);
+    assert_eq!(state.machine.drain_deferred_runtime_actions().len(), 1);
 }
 
 #[tokio::test]
@@ -324,5 +324,5 @@ async fn test_maybe_compact_mid_turn_accounts_for_runtime_prompt_overhead() {
         state.machine.tape_summary(),
         Some("MID_TURN_COMPACTION_SUMMARY")
     );
-    assert_eq!(state.turn_state.compactions_this_turn(), 1);
+    assert_eq!(state.machine.compactions_this_turn(), 1);
 }

--- a/crates/agent-engine/src/runtime/turn_executor/tests/support.rs
+++ b/crates/agent-engine/src/runtime/turn_executor/tests/support.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub(super) async fn run_deferred_runtime_actions(state: &mut RuntimeLoopState) -> usize {
     let cancel = CancellationToken::new();
-    let actions = state.turn_state.drain_deferred_runtime_actions();
+    let actions = state.machine.drain_deferred_runtime_actions();
     let count = actions.len();
     for action in actions {
         assert_eq!(

--- a/crates/agent-engine/src/runtime/turn_executor/tests/turn_execution.rs
+++ b/crates/agent-engine/src/runtime/turn_executor/tests/turn_execution.rs
@@ -659,7 +659,7 @@ async fn test_run_turn_performs_mid_turn_compaction_before_follow_up_generation(
         state.machine.tape_summary(),
         Some("Mid-turn compaction summary")
     );
-    assert_eq!(state.turn_state.compactions_this_turn(), 1);
+    assert_eq!(state.machine.compactions_this_turn(), 1);
     assert!(
         state
             .machine
@@ -736,8 +736,8 @@ async fn test_run_turn_resets_mid_turn_compaction_budget_for_new_turns() {
     state.runtime_config.compaction_keep_last = 1;
     state.runtime_config.context_window_tokens = 512;
     state.runtime_config.compaction_hard_trigger_ratio = 0.5;
-    state.turn_state.record_auto_mid_turn_compaction(256);
-    state.turn_state.record_auto_mid_turn_compaction(512);
+    state.machine.record_auto_mid_turn_compaction(256);
+    state.machine.record_auto_mid_turn_compaction(512);
 
     let cancel = CancellationToken::new();
     let mut emit = |_event: Event| async {};
@@ -758,7 +758,7 @@ async fn test_run_turn_resets_mid_turn_compaction_budget_for_new_turns() {
         state.machine.tape_summary(),
         Some("Mid-turn compaction summary")
     );
-    assert_eq!(state.turn_state.compactions_this_turn(), 1);
+    assert_eq!(state.machine.compactions_this_turn(), 1);
 }
 
 #[tokio::test]

--- a/crates/agent-engine/src/runtime/turn_support.rs
+++ b/crates/agent-engine/src/runtime/turn_support.rs
@@ -4,7 +4,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::warn;
 use uuid::Uuid;
 
-use super::agent_loop::{NormalizedToolCall, RuntimeLoopState};
+use super::agent_loop::RuntimeLoopState;
+use crate::agent_machine::NormalizedToolCall;
 
 pub(super) async fn cancel_current_task<E, F>(
     state: &mut RuntimeLoopState,
@@ -17,8 +18,8 @@ where
     warn!("Cancelling current task");
     // Clear turn-scoped pending state, but preserve machine history so the user can
     // continue the same conversation after an interrupt/cancel.
-    state.turn_state.clear();
-    state.turn_state.clear_plan_snapshot();
+    state.machine.reset_turn();
+    state.machine.clear_plan_snapshot();
     state.machine.clear_active_task();
     super::ui_surfaces::turn_completed(state.namespace_environment(), true).await?;
     emit(Event::TurnCompleted {
@@ -183,7 +184,7 @@ where
     if !cancel.is_cancelled() {
         return Ok(false);
     }
-    if !state.turn_state.is_turn_active() && !state.turn_state.has_pending_interaction() {
+    if !state.machine.is_turn_active() && !state.machine.has_pending_interaction() {
         emit(Event::Error {
             message: "No active turn to cancel.".to_string(),
             recoverable: true,

--- a/crates/agent-engine/src/runtime/virtual_tools.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools.rs
@@ -10,7 +10,7 @@ use crate::approval::MOUNT_ESCALATION_CHECKPOINT_TYPE;
 use crate::approval::{PendingConfirmation, append_skill_permission_hints};
 use crate::llm::ToolDefinition;
 
-use super::agent_loop::{NormalizedToolCall, RuntimeLoopState};
+use super::agent_loop::RuntimeLoopState;
 use super::child_run_termination_tool::{
     handle_terminate_child_run, terminate_child_run_tool_definition,
 };
@@ -21,6 +21,7 @@ pub(super) use super::mount_request_tool::parse_mount_request;
 use super::mount_request_tool::{handle_request_mount, request_mount_tool_definition};
 use super::turn_support::{check_turn_cancelled, tool_result_preview};
 pub(super) use super::virtual_tool::VirtualToolOutcome;
+use crate::agent_machine::NormalizedToolCall;
 
 pub(super) fn virtual_tool_definitions(include_delegated_skill: bool) -> Vec<ToolDefinition> {
     let mut defs = vec![
@@ -63,10 +64,8 @@ where
             .await;
 
             if let Some(mut pending) = parse_confirmation_request(&tool_call.id, tool_arguments) {
-                pending.details = append_skill_permission_hints(
-                    pending.details,
-                    state.turn_state.active_skills(),
-                );
+                pending.details =
+                    append_skill_permission_hints(pending.details, state.machine.active_skills());
                 let request_id = state
                     .write_namespace_confirmation_request(&pending)
                     .await?
@@ -91,7 +90,7 @@ where
                     true,
                 );
                 state
-                    .turn_state
+                    .machine
                     .set_confirmation_for_request(request_id.clone(), pending.clone());
                 super::ui_surfaces::paused(state.namespace_environment()).await?;
                 emit(Event::Yield {
@@ -177,7 +176,7 @@ where
                     true,
                 );
                 state
-                    .turn_state
+                    .machine
                     .set_structured_input_for_request(request_id.clone(), request.clone());
                 super::ui_surfaces::paused(state.namespace_environment()).await?;
                 emit(Event::Yield {
@@ -230,7 +229,7 @@ where
             .await;
             match parse_plan_update(tool_arguments) {
                 Some((explanation, items)) => {
-                    state.turn_state.set_plan_snapshot_at_message_count(
+                    state.machine.set_plan_snapshot_at_message_count(
                         explanation.clone(),
                         items.clone(),
                         state.machine.messages().len(),

--- a/crates/agent-engine/src/runtime/virtual_tools_tests.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools_tests.rs
@@ -1,10 +1,10 @@
 use super::*;
 use crate::{
-    agent_machine::AgentMachine,
+    agent_machine::{AgentMachine, TurnActivityState},
     config::Config,
     rollout::{RolloutItem, RolloutRecorder},
     runtime::{
-        ChildRunRecord, ChildRunStatus, NamespaceRuntimeEnvironment, RuntimeConfig, TurnState,
+        ChildRunRecord, ChildRunStatus, NamespaceRuntimeEnvironment, RuntimeConfig,
         agent_loop::NamespaceActionRecord,
         delegated_child_run::{
             ChildRuntimeResult, ChildRuntimeStatus, MAX_DELEGATED_RESULT_OUTPUT_INLINE_CHARS,
@@ -18,7 +18,6 @@ use crate::{
         },
         delegation_capabilities::DelegatedSpawnRejected,
         mount_request_tool::MountRequestAccess,
-        turn_state::TurnActivityState,
     },
     skills::{
         ActiveSkillEnvelope, DelegatedSkillInvocationRecord, ResolvedCapabilityView,
@@ -90,14 +89,12 @@ fn create_test_agent_loop_state() -> super::super::agent_loop::RuntimeLoopState 
 
     super::super::agent_loop::RuntimeLoopState {
         machine,
-        current_submission_id: None,
         environment: namespace_environment_for_virtual_tool_test(&tools)
             .with_launch_context(launch_context),
         core_config: config,
         runtime_config,
         definition_persona_dirs: Vec::new(),
         prompt_cache,
-        turn_state: TurnState::default(),
     }
 }
 
@@ -153,7 +150,7 @@ fn activate_test_delegated_skill(
     target: &str,
 ) {
     state
-        .turn_state
+        .machine
         .set_active_skills(vec![ActiveSkillEnvelope::available(
             delegated_test_skill_metadata(skill_id, target),
             SkillActivationReason::ExplicitMention {

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -60,8 +60,8 @@ fn rust_item_body<'a>(source: &'a str, marker: &str) -> &'a str {
 #[test]
 fn runtime_state_and_handles_have_no_parallel_capability_or_event_authority() {
     let loop_source = read_runtime_source("agent_loop.rs");
-    let state = rust_item_body(&loop_source, "pub struct RuntimeLoopState");
-    assert!(state.contains("pub environment: NamespaceRuntimeEnvironment"));
+    let state = rust_item_body(&loop_source, "pub(crate) struct RuntimeLoopState");
+    assert!(state.contains("pub(crate) environment: NamespaceRuntimeEnvironment"));
 
     let engine_source = read_runtime_source("engine.rs");
     let controller_source = read_runtime_source("controller.rs");
@@ -311,7 +311,7 @@ fn agent_machine_state_is_not_a_public_or_runtime_field_surface() {
 
     let machine = read_crate_source("agent_machine.rs");
     let state = rust_item_body(&machine, "pub(crate) struct AgentMachine");
-    for private_field in ["tape", "recorder", "has_active_task"] {
+    for private_field in ["tape", "recorder", "has_active_task", "transition_state"] {
         assert!(state.contains(&format!("{private_field}:")));
         assert!(
             !state.contains(&format!("pub {private_field}:")),
@@ -319,7 +319,37 @@ fn agent_machine_state_is_not_a_public_or_runtime_field_surface() {
         );
     }
 
+    let transition_state = read_crate_source("agent_machine/transition_state.rs");
+    let transition_fields = rust_item_body(
+        &transition_state,
+        "pub(super) struct MachineTransitionState",
+    );
+    assert!(transition_fields.contains("current_submission_id:"));
+    assert!(!transition_fields.contains("pub current_submission_id:"));
+    assert!(
+        !std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/runtime/turn_state.rs")
+            .exists(),
+        "turn-local state must not retain a second runtime owner"
+    );
+
+    let loop_source = read_runtime_source("agent_loop.rs");
+    let runtime_state = rust_item_body(&loop_source, "pub(crate) struct RuntimeLoopState");
+    for displaced_field in ["current_submission_id", "turn_state"] {
+        assert!(
+            !runtime_state.contains(&format!("{displaced_field}:")),
+            "RuntimeLoopState must not retain Machine field {displaced_field}"
+        );
+    }
+
     for (path, source) in read_rust_sources_under("runtime") {
+        for displaced_surface in ["TurnState", ".turn_state"] {
+            assert!(
+                !source.contains(displaced_surface),
+                "{} retains displaced Machine state surface {displaced_surface}",
+                path.display()
+            );
+        }
         for forbidden in [
             "machine.tape.",
             "machine.recorder.",

--- a/openspec/changes/deepen-agent-machine-transition-module/tasks.md
+++ b/openspec/changes/deepen-agent-machine-transition-module/tasks.md
@@ -12,14 +12,14 @@
 
 ## 2. Make Agent Machine The State Owner
 
-- [ ] 2.1 Move current submission, turn state, pending Yield, Tool replay,
+- [x] 2.1 Move current submission, turn state, pending Yield, Tool replay,
   active-task, and deferred action state behind Agent Machine semantic
   operations.
-- [ ] 2.2 Make Tape, recorder, flags, and transition state private; remove the
+- [x] 2.2 Make Tape, recorder, flags, and transition state private; remove the
   public Agent Machine re-export and replace direct field access.
 - [ ] 2.3 Keep or delete the private `RuntimeLoopState` according to whether it
   still groups cohesive Machine state; do not preserve it as a shared field bag.
-- [ ] 2.4 Add adjacent white-box tests for private Machine transitions and keep
+- [x] 2.4 Add adjacent white-box tests for private Machine transitions and keep
   supported external tests at file boundaries.
 
 ## 3. Extract The Concrete Transition Owner


### PR DESCRIPTION
## Summary

- move the former runtime TurnState into AgentMachine as one private transition state
- move current submission identity, pending Yield, Tool replay, activity, queued input, plan, compaction, and deferred-action state behind Machine operations
- remove RuntimeLoopState current-submission and turn-state fields and update consumers to use the single Machine owner
- relocate adjacent white-box tests and harden the architecture gate against reintroducing the displaced runtime state surface

Stacked on #815. This PR is the second focused owner move for deepen-agent-machine-transition-module.

## Verification

- repository pre-commit quality gate
- cargo test -p alan-agent-engine (1197 passed, 1 ignored)
- cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings
- cargo test -p alan-agent-engine --test dependency_boundary
- bash scripts/check-rust-source-size.sh
- openspec validate deepen-agent-machine-transition-module --strict