### PR TITLE
refactor(agent-engine): narrow agent file handle

### DIFF
--- a/crates/agent-engine/src/runtime/child_agents.rs
+++ b/crates/agent-engine/src/runtime/child_agents.rs
@@ -307,6 +307,7 @@ async fn spawn_child_runtime_inner(
             child_run_registry,
             timeout: spec.launch.timeout_secs.map(Duration::from_secs),
             process_lifecycle,
+            agent_files: child_process_environment.agent_files(),
             process_environment: child_process_environment,
             process_pid: child_process_pid,
         },

--- a/crates/agent-engine/src/runtime/child_agents/tests/lifecycle.rs
+++ b/crates/agent-engine/src/runtime/child_agents/tests/lifecycle.rs
@@ -17,10 +17,10 @@ async fn child_runtime_join_keeps_running_while_activity_file_is_fresh() {
     .await
     .unwrap();
     child.set_timeout_for_test(Duration::from_millis(200));
-    let environment = child.process_environment_for_test().clone();
+    let agent_files = child.process_environment_for_test().agent_files();
     tokio::spawn(async move {
         for _ in 0..5 {
-            crate::runtime::ui_surfaces::heartbeat(&environment)
+            crate::runtime::ui_surfaces::heartbeat(&agent_files)
                 .await
                 .unwrap();
             tokio::time::sleep(Duration::from_millis(35)).await;

--- a/crates/agent-engine/src/runtime/child_agents/tests/namespace_runtime.rs
+++ b/crates/agent-engine/src/runtime/child_agents/tests/namespace_runtime.rs
@@ -604,12 +604,12 @@ async fn child_namespace_launch_and_supervisor_reattachment_use_proc_pid_files()
 
     let process_reader = launch.environment.clone();
     let process_pid = launch.pid.clone();
-    launch
-        .environment
+    let agent_files = launch.environment.agent_files();
+    agent_files
         .write_assistant_output("AgentFS child result")
         .await
         .unwrap();
-    crate::runtime::ui_surfaces::turn_completed(&launch.environment, false)
+    crate::runtime::ui_surfaces::turn_completed(&agent_files, false)
         .await
         .unwrap();
     let controller = DelegatedChildRunSupervisor::new(DelegatedChildRunSupervision {
@@ -619,6 +619,7 @@ async fn child_namespace_launch_and_supervisor_reattachment_use_proc_pid_files()
         child_run_registry: ChildRunRegistry::default(),
         timeout: None,
         process_lifecycle: launch.lifecycle,
+        agent_files,
         process_environment: launch.environment,
         process_pid: process_pid.clone(),
     });
@@ -688,6 +689,7 @@ async fn external_proc_ctl_stops_child_runtime_controller() {
     .unwrap();
     let process_pid = launch.pid.clone();
     let process_environment = launch.environment.clone();
+    let agent_files = launch.environment.agent_files();
     let controller = DelegatedChildRunSupervisor::new(DelegatedChildRunSupervision {
         runtime: None,
         startup_metadata: test_startup_metadata("child-machine", None, false),
@@ -695,11 +697,12 @@ async fn external_proc_ctl_stops_child_runtime_controller() {
         child_run_registry: ChildRunRegistry::default(),
         timeout: None,
         process_lifecycle: launch.lifecycle,
+        agent_files: agent_files.clone(),
         process_environment: launch.environment,
         process_pid: process_pid.clone(),
     });
 
-    assert_eq!(process_environment.ui_events_offset().await.unwrap(), 0);
+    assert_eq!(agent_files.ui_events_offset().await.unwrap(), 0);
     process_environment
         .write_process_control_for_pid(&process_pid, "cancel")
         .await

--- a/crates/agent-engine/src/runtime/child_run_termination_tool.rs
+++ b/crates/agent-engine/src/runtime/child_run_termination_tool.rs
@@ -233,7 +233,7 @@ where
             state
                 .machine
                 .set_confirmation_for_request(request_id.clone(), pending.clone());
-            super::ui_surfaces::paused(state.namespace_environment()).await?;
+            super::ui_surfaces::paused(&state.agent_files()).await?;
             emit(Event::Yield {
                 request_id,
                 kind: YieldKind::Confirmation,

--- a/crates/agent-engine/src/runtime/compaction.rs
+++ b/crates/agent-engine/src/runtime/compaction.rs
@@ -291,8 +291,7 @@ async fn record_and_emit_compaction_attempt<E, F>(
         error!(error = %err, "Failed to persist compaction observation batch");
         return;
     }
-    if let Err(err) = super::ui_surfaces::compaction(state.namespace_environment(), &attempt).await
-    {
+    if let Err(err) = super::ui_surfaces::compaction(&state.agent_files(), &attempt).await {
         error!(error = %err, "Failed to write compaction UI state");
     }
     emit(Event::CompactionObserved { attempt }).await;
@@ -316,9 +315,7 @@ where
         return None;
     }
     let attempt_id = attempt.attempt_id.clone();
-    if let Err(err) =
-        super::ui_surfaces::memory_flush(state.namespace_environment(), &attempt).await
-    {
+    if let Err(err) = super::ui_surfaces::memory_flush(&state.agent_files(), &attempt).await {
         error!(error = %err, "Failed to write memory flush UI state");
     }
     emit(Event::MemoryFlushObserved { attempt }).await;
@@ -373,9 +370,7 @@ where
     }
 
     if let Some(message) = attempt.warning_message.clone() {
-        if let Err(err) =
-            super::ui_surfaces::warning(state.namespace_environment(), message.clone()).await
-        {
+        if let Err(err) = super::ui_surfaces::warning(&state.agent_files(), message.clone()).await {
             error!(error = %err, "Failed to write memory warning UI state");
         }
         emit(Event::Warning { message }).await;
@@ -417,7 +412,7 @@ where
             retry_count,
             failure_streak,
         );
-        super::ui_surfaces::warning(state.namespace_environment(), warning_message.clone()).await?;
+        super::ui_surfaces::warning(&state.agent_files(), warning_message.clone()).await?;
         emit(Event::Warning {
             message: warning_message.clone(),
         })
@@ -486,7 +481,7 @@ where
         retry_count,
         failure_streak,
     );
-    super::ui_surfaces::warning(state.namespace_environment(), warning_message.clone()).await?;
+    super::ui_surfaces::warning(&state.agent_files(), warning_message.clone()).await?;
     emit(Event::Warning {
         message: warning_message.clone(),
     })

--- a/crates/agent-engine/src/runtime/delegated_child_run/supervisor.rs
+++ b/crates/agent-engine/src/runtime/delegated_child_run/supervisor.rs
@@ -8,6 +8,7 @@ use tokio_util::sync::CancellationToken;
 
 use super::{ChildRuntimePause, ChildRuntimeResult, ChildRuntimeStatus};
 use crate::runtime::child_runs::ChildRunRegistry;
+use crate::runtime::transition::NamespaceAgentFiles;
 use crate::runtime::{
     AgentProcessLifecycle, ChildRunStatus, ChildRunTerminationMode, ChildRunTerminationRequest,
     NamespaceRuntimeEnvironment, RuntimeController, RuntimeStartupMetadata,
@@ -26,6 +27,7 @@ pub(crate) struct DelegatedChildRunSupervision {
     pub(crate) timeout: Option<Duration>,
     pub(crate) process_lifecycle: Arc<dyn AgentProcessLifecycle>,
     pub(crate) process_environment: NamespaceRuntimeEnvironment,
+    pub(crate) agent_files: NamespaceAgentFiles,
     pub(crate) process_pid: String,
 }
 
@@ -72,6 +74,7 @@ pub(crate) struct DelegatedChildRunSupervisor {
     timeout: Option<Duration>,
     process_lifecycle: Arc<dyn AgentProcessLifecycle>,
     process_environment: NamespaceRuntimeEnvironment,
+    agent_files: NamespaceAgentFiles,
     process_pid: String,
 }
 
@@ -85,45 +88,47 @@ impl DelegatedChildRunSupervisor {
             timeout: input.timeout,
             process_lifecycle: input.process_lifecycle,
             process_environment: input.process_environment,
+            agent_files: input.agent_files,
             process_pid: input.process_pid,
         }
     }
 
     async fn observe_files(&self) -> Result<ChildFileObservation> {
-        let environment = &self.process_environment;
+        let process_environment = &self.process_environment;
+        let agent_files = &self.agent_files;
         let pid = self.process_pid.as_str();
         let timeout = Duration::from_secs(1);
-        let process_exit_code = environment.read_process_exit_code(pid).await?;
+        let process_exit_code = process_environment.read_process_exit_code(pid).await?;
         let (process_output_offset, process_io_events_offset) =
-            environment.read_process_io_offsets(pid).await?;
-        let activity = tokio::time::timeout(timeout, environment.read_ui_activity_snapshot())
+            process_environment.read_process_io_offsets(pid).await?;
+        let activity = tokio::time::timeout(timeout, agent_files.read_ui_activity_snapshot())
             .await
             .context("observe child activity timed out")??;
-        let output_text = tokio::time::timeout(timeout, environment.read_assistant_output())
+        let output_text = tokio::time::timeout(timeout, agent_files.read_assistant_output())
             .await
             .context("observe child output timed out")??;
-        let ui_events_offset = tokio::time::timeout(timeout, environment.ui_events_offset())
+        let ui_events_offset = tokio::time::timeout(timeout, agent_files.ui_events_offset())
             .await
             .context("observe child UI events offset timed out")??;
-        let notice = tokio::time::timeout(timeout, environment.read_ui_notice_snapshot())
+        let notice = tokio::time::timeout(timeout, agent_files.read_ui_notice_snapshot())
             .await
             .context("observe child notice timed out")??;
-        let request_ids = tokio::time::timeout(timeout, environment.request_ids())
+        let request_ids = tokio::time::timeout(timeout, agent_files.request_ids())
             .await
             .context("observe child requests timed out")??;
         let pending_request_id =
-            tokio::time::timeout(timeout, environment.pending_request_id(&request_ids))
+            tokio::time::timeout(timeout, agent_files.pending_request_id(&request_ids))
                 .await
                 .context("observe child pending request timed out")??;
         let request_events_offset =
-            tokio::time::timeout(timeout, environment.request_events_offset())
+            tokio::time::timeout(timeout, agent_files.request_events_offset())
                 .await
                 .context("observe child request stream offset timed out")??;
-        let action_ids = tokio::time::timeout(timeout, environment.action_ids())
+        let action_ids = tokio::time::timeout(timeout, agent_files.action_ids())
             .await
             .context("observe child actions timed out")??;
         let action_events_offset =
-            tokio::time::timeout(timeout, environment.action_events_offset())
+            tokio::time::timeout(timeout, agent_files.action_events_offset())
                 .await
                 .context("observe child action stream offset timed out")??;
         Ok(ChildFileObservation {
@@ -324,10 +329,7 @@ impl DelegatedChildRunSupervisor {
             if observation.activity.state == alan_agent_protocol::UiActivityState::Paused
                 && let Some(request_id) = observation.pending_request_id.as_ref()
             {
-                let kind = self
-                    .process_environment
-                    .read_request_kind(request_id)
-                    .await?;
+                let kind = self.agent_files.read_request_kind(request_id).await?;
                 let kind = match kind.as_str() {
                     "confirmation" => YieldKind::Confirmation,
                     "structured_input" => YieldKind::StructuredInput,

--- a/crates/agent-engine/src/runtime/delegated_child_run/supervisor_tests.rs
+++ b/crates/agent-engine/src/runtime/delegated_child_run/supervisor_tests.rs
@@ -15,6 +15,7 @@ impl AgentProcessLifecycle for RecordingProcessLifecycle {
 
 fn test_supervisor(finish_count: Arc<AtomicUsize>) -> DelegatedChildRunSupervisor {
     let root = alan_ap::InProcessTransport::new(Arc::new(alan_ap::reference::MemFs::new()));
+    let process_environment = NamespaceRuntimeEnvironment::new(root, "/agent/42", "default");
     DelegatedChildRunSupervisor::new(DelegatedChildRunSupervision {
         runtime: None,
         startup_metadata: RuntimeStartupMetadata {
@@ -34,7 +35,8 @@ fn test_supervisor(finish_count: Arc<AtomicUsize>) -> DelegatedChildRunSuperviso
         child_run_registry: ChildRunRegistry::default(),
         timeout: None,
         process_lifecycle: Arc::new(RecordingProcessLifecycle { finish_count }),
-        process_environment: NamespaceRuntimeEnvironment::new(root, "/agent/42", "default"),
+        agent_files: process_environment.agent_files(),
+        process_environment,
         process_pid: "42".to_string(),
     })
 }

--- a/crates/agent-engine/src/runtime/delegated_skill_evidence.rs
+++ b/crates/agent-engine/src/runtime/delegated_skill_evidence.rs
@@ -56,7 +56,7 @@ pub(super) async fn persist_delegated_child_evidence(
         result_doc["child_agent_path"] = json!(agent_path);
     }
     let action_id = state
-        .namespace_environment()
+        .agent_files()
         .write_action(
             NamespaceActionRecord::new(
                 format!("delegate:{}", request.skill_id),
@@ -68,16 +68,10 @@ pub(super) async fn persist_delegated_child_evidence(
         )
         .await
         .ok()?;
-    let path = format!(
-        "{}/actions/{action_id}/output",
-        state.namespace_environment().agent_path()
-    );
-    let reference = state
-        .namespace_environment()
-        .evidence_reference(path)
-        .await?;
-    state
-        .namespace_environment()
+    let path = format!("{}/actions/{action_id}/output", state.agent_path());
+    let agent_files = state.agent_files();
+    let reference = agent_files.evidence_reference(path).await?;
+    agent_files
         .resolve_evidence_reference(&reference, None, result.child_run_value())
         .await
         .ok()?;

--- a/crates/agent-engine/src/runtime/delegated_skill_evidence_tests.rs
+++ b/crates/agent-engine/src/runtime/delegated_skill_evidence_tests.rs
@@ -115,7 +115,7 @@ async fn long_delegated_output_uses_parent_resolvable_namespace_reference() {
         length: output_ref.length,
     };
     let resolved = state
-        .namespace_environment()
+        .agent_files()
         .resolve_evidence_reference(&namespace_ref, None, None)
         .await
         .unwrap();
@@ -187,7 +187,7 @@ async fn evidence_resolution_distinguishes_missing_and_retention_expired() {
     };
 
     let missing = state
-        .namespace_environment()
+        .agent_files()
         .resolve_evidence_reference(&missing_ref, preview.clone(), child_run.clone())
         .await
         .unwrap_err();
@@ -204,7 +204,7 @@ async fn evidence_resolution_distinguishes_missing_and_retention_expired() {
         "cause": "simulated_gc"
     });
     let action_id = state
-        .namespace_environment()
+        .agent_files()
         .write_action(
             NamespaceActionRecord::new("expired-test", "completed")
                 .with_output(expired_record.to_string()),
@@ -212,13 +212,13 @@ async fn evidence_resolution_distinguishes_missing_and_retention_expired() {
         .await
         .unwrap();
     let mut expired_ref = state
-        .namespace_environment()
+        .agent_files()
         .evidence_reference(format!("/agent/1/actions/{action_id}/output"))
         .await
         .unwrap();
     expired_ref.length = Some(10_000);
     let expired = state
-        .namespace_environment()
+        .agent_files()
         .resolve_evidence_reference(&expired_ref, None, None)
         .await
         .unwrap_err();
@@ -232,7 +232,7 @@ async fn evidence_resolution_distinguishes_missing_and_retention_expired() {
 async fn evidence_resolution_honors_open_ended_ranges() {
     let (state, _shell) = create_namespace_transition_state_and_shell();
     let action_id = state
-        .namespace_environment()
+        .agent_files()
         .write_action(NamespaceActionRecord::new("range-test", "completed").with_output("abcdef"))
         .await
         .unwrap();
@@ -249,7 +249,7 @@ async fn evidence_resolution_honors_open_ended_ranges() {
             length,
         };
         let resolved = state
-            .namespace_environment()
+            .agent_files()
             .resolve_evidence_reference(&reference, None, None)
             .await
             .unwrap();

--- a/crates/agent-engine/src/runtime/engine.rs
+++ b/crates/agent-engine/src/runtime/engine.rs
@@ -3,8 +3,9 @@
 use super::controller::{AgentMachineDurabilityState, RuntimeController, RuntimeStartupMetadata};
 use super::launch_config::AgentProcessConfig;
 use super::transition::{
-    DeferredRuntimeActionExit, TransitionCompletion, accepts_inband_submissions,
-    advance_accepted_submission, run_deferred_runtime_action_with_cancel,
+    DeferredRuntimeActionExit, NamespaceAgentFiles, TransitionCompletion,
+    accepts_inband_submissions, advance_accepted_submission,
+    run_deferred_runtime_action_with_cancel,
 };
 use super::turn_driver::{
     NAMESPACE_PENDING_RESPONSE_POLL_INTERVAL, TurnInputBroker, is_turn_inband_submission,
@@ -82,7 +83,7 @@ async fn read_pending_namespace_resume_submission(
 }
 
 async fn read_pending_namespace_control_submission(
-    namespace: &super::NamespaceRuntimeEnvironment,
+    namespace: &NamespaceAgentFiles,
 ) -> Option<Result<Submission>> {
     match namespace.read_next_machine_control_submission().await {
         Ok(Some(submission)) => Some(Ok(submission)),
@@ -432,7 +433,7 @@ fn spawn_with_prepared_runtime_environment(
             definition_persona_dirs: prompt_cache_persona_dirs.clone(),
             prompt_cache,
         };
-        match super::ui_surfaces::initialize(state.namespace_environment()).await {
+        match super::ui_surfaces::initialize(&state.agent_files()).await {
             Ok(()) => {}
             Err(err) => {
                 let _ = ready_tx.send(Err(format!("{:#}", err)));
@@ -452,7 +453,7 @@ fn spawn_with_prepared_runtime_environment(
         let mut shutdown_requested = false;
 
         let mut queues = RuntimeSubmissionQueues::default();
-        let input_environment = state.namespace_environment().clone();
+        let input_environment = state.agent_files();
         let (namespace_input_tx, mut namespace_input_rx) = mpsc::channel(1);
         let namespace_input_task = tokio::spawn(async move {
             loop {
@@ -484,7 +485,7 @@ fn spawn_with_prepared_runtime_environment(
                     }
                 }
             } else if let Some(namespace_control) =
-                read_pending_namespace_control_submission(state.namespace_environment()).await
+                read_pending_namespace_control_submission(&state.agent_files()).await
             {
                 match namespace_control {
                     Ok(submission) => Some(QueuedRuntimeItem::Submission(submission)),
@@ -499,7 +500,7 @@ fn spawn_with_prepared_runtime_environment(
             } else if submissions_closed {
                 None
             } else {
-                let namespace_control = state.namespace_environment().clone();
+                let namespace_control = state.agent_files();
                 let poll_pending_namespace_response = state.machine.has_pending_interaction();
                 tokio::select! {
                     submission = sub_rx.recv() => submission.map(QueuedRuntimeItem::Submission),
@@ -568,8 +569,8 @@ fn spawn_with_prepared_runtime_environment(
                     let cancel = CancellationToken::new();
 
                     let broker_for_submission = queues.active_turn_broker.clone();
-                    let namespace_control = state.namespace_environment().clone();
-                    let namespace_heartbeat = state.namespace_environment().clone();
+                    let namespace_control = state.agent_files();
+                    let namespace_heartbeat = state.agent_files();
                     let mut submission_fut = Box::pin(advance_accepted_submission(
                         &mut state,
                         submission,
@@ -707,7 +708,7 @@ fn spawn_with_prepared_runtime_environment(
                     let action_for_requeue = action.clone();
                     let mut requeue_if_cancelled = false;
                     let cancel = CancellationToken::new();
-                    let namespace_control = state.namespace_environment().clone();
+                    let namespace_control = state.agent_files();
                     let mut action_fut = Box::pin(run_deferred_runtime_action_with_cancel(
                         &mut state, action, &cancel,
                     ));

--- a/crates/agent-engine/src/runtime/engine_runtime_tests.rs
+++ b/crates/agent-engine/src/runtime/engine_runtime_tests.rs
@@ -390,6 +390,7 @@ async fn test_outer_idle_reads_answered_namespace_request_response() {
         crate::runtime::NamespaceRuntimeEnvironment::new(root, "/agent/1", "default");
 
     let request_id = namespace_environment
+        .agent_files()
         .write_request(crate::runtime::transition::NamespaceRequestRecord::new(
             "structured_input",
             "Provide the missing value",

--- a/crates/agent-engine/src/runtime/mount_request_tool.rs
+++ b/crates/agent-engine/src/runtime/mount_request_tool.rs
@@ -277,7 +277,7 @@ where
     state
         .machine
         .set_confirmation_for_request(request_id.clone(), pending.clone());
-    super::ui_surfaces::paused(state.namespace_environment()).await?;
+    super::ui_surfaces::paused(&state.agent_files()).await?;
     emit(Event::Yield {
         request_id,
         kind: YieldKind::Confirmation,

--- a/crates/agent-engine/src/runtime/submission_handlers.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers.rs
@@ -65,10 +65,8 @@ where
             }
             let rollback = state.machine.rollback_last_turns(turns);
             state.machine.clear_plan_snapshot();
-            super::ui_surfaces::plan_updated(state.namespace_environment(), None, Vec::new())
-                .await?;
-            super::ui_surfaces::rollback(state.namespace_environment(), rollback.removed_turns)
-                .await?;
+            super::ui_surfaces::plan_updated(&state.agent_files(), None, Vec::new()).await?;
+            super::ui_surfaces::rollback(&state.agent_files(), rollback.removed_turns).await?;
             emit(Event::MachineRolledBack {
                 turns: rollback.removed_turns,
                 removed_messages: rollback.removed_messages,
@@ -90,11 +88,7 @@ where
                 is_final: true,
             })
             .await;
-            super::ui_surfaces::warning(
-                state.namespace_environment(),
-                ROLLBACK_NON_DURABLE_WARNING,
-            )
-            .await?;
+            super::ui_surfaces::warning(&state.agent_files(), ROLLBACK_NON_DURABLE_WARNING).await?;
             emit(Event::Warning {
                 message: ROLLBACK_NON_DURABLE_WARNING.to_string(),
             })
@@ -127,7 +121,7 @@ where
                 let message = format!(
                     "Applied {queued_next_turn_count} queued next_turn input(s) to this turn."
                 );
-                super::ui_surfaces::warning(state.namespace_environment(), message.clone()).await?;
+                super::ui_surfaces::warning(&state.agent_files(), message.clone()).await?;
                 emit(Event::Warning { message }).await;
             }
 
@@ -169,8 +163,7 @@ where
                             }));
                         let message =
                             "Queued follow_up input for execution after current turn.".to_string();
-                        super::ui_surfaces::warning(state.namespace_environment(), message.clone())
-                            .await?;
+                        super::ui_surfaces::warning(&state.agent_files(), message.clone()).await?;
                         emit(Event::Warning { message }).await;
                         return Ok(RuntimeOpAction::NoTurn);
                     }
@@ -189,11 +182,8 @@ where
                             let message = format!(
                                 "Queued next_turn input (queue_size={size}); it will apply to the next explicit turn."
                             );
-                            super::ui_surfaces::warning(
-                                state.namespace_environment(),
-                                message.clone(),
-                            )
-                            .await?;
+                            super::ui_surfaces::warning(&state.agent_files(), message.clone())
+                                .await?;
                             emit(Event::Warning { message }).await;
                         }
                         None => {
@@ -327,11 +317,7 @@ async fn persist_runtime_confirmation_checkpoint(
     pending: &crate::approval::PendingConfirmation,
     choice_str: &str,
 ) {
-    let knowledge_root = match state
-        .namespace_environment()
-        .current_tape_checkpoint()
-        .await
-    {
+    let knowledge_root = match state.agent_files().current_tape_checkpoint().await {
         Ok(root) => {
             let trimmed = root.trim();
             if trimmed.is_empty() { None } else { Some(root) }

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/confirmation_and_mount_support.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/confirmation_and_mount_support.inc.rs
@@ -482,12 +482,12 @@
         let (environment, _shell) = namespace_environment_with_live_process_for_test().await;
         state.environment = environment;
         state
-            .namespace_environment()
+            .agent_files()
             .write_user_state("seed confirmation context")
             .await
             .unwrap();
         let expected_root = state
-            .namespace_environment()
+            .agent_files()
             .current_tape_checkpoint()
             .await
             .unwrap();

--- a/crates/agent-engine/src/runtime/tool_orchestrator.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator.rs
@@ -267,14 +267,11 @@ async fn tool_payload_for_tape(state: &RuntimeLoopState, payload: &Value) -> Val
             Some("reference_unresolvable".to_string()),
         );
     }
-    let path = format!(
-        "{}/actions/{action_id}/output",
-        state.namespace_environment().agent_path()
-    );
-    let reference = state.namespace_environment().evidence_reference(path).await;
+    let path = format!("{}/actions/{action_id}/output", state.agent_path());
+    let agent_files = state.agent_files();
+    let reference = agent_files.evidence_reference(path).await;
     let redactions = if let Some(reference) = reference.as_ref() {
-        state
-            .namespace_environment()
+        agent_files
             .resolve_evidence_reference(reference, None, None)
             .await
             .ok()
@@ -487,17 +484,13 @@ where
                     super::guardian::ReviewOutcome::Deny { rationale } => {
                         let tripped = state.machine.record_guardian_review(true);
                         let message = format!("auto-review denied: {rationale}");
-                        super::ui_surfaces::warning(state.namespace_environment(), message.clone())
-                            .await?;
+                        super::ui_surfaces::warning(&state.agent_files(), message.clone()).await?;
                         emit(Event::Warning { message }).await;
                         if tripped {
                             let message =
                                 "auto-review circuit breaker tripped; pausing for you".to_string();
-                            super::ui_surfaces::warning(
-                                state.namespace_environment(),
-                                message.clone(),
-                            )
-                            .await?;
+                            super::ui_surfaces::warning(&state.agent_files(), message.clone())
+                                .await?;
                             emit(Event::Warning { message }).await;
                             true
                         } else {
@@ -566,7 +559,7 @@ where
                 state
                     .machine
                     .set_confirmation_for_request(request_id.clone(), pending.clone());
-                super::ui_surfaces::paused(state.namespace_environment()).await?;
+                super::ui_surfaces::paused(&state.agent_files()).await?;
                 emit(Event::Yield {
                     request_id,
                     kind: alan_agent_protocol::YieldKind::Confirmation,
@@ -684,7 +677,7 @@ where
         state
             .machine
             .set_confirmation_for_request(request_id.clone(), pending.clone());
-        super::ui_surfaces::paused(state.namespace_environment()).await?;
+        super::ui_surfaces::paused(&state.agent_files()).await?;
         emit(Event::Yield {
             request_id,
             kind: alan_agent_protocol::YieldKind::Confirmation,

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -6,7 +6,6 @@
 
 mod namespace_environment;
 
-pub(crate) use namespace_environment::NamespaceGeneration;
 #[cfg(test)]
 pub(super) use namespace_environment::NamespaceRequestRecord;
 pub use namespace_environment::{
@@ -15,6 +14,7 @@ pub use namespace_environment::{
     NamespaceRuntimeEnvironment, NamespaceToolActionOutput, NamespaceTurnOutput,
     NamespaceTurnRuntime, NamespaceTurnRuntimeConfig,
 };
+pub(crate) use namespace_environment::{NamespaceAgentFiles, NamespaceGeneration};
 
 use std::collections::VecDeque;
 
@@ -88,6 +88,10 @@ impl RuntimeLoopState {
         self.environment.generation()
     }
 
+    pub(crate) fn agent_files(&self) -> NamespaceAgentFiles {
+        self.environment.agent_files()
+    }
+
     pub(crate) async fn write_namespace_confirmation_request(
         &self,
         pending: &crate::approval::PendingConfirmation,
@@ -101,7 +105,7 @@ impl RuntimeLoopState {
             "options": pending.options.clone(),
         }))?;
         let request_id = self
-            .namespace_environment()
+            .agent_files()
             .write_request(
                 namespace_environment::NamespaceRequestRecord::new(kind, pending.summary.clone())
                     .with_options(options),
@@ -120,7 +124,7 @@ impl RuntimeLoopState {
             "questions": pending.questions.clone(),
         }))?;
         let request_id = self
-            .namespace_environment()
+            .agent_files()
             .write_request(
                 namespace_environment::NamespaceRequestRecord::new(
                     "structured_input",

--- a/crates/agent-engine/src/runtime/transition/namespace_environment.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment.rs
@@ -252,6 +252,15 @@ pub(crate) struct NamespaceGeneration {
     llm_connection: String,
 }
 
+/// Narrow handle for files owned by one AgentFS process layout.
+#[derive(Clone)]
+pub(crate) struct NamespaceAgentFiles {
+    root: InProcessTransport,
+    agent_path: String,
+    input_offset: Arc<AtomicU64>,
+    control_offset: Arc<AtomicU64>,
+}
+
 #[derive(Clone)]
 struct NamespaceToolProcessContext {
     pub(crate) pid: alan_kernel::Pid,
@@ -301,6 +310,15 @@ impl NamespaceRuntimeEnvironment {
         NamespaceGeneration {
             root: self.root.clone(),
             llm_connection: self.llm_connection.clone(),
+        }
+    }
+
+    pub(crate) fn agent_files(&self) -> NamespaceAgentFiles {
+        NamespaceAgentFiles {
+            root: self.root.clone(),
+            agent_path: self.agent_path.clone(),
+            input_offset: Arc::clone(&self.input_offset),
+            control_offset: Arc::clone(&self.control_offset),
         }
     }
 
@@ -653,6 +671,7 @@ impl NamespaceRuntimeEnvironment {
         }
         let durable_output = redact_durable_evidence_text(&result.output);
         let action_id = self
+            .agent_files()
             .write_action(
                 NamespaceActionRecord::new(tool_name, action_status)
                     .with_output(durable_output.text)
@@ -799,7 +818,10 @@ impl NamespaceTurnRuntime {
 
     /// Read the current root-hash checkpoint for this runtime's `machine/tape`.
     pub async fn current_tape_checkpoint(&self) -> Result<String> {
-        self.environment.current_tape_checkpoint().await
+        self.environment
+            .agent_files()
+            .current_tape_checkpoint()
+            .await
     }
 }
 

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/agent_files.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/agent_files.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Result, bail};
 use serde::Serialize;
 
 use super::{
-    NamespaceActionRecord, NamespaceRequestRecord, NamespaceRuntimeEnvironment,
+    NamespaceActionRecord, NamespaceAgentFiles, NamespaceRequestRecord,
     client::{InputFrame, NamespaceClient},
 };
 use crate::evidence::{
@@ -19,7 +19,11 @@ use crate::evidence::{
     is_retention_expired_record,
 };
 
-impl NamespaceRuntimeEnvironment {
+impl NamespaceAgentFiles {
+    fn client(&self) -> NamespaceClient {
+        NamespaceClient::new(self.root.clone())
+    }
+
     pub async fn read_next_input(&self) -> Result<String> {
         let input_path = format!("{}/io/input", self.agent_path);
         let client = self.client();
@@ -122,16 +126,12 @@ impl NamespaceRuntimeEnvironment {
         Ok(Some(response))
     }
 
-    pub async fn write_assistant_state(&self, response: &str) -> Result<()> {
-        self.write_assistant_output(response).await?;
-        self.write_turn_tape_state(None, response).await
-    }
-
     pub async fn write_assistant_output(&self, response: &str) -> Result<()> {
         let client = NamespaceClient::new(self.root.clone());
         write_agent_output(&client, &self.agent_path, response).await
     }
 
+    #[cfg(test)]
     pub async fn write_user_state(&self, input: &str) -> Result<()> {
         let client = NamespaceClient::new(self.root.clone());
         write_tape_records(&client, &self.agent_path, [("user", input)]).await
@@ -147,6 +147,7 @@ impl NamespaceRuntimeEnvironment {
         write_tape_records(&client, &self.agent_path, records).await
     }
 
+    #[cfg(test)]
     pub async fn begin_tape_generation(&self) -> Result<NamespaceTapeWriter> {
         let client = NamespaceClient::new(self.root.clone());
         NamespaceTapeWriter::open(client, &self.agent_path).await

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/generation.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/generation.rs
@@ -7,7 +7,6 @@ use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 use tokio_util::sync::CancellationToken;
 
-use super::agent_files::{write_agent_output, write_tape_records};
 use super::client::NamespaceClient;
 use super::{
     NamespaceGeneration, NamespaceLlmCapabilities, NamespaceTurnOutput, NamespaceTurnRuntime,
@@ -125,7 +124,8 @@ impl NamespaceTurnRuntime {
     pub async fn run_next_turn(&mut self) -> Result<NamespaceTurnOutput> {
         let client = NamespaceClient::new(self.environment.root.clone());
         let generation = self.environment.generation();
-        let message = self.environment.read_next_input().await?;
+        let agent_files = self.environment.agent_files();
+        let message = agent_files.read_next_input().await?;
 
         let request = GenerationRequest::new().with_user_message(message.clone());
         let request = if let Some(system_prompt) = self.config.system_prompt.clone() {
@@ -141,13 +141,10 @@ impl NamespaceTurnRuntime {
             read_generation_response(&client, &generation.llm_connection, &generation_id).await?;
         let response = generation_response.content;
 
-        write_agent_output(&client, &self.config.agent_path, &response).await?;
-        write_tape_records(
-            &client,
-            &self.config.agent_path,
-            [("user", message.as_str()), ("assistant", response.as_str())],
-        )
-        .await?;
+        agent_files.write_assistant_output(&response).await?;
+        agent_files
+            .write_turn_tape_state(Some(&message), &response)
+            .await?;
 
         Ok(NamespaceTurnOutput {
             input: message,

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/tests.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/tests.rs
@@ -373,8 +373,9 @@ async fn answered_request_response_resumes_engine_pending_yield_from_files() {
     let root = InProcessTransport::new(Arc::new(MountFs::new(ns)));
     let shell = Shell::new(root.clone());
     let environment = NamespaceRuntimeEnvironment::new(root.clone(), "/agent/1", "default");
+    let agent_files = environment.agent_files();
 
-    let request_id = environment
+    let request_id = agent_files
         .write_request(NamespaceRequestRecord::new(
             "structured_input",
             "Provide the missing detail",
@@ -383,7 +384,7 @@ async fn answered_request_response_resumes_engine_pending_yield_from_files() {
         .unwrap();
     assert_eq!(request_id, "r0");
     assert!(
-        environment
+        agent_files
             .resume_submission_from_answered_request(&request_id)
             .await
             .unwrap()
@@ -397,7 +398,7 @@ async fn answered_request_response_resumes_engine_pending_yield_from_files() {
         )
         .await
         .unwrap();
-    let submission = environment
+    let submission = agent_files
         .resume_submission_from_answered_request(&request_id)
         .await
         .unwrap()

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/tests/agent_files.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/tests/agent_files.rs
@@ -112,8 +112,9 @@ async fn engine_writes_requests_and_actions_as_agent_files() {
     agent_root.bind_process(pid.clone(), agentfs.clone()).await;
     agent_root.set_root_process(pid).await;
     let environment = NamespaceRuntimeEnvironment::new(root.clone(), "/agent/1", "default");
+    let agent_files = environment.agent_files();
 
-    let request_id = environment
+    let request_id = agent_files
         .write_request(
             NamespaceRequestRecord::new("confirmation", "approve this action?")
                 .with_options(r#"{"choices":["approve","deny"]}"#),
@@ -152,7 +153,7 @@ async fn engine_writes_requests_and_actions_as_agent_files() {
         r#"{"choices":["approve","deny"]}"#
     );
 
-    let action_id = environment
+    let action_id = agent_files
         .write_action(
             NamespaceActionRecord::new("read", "completed")
                 .with_output("file contents")

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/tests/submissions.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/tests/submissions.rs
@@ -12,9 +12,10 @@ async fn pending_request_selection_ignores_lexicographic_id_order() {
     let root = InProcessTransport::new(Arc::new(MountFs::new(ns)));
     let shell = Shell::new(root.clone());
     let environment = NamespaceRuntimeEnvironment::new(root, "/agent/1", "default");
+    let agent_files = environment.agent_files();
 
     for index in 0..11 {
-        let id = environment
+        let id = agent_files
             .write_request(NamespaceRequestRecord::new("confirmation", "approve?"))
             .await
             .unwrap();
@@ -27,9 +28,9 @@ async fn pending_request_selection_ignores_lexicographic_id_order() {
         }
     }
 
-    let ids = environment.request_ids().await.unwrap();
+    let ids = agent_files.request_ids().await.unwrap();
     assert_eq!(
-        environment.pending_request_id(&ids).await.unwrap(),
+        agent_files.pending_request_id(&ids).await.unwrap(),
         Some("r10".into())
     );
 }
@@ -46,6 +47,7 @@ async fn machine_ctl_records_become_control_submissions_in_order() {
     let root = InProcessTransport::new(Arc::new(MountFs::new(ns)));
     let shell = Shell::new(root.clone());
     let environment = NamespaceRuntimeEnvironment::new(root, "/agent/1", "default");
+    let agent_files = environment.agent_files();
 
     shell
         .write("/agent/1/io/output", b"assistant output")
@@ -60,14 +62,14 @@ async fn machine_ctl_records_become_control_submissions_in_order() {
         .await
         .unwrap();
 
-    let compact = environment
+    let compact = agent_files
         .read_next_machine_control_submission()
         .await
         .unwrap()
         .expect("compact command should produce a submission");
     assert!(matches!(compact.op, Op::CompactWithOptions { focus: None }));
 
-    let rollback = environment
+    let rollback = agent_files
         .read_next_machine_control_submission()
         .await
         .unwrap()
@@ -75,7 +77,7 @@ async fn machine_ctl_records_become_control_submissions_in_order() {
     assert!(matches!(rollback.op, Op::Rollback { turns: 1 }));
 
     assert!(
-        environment
+        agent_files
             .read_next_machine_control_submission()
             .await
             .unwrap()
@@ -88,7 +90,7 @@ async fn machine_ctl_records_become_control_submissions_in_order() {
         .write("/agent/1/machine/ctl", b"interrupt")
         .await
         .unwrap();
-    let interrupt = environment
+    let interrupt = agent_files
         .read_next_machine_control_submission()
         .await
         .unwrap()
@@ -108,12 +110,13 @@ async fn input_frame_becomes_engine_input_submission() {
     let root = InProcessTransport::new(Arc::new(MountFs::new(ns)));
     let shell = Shell::new(root.clone());
     let environment = NamespaceRuntimeEnvironment::new(root, "/agent/1", "default");
+    let agent_files = environment.agent_files();
 
     shell
         .write("/agent/1/io/input", b"continue from files")
         .await
         .unwrap();
-    let submission = environment
+    let submission = agent_files
         .read_next_input_submission(InputMode::FollowUp)
         .await
         .unwrap();
@@ -139,13 +142,14 @@ async fn input_frame_larger_than_initial_read_becomes_submission() {
     let root = InProcessTransport::new(Arc::new(MountFs::new(ns)));
     let shell = Shell::new(root.clone());
     let environment = NamespaceRuntimeEnvironment::new(root, "/agent/1", "default");
+    let agent_files = environment.agent_files();
     let message = "x".repeat(70 * 1024);
 
     shell
         .write("/agent/1/io/input", message.as_bytes())
         .await
         .unwrap();
-    let submission = environment
+    let submission = agent_files
         .read_next_input_submission(InputMode::FollowUp)
         .await
         .unwrap();

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/tests/tape.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/tests/tape.rs
@@ -13,10 +13,11 @@ async fn engine_tape_writer_holds_generating_lease_and_allows_readers() {
     let root = InProcessTransport::new(Arc::new(MountFs::new(ns)));
     let shell = Shell::new(root.clone());
     let environment = NamespaceRuntimeEnvironment::new(root, "/agent/1", "default");
+    let agent_files = environment.agent_files();
 
-    let mut writer = environment.begin_tape_generation().await.unwrap();
+    let mut writer = agent_files.begin_tape_generation().await.unwrap();
 
-    let second_writer = environment.begin_tape_generation().await;
+    let second_writer = agent_files.begin_tape_generation().await;
     assert!(
         second_writer.is_err(),
         "a second engine writer must not acquire machine/tape while GENERATING lease is held"
@@ -32,7 +33,7 @@ async fn engine_tape_writer_holds_generating_lease_and_allows_readers() {
     writer.append_record("assistant", "hi").await.unwrap();
     writer.finish().await.unwrap();
 
-    let mut next_writer = environment.begin_tape_generation().await.unwrap();
+    let mut next_writer = agent_files.begin_tape_generation().await.unwrap();
     next_writer
         .append_record("assistant", "after lease")
         .await

--- a/crates/agent-engine/src/runtime/turn_driver.rs
+++ b/crates/agent-engine/src/runtime/turn_driver.rs
@@ -205,10 +205,10 @@ where
 pub(super) async fn namespace_pending_resume_submission(
     state: &RuntimeLoopState,
 ) -> Result<Option<Submission>> {
-    let namespace = state.namespace_environment();
+    let agent_files = state.agent_files();
 
     for request_id in state.machine.pending_request_ids() {
-        if let Some(submission) = namespace
+        if let Some(submission) = agent_files
             .resume_submission_from_answered_request(&request_id)
             .await?
         {
@@ -446,6 +446,7 @@ mod tests {
             super::super::transition::NamespaceRuntimeEnvironment::new(root, "/agent/1", "default");
 
         let request_id = environment
+            .agent_files()
             .write_request(super::super::transition::NamespaceRequestRecord::new(
                 "structured_input",
                 "Provide the missing value",

--- a/crates/agent-engine/src/runtime/turn_executor.rs
+++ b/crates/agent-engine/src/runtime/turn_executor.rs
@@ -220,19 +220,19 @@ where
 {
     if matches!(turn_kind, TurnRunKind::NewTurn) {
         state.machine.reset_auto_mid_turn_compaction_state();
-        super::ui_surfaces::turn_started(state.namespace_environment())
+        super::ui_surfaces::turn_started(&state.agent_files())
             .await
             .context("write turn-start UI state")?;
         emit(Event::TurnStarted {}).await;
     } else {
-        super::ui_surfaces::resumed(state.namespace_environment())
+        super::ui_surfaces::resumed(&state.agent_files())
             .await
             .context("write resumed turn UI state")?;
     }
 
-    let namespace_generation = state.namespace_environment().clone();
+    let agent_files = state.agent_files();
     if matches!(turn_kind, TurnRunKind::NewTurn) && user_input.is_none() {
-        let input = namespace_generation
+        let input = agent_files
             .read_next_input()
             .await
             .context("read next namespace agent input")?;
@@ -464,7 +464,7 @@ where
         }
 
         for warning in &response.warnings {
-            super::ui_surfaces::warning(state.namespace_environment(), warning.clone())
+            super::ui_surfaces::warning(&state.agent_files(), warning.clone())
                 .await
                 .context("write provider warning UI state")?;
             emit(Event::Warning {
@@ -493,7 +493,7 @@ where
                 );
                 let message =
                     format!("Guardrail recovered ({rule_id}): {reason}. Retrying before output.");
-                super::ui_surfaces::warning(state.namespace_environment(), message.clone())
+                super::ui_surfaces::warning(&state.agent_files(), message.clone())
                     .await
                     .context("write guardrail warning UI state")?;
                 emit(Event::Warning { message }).await;
@@ -518,7 +518,7 @@ where
         if let Some(ref thinking) = response.thinking
             && !thinking.is_empty()
         {
-            super::ui_surfaces::thinking(state.namespace_environment(), thinking)
+            super::ui_surfaces::thinking(&state.agent_files(), thinking)
                 .await
                 .context("write thinking UI state")?;
             emit_thinking_chunks(emit, thinking).await;
@@ -576,11 +576,11 @@ where
 
         if assistant_message_persisted && !response.content.is_empty() {
             let namespace_input_text = namespace_user_input_for_tape.take();
-            namespace_generation
+            agent_files
                 .write_assistant_output(&response.content)
                 .await
                 .context("write namespace assistant output")?;
-            namespace_generation
+            agent_files
                 .write_turn_tape_state(namespace_input_text.as_deref(), &response.content)
                 .await
                 .context("write namespace turn tape state")?;
@@ -642,11 +642,11 @@ where
                 &response.redacted_thinking,
             );
             let namespace_input_text = namespace_user_input_for_tape.take();
-            namespace_generation
+            agent_files
                 .write_assistant_output(fallback_text)
                 .await
                 .context("write namespace fallback assistant output")?;
-            namespace_generation
+            agent_files
                 .write_turn_tape_state(namespace_input_text.as_deref(), fallback_text)
                 .await
                 .context("write namespace fallback turn tape state")?;
@@ -666,7 +666,7 @@ where
                 summary: Some("Turn completed with empty response fallback".to_string()),
             })
             .await;
-            super::ui_surfaces::turn_completed(state.namespace_environment(), false)
+            super::ui_surfaces::turn_completed(&state.agent_files(), false)
                 .await
                 .context("write fallback turn completion UI state")?;
             return Ok(TurnExecutionOutcome::Finished);

--- a/crates/agent-engine/src/runtime/turn_support.rs
+++ b/crates/agent-engine/src/runtime/turn_support.rs
@@ -21,7 +21,7 @@ where
     state.machine.reset_turn();
     state.machine.clear_plan_snapshot();
     state.machine.clear_active_task();
-    super::ui_surfaces::turn_completed(state.namespace_environment(), true).await?;
+    super::ui_surfaces::turn_completed(&state.agent_files(), true).await?;
     emit(Event::TurnCompleted {
         summary: Some("Task cancelled by user".to_string()),
     })
@@ -39,7 +39,7 @@ where
     F: std::future::Future<Output = ()>,
 {
     let summary = summary.into();
-    super::ui_surfaces::turn_completed(state.namespace_environment(), false).await?;
+    super::ui_surfaces::turn_completed(&state.agent_files(), false).await?;
     emit(Event::TurnCompleted {
         summary: Some(summary),
     })

--- a/crates/agent-engine/src/runtime/ui_surfaces.rs
+++ b/crates/agent-engine/src/runtime/ui_surfaces.rs
@@ -6,7 +6,7 @@ use alan_agent_protocol::{
 };
 use anyhow::Result;
 
-use super::transition::NamespaceRuntimeEnvironment;
+use super::transition::NamespaceAgentFiles;
 
 fn now_unix_ms() -> u64 {
     SystemTime::now()
@@ -15,7 +15,7 @@ fn now_unix_ms() -> u64 {
         .as_millis() as u64
 }
 
-pub(crate) async fn initialize(namespace: &NamespaceRuntimeEnvironment) -> Result<()> {
+pub(crate) async fn initialize(namespace: &NamespaceAgentFiles) -> Result<()> {
     namespace
         .write_ui_activity_snapshot(&UiActivitySnapshot::idle())
         .await?;
@@ -30,7 +30,7 @@ pub(crate) async fn initialize(namespace: &NamespaceRuntimeEnvironment) -> Resul
         .await
 }
 
-pub(crate) async fn turn_started(namespace: &NamespaceRuntimeEnvironment) -> Result<()> {
+pub(crate) async fn turn_started(namespace: &NamespaceAgentFiles) -> Result<()> {
     let activity = UiActivitySnapshot::running(now_unix_ms());
     namespace.write_ui_activity_snapshot(&activity).await?;
     namespace
@@ -48,10 +48,7 @@ pub(crate) async fn turn_started(namespace: &NamespaceRuntimeEnvironment) -> Res
         .await
 }
 
-pub(crate) async fn turn_completed(
-    namespace: &NamespaceRuntimeEnvironment,
-    cancelled: bool,
-) -> Result<()> {
+pub(crate) async fn turn_completed(namespace: &NamespaceAgentFiles, cancelled: bool) -> Result<()> {
     if cancelled {
         plan_updated(namespace, None, Vec::new()).await?;
     }
@@ -62,10 +59,7 @@ pub(crate) async fn turn_completed(
         .await
 }
 
-pub(crate) async fn turn_failed(
-    namespace: &NamespaceRuntimeEnvironment,
-    message: &str,
-) -> Result<()> {
+pub(crate) async fn turn_failed(namespace: &NamespaceAgentFiles, message: &str) -> Result<()> {
     let notice = UiNoticeSnapshot::new(UiNoticeKind::Error, message);
     namespace.write_ui_notice_snapshot(&notice).await?;
     namespace
@@ -80,7 +74,7 @@ pub(crate) async fn turn_failed(
     turn_completed(namespace, false).await
 }
 
-pub(crate) async fn paused(namespace: &NamespaceRuntimeEnvironment) -> Result<()> {
+pub(crate) async fn paused(namespace: &NamespaceAgentFiles) -> Result<()> {
     let activity = UiActivitySnapshot::paused(None);
     namespace.write_ui_activity_snapshot(&activity).await?;
     namespace
@@ -88,7 +82,7 @@ pub(crate) async fn paused(namespace: &NamespaceRuntimeEnvironment) -> Result<()
         .await
 }
 
-pub(crate) async fn resumed(namespace: &NamespaceRuntimeEnvironment) -> Result<()> {
+pub(crate) async fn resumed(namespace: &NamespaceAgentFiles) -> Result<()> {
     let activity = UiActivitySnapshot::running(now_unix_ms());
     namespace.write_ui_activity_snapshot(&activity).await?;
     namespace
@@ -96,7 +90,7 @@ pub(crate) async fn resumed(namespace: &NamespaceRuntimeEnvironment) -> Result<(
         .await
 }
 
-pub(crate) async fn heartbeat(namespace: &NamespaceRuntimeEnvironment) -> Result<()> {
+pub(crate) async fn heartbeat(namespace: &NamespaceAgentFiles) -> Result<()> {
     if namespace.read_ui_activity_snapshot().await?.state != UiActivityState::Running {
         return Ok(());
     }
@@ -106,7 +100,7 @@ pub(crate) async fn heartbeat(namespace: &NamespaceRuntimeEnvironment) -> Result
 }
 
 pub(crate) async fn plan_updated(
-    namespace: &NamespaceRuntimeEnvironment,
+    namespace: &NamespaceAgentFiles,
     explanation: Option<String>,
     items: Vec<alan_agent_protocol::PlanItem>,
 ) -> Result<()> {
@@ -115,7 +109,7 @@ pub(crate) async fn plan_updated(
     namespace.append_ui_event(&UiEvent::Plan { snapshot }).await
 }
 
-pub(crate) async fn rollback(namespace: &NamespaceRuntimeEnvironment, turns: u32) -> Result<()> {
+pub(crate) async fn rollback(namespace: &NamespaceAgentFiles, turns: u32) -> Result<()> {
     let snapshot =
         UiNoticeSnapshot::new(UiNoticeKind::Rollback, format!("rolled back {turns} turns"));
     namespace.write_ui_notice_snapshot(&snapshot).await?;
@@ -124,7 +118,7 @@ pub(crate) async fn rollback(namespace: &NamespaceRuntimeEnvironment, turns: u32
         .await
 }
 
-pub(crate) async fn thinking(namespace: &NamespaceRuntimeEnvironment, text: &str) -> Result<()> {
+pub(crate) async fn thinking(namespace: &NamespaceAgentFiles, text: &str) -> Result<()> {
     let started = Instant::now();
     let mut visible = String::new();
     for chunk in super::turn_support::split_text_for_typing(text) {
@@ -143,7 +137,7 @@ pub(crate) async fn thinking(namespace: &NamespaceRuntimeEnvironment, text: &str
 }
 
 pub(crate) async fn warning(
-    namespace: &NamespaceRuntimeEnvironment,
+    namespace: &NamespaceAgentFiles,
     message: impl Into<String>,
 ) -> Result<()> {
     let snapshot = UiNoticeSnapshot::new(UiNoticeKind::Warning, message.into());
@@ -154,7 +148,7 @@ pub(crate) async fn warning(
 }
 
 pub(crate) async fn compaction(
-    namespace: &NamespaceRuntimeEnvironment,
+    namespace: &NamespaceAgentFiles,
     attempt: &CompactionAttemptSnapshot,
 ) -> Result<()> {
     let snapshot =
@@ -166,7 +160,7 @@ pub(crate) async fn compaction(
 }
 
 pub(crate) async fn memory_flush(
-    namespace: &NamespaceRuntimeEnvironment,
+    namespace: &NamespaceAgentFiles,
     attempt: &MemoryFlushAttemptSnapshot,
 ) -> Result<()> {
     let snapshot = UiNoticeSnapshot::new(
@@ -231,8 +225,9 @@ mod tests {
     use serde_json::Value;
 
     use super::*;
+    use crate::runtime::transition::NamespaceRuntimeEnvironment;
 
-    fn namespace_environment() -> (NamespaceRuntimeEnvironment, alan_shell::Shell) {
+    fn agent_files() -> (NamespaceAgentFiles, alan_shell::Shell) {
         let agentfs = Arc::new(AgentFs::new());
         let mut namespace = Namespace::new();
         namespace.mount(
@@ -242,15 +237,13 @@ mod tests {
         );
         let root = InProcessTransport::new(Arc::new(MountFs::new(namespace)));
         let shell = alan_shell::Shell::new(root.clone());
-        (
-            NamespaceRuntimeEnvironment::new(root, "/agent/1", "default"),
-            shell,
-        )
+        let environment = NamespaceRuntimeEnvironment::new(root, "/agent/1", "default");
+        (environment.agent_files(), shell)
     }
 
     #[tokio::test]
     async fn owners_write_snapshots_and_append_ui_events() {
-        let (environment, shell) = namespace_environment();
+        let (environment, shell) = agent_files();
         initialize(&environment).await.unwrap();
         turn_started(&environment).await.unwrap();
         thinking(&environment, "reasoning").await.unwrap();
@@ -312,7 +305,7 @@ mod tests {
 
     #[tokio::test]
     async fn cancelled_turn_clears_plan_snapshot() {
-        let (environment, shell) = namespace_environment();
+        let (environment, shell) = agent_files();
         initialize(&environment).await.unwrap();
         plan_updated(
             &environment,
@@ -334,7 +327,7 @@ mod tests {
 
     #[tokio::test]
     async fn failed_turn_records_file_terminal_error() {
-        let (environment, _) = namespace_environment();
+        let (environment, _) = agent_files();
         initialize(&environment).await.unwrap();
         turn_started(&environment).await.unwrap();
         turn_failed(&environment, "provider failed").await.unwrap();
@@ -346,7 +339,7 @@ mod tests {
 
     #[tokio::test]
     async fn heartbeat_preserves_paused_activity() {
-        let (environment, _) = namespace_environment();
+        let (environment, _) = agent_files();
         initialize(&environment).await.unwrap();
         paused(&environment).await.unwrap();
 

--- a/crates/agent-engine/src/runtime/virtual_tools.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools.rs
@@ -92,7 +92,7 @@ where
                 state
                     .machine
                     .set_confirmation_for_request(request_id.clone(), pending.clone());
-                super::ui_surfaces::paused(state.namespace_environment()).await?;
+                super::ui_surfaces::paused(&state.agent_files()).await?;
                 emit(Event::Yield {
                     request_id,
                     kind: alan_agent_protocol::YieldKind::Confirmation,
@@ -178,7 +178,7 @@ where
                 state
                     .machine
                     .set_structured_input_for_request(request_id.clone(), request.clone());
-                super::ui_surfaces::paused(state.namespace_environment()).await?;
+                super::ui_surfaces::paused(&state.agent_files()).await?;
                 emit(Event::Yield {
                     request_id,
                     kind: alan_agent_protocol::YieldKind::StructuredInput,
@@ -235,7 +235,7 @@ where
                         state.machine.messages().len(),
                     );
                     super::ui_surfaces::plan_updated(
-                        state.namespace_environment(),
+                        &state.agent_files(),
                         explanation.clone(),
                         items.clone(),
                     )

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -276,6 +276,52 @@ fn turn_generation_uses_only_the_file_native_namespace_boundary() {
 }
 
 #[test]
+fn agent_file_workflows_use_only_the_narrow_agent_files_handle() {
+    let namespace = read_runtime_source("transition/namespace_environment.rs");
+    let agent_files_handle = rust_item_body(&namespace, "pub(crate) struct NamespaceAgentFiles");
+    for required_field in ["root: InProcessTransport", "agent_path: String"] {
+        assert!(
+            agent_files_handle.contains(required_field),
+            "agent files handle must retain {required_field}"
+        );
+    }
+    for forbidden_field in [
+        "llm_connection",
+        "tool_process_context",
+        "child_run_registry",
+        "launch_context",
+    ] {
+        assert!(
+            !agent_files_handle.contains(forbidden_field),
+            "agent files handle must not gain {forbidden_field}"
+        );
+    }
+
+    let file_operations = read_runtime_source("transition/namespace_environment/agent_files.rs");
+    assert!(file_operations.contains("impl NamespaceAgentFiles"));
+    assert!(!file_operations.contains("impl NamespaceRuntimeEnvironment"));
+
+    let ui = read_runtime_source("ui_surfaces.rs");
+    let ui_production = ui.split("\n#[cfg(test)]\nmod tests").next().unwrap();
+    assert!(ui_production.contains("&NamespaceAgentFiles"));
+    assert!(!ui_production.contains("NamespaceRuntimeEnvironment"));
+
+    let supervisor = read_runtime_source("delegated_child_run/supervisor.rs");
+    assert!(supervisor.contains("agent_files: NamespaceAgentFiles"));
+    for operation in [
+        "read_ui_activity_snapshot",
+        "read_assistant_output",
+        "request_ids",
+        "action_ids",
+    ] {
+        assert!(
+            supervisor.contains(&format!("agent_files.{operation}")),
+            "delegated supervisor must read {operation} through NamespaceAgentFiles"
+        );
+    }
+}
+
+#[test]
 fn engine_does_not_assemble_alan_os() {
     let source = read_runtime_source("engine.rs");
     let production = source.split("\n#[cfg(test)]\nmod tests").next().unwrap();


### PR DESCRIPTION
Stacked on #818.

Moves the AgentFS file protocol behind a concrete `NamespaceAgentFiles` handle:

- Agent input/control, request/action, tape, UI, and evidence operations no longer live on `NamespaceRuntimeEnvironment`
- generation/turn/UI/evidence workflows receive only the file handle
- delegated child supervision separates AgentFS observation from `/proc` process control
- deletes the displaced broad forwarding path and an unused combined assistant-state helper
- adds a dependency-boundary guard against regrowing LLM/tool/child authority on the file handle

Validation:
- `cargo test -p alan-agent-engine` (1198 passed, 1 ignored)
- dependency boundary (10/10)
- `cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings`
- repository quality gate (0 warnings)