### PR TITLE
refactor(agent-engine): narrow child launch capability

### DIFF
--- a/crates/agent-engine/src/runtime/child_agents.rs
+++ b/crates/agent-engine/src/runtime/child_agents.rs
@@ -148,7 +148,7 @@ async fn spawn_child_runtime_inner(
     let launch_root_dir = resolve_launch_root_dir(parent, &spec.target)?;
     let child_agent_config = build_child_agent_config(parent, &spec);
     let parent_launch_context = parent
-        .namespace_environment()
+        .child_launch()
         .launch_context()
         .cloned()
         .unwrap_or_else(crate::ProcessLaunchContext::root);
@@ -221,8 +221,8 @@ async fn spawn_child_runtime_inner(
         None
     };
     let assembler = parent
-        .namespace_environment()
-        .child_process_assembler()
+        .child_launch()
+        .assembler()
         .context("parent Agent Process has no Agent Runtime Service child assembly capability")?;
     let assembly = assembler
         .assemble(super::ChildAgentProcessAssemblyRequest {

--- a/crates/agent-engine/src/runtime/child_agents/delegated_launch.rs
+++ b/crates/agent-engine/src/runtime/child_agents/delegated_launch.rs
@@ -67,11 +67,12 @@ fn namespace_summary_from_child_plan(
 async fn namespace_summary_from_parent(
     parent: &RuntimeLoopState,
 ) -> Result<alan_agent_protocol::DelegatedNamespaceSummary> {
-    let mut described = parent
-        .namespace_environment()
-        .launch_context()
+    let child_launch = parent.child_launch();
+    let launch_context = child_launch.launch_context();
+    let mut described = launch_context
         .map(|context| context.namespace.describe())
         .unwrap_or_default();
+    let cwd = launch_context.map(|context| PathBuf::from(&context.cwd));
     described.extend([
         ("/agent".to_string(), alan_kernel::Access::ReadWrite),
         ("/mnt/llm".to_string(), alan_kernel::Access::ReadWrite),
@@ -91,10 +92,7 @@ async fn namespace_summary_from_parent(
             .into_iter()
             .map(|tool| format!("/bin/{tool}"))
             .collect(),
-        parent
-            .namespace_environment()
-            .launch_context()
-            .map(|context| PathBuf::from(&context.cwd)),
+        cwd,
         Some(
             parent
                 .core_config

--- a/crates/agent-engine/src/runtime/child_agents/launch_context.rs
+++ b/crates/agent-engine/src/runtime/child_agents/launch_context.rs
@@ -8,7 +8,8 @@ pub(super) fn ensure_child_connection_is_passed(
     parent: &RuntimeLoopState,
     requested: &str,
 ) -> Result<()> {
-    let passed = parent.namespace_environment().llm_connection();
+    let child_launch = parent.child_launch();
+    let passed = child_launch.connection_name();
     if requested != passed {
         bail!(
             "Connection '{requested}' was not passed to the child Agent Process by the parent Process; available Connection is '{passed}'."
@@ -161,17 +162,15 @@ pub(super) fn resolve_launch_root_dir(
 ) -> Result<Option<ResolvedLaunchRoot>> {
     match target {
         SpawnTarget::DefinitionDescriptor { descriptor } => {
-            let descriptor = parent
-                .namespace_environment()
-                .launch_context()
+            let child_launch = parent.child_launch();
+            let launch_context = child_launch.launch_context();
+            let descriptor = launch_context
                 .and_then(|context| context.descriptor(descriptor))
                 .with_context(|| format!("parent Process has no `{descriptor}` descriptor"))?;
             let root = if descriptor.file_tree.is_some() {
                 PathBuf::from(&descriptor.path)
             } else {
-                parent
-                    .namespace_environment()
-                    .launch_context()
+                launch_context
                     .and_then(|context| context.host_path(&descriptor.path))
                     .with_context(|| {
                         format!(

--- a/crates/agent-engine/src/runtime/child_agents/tests.rs
+++ b/crates/agent-engine/src/runtime/child_agents/tests.rs
@@ -539,7 +539,7 @@ fn parent_test_tools(config: &crate::Config) -> ToolRegistry {
 
 fn inherited_launch_context(parent: &RuntimeLoopState) -> crate::ProcessLaunchContext {
     parent
-        .namespace_environment()
+        .child_launch()
         .launch_context()
         .expect("test parent has a Process Launch Context")
         .child()

--- a/crates/agent-engine/src/runtime/child_agents/tests/launch_contract.rs
+++ b/crates/agent-engine/src/runtime/child_agents/tests/launch_contract.rs
@@ -79,11 +79,7 @@ async fn spawn_child_runtime_preserves_explicit_connection_profile() {
     let mut parent = make_parent_state(&temp, requests.clone(), response.clone());
     let profile_id = "explicit-main";
     parent.core_config.connection_profile = Some(profile_id.to_string());
-    let launch_context = parent
-        .namespace_environment()
-        .launch_context()
-        .unwrap()
-        .clone();
+    let launch_context = parent.child_launch().launch_context().unwrap().clone();
     parent.environment = namespace_environment_for_parent_test_with_connection(
         Arc::new(alan_routefs::RouteFs::new()),
         Arc::new(alan_llmfs::LlmFs::new()),
@@ -250,13 +246,14 @@ fn child_launch_context_does_not_inherit_parent_host_mounts_or_descriptors_by_de
         RecordedRequests::default(),
         completed_response("done"),
     );
-    let parent_context = parent.namespace_environment().launch_context().unwrap();
+    let parent_context = parent.child_launch().launch_context().cloned().unwrap();
     let definition = temp.path().join("child-definition");
     let mut spec = launch_spec(definition.clone());
     spec.handles.clear();
 
     let definition = host_launch_root(definition);
-    let child = build_child_launch_context(parent_context, &spec, None, Some(&definition)).unwrap();
+    let child =
+        build_child_launch_context(&parent_context, &spec, None, Some(&definition)).unwrap();
 
     assert_eq!(child.cwd, "/");
     assert!(child.namespace.resolve("/mnt/source").is_err());
@@ -541,12 +538,13 @@ fn child_launch_context_passes_parent_host_mounts_only_with_explicit_handle() {
         RecordedRequests::default(),
         completed_response("done"),
     );
-    let parent_context = parent.namespace_environment().launch_context().unwrap();
+    let parent_context = parent.child_launch().launch_context().cloned().unwrap();
     let definition = temp.path().join("child-definition");
     let spec = launch_spec(definition.clone());
 
     let definition = host_launch_root(definition);
-    let child = build_child_launch_context(parent_context, &spec, None, Some(&definition)).unwrap();
+    let child =
+        build_child_launch_context(&parent_context, &spec, None, Some(&definition)).unwrap();
 
     assert_eq!(child.cwd, "/mnt/source");
     assert!(child.namespace.resolve("/mnt/source").is_ok());
@@ -566,14 +564,14 @@ fn child_launch_rejects_cwd_inside_an_unpassed_host_mount() {
         RecordedRequests::default(),
         completed_response("done"),
     );
-    let parent_context = parent.namespace_environment().launch_context().unwrap();
+    let parent_context = parent.child_launch().launch_context().cloned().unwrap();
     let definition = temp.path().join("child-definition");
     let mut spec = launch_spec(definition.clone());
     spec.handles.clear();
 
     let definition = host_launch_root(definition);
     let error = build_child_launch_context(
-        parent_context,
+        &parent_context,
         &spec,
         Some("/mnt/source".to_string()),
         Some(&definition),

--- a/crates/agent-engine/src/runtime/child_agents/tests/namespace_runtime.rs
+++ b/crates/agent-engine/src/runtime/child_agents/tests/namespace_runtime.rs
@@ -236,11 +236,7 @@ async fn child_namespace_plan_mounts_only_allowed_tools() {
         allowed_tools: vec!["alpha".to_string()],
     });
 
-    let launch_context = parent
-        .namespace_environment()
-        .launch_context()
-        .unwrap()
-        .child();
+    let launch_context = parent.child_launch().launch_context().unwrap().child();
     let plan =
         build_child_namespace_assembly_plan(&parent, &spec, &parent.core_config, launch_context)
             .await
@@ -458,7 +454,10 @@ async fn child_namespace_launch_and_supervisor_reattachment_use_proc_pid_files()
 
     assert_eq!(launch.pid, "1");
     assert_eq!(launch.environment.agent_path(), "/agent/1");
-    assert_eq!(launch.environment.llm_connection(), "default");
+    assert_eq!(
+        launch.environment.child_launch().connection_name(),
+        "default"
+    );
     assert_eq!(
         launch.exec,
         plan.clone_exec_spec_for_pid("1", "/bin/alan-agent", std::iter::empty::<String>())

--- a/crates/agent-engine/src/runtime/delegated_skill_tool.rs
+++ b/crates/agent-engine/src/runtime/delegated_skill_tool.rs
@@ -480,10 +480,9 @@ fn build_delegated_spawn_spec(
     request: &DelegatedSkillInvocationRequest,
     target: alan_agent_protocol::SpawnTarget,
 ) -> DelegatedSkillSpawnResult<SpawnSpec> {
-    let parent_namespace_cwd = state
-        .namespace_environment()
-        .launch_context()
-        .map(|context| Path::new(&context.cwd));
+    let child_launch = state.child_launch();
+    let launch_context = child_launch.launch_context();
+    let parent_namespace_cwd = launch_context.map(|context| Path::new(&context.cwd));
     let cwd = request
         .cwd
         .as_deref()
@@ -493,15 +492,12 @@ fn build_delegated_spawn_spec(
     let requirements = classify_delegated_task_requirements(&request.task, cwd.as_deref());
     let mut handles = vec![SpawnHandle::ApprovalScope];
     if cwd.as_deref().is_some_and(|cwd| {
-        state
-            .namespace_environment()
-            .launch_context()
-            .is_some_and(|context| {
-                context
-                    .host_mounts
-                    .iter()
-                    .any(|grant| grant.resolve_host_path(&cwd.to_string_lossy()).is_some())
-            })
+        launch_context.is_some_and(|context| {
+            context
+                .host_mounts
+                .iter()
+                .any(|grant| grant.resolve_host_path(&cwd.to_string_lossy()).is_some())
+        })
     }) {
         handles.push(SpawnHandle::HostMounts);
     }

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/confirmation_and_mount_support.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/confirmation_and_mount_support.inc.rs
@@ -742,7 +742,7 @@
         assert_eq!(grants[0].reason, "Need to edit project files");
 
         let child_context = state
-            .namespace_environment()
+            .child_launch()
             .launch_context()
             .expect("approved grant should persist in the Process Launch Context")
             .child();

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
@@ -47,7 +47,7 @@
         assert_eq!(binding.namespace_cwd, std::path::Path::new("/mnt/project"));
         assert_eq!(
             state
-                .namespace_environment()
+                .child_launch()
                 .launch_context()
                 .expect("the Process Launch Context should remain available")
                 .cwd,
@@ -250,8 +250,9 @@
         }
 
         let launch_context = state
-            .namespace_environment()
+            .child_launch()
             .launch_context()
+            .cloned()
             .expect("approved grant should remain in the Process Launch Context");
         assert_eq!(
             launch_context.host_path("/mnt/project/file.txt"),

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -15,7 +15,8 @@ pub use namespace_environment::{
     NamespaceTurnRuntime, NamespaceTurnRuntimeConfig,
 };
 pub(crate) use namespace_environment::{
-    NamespaceAgentFiles, NamespaceGeneration, NamespaceProcessFiles, NamespaceToolExecution,
+    NamespaceAgentFiles, NamespaceChildLaunch, NamespaceGeneration, NamespaceProcessFiles,
+    NamespaceToolExecution,
 };
 
 use std::collections::VecDeque;
@@ -96,6 +97,10 @@ impl RuntimeLoopState {
 
     pub(crate) fn process_files(&self) -> NamespaceProcessFiles {
         self.environment.process_files()
+    }
+
+    pub(crate) fn child_launch(&self) -> NamespaceChildLaunch {
+        self.environment.child_launch()
     }
 
     pub(crate) fn tool_execution(&self) -> NamespaceToolExecution {

--- a/crates/agent-engine/src/runtime/transition/namespace_environment.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment.rs
@@ -6,6 +6,7 @@
 //! spawned through `/proc/clone`, and state is written back to `/agent/<pid>`.
 
 mod agent_files;
+mod child_launch;
 mod client;
 mod generation;
 mod process_files;
@@ -266,6 +267,14 @@ pub(crate) struct NamespaceProcessFiles {
     agent_path: String,
 }
 
+/// Narrow handle for child Agent Process launch capabilities.
+#[derive(Clone)]
+pub(crate) struct NamespaceChildLaunch {
+    llm_connection: String,
+    launch_context: Option<crate::ProcessLaunchContext>,
+    child_process_assembler: Option<Arc<dyn super::super::ChildAgentProcessAssembler>>,
+}
+
 /// Narrow handle for Tool package discovery, policy capability, and execution.
 #[derive(Clone)]
 pub(crate) struct NamespaceToolExecution {
@@ -343,6 +352,14 @@ impl NamespaceRuntimeEnvironment {
         }
     }
 
+    pub(crate) fn child_launch(&self) -> NamespaceChildLaunch {
+        NamespaceChildLaunch {
+            llm_connection: self.llm_connection.clone(),
+            launch_context: self.launch_context.clone(),
+            child_process_assembler: self.child_process_assembler.clone(),
+        }
+    }
+
     pub(crate) fn tool_execution(&self) -> NamespaceToolExecution {
         NamespaceToolExecution {
             root: self.root.clone(),
@@ -350,10 +367,6 @@ impl NamespaceRuntimeEnvironment {
             agent_files: self.agent_files(),
             tool_process_context: self.tool_process_context.clone(),
         }
-    }
-
-    pub(crate) fn launch_context(&self) -> Option<&crate::ProcessLaunchContext> {
-        self.launch_context.as_ref()
     }
 
     /// Bind transition-local Tool execution to its already-created Process.
@@ -429,16 +442,6 @@ impl NamespaceRuntimeEnvironment {
     ) -> Self {
         self.child_process_assembler = Some(assembler);
         self
-    }
-
-    pub(crate) fn child_process_assembler(
-        &self,
-    ) -> Option<Arc<dyn super::super::ChildAgentProcessAssembler>> {
-        self.child_process_assembler.clone()
-    }
-
-    pub fn llm_connection(&self) -> &str {
-        &self.llm_connection
     }
 
     pub fn root_transport(&self) -> InProcessTransport {

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/child_launch.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/child_launch.rs
@@ -1,0 +1,19 @@
+//! Child Agent Process launch capabilities passed through the namespace boundary.
+
+use std::sync::Arc;
+
+use super::NamespaceChildLaunch;
+
+impl NamespaceChildLaunch {
+    pub(crate) fn connection_name(&self) -> &str {
+        &self.llm_connection
+    }
+
+    pub(crate) fn launch_context(&self) -> Option<&crate::ProcessLaunchContext> {
+        self.launch_context.as_ref()
+    }
+
+    pub(crate) fn assembler(&self) -> Option<Arc<dyn crate::runtime::ChildAgentProcessAssembler>> {
+        self.child_process_assembler.clone()
+    }
+}

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -410,6 +410,51 @@ fn tool_workflows_use_only_the_narrow_tool_execution_handle() {
 }
 
 #[test]
+fn child_launch_workflows_use_only_the_narrow_child_launch_handle() {
+    let namespace = read_runtime_source("transition/namespace_environment.rs");
+    let child_launch = rust_item_body(&namespace, "pub(crate) struct NamespaceChildLaunch");
+    for required_field in [
+        "llm_connection: String",
+        "launch_context: Option<crate::ProcessLaunchContext>",
+        "child_process_assembler: Option<Arc<dyn super::super::ChildAgentProcessAssembler>>",
+    ] {
+        assert!(
+            child_launch.contains(required_field),
+            "child launch handle must retain {required_field}"
+        );
+    }
+    for forbidden_field in [
+        "root: InProcessTransport",
+        "agent_path",
+        "tool_process_context",
+        "mount_grant_applicator",
+        "child_run_registry",
+    ] {
+        assert!(
+            !child_launch.contains(forbidden_field),
+            "child launch handle must not gain {forbidden_field}"
+        );
+    }
+
+    let operations = read_runtime_source("transition/namespace_environment/child_launch.rs");
+    assert!(operations.contains("impl NamespaceChildLaunch"));
+    assert!(!operations.contains("impl NamespaceRuntimeEnvironment"));
+
+    for path in [
+        "child_agents.rs",
+        "child_agents/launch_context.rs",
+        "child_agents/delegated_launch.rs",
+        "delegated_skill_tool.rs",
+    ] {
+        let source = read_runtime_source(path);
+        assert!(
+            !source.contains("namespace_environment()"),
+            "{path} must not reach complete namespace environment for child launch work"
+        );
+    }
+}
+
+#[test]
 fn engine_does_not_assemble_alan_os() {
     let source = read_runtime_source("engine.rs");
     let production = source.split("\n#[cfg(test)]\nmod tests").next().unwrap();
@@ -459,7 +504,8 @@ fn engine_has_no_host_connection_store_or_provider_factory_authority() {
         );
     }
     assert!(child.contains("ensure_child_connection_is_passed"));
-    assert!(child.contains("child_process_assembler()"));
+    assert!(child.contains(".child_launch()"));
+    assert!(child.contains(".assembler()"));
     assert!(child.contains("Agent Runtime Service child assembly capability"));
 }
 

--- a/crates/service-manager/tests/agent_runtime_ownership.rs
+++ b/crates/service-manager/tests/agent_runtime_ownership.rs
@@ -58,8 +58,10 @@ fn runtime_assembly_call_paths_have_explicit_owners() {
 
     let child_runtime = include_str!("../../agent-engine/src/runtime/child_agents.rs");
     let live_child_launch = rust_item_body(child_runtime, "async fn spawn_child_runtime_inner");
-    assert!(live_child_launch.contains("child_process_assembler()"));
+    assert!(live_child_launch.contains(".child_launch()"));
+    assert!(live_child_launch.contains(".assembler()"));
     for displaced in [
+        "child_process_assembler()",
         "AgentFs::new()",
         "bind_process(",
         "LiveNamespace::new(",


### PR DESCRIPTION
## Summary

- introduce the concrete `NamespaceChildLaunch` handle for the passed Connection, parent Process Launch Context, and Agent Runtime Service assembler
- move child Agent Process and delegated launch workflows off the complete `NamespaceRuntimeEnvironment`
- delete the displaced environment getters and guard the new dependency boundary

## Stack

Depends on #821. Review only the final commit in this PR.

## Validation

- `cargo test -p alan-agent-engine --quiet` (1198 passed, 1 ignored; dependency boundary 13 passed)
- `cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings`
- repository quality gate from the pre-commit hook (0 warnings)