### PR TITLE
refactor(agent-engine): narrow transition leaf dependencies

### DIFF
--- a/crates/agent-engine/src/runtime/response_guardrails.rs
+++ b/crates/agent-engine/src/runtime/response_guardrails.rs
@@ -3,7 +3,8 @@
 //! These checks enforce runtime-level invariants before emitting a response.
 //! They are intentionally independent from task/domain skills.
 
-use super::transition::RuntimeLoopState;
+use super::transition::NamespaceToolExecution;
+use crate::agent_machine::AgentMachine;
 use crate::tape::{ContentPart, Message, ToolRequest, ToolResponse};
 use alan_agent_protocol::ToolCapability;
 use serde_json::Value;
@@ -41,11 +42,12 @@ pub(super) struct ResponseGuardrailContext {
 }
 
 impl ResponseGuardrailContext {
-    pub(super) fn from_state(
-        state: &RuntimeLoopState,
+    pub(super) fn from_machine(
+        machine: &AgentMachine,
+        tool_execution: &NamespaceToolExecution,
         tool_packages: &[super::ToolPackageManifest],
     ) -> Self {
-        let recent_failures = current_turn_tool_failures(state, tool_packages);
+        let recent_failures = current_turn_tool_failures(machine, tool_execution, tool_packages);
 
         Self {
             has_any_tools: !tool_packages.is_empty(),
@@ -143,12 +145,14 @@ impl ResponseGuardrails {
 }
 
 fn current_turn_tool_failures(
-    state: &RuntimeLoopState,
+    machine: &AgentMachine,
+    tool_execution: &NamespaceToolExecution,
     tool_packages: &[super::ToolPackageManifest],
 ) -> RecentToolFailureContext {
-    let messages = state.machine.messages();
-    let current_turn = active_turn_messages(messages, state.machine.active_turn_message_start());
-    let tool_capabilities = current_turn_tool_capabilities(state, tool_packages, current_turn);
+    let messages = machine.messages();
+    let current_turn = active_turn_messages(messages, machine.active_turn_message_start());
+    let tool_capabilities =
+        current_turn_tool_capabilities(tool_execution, tool_packages, current_turn);
     let mut failures = RecentToolFailureContext::default();
 
     for message in current_turn.iter().rev() {
@@ -183,7 +187,7 @@ fn active_turn_messages(messages: &[Message], active_turn_start: Option<usize>) 
 }
 
 fn current_turn_tool_capabilities(
-    state: &RuntimeLoopState,
+    tool_execution: &NamespaceToolExecution,
     tool_packages: &[super::ToolPackageManifest],
     messages: &[Message],
 ) -> HashMap<String, ToolCapability> {
@@ -195,7 +199,9 @@ fn current_turn_tool_capabilities(
         };
 
         for request in tool_requests {
-            if let Some(capability) = capability_for_tool_request(state, tool_packages, request) {
+            if let Some(capability) =
+                capability_for_tool_request(tool_execution, tool_packages, request)
+            {
                 capabilities.insert(request.id.clone(), capability);
             }
         }
@@ -205,18 +211,14 @@ fn current_turn_tool_capabilities(
 }
 
 fn capability_for_tool_request(
-    state: &RuntimeLoopState,
+    tool_execution: &NamespaceToolExecution,
     tool_packages: &[super::ToolPackageManifest],
     request: &ToolRequest,
 ) -> Option<ToolCapability> {
     tool_packages
         .iter()
         .find(|package| package.name == request.name)
-        .map(|package| {
-            state
-                .tool_execution()
-                .resolve_capability(package, &request.arguments)
-        })
+        .map(|package| tool_execution.resolve_capability(package, &request.arguments))
 }
 
 fn tool_response_has_failure(response: &ToolResponse) -> bool {

--- a/crates/agent-engine/src/runtime/steering_queue.rs
+++ b/crates/agent-engine/src/runtime/steering_queue.rs
@@ -2,13 +2,12 @@ use alan_agent_protocol::{Event, InputMode, Op};
 use anyhow::Result;
 use serde_json::json;
 
-use super::transition::RuntimeLoopState;
 use super::turn_driver::{MAX_BUFFERED_INBAND_USER_INPUTS, TurnInputBroker};
 use super::turn_support::tool_result_preview;
-use crate::agent_machine::NormalizedToolCall;
+use crate::agent_machine::{AgentMachine, NormalizedToolCall};
 
 pub(super) async fn handle_queued_steering_inputs<E, F>(
-    state: &mut RuntimeLoopState,
+    machine: &mut AgentMachine,
     tool_calls: &[NormalizedToolCall],
     remaining_start_idx: usize,
     steering_broker: Option<&TurnInputBroker>,
@@ -39,7 +38,7 @@ where
                 mode: InputMode::FollowUp,
                 ..
             }
-        ) && state.machine.buffered_inband_user_input_count() >= MAX_BUFFERED_INBAND_USER_INPUTS
+        ) && machine.buffered_inband_user_input_count() >= MAX_BUFFERED_INBAND_USER_INPUTS
         {
             emit(Event::Error {
                 message: format!(
@@ -51,16 +50,16 @@ where
             continue;
         }
 
-        state.machine.push_buffered_inband_submission(submission);
+        machine.push_buffered_inband_submission(submission);
     }
 
     if steering_inputs.is_empty() {
         return Ok(false);
     }
 
-    state.machine.note_resumed_user_input();
+    machine.note_resumed_user_input();
     for parts in steering_inputs {
-        state.machine.add_user_message_parts(parts);
+        machine.add_user_message_parts(parts);
     }
 
     let remaining = &tool_calls[remaining_start_idx..];
@@ -96,15 +95,13 @@ where
             audit: None,
         })
         .await;
-        state.machine.record_tool_call(
+        machine.record_tool_call(
             &skipped.name,
             skipped.arguments.clone(),
             skipped_payload.clone(),
             false,
         );
-        state
-            .machine
-            .add_tool_message(&skipped.id, &skipped.name, skipped_payload);
+        machine.add_tool_message(&skipped.id, &skipped.name, skipped_payload);
     }
 
     Ok(true)

--- a/crates/agent-engine/src/runtime/tool_orchestrator.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator.rs
@@ -925,7 +925,7 @@ where
             } => {
                 refresh_context |= call_refresh;
                 if handle_queued_steering_inputs(
-                    state,
+                    &mut state.machine,
                     tool_calls,
                     idx + 1,
                     inputs.steering_broker,

--- a/crates/agent-engine/src/runtime/tool_orchestrator/tests/namespace_and_batch_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator/tests/namespace_and_batch_contract.inc.rs
@@ -416,9 +416,15 @@
             async {}
         };
 
-        let handled = handle_queued_steering_inputs(&mut state, &[], 0, Some(&broker), &mut emit)
-            .await
-            .unwrap();
+        let handled = handle_queued_steering_inputs(
+            &mut state.machine,
+            &[],
+            0,
+            Some(&broker),
+            &mut emit,
+        )
+        .await
+        .unwrap();
         assert!(!handled);
         assert_eq!(
             state.machine.buffered_inband_user_input_count(),
@@ -458,9 +464,15 @@
         );
         let mut emit = |_event: Event| async {};
 
-        let handled = handle_queued_steering_inputs(&mut state, &[], 0, Some(&broker), &mut emit)
-            .await
-            .unwrap();
+        let handled = handle_queued_steering_inputs(
+            &mut state.machine,
+            &[],
+            0,
+            Some(&broker),
+            &mut emit,
+        )
+        .await
+        .unwrap();
 
         assert!(handled);
         assert!(!state.machine.plan_snapshot_is_from_active_turn());

--- a/crates/agent-engine/src/runtime/turn_executor.rs
+++ b/crates/agent-engine/src/runtime/turn_executor.rs
@@ -103,14 +103,13 @@ async fn finalize_turn_memory_best_effort(
 }
 
 async fn turn_tool_definitions(
-    state: &RuntimeLoopState,
+    include_runtime_delegated_tool: bool,
+    tool_execution: &super::transition::NamespaceToolExecution,
 ) -> anyhow::Result<(
     Vec<super::ToolPackageManifest>,
     Vec<crate::llm::ToolDefinition>,
 )> {
-    let include_runtime_delegated_tool = state.prompt_cache.supports_delegated_skill_invocation();
-
-    let tool_packages = state.tool_execution().discover_packages().await?;
+    let tool_packages = tool_execution.discover_packages().await?;
     let mut tools = tool_packages
         .iter()
         .map(|package| package.model_definition())
@@ -320,7 +319,10 @@ where
     let _domain_prompt = prompt_build.domain_prompt;
     let system_prompt = prompt_build.system_prompt;
 
-    let (tool_packages, tools) = turn_tool_definitions(state).await?;
+    let include_runtime_delegated_tool = state.prompt_cache.supports_delegated_skill_invocation();
+    let tool_execution = state.tool_execution();
+    let (tool_packages, tools) =
+        turn_tool_definitions(include_runtime_delegated_tool, &tool_execution).await?;
     let tool_names = tools
         .iter()
         .map(|tool| tool.name.clone())
@@ -472,7 +474,9 @@ where
 
         let tool_calls = normalize_tool_calls(response.tool_calls);
 
-        let guardrail_context = ResponseGuardrailContext::from_state(state, &tool_packages);
+        let tool_execution = state.tool_execution();
+        let guardrail_context =
+            ResponseGuardrailContext::from_machine(&state.machine, &tool_execution, &tool_packages);
         let guardrail_draft = AssistantDraft::new(&response.content, !tool_calls.is_empty());
         match response_guardrails.evaluate(&guardrail_context, &guardrail_draft) {
             GuardrailDecision::Accept => {

--- a/crates/agent-engine/src/runtime/turn_executor/tests/prompt_and_tools.rs
+++ b/crates/agent-engine/src/runtime/turn_executor/tests/prompt_and_tools.rs
@@ -9,7 +9,8 @@ async fn test_turn_tool_definitions_include_runtime_delegated_schema_when_suppor
             .with_delegated_skill_invocation(),
     );
 
-    let (_, tools) = turn_tool_definitions(&state).await.unwrap();
+    let tool_execution = state.tool_execution();
+    let (_, tools) = turn_tool_definitions(true, &tool_execution).await.unwrap();
     assert!(
         tools
             .iter()
@@ -21,7 +22,8 @@ async fn test_turn_tool_definitions_include_runtime_delegated_schema_when_suppor
 async fn unmounted_tool_is_not_model_callable() {
     let state = create_test_state_with_provider(ContentMockProvider::new("ok"));
 
-    let (_, tools) = turn_tool_definitions(&state).await.unwrap();
+    let tool_execution = state.tool_execution();
+    let (_, tools) = turn_tool_definitions(false, &tool_execution).await.unwrap();
     assert!(!tools.iter().any(|tool| tool.name == "network_probe"));
 }
 

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -311,6 +311,27 @@ fn turn_generation_uses_only_the_file_native_namespace_boundary() {
 }
 
 #[test]
+fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
+    for path in ["response_guardrails.rs", "steering_queue.rs"] {
+        let source = read_runtime_source(path);
+        assert!(
+            !source.contains("RuntimeLoopState"),
+            "{path} must receive Agent Machine state and namespace handles directly"
+        );
+    }
+
+    let executor = read_runtime_source("turn_executor.rs");
+    let tool_definitions = &executor[executor
+        .find("async fn turn_tool_definitions")
+        .expect("find turn_tool_definitions")..];
+    let tool_definitions = &tool_definitions[..tool_definitions
+        .find("fn log_generation_failure")
+        .expect("find end of turn_tool_definitions")];
+    assert!(!tool_definitions.contains("RuntimeLoopState"));
+    assert!(tool_definitions.contains("NamespaceToolExecution"));
+}
+
+#[test]
 fn agent_file_workflows_use_only_the_narrow_agent_files_handle() {
     let namespace = read_runtime_source("transition/namespace_environment.rs");
     let agent_files_handle = rust_item_body(&namespace, "pub(crate) struct NamespaceAgentFiles");


### PR DESCRIPTION
## Summary
- pass Agent Machine and the Tool execution handle directly into response guardrails
- make queued steering depend only on Agent Machine state
- make Tool definition discovery consume an explicit capability flag and Tool execution handle
- add an architecture absence guard for these leaf workflows

## Validation
- cargo test -p alan-agent-engine
- cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings
- repository commit quality gate

Follow-up slices will remove the remaining broad RuntimeLoopState dependencies before the OpenSpec contract is synchronized.