### PR TITLE
refactor(agent-engine): narrow namespace generation handle

### DIFF
--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -6,6 +6,7 @@
 
 mod namespace_environment;
 
+pub(crate) use namespace_environment::NamespaceGeneration;
 #[cfg(test)]
 pub(super) use namespace_environment::NamespaceRequestRecord;
 pub use namespace_environment::{
@@ -83,6 +84,10 @@ impl RuntimeLoopState {
         &self.environment
     }
 
+    pub(crate) fn namespace_generation(&self) -> NamespaceGeneration {
+        self.environment.generation()
+    }
+
     pub(crate) async fn write_namespace_confirmation_request(
         &self,
         pending: &crate::approval::PendingConfirmation,
@@ -133,8 +138,8 @@ impl RuntimeLoopState {
         cancel: &CancellationToken,
         cancel_message: &'static str,
     ) -> Result<crate::llm::GenerationResponse> {
-        let namespace = self.namespace_environment().clone();
-        match namespace.generate_controlled(&request, 0, cancel).await {
+        let generation = self.namespace_generation();
+        match generation.generate_controlled(&request, 0, cancel).await {
             Err(_) if cancel.is_cancelled() => Err(anyhow::anyhow!(cancel_message)),
             result => result,
         }
@@ -154,9 +159,9 @@ impl RuntimeLoopState {
                 return Err(anyhow::anyhow!("LLM request cancelled"));
             }
 
-            let namespace = self.namespace_environment().clone();
+            let generation = self.namespace_generation();
             let attempt_request = request.clone();
-            let result = namespace
+            let result = generation
                 .generate_controlled(&attempt_request, timeout_secs, cancel)
                 .await;
 

--- a/crates/agent-engine/src/runtime/transition/namespace_environment.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment.rs
@@ -245,6 +245,13 @@ pub struct NamespaceRuntimeEnvironment {
     launch_context: Option<crate::ProcessLaunchContext>,
 }
 
+/// Narrow file-native handle for one mounted LLM Connection.
+#[derive(Clone)]
+pub(crate) struct NamespaceGeneration {
+    root: InProcessTransport,
+    llm_connection: String,
+}
+
 #[derive(Clone)]
 struct NamespaceToolProcessContext {
     pub(crate) pid: alan_kernel::Pid,
@@ -288,6 +295,13 @@ impl NamespaceRuntimeEnvironment {
     pub fn with_launch_context(mut self, launch_context: crate::ProcessLaunchContext) -> Self {
         self.launch_context = Some(launch_context);
         self
+    }
+
+    pub(crate) fn generation(&self) -> NamespaceGeneration {
+        NamespaceGeneration {
+            root: self.root.clone(),
+            llm_connection: self.llm_connection.clone(),
+        }
     }
 
     pub(crate) fn launch_context(&self) -> Option<&crate::ProcessLaunchContext> {

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/generation.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/generation.rs
@@ -10,8 +10,7 @@ use tokio_util::sync::CancellationToken;
 use super::agent_files::{write_agent_output, write_tape_records};
 use super::client::NamespaceClient;
 use super::{
-    NamespaceLlmCapabilities, NamespaceRuntimeEnvironment, NamespaceTurnOutput,
-    NamespaceTurnRuntime,
+    NamespaceGeneration, NamespaceLlmCapabilities, NamespaceTurnOutput, NamespaceTurnRuntime,
 };
 
 #[derive(Deserialize)]
@@ -22,10 +21,10 @@ struct LlmCapabilitiesDoc {
     capabilities: alan_llm::ProviderCapabilities,
 }
 
-impl NamespaceRuntimeEnvironment {
+impl NamespaceGeneration {
     pub async fn read_llm_connection_capabilities(&self) -> Result<NamespaceLlmCapabilities> {
         let path = format!("/mnt/llm/connections/{}/capabilities", self.llm_connection);
-        let client = self.client();
+        let client = NamespaceClient::new(self.root.clone());
         let raw = client
             .read_file(&path)
             .await
@@ -46,17 +45,6 @@ impl NamespaceRuntimeEnvironment {
             provider: doc.provider,
             capabilities: doc.capabilities,
         })
-    }
-
-    pub async fn generate(&self, request: &GenerationRequest) -> Result<GenerationResponse> {
-        let request_doc = LlmRequestDoc::from_generation_request(request)?;
-        let request_bytes = serde_json::to_vec(&request_doc).context("serialize llmfs request")?;
-        let client = NamespaceClient::new(self.root.clone());
-        let generation_id = start_generation(&client, &self.llm_connection, &request_bytes).await?;
-        let response = read_generation_response(&client, &self.llm_connection, &generation_id)
-            .await
-            .with_context(|| format!("read llmfs generation {generation_id}"))?;
-        Ok(response)
     }
 
     pub async fn generate_controlled(
@@ -84,30 +72,6 @@ impl NamespaceRuntimeEnvironment {
             &generation_id,
             timeout_secs,
             cancel,
-        )
-        .await
-        .with_context(|| format!("read llmfs generation {generation_id}"))?;
-        Ok(response)
-    }
-
-    pub async fn generate_with_text_events<E, F>(
-        &self,
-        request: &GenerationRequest,
-        emit: &mut E,
-    ) -> Result<(GenerationResponse, bool)>
-    where
-        E: FnMut(Event) -> F,
-        F: std::future::Future<Output = ()>,
-    {
-        let request_doc = LlmRequestDoc::from_generation_request(request)?;
-        let request_bytes = serde_json::to_vec(&request_doc).context("serialize llmfs request")?;
-        let client = NamespaceClient::new(self.root.clone());
-        let generation_id = start_generation(&client, &self.llm_connection, &request_bytes).await?;
-        let response = read_generation_response_with_text_events(
-            &client,
-            &self.llm_connection,
-            &generation_id,
-            emit,
         )
         .await
         .with_context(|| format!("read llmfs generation {generation_id}"))?;
@@ -160,6 +124,7 @@ impl NamespaceTurnRuntime {
     /// Run one turn from the next committed `io/input` message.
     pub async fn run_next_turn(&mut self) -> Result<NamespaceTurnOutput> {
         let client = NamespaceClient::new(self.environment.root.clone());
+        let generation = self.environment.generation();
         let message = self.environment.read_next_input().await?;
 
         let request = GenerationRequest::new().with_user_message(message.clone());
@@ -171,9 +136,9 @@ impl NamespaceTurnRuntime {
         let request_doc = LlmRequestDoc::from_generation_request(&request)?;
         let request_bytes = serde_json::to_vec(&request_doc).context("serialize llmfs request")?;
         let generation_id =
-            start_generation(&client, &self.config.llm_connection, &request_bytes).await?;
+            start_generation(&client, &generation.llm_connection, &request_bytes).await?;
         let generation_response =
-            read_generation_response(&client, &self.config.llm_connection, &generation_id).await?;
+            read_generation_response(&client, &generation.llm_connection, &generation_id).await?;
         let response = generation_response.content;
 
         write_agent_output(&client, &self.config.agent_path, &response).await?;

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/tests/client_io.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/tests/client_io.rs
@@ -103,6 +103,7 @@ async fn controlled_generation_aborts_llmfs_on_cancel() {
             let request = GenerationRequest::new().with_user_message("hello");
             let mut ignore = |_event: Event| async {};
             environment
+                .generation()
                 .generate_with_text_events_controlled(&request, &mut ignore, 30, &cancel)
                 .await
         }

--- a/crates/agent-engine/src/runtime/turn_executor.rs
+++ b/crates/agent-engine/src/runtime/turn_executor.rs
@@ -328,7 +328,8 @@ where
         .iter()
         .map(|tool| tool.name.clone())
         .collect::<Vec<_>>();
-    let generation = NamespaceTurnGeneration::load(state).await;
+    let llm_generation = state.namespace_generation();
+    let generation = NamespaceTurnGeneration::load(&llm_generation).await;
     let initial_provider_capabilities = generation.capabilities();
     let turn_request_controls = crate::resolve_turn_request_controls(
         &state.core_config,
@@ -434,7 +435,7 @@ where
         }
         let llm_request_timeout_secs = state.runtime_config.llm_request_timeout_secs;
         let (response, live_text_chunks) = match generation
-            .generate(state, request, llm_request_timeout_secs, cancel)
+            .generate(&llm_generation, request, llm_request_timeout_secs, cancel)
             .await
         {
             Ok(response) => response,

--- a/crates/agent-engine/src/runtime/turn_executor/namespace_generation.rs
+++ b/crates/agent-engine/src/runtime/turn_executor/namespace_generation.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
-use super::RuntimeLoopState;
+use crate::runtime::transition::NamespaceGeneration;
 
 /// File-native generation context for one logical turn.
 ///
@@ -17,12 +17,8 @@ pub(super) struct NamespaceTurnGeneration {
 }
 
 impl NamespaceTurnGeneration {
-    pub(super) async fn load(state: &RuntimeLoopState) -> Self {
-        match state
-            .namespace_environment()
-            .read_llm_connection_capabilities()
-            .await
-        {
+    pub(super) async fn load(generation: &NamespaceGeneration) -> Self {
+        match generation.read_llm_connection_capabilities().await {
             Ok(info) => Self {
                 provider: info.provider,
                 capabilities: neutralize_namespace_capabilities(info.capabilities),
@@ -50,7 +46,7 @@ impl NamespaceTurnGeneration {
 
     pub(super) async fn generate(
         &self,
-        state: &RuntimeLoopState,
+        generation: &NamespaceGeneration,
         request: crate::llm::GenerationRequest,
         timeout_secs: u64,
         cancel: &CancellationToken,
@@ -63,7 +59,6 @@ impl NamespaceTurnGeneration {
                 return Err(anyhow::anyhow!("LLM request cancelled"));
             }
 
-            let namespace = state.namespace_environment().clone();
             let attempt_request = request.clone();
             let mut live_text_chunks = Vec::new();
             let mut collect_text = |event: Event| {
@@ -77,7 +72,7 @@ impl NamespaceTurnGeneration {
                 }
                 async {}
             };
-            let result = namespace
+            let result = generation
                 .generate_with_text_events_controlled(
                     &attempt_request,
                     &mut collect_text,

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -240,6 +240,27 @@ fn turn_generation_uses_only_the_file_native_namespace_boundary() {
     let generation = read_runtime_source("turn_executor/namespace_generation.rs");
     assert!(generation.contains("generate_with_text_events_controlled"));
     assert!(generation.contains("neutralize_namespace_capabilities"));
+    for forbidden in ["RuntimeLoopState", "namespace_environment()"] {
+        assert!(
+            !generation.contains(forbidden),
+            "generation workflow must receive its narrow handle, not {forbidden}"
+        );
+    }
+
+    let namespace = read_runtime_source("transition/namespace_environment.rs");
+    let generation_handle = rust_item_body(&namespace, "pub(crate) struct NamespaceGeneration");
+    assert!(generation_handle.contains("root: InProcessTransport"));
+    assert!(generation_handle.contains("llm_connection: String"));
+    for forbidden_field in ["agent_path", "tool_process_context", "child_run_registry"] {
+        assert!(
+            !generation_handle.contains(forbidden_field),
+            "generation handle must not gain {forbidden_field}"
+        );
+    }
+
+    let file_operations = read_runtime_source("transition/namespace_environment/generation.rs");
+    assert!(file_operations.contains("impl NamespaceGeneration"));
+    assert!(!file_operations.contains("impl NamespaceRuntimeEnvironment"));
 
     let projection = read_crate_source("llm/input_projection.rs");
     for forbidden in [


### PR DESCRIPTION
## Summary
- move mounted LLM Connection operations off the complete namespace environment onto a concrete generation handle
- restrict the handle to the aP root transport and selected connection name
- make the turn-generation child workflow accept that narrow handle instead of RuntimeLoopState
- delete the two now-unused generation entrypoints and add an architecture regression guard

## Verification
- cargo test -p alan-agent-engine (1198 passed, 1 ignored)
- cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings
- cargo test -p alan-agent-engine --test dependency_boundary (9 passed)
- openspec validate --all --strict (88 passed)
- just quality (0 maintainability warnings)