### PR TITLE
refactor(agent-engine): constrain runtime loop context

### DIFF
--- a/crates/agent-engine/src/runtime/compaction.rs
+++ b/crates/agent-engine/src/runtime/compaction.rs
@@ -822,8 +822,8 @@ mod tests {
         agent_machine::AgentMachine,
         config::Config,
         runtime::{
-            NamespaceRuntimeEnvironment, RuntimeConfig, RuntimeLoopState,
-            prompt_cache::PromptAssemblyCache,
+            NamespaceRuntimeEnvironment, RuntimeConfig, prompt_cache::PromptAssemblyCache,
+            transition::RuntimeLoopState,
         },
     };
 

--- a/crates/agent-engine/src/runtime/engine.rs
+++ b/crates/agent-engine/src/runtime/engine.rs
@@ -11,7 +11,7 @@ use super::turn_driver::{
     NAMESPACE_PENDING_RESPONSE_POLL_INTERVAL, TurnInputBroker, is_turn_inband_submission,
     namespace_pending_resume_submission,
 };
-use super::{NamespaceRuntimeEnvironment, RuntimeLoopState};
+use super::{NamespaceRuntimeEnvironment, transition::RuntimeLoopState};
 use crate::agent_machine::AgentMachine;
 use alan_agent_protocol::{InputMode, Submission};
 use anyhow::Result;

--- a/crates/agent-engine/src/runtime/memory_flush.rs
+++ b/crates/agent-engine/src/runtime/memory_flush.rs
@@ -549,8 +549,8 @@ mod tests {
         agent_machine::AgentMachine,
         config::Config,
         runtime::{
-            NamespaceRuntimeEnvironment, RuntimeConfig, RuntimeLoopState,
-            prompt_cache::PromptAssemblyCache,
+            NamespaceRuntimeEnvironment, RuntimeConfig, prompt_cache::PromptAssemblyCache,
+            transition::RuntimeLoopState,
         },
     };
     use std::path::PathBuf;

--- a/crates/agent-engine/src/runtime/memory_promotion/tests.rs
+++ b/crates/agent-engine/src/runtime/memory_promotion/tests.rs
@@ -13,8 +13,8 @@ use tempfile::TempDir;
 use crate::{
     config::Config,
     runtime::{
-        NamespaceRuntimeEnvironment, RuntimeConfig, RuntimeLoopState,
-        prompt_cache::PromptAssemblyCache,
+        NamespaceRuntimeEnvironment, RuntimeConfig, prompt_cache::PromptAssemblyCache,
+        transition::RuntimeLoopState,
     },
 };
 

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -61,10 +61,9 @@ pub use transition::{
     NamespaceTurnRuntime, NamespaceTurnRuntimeConfig,
 };
 
-// Re-export the transition context for internal runtime modules.
+// Re-export the memory-promotion job for internal runtime modules.
 pub(crate) use memory_promotion::TurnMemoryPromotionJob;
 pub use tool_packages::ToolPackageManifest;
-pub(crate) use transition::RuntimeLoopState;
 
 /// Configuration for the agent runtime
 #[derive(Debug, Clone)]

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -56,14 +56,17 @@ pub(super) enum DeferredRuntimeActionExit {
     Cancelled,
 }
 
-/// Agent state for the execution loop
-pub(crate) struct RuntimeLoopState {
-    pub(crate) machine: AgentMachine,
-    pub(crate) environment: NamespaceRuntimeEnvironment,
-    pub(crate) core_config: Config,
-    pub(crate) runtime_config: RuntimeConfig,
-    pub(crate) definition_persona_dirs: Vec<std::path::PathBuf>,
-    pub(crate) prompt_cache: super::prompt_cache::PromptAssemblyCache,
+/// Process-loop aggregate for one Agent Machine and its stable transition dependencies.
+///
+/// Transition-local execution state belongs exclusively to `machine`; the remaining fields are
+/// configuration, namespace capability sources, and derived prompt inputs.
+pub(super) struct RuntimeLoopState {
+    pub(super) machine: AgentMachine,
+    pub(super) environment: NamespaceRuntimeEnvironment,
+    pub(super) core_config: Config,
+    pub(super) runtime_config: RuntimeConfig,
+    pub(super) definition_persona_dirs: Vec<std::path::PathBuf>,
+    pub(super) prompt_cache: super::prompt_cache::PromptAssemblyCache,
 }
 
 impl RuntimeLoopState {

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -60,10 +60,45 @@ fn rust_item_body<'a>(source: &'a str, marker: &str) -> &'a str {
 #[test]
 fn runtime_state_and_handles_have_no_parallel_capability_or_event_authority() {
     let transition_source = read_runtime_source("transition.rs");
-    let state = rust_item_body(&transition_source, "pub(crate) struct RuntimeLoopState");
-    assert!(state.contains("pub(crate) environment: NamespaceRuntimeEnvironment"));
+    let state = rust_item_body(&transition_source, "pub(super) struct RuntimeLoopState");
+    for required_field in [
+        "pub(super) machine: AgentMachine",
+        "pub(super) environment: NamespaceRuntimeEnvironment",
+        "pub(super) core_config: Config",
+        "pub(super) runtime_config: RuntimeConfig",
+        "pub(super) definition_persona_dirs: Vec<std::path::PathBuf>",
+        "pub(super) prompt_cache: super::prompt_cache::PromptAssemblyCache",
+    ] {
+        assert!(
+            state.contains(required_field),
+            "runtime loop aggregate must retain {required_field}"
+        );
+    }
+    assert_eq!(
+        state
+            .lines()
+            .filter(|line| line.trim_start().starts_with("pub(super) "))
+            .count(),
+        6,
+        "runtime loop aggregate must keep exactly its six cohesive fields"
+    );
+    for displaced_state in [
+        "current_submission",
+        "turn_state",
+        "pending_yield",
+        "tool_replay",
+        "active_task",
+        "deferred_action",
+    ] {
+        assert!(
+            !state.contains(displaced_state),
+            "runtime loop aggregate must not regain Machine state {displaced_state}"
+        );
+    }
 
     let engine_source = read_runtime_source("engine.rs");
+    let runtime_module = read_runtime_source("mod.rs");
+    assert!(!runtime_module.contains("use transition::RuntimeLoopState"));
     let controller_source = read_runtime_source("controller.rs");
     let handle = rust_item_body(&controller_source, "pub struct RuntimeHandle");
     let controller = rust_item_body(&controller_source, "pub struct RuntimeController");
@@ -619,7 +654,7 @@ fn agent_machine_state_is_not_a_public_or_runtime_field_surface() {
     );
 
     let transition_source = read_runtime_source("transition.rs");
-    let runtime_state = rust_item_body(&transition_source, "pub(crate) struct RuntimeLoopState");
+    let runtime_state = rust_item_body(&transition_source, "pub(super) struct RuntimeLoopState");
     for displaced_field in ["current_submission_id", "turn_state"] {
         assert!(
             !runtime_state.contains(&format!("{displaced_field}:")),


### PR DESCRIPTION
## Summary
- keep RuntimeLoopState as the six-field Process-loop aggregate for one Agent Machine
- make the aggregate and its fields private to the runtime module and remove the top-level re-export
- guard the exact field set so transition-local Machine state cannot return to the runtime aggregate

## Verification
- full repository quality gate via commit hook
- cargo test -p alan-agent-engine --quiet
- cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings