### PR TITLE
refactor(agent-engine): narrow process file handle

### DIFF
--- a/crates/agent-engine/src/runtime/child_agents.rs
+++ b/crates/agent-engine/src/runtime/child_agents.rs
@@ -308,7 +308,7 @@ async fn spawn_child_runtime_inner(
             timeout: spec.launch.timeout_secs.map(Duration::from_secs),
             process_lifecycle,
             agent_files: child_process_environment.agent_files(),
-            process_environment: child_process_environment,
+            process_files: child_process_environment.process_files(),
             process_pid: child_process_pid,
         },
     ))

--- a/crates/agent-engine/src/runtime/child_agents/tests/lifecycle.rs
+++ b/crates/agent-engine/src/runtime/child_agents/tests/lifecycle.rs
@@ -17,7 +17,7 @@ async fn child_runtime_join_keeps_running_while_activity_file_is_fresh() {
     .await
     .unwrap();
     child.set_timeout_for_test(Duration::from_millis(200));
-    let agent_files = child.process_environment_for_test().agent_files();
+    let agent_files = child.agent_files_for_test();
     tokio::spawn(async move {
         for _ in 0..5 {
             crate::runtime::ui_surfaces::heartbeat(&agent_files)
@@ -89,7 +89,7 @@ async fn child_runtime_join_returns_promptly_after_timeout() {
     })
     .await
     .unwrap();
-    let process_environment = child.process_environment_for_test().clone();
+    let process_files = child.process_files_for_test();
     let process_pid = child.process_pid_for_test().to_string();
 
     let started_at = std::time::Instant::now();
@@ -97,7 +97,7 @@ async fn child_runtime_join_returns_promptly_after_timeout() {
 
     assert_eq!(result.status, ChildRuntimeStatus::TimedOut);
     assert_eq!(
-        process_environment
+        process_files
             .read_process_exit_code(&process_pid)
             .await
             .unwrap(),

--- a/crates/agent-engine/src/runtime/child_agents/tests/namespace_runtime.rs
+++ b/crates/agent-engine/src/runtime/child_agents/tests/namespace_runtime.rs
@@ -553,6 +553,7 @@ async fn child_namespace_launch_and_supervisor_reattachment_use_proc_pid_files()
     assert_eq!(
         nested
             .environment
+            .process_files()
             .read_process_exit_code(&nested.pid)
             .await
             .unwrap(),
@@ -602,7 +603,7 @@ async fn child_namespace_launch_and_supervisor_reattachment_use_proc_pid_files()
         "child-spawned processes inherit mounted tools: {tool_namespace:?}"
     );
 
-    let process_reader = launch.environment.clone();
+    let process_reader = launch.environment.process_files();
     let process_pid = launch.pid.clone();
     let agent_files = launch.environment.agent_files();
     agent_files
@@ -620,7 +621,7 @@ async fn child_namespace_launch_and_supervisor_reattachment_use_proc_pid_files()
         timeout: None,
         process_lifecycle: launch.lifecycle,
         agent_files,
-        process_environment: launch.environment,
+        process_files: launch.environment.process_files(),
         process_pid: process_pid.clone(),
     });
 
@@ -688,7 +689,7 @@ async fn external_proc_ctl_stops_child_runtime_controller() {
     .await
     .unwrap();
     let process_pid = launch.pid.clone();
-    let process_environment = launch.environment.clone();
+    let process_files = launch.environment.process_files();
     let agent_files = launch.environment.agent_files();
     let controller = DelegatedChildRunSupervisor::new(DelegatedChildRunSupervision {
         runtime: None,
@@ -698,12 +699,12 @@ async fn external_proc_ctl_stops_child_runtime_controller() {
         timeout: None,
         process_lifecycle: launch.lifecycle,
         agent_files: agent_files.clone(),
-        process_environment: launch.environment,
+        process_files: launch.environment.process_files(),
         process_pid: process_pid.clone(),
     });
 
     assert_eq!(agent_files.ui_events_offset().await.unwrap(), 0);
-    process_environment
+    process_files
         .write_process_control_for_pid(&process_pid, "cancel")
         .await
         .unwrap();
@@ -720,7 +721,7 @@ async fn external_proc_ctl_stops_child_runtime_controller() {
             .is_some_and(|message| message.contains("/proc/<pid>/ctl"))
     );
     assert_eq!(
-        process_environment
+        process_files
             .read_process_exit_code(&process_pid)
             .await
             .unwrap(),

--- a/crates/agent-engine/src/runtime/delegated_child_run/supervisor.rs
+++ b/crates/agent-engine/src/runtime/delegated_child_run/supervisor.rs
@@ -8,10 +8,10 @@ use tokio_util::sync::CancellationToken;
 
 use super::{ChildRuntimePause, ChildRuntimeResult, ChildRuntimeStatus};
 use crate::runtime::child_runs::ChildRunRegistry;
-use crate::runtime::transition::NamespaceAgentFiles;
+use crate::runtime::transition::{NamespaceAgentFiles, NamespaceProcessFiles};
 use crate::runtime::{
     AgentProcessLifecycle, ChildRunStatus, ChildRunTerminationMode, ChildRunTerminationRequest,
-    NamespaceRuntimeEnvironment, RuntimeController, RuntimeStartupMetadata,
+    RuntimeController, RuntimeStartupMetadata,
 };
 
 const MAX_OBSERVED_CHILD_WARNINGS: usize = 32;
@@ -26,8 +26,8 @@ pub(crate) struct DelegatedChildRunSupervision {
     pub(crate) child_run_registry: ChildRunRegistry,
     pub(crate) timeout: Option<Duration>,
     pub(crate) process_lifecycle: Arc<dyn AgentProcessLifecycle>,
-    pub(crate) process_environment: NamespaceRuntimeEnvironment,
     pub(crate) agent_files: NamespaceAgentFiles,
+    pub(crate) process_files: NamespaceProcessFiles,
     pub(crate) process_pid: String,
 }
 
@@ -73,8 +73,8 @@ pub(crate) struct DelegatedChildRunSupervisor {
     child_run_registry: ChildRunRegistry,
     timeout: Option<Duration>,
     process_lifecycle: Arc<dyn AgentProcessLifecycle>,
-    process_environment: NamespaceRuntimeEnvironment,
     agent_files: NamespaceAgentFiles,
+    process_files: NamespaceProcessFiles,
     process_pid: String,
 }
 
@@ -87,20 +87,20 @@ impl DelegatedChildRunSupervisor {
             child_run_registry: input.child_run_registry,
             timeout: input.timeout,
             process_lifecycle: input.process_lifecycle,
-            process_environment: input.process_environment,
             agent_files: input.agent_files,
+            process_files: input.process_files,
             process_pid: input.process_pid,
         }
     }
 
     async fn observe_files(&self) -> Result<ChildFileObservation> {
-        let process_environment = &self.process_environment;
+        let process_files = &self.process_files;
         let agent_files = &self.agent_files;
         let pid = self.process_pid.as_str();
         let timeout = Duration::from_secs(1);
-        let process_exit_code = process_environment.read_process_exit_code(pid).await?;
+        let process_exit_code = process_files.read_process_exit_code(pid).await?;
         let (process_output_offset, process_io_events_offset) =
-            process_environment.read_process_io_offsets(pid).await?;
+            process_files.read_process_io_offsets(pid).await?;
         let activity = tokio::time::timeout(timeout, agent_files.read_ui_activity_snapshot())
             .await
             .context("observe child activity timed out")??;
@@ -466,34 +466,34 @@ impl DelegatedChildRunSupervisor {
     }
 
     async fn terminate_process_and_reconcile(&self) {
-        let environment = &self.process_environment;
+        let process_files = &self.process_files;
         let pid = self.process_pid.as_str();
-        if let Ok(Some(exit_code)) = environment.read_process_exit_code(pid).await {
+        if let Ok(Some(exit_code)) = process_files.read_process_exit_code(pid).await {
             self.process_lifecycle.finish(exit_code).await;
             self.child_run_registry
                 .reconcile_process_exit(&self.child_run_id, exit_code);
             return;
         }
-        let _ = environment
+        let _ = process_files
             .write_process_control_for_pid(pid, "cancel")
             .await;
-        let exit_code = environment
+        let exit_code = process_files
             .read_process_exit_code(pid)
             .await
             .ok()
             .flatten()
             .unwrap_or(130);
         self.process_lifecycle.finish(exit_code).await;
-        if let Ok(Some(exit_code)) = environment.read_process_exit_code(pid).await {
+        if let Ok(Some(exit_code)) = process_files.read_process_exit_code(pid).await {
             self.child_run_registry
                 .reconcile_process_exit(&self.child_run_id, exit_code);
         }
     }
 
     async fn reconcile_exited_process(&self) {
-        let environment = &self.process_environment;
+        let process_files = &self.process_files;
         let pid = self.process_pid.as_str();
-        if let Ok(Some(exit_code)) = environment.read_process_exit_code(pid).await {
+        if let Ok(Some(exit_code)) = process_files.read_process_exit_code(pid).await {
             self.child_run_registry
                 .reconcile_process_exit(&self.child_run_id, exit_code);
         }
@@ -524,8 +524,13 @@ impl DelegatedChildRunSupervisor {
     }
 
     #[cfg(test)]
-    pub(crate) fn process_environment_for_test(&self) -> &NamespaceRuntimeEnvironment {
-        &self.process_environment
+    pub(crate) fn agent_files_for_test(&self) -> NamespaceAgentFiles {
+        self.agent_files.clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn process_files_for_test(&self) -> NamespaceProcessFiles {
+        self.process_files.clone()
     }
 
     #[cfg(test)]

--- a/crates/agent-engine/src/runtime/delegated_child_run/supervisor_tests.rs
+++ b/crates/agent-engine/src/runtime/delegated_child_run/supervisor_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::runtime::NamespaceRuntimeEnvironment;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[derive(Debug)]
@@ -36,7 +37,7 @@ fn test_supervisor(finish_count: Arc<AtomicUsize>) -> DelegatedChildRunSuperviso
         timeout: None,
         process_lifecycle: Arc::new(RecordingProcessLifecycle { finish_count }),
         agent_files: process_environment.agent_files(),
-        process_environment,
+        process_files: process_environment.process_files(),
         process_pid: "42".to_string(),
     })
 }

--- a/crates/agent-engine/src/runtime/engine.rs
+++ b/crates/agent-engine/src/runtime/engine.rs
@@ -382,7 +382,7 @@ fn spawn_with_prepared_runtime_environment(
 
     // Spawn the main runtime task
     let task_handle = tokio::spawn(async move {
-        let process_path = match environment.process_path() {
+        let process_path = match environment.process_files().process_path() {
             Ok(path) => path,
             Err(err) => {
                 let _ = ready_tx.send(Err(format!("{:#}", err)));

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -14,7 +14,9 @@ pub use namespace_environment::{
     NamespaceRuntimeEnvironment, NamespaceToolActionOutput, NamespaceTurnOutput,
     NamespaceTurnRuntime, NamespaceTurnRuntimeConfig,
 };
-pub(crate) use namespace_environment::{NamespaceAgentFiles, NamespaceGeneration};
+pub(crate) use namespace_environment::{
+    NamespaceAgentFiles, NamespaceGeneration, NamespaceProcessFiles,
+};
 
 use std::collections::VecDeque;
 
@@ -66,7 +68,7 @@ pub(crate) struct RuntimeLoopState {
 impl RuntimeLoopState {
     /// Authoritative AgentFS path for the Process that owns this runtime state.
     pub(crate) fn process_path(&self) -> String {
-        self.namespace_environment()
+        self.process_files()
             .process_path()
             .expect("runtime namespace was created with a valid /agent/<pid> path")
     }
@@ -90,6 +92,10 @@ impl RuntimeLoopState {
 
     pub(crate) fn agent_files(&self) -> NamespaceAgentFiles {
         self.environment.agent_files()
+    }
+
+    pub(crate) fn process_files(&self) -> NamespaceProcessFiles {
+        self.environment.process_files()
     }
 
     pub(crate) async fn write_namespace_confirmation_request(

--- a/crates/agent-engine/src/runtime/transition/namespace_environment.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment.rs
@@ -8,6 +8,7 @@
 mod agent_files;
 mod client;
 mod generation;
+mod process_files;
 
 use std::{
     path::PathBuf,
@@ -19,6 +20,7 @@ use anyhow::{Context, Result, bail};
 use tokio_util::sync::CancellationToken;
 
 use self::client::NamespaceClient;
+use self::process_files::NamespaceProcessResult;
 use crate::evidence::redact_durable_evidence_text;
 
 /// Configuration for one namespace-native Agent Process turn driver.
@@ -261,6 +263,13 @@ pub(crate) struct NamespaceAgentFiles {
     control_offset: Arc<AtomicU64>,
 }
 
+/// Narrow handle for lifecycle and stream files owned by the Process table.
+#[derive(Clone)]
+pub(crate) struct NamespaceProcessFiles {
+    root: InProcessTransport,
+    agent_path: String,
+}
+
 #[derive(Clone)]
 struct NamespaceToolProcessContext {
     pub(crate) pid: alan_kernel::Pid,
@@ -319,6 +328,13 @@ impl NamespaceRuntimeEnvironment {
             agent_path: self.agent_path.clone(),
             input_offset: Arc::clone(&self.input_offset),
             control_offset: Arc::clone(&self.control_offset),
+        }
+    }
+
+    pub(crate) fn process_files(&self) -> NamespaceProcessFiles {
+        NamespaceProcessFiles {
+            root: self.root.clone(),
+            agent_path: self.agent_path.clone(),
         }
     }
 
@@ -431,11 +447,6 @@ impl NamespaceRuntimeEnvironment {
         &self.agent_path
     }
 
-    /// Authoritative `/proc/<pid>` path corresponding to this AgentFS view.
-    pub fn process_path(&self) -> Result<String> {
-        Ok(format!("/proc/{}", agent_pid_from_path(&self.agent_path)?))
-    }
-
     /// Process-local projection registry for delegated child Agent Processes.
     pub(crate) fn child_run_registry(&self) -> &super::super::child_runs::ChildRunRegistry {
         &self.child_run_registry
@@ -511,84 +522,6 @@ impl NamespaceRuntimeEnvironment {
         }
     }
 
-    pub async fn write_process_control(&self, command: &str) -> Result<()> {
-        let pid = agent_pid_from_path(&self.agent_path)?;
-        self.write_process_control_for_pid(pid, command).await
-    }
-
-    pub async fn write_process_control_for_pid(&self, pid: &str, command: &str) -> Result<()> {
-        let client = NamespaceClient::new(self.root.clone());
-        let ctl_path = format!("/proc/{pid}/ctl");
-        client
-            .write_document(&ctl_path, command.as_bytes())
-            .await
-            .with_context(|| format!("write process control command to {ctl_path}"))
-    }
-
-    /// Read terminal process state from authoritative `/proc`.
-    pub(crate) async fn read_process_exit_code(&self, pid: &str) -> Result<Option<i32>> {
-        let client = NamespaceClient::new(self.root.clone());
-        let status_path = format!("/proc/{pid}/status");
-        let status = String::from_utf8(
-            client
-                .read_file(&status_path)
-                .await
-                .with_context(|| format!("read process status from {status_path}"))?,
-        )
-        .context("process status is utf8")?;
-        if status.trim() != "exited" {
-            return Ok(None);
-        }
-        let exit_path = format!("/proc/{pid}/exit");
-        let exit = String::from_utf8(
-            client
-                .read_file(&exit_path)
-                .await
-                .with_context(|| format!("read process exit from {exit_path}"))?,
-        )
-        .context("process exit is utf8")?;
-        let code = exit
-            .trim()
-            .parse::<i32>()
-            .with_context(|| format!("parse process exit code from {exit_path}"))?;
-        Ok(Some(code))
-    }
-
-    pub(crate) async fn read_process_io_offsets(&self, pid: &str) -> Result<(u64, u64)> {
-        let client = NamespaceClient::new(self.root.clone());
-        let output_path = format!("/proc/{pid}/io/output");
-        let events_path = format!("/proc/{pid}/io/events");
-        let output = client
-            .stat_path(&output_path)
-            .await
-            .with_context(|| format!("stat process output at {output_path}"))?
-            .length;
-        let events = client
-            .stat_path(&events_path)
-            .await
-            .with_context(|| format!("stat process IO events at {events_path}"))?
-            .length;
-        Ok((output, events))
-    }
-
-    pub async fn spawn_process<I, S>(&self, executable: &str, args: I) -> Result<String>
-    where
-        I: IntoIterator<Item = S>,
-        S: Into<String>,
-    {
-        let client = NamespaceClient::new(self.root.clone());
-        let args: Vec<String> = args.into_iter().map(Into::into).collect();
-        let exec_spec = serde_json::json!({
-            "executable": executable,
-            "args": args,
-        });
-        let exec_spec = serde_json::to_vec(&exec_spec).context("serialize exec spec")?;
-        client
-            .clone_with_document("/proc/clone", &exec_spec)
-            .await
-            .with_context(|| format!("spawn {executable} through /proc/clone"))
-    }
-
     pub async fn run_tool_action<I, S>(
         &self,
         tool_name: &str,
@@ -634,17 +567,18 @@ impl NamespaceRuntimeEnvironment {
         if cancel.is_cancelled() {
             bail!("tool process cancelled before spawn");
         }
-        let pid = self.spawn_process(executable, args).await?;
+        let process_files = self.process_files();
+        let pid = process_files.spawn_process(executable, args).await?;
         let result = tokio::select! {
             _ = cancel.cancelled() => {
-                let _ = self.write_process_control_for_pid(&pid, "cancel").await;
+                let _ = process_files.write_process_control_for_pid(&pid, "cancel").await;
                 bail!("tool process {pid} cancelled");
             }
-            result = self.read_process_result(&pid, timeout_secs) => {
+            result = process_files.read_process_result(&pid, timeout_secs) => {
                 match result {
                     Ok(result) => result,
                     Err(err) => {
-                        let _ = self.write_process_control_for_pid(&pid, "cancel").await;
+                        let _ = process_files.write_process_control_for_pid(&pid, "cancel").await;
                         return Err(err).with_context(|| {
                             format!("read tool process {pid} result")
                         });
@@ -687,74 +621,6 @@ impl NamespaceRuntimeEnvironment {
             exit_code: action_exit_code,
         })
     }
-
-    async fn read_process_result(
-        &self,
-        pid: &str,
-        timeout_secs: usize,
-    ) -> Result<NamespaceProcessResult> {
-        if timeout_secs == 0 {
-            return self.read_process_result_until_exit(pid).await;
-        }
-        tokio::time::timeout(
-            std::time::Duration::from_secs(timeout_secs as u64),
-            self.read_process_result_until_exit(pid),
-        )
-        .await
-        .with_context(|| format!("timed out waiting {timeout_secs}s for process {pid} to exit"))?
-    }
-
-    async fn read_process_result_until_exit(&self, pid: &str) -> Result<NamespaceProcessResult> {
-        let client = NamespaceClient::new(self.root.clone());
-        let status_path = format!("/proc/{pid}/status");
-        let exit_path = format!("/proc/{pid}/exit");
-        let output_path = format!("/proc/{pid}/io/output");
-        loop {
-            let status = String::from_utf8(
-                client
-                    .read_file(&status_path)
-                    .await
-                    .with_context(|| format!("read {status_path}"))?,
-            )
-            .context("process status is not utf8")?;
-            if status.trim() == "exited" {
-                let exit_code = String::from_utf8(
-                    client
-                        .read_file(&exit_path)
-                        .await
-                        .with_context(|| format!("read {exit_path}"))?,
-                )
-                .context("process exit code is not utf8")?
-                .trim()
-                .parse::<i32>()
-                .context("process exit code is not an integer")?;
-                let output = if client
-                    .stat_path(&output_path)
-                    .await
-                    .with_context(|| format!("stat {output_path}"))?
-                    .length
-                    == 0
-                {
-                    String::new()
-                } else {
-                    String::from_utf8(
-                        client
-                            .read_file(&output_path)
-                            .await
-                            .with_context(|| format!("read {output_path}"))?,
-                    )
-                    .context("process output is not utf8")?
-                };
-                return Ok(NamespaceProcessResult { output, exit_code });
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
-    }
-}
-
-struct NamespaceProcessResult {
-    output: String,
-    exit_code: i32,
 }
 
 fn logical_tool_action_exit_code(result: &NamespaceProcessResult) -> i32 {
@@ -828,20 +694,6 @@ impl NamespaceTurnRuntime {
 impl NamespaceRuntimeEnvironment {
     fn client(&self) -> NamespaceClient {
         NamespaceClient::new(self.root.clone())
-    }
-}
-
-fn agent_pid_from_path(agent_path: &str) -> Result<&str> {
-    let components = agent_path
-        .split('/')
-        .filter(|component| !component.is_empty())
-        .collect::<Vec<_>>();
-    match components.as_slice() {
-        ["agent", pid] if *pid != "root" => Ok(*pid),
-        ["agent", "root"] => {
-            bail!("process control requires a concrete /agent/<pid> path, got /agent/root")
-        }
-        _ => bail!("invalid agent path for process control: {agent_path}"),
     }
 }
 

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/process_files.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/process_files.rs
@@ -1,0 +1,169 @@
+//! Process lifecycle and stream files exposed through `/proc`.
+
+use anyhow::{Context, Result, bail};
+
+use super::{NamespaceProcessFiles, client::NamespaceClient};
+
+impl NamespaceProcessFiles {
+    fn client(&self) -> NamespaceClient {
+        NamespaceClient::new(self.root.clone())
+    }
+
+    /// Authoritative `/proc/<pid>` path corresponding to this AgentFS view.
+    pub fn process_path(&self) -> Result<String> {
+        Ok(format!("/proc/{}", agent_pid_from_path(&self.agent_path)?))
+    }
+
+    pub async fn write_process_control_for_pid(&self, pid: &str, command: &str) -> Result<()> {
+        let ctl_path = format!("/proc/{pid}/ctl");
+        self.client()
+            .write_document(&ctl_path, command.as_bytes())
+            .await
+            .with_context(|| format!("write process control command to {ctl_path}"))
+    }
+
+    /// Read terminal process state from authoritative `/proc`.
+    pub(crate) async fn read_process_exit_code(&self, pid: &str) -> Result<Option<i32>> {
+        let client = self.client();
+        let status_path = format!("/proc/{pid}/status");
+        let status = String::from_utf8(
+            client
+                .read_file(&status_path)
+                .await
+                .with_context(|| format!("read process status from {status_path}"))?,
+        )
+        .context("process status is utf8")?;
+        if status.trim() != "exited" {
+            return Ok(None);
+        }
+        let exit_path = format!("/proc/{pid}/exit");
+        let exit = String::from_utf8(
+            client
+                .read_file(&exit_path)
+                .await
+                .with_context(|| format!("read process exit from {exit_path}"))?,
+        )
+        .context("process exit is utf8")?;
+        let code = exit
+            .trim()
+            .parse::<i32>()
+            .with_context(|| format!("parse process exit code from {exit_path}"))?;
+        Ok(Some(code))
+    }
+
+    pub(crate) async fn read_process_io_offsets(&self, pid: &str) -> Result<(u64, u64)> {
+        let client = self.client();
+        let output_path = format!("/proc/{pid}/io/output");
+        let events_path = format!("/proc/{pid}/io/events");
+        let output = client
+            .stat_path(&output_path)
+            .await
+            .with_context(|| format!("stat process output at {output_path}"))?
+            .length;
+        let events = client
+            .stat_path(&events_path)
+            .await
+            .with_context(|| format!("stat process IO events at {events_path}"))?
+            .length;
+        Ok((output, events))
+    }
+
+    pub async fn spawn_process<I, S>(&self, executable: &str, args: I) -> Result<String>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let args: Vec<String> = args.into_iter().map(Into::into).collect();
+        let exec_spec = serde_json::json!({
+            "executable": executable,
+            "args": args,
+        });
+        let exec_spec = serde_json::to_vec(&exec_spec).context("serialize exec spec")?;
+        self.client()
+            .clone_with_document("/proc/clone", &exec_spec)
+            .await
+            .with_context(|| format!("spawn {executable} through /proc/clone"))
+    }
+
+    pub(super) async fn read_process_result(
+        &self,
+        pid: &str,
+        timeout_secs: usize,
+    ) -> Result<NamespaceProcessResult> {
+        if timeout_secs == 0 {
+            return self.read_process_result_until_exit(pid).await;
+        }
+        tokio::time::timeout(
+            std::time::Duration::from_secs(timeout_secs as u64),
+            self.read_process_result_until_exit(pid),
+        )
+        .await
+        .with_context(|| format!("timed out waiting {timeout_secs}s for process {pid} to exit"))?
+    }
+
+    async fn read_process_result_until_exit(&self, pid: &str) -> Result<NamespaceProcessResult> {
+        let client = self.client();
+        let status_path = format!("/proc/{pid}/status");
+        let exit_path = format!("/proc/{pid}/exit");
+        let output_path = format!("/proc/{pid}/io/output");
+        loop {
+            let status = String::from_utf8(
+                client
+                    .read_file(&status_path)
+                    .await
+                    .with_context(|| format!("read {status_path}"))?,
+            )
+            .context("process status is not utf8")?;
+            if status.trim() == "exited" {
+                let exit_code = String::from_utf8(
+                    client
+                        .read_file(&exit_path)
+                        .await
+                        .with_context(|| format!("read {exit_path}"))?,
+                )
+                .context("process exit code is not utf8")?
+                .trim()
+                .parse::<i32>()
+                .context("process exit code is not an integer")?;
+                let output = if client
+                    .stat_path(&output_path)
+                    .await
+                    .with_context(|| format!("stat {output_path}"))?
+                    .length
+                    == 0
+                {
+                    String::new()
+                } else {
+                    String::from_utf8(
+                        client
+                            .read_file(&output_path)
+                            .await
+                            .with_context(|| format!("read {output_path}"))?,
+                    )
+                    .context("process output is not utf8")?
+                };
+                return Ok(NamespaceProcessResult { output, exit_code });
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+}
+
+pub(super) struct NamespaceProcessResult {
+    pub(super) output: String,
+    pub(super) exit_code: i32,
+}
+
+fn agent_pid_from_path(agent_path: &str) -> Result<&str> {
+    let components = agent_path
+        .split('/')
+        .filter(|component| !component.is_empty())
+        .collect::<Vec<_>>();
+    match components.as_slice() {
+        ["agent", pid] if *pid != "root" => Ok(*pid),
+        ["agent", "root"] => {
+            bail!("process control requires a concrete /agent/<pid> path, got /agent/root")
+        }
+        _ => bail!("invalid agent path for process control: {agent_path}"),
+    }
+}

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/tests/process_actions.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/tests/process_actions.rs
@@ -33,6 +33,7 @@ async fn engine_spawns_process_with_spawner_assembled_namespace() {
     let environment = NamespaceRuntimeEnvironment::new(root, "/agent/root", "default");
 
     let pid = environment
+        .process_files()
         .spawn_process("/bin/agent", Vec::<String>::new())
         .await
         .unwrap();
@@ -104,7 +105,11 @@ async fn engine_runs_tool_as_process_and_projects_action_files() {
     assert_eq!(action.output, "hello from-process\n");
     assert_eq!(action.exit_code, 0);
     assert_eq!(
-        environment.read_process_exit_code("1").await.unwrap(),
+        environment
+            .process_files()
+            .read_process_exit_code("1")
+            .await
+            .unwrap(),
         Some(0)
     );
     assert_eq!(

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -322,6 +322,49 @@ fn agent_file_workflows_use_only_the_narrow_agent_files_handle() {
 }
 
 #[test]
+fn process_file_workflows_use_only_the_narrow_process_files_handle() {
+    let namespace = read_runtime_source("transition/namespace_environment.rs");
+    let process_files_handle =
+        rust_item_body(&namespace, "pub(crate) struct NamespaceProcessFiles");
+    for required_field in ["root: InProcessTransport", "agent_path: String"] {
+        assert!(
+            process_files_handle.contains(required_field),
+            "process files handle must retain {required_field}"
+        );
+    }
+    for forbidden_field in [
+        "llm_connection",
+        "tool_process_context",
+        "child_run_registry",
+        "input_offset",
+        "control_offset",
+    ] {
+        assert!(
+            !process_files_handle.contains(forbidden_field),
+            "process files handle must not gain {forbidden_field}"
+        );
+    }
+
+    let file_operations = read_runtime_source("transition/namespace_environment/process_files.rs");
+    assert!(file_operations.contains("impl NamespaceProcessFiles"));
+    assert!(!file_operations.contains("impl NamespaceRuntimeEnvironment"));
+
+    let supervisor = read_runtime_source("delegated_child_run/supervisor.rs");
+    assert!(supervisor.contains("process_files: NamespaceProcessFiles"));
+    assert!(!supervisor.contains("NamespaceRuntimeEnvironment"));
+    for operation in [
+        "read_process_exit_code",
+        "read_process_io_offsets",
+        "write_process_control_for_pid",
+    ] {
+        assert!(
+            supervisor.contains(&format!(".{operation}")),
+            "delegated supervisor must access {operation} through NamespaceProcessFiles"
+        );
+    }
+}
+
+#[test]
 fn engine_does_not_assemble_alan_os() {
     let source = read_runtime_source("engine.rs");
     let production = source.split("\n#[cfg(test)]\nmod tests").next().unwrap();


### PR DESCRIPTION
Stacked on #819.

Moves Process table lifecycle and stream operations behind a concrete `NamespaceProcessFiles` handle:

- extracts `/proc` path resolution, clone, control, exit, IO offsets, and result polling
- removes those operations from `NamespaceRuntimeEnvironment`
- delegated child supervision now receives separate AgentFS and Process handles and no complete namespace environment
- Tool action execution composes the Process handle internally without a forwarding compatibility path
- adds a dependency-boundary guard against regrowing LLM, Tool, AgentFS, or child authority on the Process handle

Validation:
- `cargo test -p alan-agent-engine` (1198 passed, 1 ignored)
- dependency boundary (11/11)
- `cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings`
- repository quality gate (0 warnings)