### PR TITLE
refactor(agent-engine): narrow Tool execution handle

### DIFF
--- a/crates/agent-engine/src/runtime/child_agents.rs
+++ b/crates/agent-engine/src/runtime/child_agents.rs
@@ -343,10 +343,7 @@ async fn build_child_namespace_assembly_plan(
         launch_context,
     };
 
-    let packages = parent
-        .namespace_environment()
-        .discover_tool_packages()
-        .await?;
+    let packages = parent.tool_execution().discover_packages().await?;
     plan.tool_packages = if let Some(profile) = spec.runtime_overrides.tool_profile.as_ref() {
         let available = packages
             .iter()

--- a/crates/agent-engine/src/runtime/child_agents/tests/namespace_runtime.rs
+++ b/crates/agent-engine/src/runtime/child_agents/tests/namespace_runtime.rs
@@ -570,7 +570,8 @@ async fn child_namespace_launch_and_supervisor_reattachment_use_proc_pid_files()
 
     let tool = launch
         .environment
-        .run_tool_action("alpha", "/bin/alpha", ["{}"])
+        .tool_execution()
+        .run_action("alpha", "/bin/alpha", ["{}"])
         .await
         .unwrap();
     assert_eq!(tool.pid, "3");

--- a/crates/agent-engine/src/runtime/engine_tests.rs
+++ b/crates/agent-engine/src/runtime/engine_tests.rs
@@ -116,7 +116,8 @@ async fn namespace_discovery_ignores_incomplete_tool_packages() {
 
     assert!(
         environment
-            .discover_tool_packages()
+            .tool_execution()
+            .discover_packages()
             .await
             .unwrap()
             .is_empty()
@@ -139,7 +140,13 @@ async fn namespace_discovery_rejects_invalid_mounted_manifest() {
     let root = InProcessTransport::new(Arc::new(alan_kernel::MountFs::new(mounts)));
     let environment = crate::runtime::NamespaceRuntimeEnvironment::new(root, "/agent/1", "default");
 
-    assert!(environment.discover_tool_packages().await.is_err());
+    assert!(
+        environment
+            .tool_execution()
+            .discover_packages()
+            .await
+            .is_err()
+    );
 }
 
 #[test]

--- a/crates/agent-engine/src/runtime/response_guardrails.rs
+++ b/crates/agent-engine/src/runtime/response_guardrails.rs
@@ -214,8 +214,8 @@ fn capability_for_tool_request(
         .find(|package| package.name == request.name)
         .map(|package| {
             state
-                .namespace_environment()
-                .resolve_tool_capability(package, &request.arguments)
+                .tool_execution()
+                .resolve_capability(package, &request.arguments)
         })
 }
 

--- a/crates/agent-engine/src/runtime/submission_handlers.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers.rs
@@ -491,8 +491,8 @@ fn handle_mount_escalation_resolution(
     });
     let namespace_applied = approved && namespace_application.namespace_applied;
     let scratch_dir = state
-        .namespace_environment()
-        .tool_execution_binding()
+        .tool_execution()
+        .execution_binding()
         .map(|binding| binding.scratch_dir)
         .or_else(|| {
             state
@@ -510,7 +510,7 @@ fn handle_mount_escalation_resolution(
         });
     let tool_sandbox_applied = namespace_applied
         && grant.as_ref().is_some_and(|grant| {
-            let binding = state.namespace_environment().tool_execution_binding();
+            let binding = state.tool_execution().execution_binding();
             binding.is_some_and(|binding| {
                 binding.host_mounts.iter().any(|mounted| {
                     mounted.namespace_path == grant.namespace_path

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/confirmation_and_mount_support.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/confirmation_and_mount_support.inc.rs
@@ -144,7 +144,7 @@
             .clone()
             .with_launch_context(launch_context.clone());
         assert!(
-            state.namespace_environment().set_tool_execution_binding(
+            state.tool_execution().set_execution_binding(
                 crate::tools::ToolExecutionBinding::from_launch_context(
                     &launch_context,
                     source.join("scratch"),
@@ -652,7 +652,7 @@
             tool_result["mount_request"]["namespace_path"],
             "/mnt/project"
         );
-        let roots = state.namespace_environment().tool_sandbox_writable_roots();
+        let roots = state.tool_execution().sandbox_writable_roots();
         assert_eq!(
             roots,
             vec![dunce::canonicalize(host_mount_root.path()).unwrap()]
@@ -728,7 +728,7 @@
         assert_eq!(tool_result["tool_sandbox_applied"], true);
         assert_eq!(tool_result["tool_sandbox_projection_changed"], true);
         assert_eq!(
-            state.namespace_environment().tool_sandbox_writable_roots(),
+            state.tool_execution().sandbox_writable_roots(),
             vec![
                 dunce::canonicalize(host_mount_root.path()).unwrap(),
                 dunce::canonicalize(approved_host.path()).unwrap()

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
@@ -37,8 +37,8 @@
         .unwrap();
 
         let binding = state
-            .namespace_environment()
-            .tool_execution_binding()
+            .tool_execution()
+            .execution_binding()
             .expect("first approved Host Mount should create a Tool binding");
         assert_eq!(
             binding.cwd,
@@ -119,7 +119,7 @@
         assert_eq!(tool_result["tool_sandbox_applied"], true);
         assert_eq!(tool_result["tool_sandbox_projection_changed"], true);
         assert_eq!(
-            state.namespace_environment().tool_sandbox_writable_roots(),
+            state.tool_execution().sandbox_writable_roots(),
             vec![dunce::canonicalize(host_mount_root.path()).unwrap()]
         );
         let grants = applicator.grants();
@@ -164,7 +164,7 @@
         assert_eq!(tool_result["tool_sandbox_applied"], false);
         assert_eq!(tool_result["tool_sandbox_projection_changed"], false);
         assert_eq!(
-            state.namespace_environment().tool_sandbox_writable_roots(),
+            state.tool_execution().sandbox_writable_roots(),
             vec![dunce::canonicalize(host_mount_root.path()).unwrap()]
         );
         let grants = applicator.grants();
@@ -203,7 +203,7 @@
             .unwrap();
         }
 
-        let roots = state.namespace_environment().tool_sandbox_writable_roots();
+        let roots = state.tool_execution().sandbox_writable_roots();
         assert_eq!(
             roots,
             vec![
@@ -258,7 +258,7 @@
             Some(replacement_host.path().join("file.txt"))
         );
         assert_eq!(
-            state.namespace_environment().tool_sandbox_writable_roots(),
+            state.tool_execution().sandbox_writable_roots(),
             vec![
                 dunce::canonicalize(host_mount_root.path()).unwrap(),
                 dunce::canonicalize(replacement_host.path()).unwrap()
@@ -304,7 +304,7 @@
         assert_eq!(tool_result["tool_sandbox_applied"], true);
         assert_eq!(tool_result["tool_sandbox_projection_changed"], true);
         assert_eq!(
-            state.namespace_environment().tool_sandbox_writable_roots(),
+            state.tool_execution().sandbox_writable_roots(),
             vec![dunce::canonicalize(host_mount_root.path()).unwrap()]
         );
     }
@@ -352,7 +352,7 @@
         assert_eq!(tool_result["tool_sandbox_projection_changed"], false);
         assert_eq!(tool_result["live_applied"], false);
         assert_eq!(
-            state.namespace_environment().tool_sandbox_writable_roots(),
+            state.tool_execution().sandbox_writable_roots(),
             vec![dunce::canonicalize(host_mount_root.path()).unwrap()]
         );
 

--- a/crates/agent-engine/src/runtime/tool_orchestrator.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator.rs
@@ -288,7 +288,7 @@ async fn tool_payload_for_tape(state: &RuntimeLoopState, payload: &Value) -> Val
 }
 
 async fn execute_tool_effect(
-    namespace: crate::runtime::NamespaceRuntimeEnvironment,
+    tools: crate::runtime::transition::NamespaceToolExecution,
     tool_name: &str,
     tool_arguments: Value,
     cancel: &CancellationToken,
@@ -297,8 +297,8 @@ async fn execute_tool_effect(
     let executable = format!("/bin/{tool_name}");
     let arguments_doc =
         serde_json::to_string(&tool_arguments).context("serialize tool arguments")?;
-    let tool = namespace
-        .run_tool_action_with_cancel_and_timeout(
+    let tool = tools
+        .run_action_with_cancel_and_timeout(
             tool_name,
             &executable,
             [arguments_doc],
@@ -357,8 +357,8 @@ where
     }
 
     let tool_package = state
-        .namespace_environment()
-        .discover_tool_packages()
+        .tool_execution()
+        .discover_packages()
         .await?
         .into_iter()
         .find(|package| package.name == tool_call.name);
@@ -400,8 +400,8 @@ where
         });
     };
     let tool_capability = state
-        .namespace_environment()
-        .resolve_tool_capability(&tool_package, &tool_arguments);
+        .tool_execution()
+        .resolve_capability(&tool_package, &tool_arguments);
     let current_tool_cwd = state.default_tool_cwd();
     let policy_decision = maybe_allow_approved_tool_escalation_replay(
         evaluate_tool_policy(
@@ -772,7 +772,7 @@ where
         None
     };
 
-    let execution_target = state.namespace_environment().clone();
+    let execution_target = state.tool_execution();
     let tool_start = Instant::now();
     let tool_timeout_secs = tool_package.timeout_secs;
     let tool_result = execute_tool_effect(

--- a/crates/agent-engine/src/runtime/tool_orchestrator/tests/namespace_and_batch_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator/tests/namespace_and_batch_contract.inc.rs
@@ -295,12 +295,12 @@
     #[tokio::test]
     async fn namespace_execution_target_spawns_every_builtin_bin_tool() {
         let (state, shell) = create_namespace_test_state_and_shell();
-        let namespace = state.namespace_environment().clone();
+        let tools = state.tool_execution();
         let cancel = CancellationToken::new();
 
         for (idx, tool_name) in BUILTIN_BIN_TOOLS.iter().enumerate() {
             let payload = execute_tool_effect(
-                namespace.clone(),
+                tools.clone(),
                 tool_name,
                 json!({ "tool": tool_name, "call_index": idx }),
                 &cancel,

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -15,7 +15,7 @@ pub use namespace_environment::{
     NamespaceTurnRuntime, NamespaceTurnRuntimeConfig,
 };
 pub(crate) use namespace_environment::{
-    NamespaceAgentFiles, NamespaceGeneration, NamespaceProcessFiles,
+    NamespaceAgentFiles, NamespaceGeneration, NamespaceProcessFiles, NamespaceToolExecution,
 };
 
 use std::collections::VecDeque;
@@ -96,6 +96,10 @@ impl RuntimeLoopState {
 
     pub(crate) fn process_files(&self) -> NamespaceProcessFiles {
         self.environment.process_files()
+    }
+
+    pub(crate) fn tool_execution(&self) -> NamespaceToolExecution {
+        self.environment.tool_execution()
     }
 
     pub(crate) async fn write_namespace_confirmation_request(
@@ -196,8 +200,8 @@ impl RuntimeLoopState {
 
     pub(crate) async fn static_tool_names(&self) -> Result<Vec<String>> {
         Ok(self
-            .namespace_environment()
-            .discover_tool_packages()
+            .tool_execution()
+            .discover_packages()
             .await?
             .into_iter()
             .map(|manifest| manifest.name)
@@ -205,8 +209,8 @@ impl RuntimeLoopState {
     }
 
     pub(crate) fn default_tool_cwd(&self) -> Option<std::path::PathBuf> {
-        self.namespace_environment()
-            .tool_execution_binding()
+        self.tool_execution()
+            .execution_binding()
             .map(|binding| binding.cwd)
     }
 }

--- a/crates/agent-engine/src/runtime/transition/namespace_environment.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment.rs
@@ -9,6 +9,7 @@ mod agent_files;
 mod client;
 mod generation;
 mod process_files;
+mod tool_execution;
 
 use std::{
     path::PathBuf,
@@ -16,12 +17,7 @@ use std::{
 };
 
 use alan_ap::InProcessTransport;
-use anyhow::{Context, Result, bail};
-use tokio_util::sync::CancellationToken;
-
-use self::client::NamespaceClient;
-use self::process_files::NamespaceProcessResult;
-use crate::evidence::redact_durable_evidence_text;
+use anyhow::Result;
 
 /// Configuration for one namespace-native Agent Process turn driver.
 #[derive(Debug, Clone)]
@@ -270,6 +266,15 @@ pub(crate) struct NamespaceProcessFiles {
     agent_path: String,
 }
 
+/// Narrow handle for Tool package discovery, policy capability, and execution.
+#[derive(Clone)]
+pub(crate) struct NamespaceToolExecution {
+    root: InProcessTransport,
+    process_files: NamespaceProcessFiles,
+    agent_files: NamespaceAgentFiles,
+    tool_process_context: Option<NamespaceToolProcessContext>,
+}
+
 #[derive(Clone)]
 struct NamespaceToolProcessContext {
     pub(crate) pid: alan_kernel::Pid,
@@ -338,6 +343,15 @@ impl NamespaceRuntimeEnvironment {
         }
     }
 
+    pub(crate) fn tool_execution(&self) -> NamespaceToolExecution {
+        NamespaceToolExecution {
+            root: self.root.clone(),
+            process_files: self.process_files(),
+            agent_files: self.agent_files(),
+            tool_process_context: self.tool_process_context.clone(),
+        }
+    }
+
     pub(crate) fn launch_context(&self) -> Option<&crate::ProcessLaunchContext> {
         self.launch_context.as_ref()
     }
@@ -350,42 +364,6 @@ impl NamespaceRuntimeEnvironment {
     ) -> Self {
         self.tool_process_context = Some(NamespaceToolProcessContext { pid, tool_runner });
         self
-    }
-
-    pub(crate) fn tool_execution_binding(&self) -> Option<crate::tools::ToolExecutionBinding> {
-        let context = self.tool_process_context.as_ref()?;
-        context.tool_runner.process_binding(context.pid)
-    }
-
-    pub(crate) fn resolve_tool_capability(
-        &self,
-        package: &super::super::ToolPackageManifest,
-        arguments: &serde_json::Value,
-    ) -> alan_agent_protocol::ToolCapability {
-        if !package.capability_is_argument_dependent {
-            return package.capability;
-        }
-        self.tool_process_context
-            .as_ref()
-            .and_then(|context| {
-                context
-                    .tool_runner
-                    .capability_for_tool(&package.name, arguments)
-            })
-            .unwrap_or(alan_agent_protocol::ToolCapability::Unknown)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn set_tool_execution_binding(
-        &self,
-        binding: crate::tools::ToolExecutionBinding,
-    ) -> bool {
-        self.tool_process_context.as_ref().is_some_and(|context| {
-            context
-                .tool_runner
-                .register_process_binding(context.pid, binding);
-            true
-        })
     }
 
     pub(crate) fn persist_approved_host_mount(&mut self, grant: crate::HostMountGrant) -> bool {
@@ -427,14 +405,6 @@ impl NamespaceRuntimeEnvironment {
         changed
     }
 
-    #[cfg(test)]
-    pub(crate) fn tool_sandbox_writable_roots(&self) -> Vec<std::path::PathBuf> {
-        self.tool_execution_binding()
-            .and_then(|binding| binding.sandbox_spec)
-            .map(|spec| spec.writable_roots)
-            .unwrap_or_default()
-    }
-
     pub fn with_mount_grant_applicator(
         mut self,
         applicator: Arc<dyn MountGrantApplicator>,
@@ -471,33 +441,6 @@ impl NamespaceRuntimeEnvironment {
         &self.llm_connection
     }
 
-    /// Discover model-callable Tools from complete packages visible in this namespace.
-    pub(crate) async fn discover_tool_packages(
-        &self,
-    ) -> Result<Vec<super::super::ToolPackageManifest>> {
-        let client = self.client();
-        let mut packages = Vec::new();
-        for name in client
-            .try_read_directory_names("/bin")
-            .await?
-            .unwrap_or_default()
-        {
-            if name.is_empty() || name.contains('/') {
-                continue;
-            }
-            let path = format!("/lib/exec/{name}/manifest");
-            let Some(raw) = client.try_read_file(&path).await? else {
-                continue;
-            };
-            let manifest: super::super::ToolPackageManifest = serde_json::from_slice(&raw)
-                .with_context(|| format!("parse Tool manifest at {path}"))?;
-            manifest.validate_for_name(&name)?;
-            packages.push(manifest);
-        }
-        packages.sort_by(|left, right| left.name.cmp(&right.name));
-        Ok(packages)
-    }
-
     pub fn root_transport(&self) -> InProcessTransport {
         self.root.clone()
     }
@@ -521,140 +464,6 @@ impl NamespaceRuntimeEnvironment {
             Err(error) => NamespaceMountApplication::failed(error),
         }
     }
-
-    pub async fn run_tool_action<I, S>(
-        &self,
-        tool_name: &str,
-        executable: &str,
-        args: I,
-    ) -> Result<NamespaceToolActionOutput>
-    where
-        I: IntoIterator<Item = S>,
-        S: Into<String>,
-    {
-        let cancel = CancellationToken::new();
-        self.run_tool_action_with_cancel_and_timeout(tool_name, executable, args, &cancel, 30)
-            .await
-    }
-
-    pub async fn run_tool_action_with_cancel<I, S>(
-        &self,
-        tool_name: &str,
-        executable: &str,
-        args: I,
-        cancel: &CancellationToken,
-    ) -> Result<NamespaceToolActionOutput>
-    where
-        I: IntoIterator<Item = S>,
-        S: Into<String>,
-    {
-        self.run_tool_action_with_cancel_and_timeout(tool_name, executable, args, cancel, 30)
-            .await
-    }
-
-    pub async fn run_tool_action_with_cancel_and_timeout<I, S>(
-        &self,
-        tool_name: &str,
-        executable: &str,
-        args: I,
-        cancel: &CancellationToken,
-        timeout_secs: usize,
-    ) -> Result<NamespaceToolActionOutput>
-    where
-        I: IntoIterator<Item = S>,
-        S: Into<String>,
-    {
-        if cancel.is_cancelled() {
-            bail!("tool process cancelled before spawn");
-        }
-        let process_files = self.process_files();
-        let pid = process_files.spawn_process(executable, args).await?;
-        let result = tokio::select! {
-            _ = cancel.cancelled() => {
-                let _ = process_files.write_process_control_for_pid(&pid, "cancel").await;
-                bail!("tool process {pid} cancelled");
-            }
-            result = process_files.read_process_result(&pid, timeout_secs) => {
-                match result {
-                    Ok(result) => result,
-                    Err(err) => {
-                        let _ = process_files.write_process_control_for_pid(&pid, "cancel").await;
-                        return Err(err).with_context(|| {
-                            format!("read tool process {pid} result")
-                        });
-                    }
-                }
-            }
-        };
-        let action_exit_code = logical_tool_action_exit_code(&result);
-        let action_status = if action_exit_code == 0 {
-            "completed"
-        } else {
-            "failed"
-        };
-        let mut result_doc = serde_json::json!({
-            "exit_code": action_exit_code,
-        });
-        if action_exit_code != result.exit_code
-            && let Some(object) = result_doc.as_object_mut()
-        {
-            object.insert(
-                "process_exit_code".to_string(),
-                serde_json::json!(result.exit_code),
-            );
-        }
-        let durable_output = redact_durable_evidence_text(&result.output);
-        let action_id = self
-            .agent_files()
-            .write_action(
-                NamespaceActionRecord::new(tool_name, action_status)
-                    .with_output(durable_output.text)
-                    .with_result(result_doc.to_string())
-                    .with_approval("not_required")
-                    .with_process(format!("/proc/{pid}")),
-            )
-            .await?;
-        Ok(NamespaceToolActionOutput {
-            action_id,
-            pid,
-            output: result.output,
-            exit_code: action_exit_code,
-        })
-    }
-}
-
-fn logical_tool_action_exit_code(result: &NamespaceProcessResult) -> i32 {
-    let trimmed = result.output.trim();
-    if trimmed.is_empty() {
-        return result.exit_code;
-    }
-
-    let Ok(payload) = serde_json::from_str::<serde_json::Value>(trimmed) else {
-        return result.exit_code;
-    };
-    let payload_exit_code = payload
-        .get("exit_code")
-        .and_then(serde_json::Value::as_i64)
-        .and_then(|code| i32::try_from(code).ok());
-    let payload_success = payload.get("success").and_then(serde_json::Value::as_bool);
-
-    if matches!(payload_success, Some(false)) {
-        return payload_exit_code
-            .filter(|code| *code != 0)
-            .unwrap_or(if result.exit_code != 0 {
-                result.exit_code
-            } else {
-                1
-            });
-    }
-
-    if let Some(exit_code) = payload_exit_code
-        && exit_code != 0
-    {
-        return exit_code;
-    }
-
-    result.exit_code
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -688,12 +497,6 @@ impl NamespaceTurnRuntime {
             .agent_files()
             .current_tape_checkpoint()
             .await
-    }
-}
-
-impl NamespaceRuntimeEnvironment {
-    fn client(&self) -> NamespaceClient {
-        NamespaceClient::new(self.root.clone())
     }
 }
 

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/tests.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/tests.rs
@@ -16,7 +16,9 @@ use alan_llm::{GenerationRequest, GenerationResponse, LlmProvider, MockLlmProvid
 use alan_llmfs::LlmFs;
 use alan_shell::Shell;
 use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
 
+use super::client::NamespaceClient;
 use super::*;
 
 struct EchoRunner;

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/tests/process_actions.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/tests/process_actions.rs
@@ -92,7 +92,8 @@ async fn engine_runs_tool_as_process_and_projects_action_files() {
     let environment = NamespaceRuntimeEnvironment::new(root, "/agent/1", "default");
 
     let action = environment
-        .run_tool_action(
+        .tool_execution()
+        .run_action(
             "echo",
             "/bin/greeting",
             ["hello".to_string(), "from-process".to_string()],
@@ -147,7 +148,8 @@ async fn run_tool_action_projects_logical_payload_failure_as_failed_action() {
     let (environment, shell) = tool_test_environment(Arc::new(LogicalFailureRunner));
 
     let action = environment
-        .run_tool_action("bash", "/bin/bash", ["{}"])
+        .tool_execution()
+        .run_action("bash", "/bin/bash", ["{}"])
         .await
         .unwrap();
 
@@ -182,12 +184,8 @@ async fn run_tool_action_cancels_spawned_process_on_cancel() {
         let cancel = cancel.clone();
         async move {
             environment
-                .run_tool_action_with_cancel(
-                    "blocked",
-                    "/bin/blocked",
-                    Vec::<String>::new(),
-                    &cancel,
-                )
+                .tool_execution()
+                .run_action_with_cancel("blocked", "/bin/blocked", Vec::<String>::new(), &cancel)
                 .await
         }
     });
@@ -225,7 +223,8 @@ async fn run_tool_action_cancels_spawned_process_on_wait_timeout() {
         let cancel = cancel.clone();
         async move {
             environment
-                .run_tool_action_with_cancel_and_timeout(
+                .tool_execution()
+                .run_action_with_cancel_and_timeout(
                     "blocked",
                     "/bin/blocked",
                     Vec::<String>::new(),
@@ -264,7 +263,8 @@ async fn run_tool_action_reads_output_larger_than_initial_read() {
     let (environment, _shell) = tool_test_environment(Arc::new(LargeOutputRunner));
 
     let action = environment
-        .run_tool_action("large", "/bin/large", Vec::<String>::new())
+        .tool_execution()
+        .run_action("large", "/bin/large", Vec::<String>::new())
         .await
         .unwrap();
 
@@ -279,7 +279,9 @@ async fn run_tool_action_reads_exact_chunk_output_without_waiting_for_more() {
 
     let action = tokio::time::timeout(
         std::time::Duration::from_secs(1),
-        environment.run_tool_action("exact", "/bin/exact", Vec::<String>::new()),
+        environment
+            .tool_execution()
+            .run_action("exact", "/bin/exact", Vec::<String>::new()),
     )
     .await
     .expect("exact chunk output should not wait at the live stream edge")

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/tool_execution.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/tool_execution.rs
@@ -1,0 +1,223 @@
+//! Tool package discovery, capability resolution, and Process-backed execution.
+
+use anyhow::{Context, Result, bail};
+use tokio_util::sync::CancellationToken;
+
+use super::{
+    NamespaceActionRecord, NamespaceToolActionOutput, NamespaceToolExecution,
+    client::NamespaceClient, process_files::NamespaceProcessResult,
+};
+use crate::{evidence::redact_durable_evidence_text, runtime::ToolPackageManifest};
+
+impl NamespaceToolExecution {
+    fn client(&self) -> NamespaceClient {
+        NamespaceClient::new(self.root.clone())
+    }
+
+    pub(crate) fn execution_binding(&self) -> Option<crate::tools::ToolExecutionBinding> {
+        let context = self.tool_process_context.as_ref()?;
+        context.tool_runner.process_binding(context.pid)
+    }
+
+    pub(crate) fn resolve_capability(
+        &self,
+        package: &ToolPackageManifest,
+        arguments: &serde_json::Value,
+    ) -> alan_agent_protocol::ToolCapability {
+        if !package.capability_is_argument_dependent {
+            return package.capability;
+        }
+        self.tool_process_context
+            .as_ref()
+            .and_then(|context| {
+                context
+                    .tool_runner
+                    .capability_for_tool(&package.name, arguments)
+            })
+            .unwrap_or(alan_agent_protocol::ToolCapability::Unknown)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_execution_binding(
+        &self,
+        binding: crate::tools::ToolExecutionBinding,
+    ) -> bool {
+        self.tool_process_context.as_ref().is_some_and(|context| {
+            context
+                .tool_runner
+                .register_process_binding(context.pid, binding);
+            true
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn sandbox_writable_roots(&self) -> Vec<std::path::PathBuf> {
+        self.execution_binding()
+            .and_then(|binding| binding.sandbox_spec)
+            .map(|spec| spec.writable_roots)
+            .unwrap_or_default()
+    }
+
+    /// Discover model-callable Tools from complete packages visible in this namespace.
+    pub(crate) async fn discover_packages(&self) -> Result<Vec<ToolPackageManifest>> {
+        let client = self.client();
+        let mut packages = Vec::new();
+        for name in client
+            .try_read_directory_names("/bin")
+            .await?
+            .unwrap_or_default()
+        {
+            if name.is_empty() || name.contains('/') {
+                continue;
+            }
+            let path = format!("/lib/exec/{name}/manifest");
+            let Some(raw) = client.try_read_file(&path).await? else {
+                continue;
+            };
+            let manifest: ToolPackageManifest = serde_json::from_slice(&raw)
+                .with_context(|| format!("parse Tool manifest at {path}"))?;
+            manifest.validate_for_name(&name)?;
+            packages.push(manifest);
+        }
+        packages.sort_by(|left, right| left.name.cmp(&right.name));
+        Ok(packages)
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn run_action<I, S>(
+        &self,
+        tool_name: &str,
+        executable: &str,
+        args: I,
+    ) -> Result<NamespaceToolActionOutput>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let cancel = CancellationToken::new();
+        self.run_action_with_cancel_and_timeout(tool_name, executable, args, &cancel, 30)
+            .await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn run_action_with_cancel<I, S>(
+        &self,
+        tool_name: &str,
+        executable: &str,
+        args: I,
+        cancel: &CancellationToken,
+    ) -> Result<NamespaceToolActionOutput>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.run_action_with_cancel_and_timeout(tool_name, executable, args, cancel, 30)
+            .await
+    }
+
+    pub(crate) async fn run_action_with_cancel_and_timeout<I, S>(
+        &self,
+        tool_name: &str,
+        executable: &str,
+        args: I,
+        cancel: &CancellationToken,
+        timeout_secs: usize,
+    ) -> Result<NamespaceToolActionOutput>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        if cancel.is_cancelled() {
+            bail!("tool process cancelled before spawn");
+        }
+        let pid = self.process_files.spawn_process(executable, args).await?;
+        let result = tokio::select! {
+            _ = cancel.cancelled() => {
+                let _ = self.process_files.write_process_control_for_pid(&pid, "cancel").await;
+                bail!("tool process {pid} cancelled");
+            }
+            result = self.process_files.read_process_result(&pid, timeout_secs) => {
+                match result {
+                    Ok(result) => result,
+                    Err(err) => {
+                        let _ = self
+                            .process_files
+                            .write_process_control_for_pid(&pid, "cancel")
+                            .await;
+                        return Err(err).with_context(|| {
+                            format!("read tool process {pid} result")
+                        });
+                    }
+                }
+            }
+        };
+        let action_exit_code = logical_tool_action_exit_code(&result);
+        let action_status = if action_exit_code == 0 {
+            "completed"
+        } else {
+            "failed"
+        };
+        let mut result_doc = serde_json::json!({
+            "exit_code": action_exit_code,
+        });
+        if action_exit_code != result.exit_code
+            && let Some(object) = result_doc.as_object_mut()
+        {
+            object.insert(
+                "process_exit_code".to_string(),
+                serde_json::json!(result.exit_code),
+            );
+        }
+        let durable_output = redact_durable_evidence_text(&result.output);
+        let action_id = self
+            .agent_files
+            .write_action(
+                NamespaceActionRecord::new(tool_name, action_status)
+                    .with_output(durable_output.text)
+                    .with_result(result_doc.to_string())
+                    .with_approval("not_required")
+                    .with_process(format!("/proc/{pid}")),
+            )
+            .await?;
+        Ok(NamespaceToolActionOutput {
+            action_id,
+            pid,
+            output: result.output,
+            exit_code: action_exit_code,
+        })
+    }
+}
+
+fn logical_tool_action_exit_code(result: &NamespaceProcessResult) -> i32 {
+    let trimmed = result.output.trim();
+    if trimmed.is_empty() {
+        return result.exit_code;
+    }
+
+    let Ok(payload) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+        return result.exit_code;
+    };
+    let payload_exit_code = payload
+        .get("exit_code")
+        .and_then(serde_json::Value::as_i64)
+        .and_then(|code| i32::try_from(code).ok());
+    let payload_success = payload.get("success").and_then(serde_json::Value::as_bool);
+
+    if matches!(payload_success, Some(false)) {
+        return payload_exit_code
+            .filter(|code| *code != 0)
+            .unwrap_or(if result.exit_code != 0 {
+                result.exit_code
+            } else {
+                1
+            });
+    }
+
+    if let Some(exit_code) = payload_exit_code
+        && exit_code != 0
+    {
+        return exit_code;
+    }
+
+    result.exit_code
+}

--- a/crates/agent-engine/src/runtime/turn_executor.rs
+++ b/crates/agent-engine/src/runtime/turn_executor.rs
@@ -110,10 +110,7 @@ async fn turn_tool_definitions(
 )> {
     let include_runtime_delegated_tool = state.prompt_cache.supports_delegated_skill_invocation();
 
-    let tool_packages = state
-        .namespace_environment()
-        .discover_tool_packages()
-        .await?;
+    let tool_packages = state.tool_execution().discover_packages().await?;
     let mut tools = tool_packages
         .iter()
         .map(|package| package.model_definition())

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -402,9 +402,8 @@ fn tool_workflows_use_only_the_narrow_tool_execution_handle() {
         "submission_handlers.rs",
     ] {
         let source = read_runtime_source(path);
-        let production = source.split("\n#[cfg(test)]").next().unwrap();
         assert!(
-            !production.contains("namespace_environment()"),
+            !source.contains("namespace_environment()"),
             "{path} must not reach complete namespace environment for Tool work"
         );
     }

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -365,6 +365,52 @@ fn process_file_workflows_use_only_the_narrow_process_files_handle() {
 }
 
 #[test]
+fn tool_workflows_use_only_the_narrow_tool_execution_handle() {
+    let namespace = read_runtime_source("transition/namespace_environment.rs");
+    let tool_handle = rust_item_body(&namespace, "pub(crate) struct NamespaceToolExecution");
+    for required_field in [
+        "root: InProcessTransport",
+        "process_files: NamespaceProcessFiles",
+        "agent_files: NamespaceAgentFiles",
+        "tool_process_context: Option<NamespaceToolProcessContext>",
+    ] {
+        assert!(
+            tool_handle.contains(required_field),
+            "Tool execution handle must retain {required_field}"
+        );
+    }
+    for forbidden_field in [
+        "llm_connection",
+        "launch_context",
+        "child_run_registry",
+        "mount_grant_applicator",
+    ] {
+        assert!(
+            !tool_handle.contains(forbidden_field),
+            "Tool execution handle must not gain {forbidden_field}"
+        );
+    }
+
+    let tool_operations = read_runtime_source("transition/namespace_environment/tool_execution.rs");
+    assert!(tool_operations.contains("impl NamespaceToolExecution"));
+    assert!(!tool_operations.contains("impl NamespaceRuntimeEnvironment"));
+
+    for path in [
+        "tool_orchestrator.rs",
+        "turn_executor.rs",
+        "response_guardrails.rs",
+        "submission_handlers.rs",
+    ] {
+        let source = read_runtime_source(path);
+        let production = source.split("\n#[cfg(test)]").next().unwrap();
+        assert!(
+            !production.contains("namespace_environment()"),
+            "{path} must not reach complete namespace environment for Tool work"
+        );
+    }
+}
+
+#[test]
 fn engine_does_not_assemble_alan_os() {
     let source = read_runtime_source("engine.rs");
     let production = source.split("\n#[cfg(test)]\nmod tests").next().unwrap();


### PR DESCRIPTION
## Summary

- introduce the concrete `NamespaceToolExecution` handle for Tool package discovery, capability resolution, Process-backed execution, and AgentFS action evidence
- move Tool workflows off the complete `NamespaceRuntimeEnvironment`
- delete the displaced broad Tool helpers and add an architecture dependency guard

## Stack

Depends on #820. Review only the final commit in this PR.

## Validation

- `cargo test -p alan-agent-engine --quiet` (1198 passed, 1 ignored; dependency boundary 12 passed)
- `cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings`
- repository quality gate from the pre-commit hook (0 warnings)