### PR TITLE
refactor(agent-engine): narrow Namespace mount control

### DIFF
--- a/crates/agent-engine/src/runtime/child_agents/test_namespace.rs
+++ b/crates/agent-engine/src/runtime/child_agents/test_namespace.rs
@@ -315,15 +315,17 @@ pub(super) async fn spawn_child_namespace_runtime_environment(
         .iter()
         .find(|grant| grant.namespace_path == "/agent-definition")
     {
-        let applied = environment.apply_approved_mount_grant(&ApprovedMountGrant::new(
-            grant.namespace_path.clone(),
-            grant.host_path.clone(),
-            match grant.access {
-                alan_kernel::Access::ReadOnly => ApprovedMountGrantAccess::ReadOnly,
-                alan_kernel::Access::ReadWrite => ApprovedMountGrantAccess::ReadWrite,
-            },
-            "Agent Definition launch reference",
-        ));
+        let applied = environment
+            .mount_control()
+            .apply_approved_grant(&ApprovedMountGrant::new(
+                grant.namespace_path.clone(),
+                grant.host_path.clone(),
+                match grant.access {
+                    alan_kernel::Access::ReadOnly => ApprovedMountGrantAccess::ReadOnly,
+                    alan_kernel::Access::ReadWrite => ApprovedMountGrantAccess::ReadWrite,
+                },
+                "Agent Definition launch reference",
+            ));
         if has_mount_grant_applicator {
             anyhow::ensure!(
                 applied.namespace_applied,

--- a/crates/agent-engine/src/runtime/child_agents/tests/namespace_runtime.rs
+++ b/crates/agent-engine/src/runtime/child_agents/tests/namespace_runtime.rs
@@ -819,14 +819,16 @@ async fn child_namespace_launch_attaches_mount_grant_applicator_factory() {
             .any(|line| line == "/agent-definition ro"),
         "child Agent Process must receive its target definition: {definition_namespace:?}"
     );
-    let applied = launch
-        .environment
-        .apply_approved_mount_grant(&ApprovedMountGrant::new(
-            "/mnt/project",
-            PathBuf::from("/unused/by/test/applicator"),
-            ApprovedMountGrantAccess::ReadWrite,
-            "Need project files",
-        ));
+    let applied =
+        launch
+            .environment
+            .mount_control()
+            .apply_approved_grant(&ApprovedMountGrant::new(
+                "/mnt/project",
+                PathBuf::from("/unused/by/test/applicator"),
+                ApprovedMountGrantAccess::ReadWrite,
+                "Need project files",
+            ));
     assert!(applied.namespace_applied);
     assert_eq!(applied.namespace_error, None);
 

--- a/crates/agent-engine/src/runtime/engine.rs
+++ b/crates/agent-engine/src/runtime/engine.rs
@@ -552,7 +552,7 @@ fn spawn_with_prepared_runtime_environment(
                 if shutdown_requested || submissions_closed {
                     if shutdown_requested {
                         info!(
-                            process_path = %state.namespace_environment().agent_path(),
+                            process_path = %state.agent_path(),
                             "Shutdown signal received, stopping runtime"
                         );
                     }
@@ -791,7 +791,7 @@ fn spawn_with_prepared_runtime_environment(
         namespace_input_task.abort();
         let _ = namespace_input_task.await;
         info!(
-            process_path = %state.namespace_environment().agent_path(),
+            process_path = %state.agent_path(),
             "Agent runtime stopped"
         );
         state.machine.flush().await;

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -56,9 +56,9 @@ pub use launch_config::{
 };
 pub use transition::{
     ApprovedMountGrant, ApprovedMountGrantAccess, MountGrantApplicator,
-    MountGrantApplicatorFactory, NamespaceMountApplication, NamespaceRuntimeEnvironment,
-    NamespaceToolActionOutput, NamespaceTurnOutput, NamespaceTurnRuntime,
-    NamespaceTurnRuntimeConfig,
+    MountGrantApplicatorFactory, NamespaceMountApplication, NamespaceMountControl,
+    NamespaceRuntimeEnvironment, NamespaceToolActionOutput, NamespaceTurnOutput,
+    NamespaceTurnRuntime, NamespaceTurnRuntimeConfig,
 };
 
 // Re-export the transition context for internal runtime modules.

--- a/crates/agent-engine/src/runtime/submission_handlers.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers.rs
@@ -466,8 +466,8 @@ fn handle_mount_escalation_resolution(
             .as_ref()
             .map(|grant| {
                 state
-                    .environment
-                    .apply_approved_mount_grant(&grant.approved_mount_grant())
+                    .mount_control()
+                    .apply_approved_grant(&grant.approved_mount_grant())
             })
             .unwrap_or_else(|| {
                 NamespaceMountApplication::unavailable("missing approved mount grant details")
@@ -503,10 +503,11 @@ fn handle_mount_escalation_resolution(
         });
     let tool_sandbox_projection_changed = namespace_applied
         && native_grant.as_ref().is_some_and(|grant| {
-            state.environment.persist_approved_host_mount(grant.clone());
+            let mut mount_control = state.mount_control();
+            mount_control.retain_host_mount(grant.clone());
             scratch_dir
                 .clone()
-                .is_some_and(|scratch| state.environment.sync_tool_execution_binding(scratch))
+                .is_some_and(|scratch| mount_control.sync_tool_binding(scratch))
         });
     let tool_sandbox_applied = namespace_applied
         && grant.as_ref().is_some_and(|grant| {

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -11,8 +11,8 @@ pub(super) use namespace_environment::NamespaceRequestRecord;
 pub use namespace_environment::{
     ApprovedMountGrant, ApprovedMountGrantAccess, MountGrantApplicator,
     MountGrantApplicatorFactory, NamespaceActionRecord, NamespaceMountApplication,
-    NamespaceRuntimeEnvironment, NamespaceToolActionOutput, NamespaceTurnOutput,
-    NamespaceTurnRuntime, NamespaceTurnRuntimeConfig,
+    NamespaceMountControl, NamespaceRuntimeEnvironment, NamespaceToolActionOutput,
+    NamespaceTurnOutput, NamespaceTurnRuntime, NamespaceTurnRuntimeConfig,
 };
 pub(crate) use namespace_environment::{
     NamespaceAgentFiles, NamespaceChildLaunch, NamespaceGeneration, NamespaceProcessFiles,
@@ -76,15 +76,11 @@ impl RuntimeLoopState {
 
     /// AgentFS projection path for the owning Process.
     pub(crate) fn agent_path(&self) -> &str {
-        self.namespace_environment().agent_path()
+        self.environment.agent_path()
     }
 
     pub(crate) fn child_run_registry(&self) -> &super::child_runs::ChildRunRegistry {
-        self.namespace_environment().child_run_registry()
-    }
-
-    pub(crate) fn namespace_environment(&self) -> &NamespaceRuntimeEnvironment {
-        &self.environment
+        self.environment.child_run_registry()
     }
 
     pub(crate) fn namespace_generation(&self) -> NamespaceGeneration {
@@ -101,6 +97,10 @@ impl RuntimeLoopState {
 
     pub(crate) fn child_launch(&self) -> NamespaceChildLaunch {
         self.environment.child_launch()
+    }
+
+    pub(crate) fn mount_control(&mut self) -> NamespaceMountControl<'_> {
+        self.environment.mount_control()
     }
 
     pub(crate) fn tool_execution(&self) -> NamespaceToolExecution {

--- a/crates/agent-engine/src/runtime/transition/namespace_environment.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment.rs
@@ -9,6 +9,7 @@ mod agent_files;
 mod child_launch;
 mod client;
 mod generation;
+mod mount_control;
 mod process_files;
 mod tool_execution;
 
@@ -275,6 +276,13 @@ pub(crate) struct NamespaceChildLaunch {
     child_process_assembler: Option<Arc<dyn super::super::ChildAgentProcessAssembler>>,
 }
 
+/// Narrow control surface for applying and retaining approved Namespace mounts.
+pub struct NamespaceMountControl<'a> {
+    launch_context: &'a mut Option<crate::ProcessLaunchContext>,
+    mount_grant_applicator: Option<Arc<dyn MountGrantApplicator>>,
+    tool_process_context: Option<NamespaceToolProcessContext>,
+}
+
 /// Narrow handle for Tool package discovery, policy capability, and execution.
 #[derive(Clone)]
 pub(crate) struct NamespaceToolExecution {
@@ -360,6 +368,15 @@ impl NamespaceRuntimeEnvironment {
         }
     }
 
+    /// Borrow the concrete control surface for approved Namespace mount changes.
+    pub fn mount_control(&mut self) -> NamespaceMountControl<'_> {
+        NamespaceMountControl {
+            launch_context: &mut self.launch_context,
+            mount_grant_applicator: self.mount_grant_applicator.clone(),
+            tool_process_context: self.tool_process_context.clone(),
+        }
+    }
+
     pub(crate) fn tool_execution(&self) -> NamespaceToolExecution {
         NamespaceToolExecution {
             root: self.root.clone(),
@@ -377,45 +394,6 @@ impl NamespaceRuntimeEnvironment {
     ) -> Self {
         self.tool_process_context = Some(NamespaceToolProcessContext { pid, tool_runner });
         self
-    }
-
-    pub(crate) fn persist_approved_host_mount(&mut self, grant: crate::HostMountGrant) -> bool {
-        let Some(context) = self.launch_context.as_mut() else {
-            return false;
-        };
-        if let Some(index) = context
-            .host_mounts
-            .iter()
-            .position(|existing| existing.namespace_path == grant.namespace_path)
-        {
-            let changed = context.host_mounts[index] != grant;
-            context.host_mounts[index] = grant;
-            return changed;
-        }
-        context.host_mounts.push(grant);
-        true
-    }
-
-    pub(crate) fn sync_tool_execution_binding(&self, scratch_dir: PathBuf) -> bool {
-        let Some(launch_context) = self.launch_context.as_ref() else {
-            return false;
-        };
-        let Ok(binding) =
-            crate::tools::ToolExecutionBinding::from_launch_context(launch_context, scratch_dir)
-        else {
-            return false;
-        };
-        let Some(process_context) = self.tool_process_context.as_ref() else {
-            return false;
-        };
-        let changed = process_context
-            .tool_runner
-            .process_binding(process_context.pid)
-            != Some(binding.clone());
-        process_context
-            .tool_runner
-            .register_process_binding(process_context.pid, binding);
-        changed
     }
 
     pub fn with_mount_grant_applicator(
@@ -446,26 +424,6 @@ impl NamespaceRuntimeEnvironment {
 
     pub fn root_transport(&self) -> InProcessTransport {
         self.root.clone()
-    }
-
-    pub fn apply_approved_mount_grant(
-        &mut self,
-        grant: &ApprovedMountGrant,
-    ) -> NamespaceMountApplication {
-        let Some(applicator) = self.mount_grant_applicator.clone() else {
-            return NamespaceMountApplication::unavailable(
-                "live namespace mount applicator unavailable",
-            );
-        };
-        match applicator.apply_mount_grant(grant) {
-            Ok(namespace) => {
-                if let Some(context) = self.launch_context.as_mut() {
-                    context.namespace = namespace;
-                }
-                NamespaceMountApplication::applied()
-            }
-            Err(error) => NamespaceMountApplication::failed(error),
-        }
     }
 }
 

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/mount_control.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/mount_control.rs
@@ -1,0 +1,67 @@
+//! Approved Namespace mount mutation and dependent Tool binding projection.
+
+use std::path::PathBuf;
+
+use super::{ApprovedMountGrant, NamespaceMountApplication, NamespaceMountControl};
+
+impl NamespaceMountControl<'_> {
+    /// Apply an approved grant to the live Namespace and retain its new snapshot.
+    pub fn apply_approved_grant(
+        &mut self,
+        grant: &ApprovedMountGrant,
+    ) -> NamespaceMountApplication {
+        let Some(applicator) = self.mount_grant_applicator.clone() else {
+            return NamespaceMountApplication::unavailable(
+                "live namespace mount applicator unavailable",
+            );
+        };
+        match applicator.apply_mount_grant(grant) {
+            Ok(namespace) => {
+                if let Some(context) = self.launch_context.as_mut() {
+                    context.namespace = namespace;
+                }
+                NamespaceMountApplication::applied()
+            }
+            Err(error) => NamespaceMountApplication::failed(error),
+        }
+    }
+
+    pub(crate) fn retain_host_mount(&mut self, grant: crate::HostMountGrant) -> bool {
+        let Some(context) = self.launch_context.as_mut() else {
+            return false;
+        };
+        if let Some(index) = context
+            .host_mounts
+            .iter()
+            .position(|existing| existing.namespace_path == grant.namespace_path)
+        {
+            let changed = context.host_mounts[index] != grant;
+            context.host_mounts[index] = grant;
+            return changed;
+        }
+        context.host_mounts.push(grant);
+        true
+    }
+
+    pub(crate) fn sync_tool_binding(&self, scratch_dir: PathBuf) -> bool {
+        let Some(launch_context) = self.launch_context.as_ref() else {
+            return false;
+        };
+        let Ok(binding) =
+            crate::tools::ToolExecutionBinding::from_launch_context(launch_context, scratch_dir)
+        else {
+            return false;
+        };
+        let Some(process_context) = self.tool_process_context.as_ref() else {
+            return false;
+        };
+        let changed = process_context
+            .tool_runner
+            .process_binding(process_context.pid)
+            != Some(binding.clone());
+        process_context
+            .tool_runner
+            .register_process_binding(process_context.pid, binding);
+        changed
+    }
+}

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -455,6 +455,58 @@ fn child_launch_workflows_use_only_the_narrow_child_launch_handle() {
 }
 
 #[test]
+fn mount_changes_use_only_the_narrow_namespace_mount_control() {
+    let namespace = read_runtime_source("transition/namespace_environment.rs");
+    let mount_control = rust_item_body(&namespace, "pub struct NamespaceMountControl<'a>");
+    for required_field in [
+        "launch_context: &'a mut Option<crate::ProcessLaunchContext>",
+        "mount_grant_applicator: Option<Arc<dyn MountGrantApplicator>>",
+        "tool_process_context: Option<NamespaceToolProcessContext>",
+    ] {
+        assert!(
+            mount_control.contains(required_field),
+            "Namespace mount control must retain {required_field}"
+        );
+    }
+    for forbidden_field in [
+        "root: InProcessTransport",
+        "agent_path",
+        "llm_connection",
+        "child_run_registry",
+        "child_process_assembler",
+    ] {
+        assert!(
+            !mount_control.contains(forbidden_field),
+            "Namespace mount control must not gain {forbidden_field}"
+        );
+    }
+
+    let operations = read_runtime_source("transition/namespace_environment/mount_control.rs");
+    assert!(operations.contains("impl NamespaceMountControl"));
+    assert!(!operations.contains("impl NamespaceRuntimeEnvironment"));
+
+    for displaced in [
+        "apply_approved_mount_grant",
+        "persist_approved_host_mount",
+        "sync_tool_execution_binding",
+    ] {
+        assert!(
+            !namespace.contains(displaced),
+            "complete namespace environment retained displaced mount operation {displaced}"
+        );
+    }
+
+    let submission_handlers = read_runtime_source("submission_handlers.rs");
+    assert!(submission_handlers.contains(".mount_control()"));
+    assert!(!submission_handlers.contains("state.environment"));
+
+    let transition = read_runtime_source("transition.rs");
+    let engine = read_runtime_source("engine.rs");
+    assert!(!transition.contains("fn namespace_environment("));
+    assert!(!engine.contains("namespace_environment()"));
+}
+
+#[test]
 fn engine_does_not_assemble_alan_os() {
     let source = read_runtime_source("engine.rs");
     let production = source.split("\n#[cfg(test)]\nmod tests").next().unwrap();

--- a/crates/service-manager/src/agent_runtime.rs
+++ b/crates/service-manager/src/agent_runtime.rs
@@ -655,7 +655,7 @@ fn apply_agent_definition_grant(
     else {
         return Ok(());
     };
-    let applied = environment.apply_approved_mount_grant(
+    let applied = environment.mount_control().apply_approved_grant(
         &alan_agent_engine::runtime::ApprovedMountGrant::new(
             grant.namespace_path.clone(),
             grant.host_path.clone(),


### PR DESCRIPTION
## Summary

- introduce the concrete `NamespaceMountControl` for live Namespace projection, launch-context retention, and dependent Tool binding refresh
- move transition and Service Manager mount application off broad environment operations
- delete the displaced mount methods and the complete `namespace_environment()` runtime getter

## Stack

Depends on #822. Review only the final commit in this PR.

## Validation

- `cargo test -p alan-agent-engine --quiet` (1198 passed, 1 ignored; dependency boundary 14 passed)
- `cargo test -p alan-service-manager --quiet` (75 unit tests plus both ownership integration tests passed)
- `cargo clippy -p alan-agent-engine -p alan-service-manager --all-targets --all-features -- -D warnings`
- repository quality gate from the pre-commit hook (0 warnings)