### PR TITLE
refactor(agent-engine): move operations onto namespace handles

### DIFF
--- a/crates/agent-engine/src/runtime/child_agents/delegated_launch.rs
+++ b/crates/agent-engine/src/runtime/child_agents/delegated_launch.rs
@@ -87,6 +87,7 @@ async fn namespace_summary_from_parent(
             .map(|(path, _)| path.clone())
             .collect(),
         parent
+            .tool_execution()
             .static_tool_names()
             .await?
             .into_iter()

--- a/crates/agent-engine/src/runtime/child_run_termination_tool.rs
+++ b/crates/agent-engine/src/runtime/child_run_termination_tool.rs
@@ -173,7 +173,7 @@ where
             &tool_call.name,
             tool_arguments,
             alan_agent_protocol::ToolCapability::Write,
-            state.default_tool_cwd().as_deref(),
+            state.tool_execution().default_cwd().as_deref(),
             super::tool_policy::SandboxConfinement::detect(),
         ),
         allow_approved_tool_escalation_execution,
@@ -227,9 +227,9 @@ where
                 Some(audit),
             );
             let request_id = state
-                .write_namespace_confirmation_request(&pending)
-                .await?
-                .unwrap_or_else(|| pending.checkpoint_id.clone());
+                .agent_files()
+                .write_confirmation_request(&pending)
+                .await?;
             state
                 .machine
                 .set_confirmation_for_request(request_id.clone(), pending.clone());

--- a/crates/agent-engine/src/runtime/compaction.rs
+++ b/crates/agent-engine/src/runtime/compaction.rs
@@ -659,6 +659,7 @@ where
         );
 
         match state
+            .namespace_generation()
             .generate_once_with_cancel(generation_request, cancel, "Compaction cancelled")
             .await
         {

--- a/crates/agent-engine/src/runtime/memory_flush.rs
+++ b/crates/agent-engine/src/runtime/memory_flush.rs
@@ -313,6 +313,7 @@ async fn generate_flush_content(
     );
 
     let response = state
+        .namespace_generation()
         .generate_once_with_cancel(request, cancel, "memory flush cancelled")
         .await?;
 

--- a/crates/agent-engine/src/runtime/memory_promotion.rs
+++ b/crates/agent-engine/src/runtime/memory_promotion.rs
@@ -307,6 +307,7 @@ pub(crate) async fn run_turn_memory_promotion_job_for_runtime_with_cancel(
 ) -> Result<()> {
     let request = build_memory_promotion_request(job.active_turn_user_messages.clone());
     let response = state
+        .namespace_generation()
         .generate_response_with_retry(request, job.llm_request_timeout_secs, cancel)
         .await
         .context("generate turn-end memory promotion plan")?;

--- a/crates/agent-engine/src/runtime/mount_request_tool.rs
+++ b/crates/agent-engine/src/runtime/mount_request_tool.rs
@@ -117,7 +117,7 @@ where
         &tool_call.name,
         &mount_payload,
         mount_request.access.policy_capability(),
-        state.default_tool_cwd().as_deref(),
+        state.tool_execution().default_cwd().as_deref(),
         sandbox_confinement,
     );
     if mount_request.access == MountRequestAccess::ReadWrite {
@@ -127,7 +127,7 @@ where
             &tool_call.name,
             &mount_payload,
             alan_agent_protocol::ToolCapability::Read,
-            state.default_tool_cwd().as_deref(),
+            state.tool_execution().default_cwd().as_deref(),
             sandbox_confinement,
         );
         decision = merge_mount_policy_decision(decision, read_decision);
@@ -249,9 +249,9 @@ where
     };
 
     let request_id = state
-        .write_namespace_confirmation_request(&pending)
-        .await?
-        .unwrap_or_else(|| pending.checkpoint_id.clone());
+        .agent_files()
+        .write_confirmation_request(&pending)
+        .await?;
     let payload = json!({
         "status": "pending_mount_approval",
         "request_id": request_id.clone(),

--- a/crates/agent-engine/src/runtime/tool_orchestrator.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator.rs
@@ -402,7 +402,7 @@ where
     let tool_capability = state
         .tool_execution()
         .resolve_capability(&tool_package, &tool_arguments);
-    let current_tool_cwd = state.default_tool_cwd();
+    let current_tool_cwd = state.tool_execution().default_cwd();
     let policy_decision = maybe_allow_approved_tool_escalation_replay(
         evaluate_tool_policy(
             &state.runtime_config.policy_engine,
@@ -468,6 +468,7 @@ where
                     let llm_request_timeout_secs = state.runtime_config.llm_request_timeout_secs;
                     let request = super::guardian::build_review_request(&review_ctx);
                     let result = state
+                        .namespace_generation()
                         .generate_response_with_retry(
                             request,
                             llm_request_timeout_secs,
@@ -546,9 +547,9 @@ where
                     options: vec!["approve".to_string(), "reject".to_string()],
                 };
                 let request_id = state
-                    .write_namespace_confirmation_request(&pending)
-                    .await?
-                    .unwrap_or_else(|| pending.checkpoint_id.clone());
+                    .agent_files()
+                    .write_confirmation_request(&pending)
+                    .await?;
                 state.machine.record_tool_call_with_audit(
                     &tool_call.name,
                     tool_arguments.clone(),
@@ -658,9 +659,9 @@ where
             options: vec!["approve".to_string(), "reject".to_string()],
         };
         let request_id = state
-            .write_namespace_confirmation_request(&pending)
-            .await?
-            .unwrap_or_else(|| pending.checkpoint_id.clone());
+            .agent_files()
+            .write_confirmation_request(&pending)
+            .await?;
         state.machine.record_tool_call_with_audit(
             &tool_call.name,
             tool_arguments.clone(),

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -31,7 +31,6 @@ use crate::agent_machine::NormalizedToolCall;
 use crate::{
     agent_machine::{AgentMachine, DeferredRuntimeAction, TurnActivityState},
     config::Config,
-    retry,
     runtime::RuntimeConfig,
 };
 
@@ -108,118 +107,6 @@ impl RuntimeLoopState {
 
     pub(crate) fn tool_execution(&self) -> NamespaceToolExecution {
         self.environment.tool_execution()
-    }
-
-    pub(crate) async fn write_namespace_confirmation_request(
-        &self,
-        pending: &crate::approval::PendingConfirmation,
-    ) -> Result<Option<String>> {
-        let kind = crate::approval::runtime_confirmation_control_kind(&pending.checkpoint_type)
-            .unwrap_or("confirmation");
-        let options = serde_json::to_string(&serde_json::json!({
-            "checkpoint_id": pending.checkpoint_id.clone(),
-            "checkpoint_type": pending.checkpoint_type.clone(),
-            "details": pending.details.clone(),
-            "options": pending.options.clone(),
-        }))?;
-        let request_id = self
-            .agent_files()
-            .write_request(
-                namespace_environment::NamespaceRequestRecord::new(kind, pending.summary.clone())
-                    .with_options(options),
-            )
-            .await?;
-        Ok(Some(request_id))
-    }
-
-    pub(crate) async fn write_namespace_structured_input_request(
-        &self,
-        pending: &crate::approval::PendingStructuredInputRequest,
-    ) -> Result<Option<String>> {
-        let options = serde_json::to_string(&serde_json::json!({
-            "request_id": pending.request_id.clone(),
-            "title": pending.title.clone(),
-            "questions": pending.questions.clone(),
-        }))?;
-        let request_id = self
-            .agent_files()
-            .write_request(
-                namespace_environment::NamespaceRequestRecord::new(
-                    "structured_input",
-                    pending.prompt.clone(),
-                )
-                .with_options(options),
-            )
-            .await?;
-        Ok(Some(request_id))
-    }
-
-    pub(crate) async fn generate_once_with_cancel(
-        &mut self,
-        request: crate::llm::GenerationRequest,
-        cancel: &CancellationToken,
-        cancel_message: &'static str,
-    ) -> Result<crate::llm::GenerationResponse> {
-        let generation = self.namespace_generation();
-        match generation.generate_controlled(&request, 0, cancel).await {
-            Err(_) if cancel.is_cancelled() => Err(anyhow::anyhow!(cancel_message)),
-            result => result,
-        }
-    }
-
-    pub(crate) async fn generate_response_with_retry(
-        &mut self,
-        request: crate::llm::GenerationRequest,
-        timeout_secs: u64,
-        cancel: &CancellationToken,
-    ) -> Result<crate::llm::GenerationResponse> {
-        let max_retries = retry::DEFAULT_MAX_RETRIES;
-        let mut last_error = None;
-
-        for attempt in 0..=max_retries {
-            if cancel.is_cancelled() {
-                return Err(anyhow::anyhow!("LLM request cancelled"));
-            }
-
-            let generation = self.namespace_generation();
-            let attempt_request = request.clone();
-            let result = generation
-                .generate_controlled(&attempt_request, timeout_secs, cancel)
-                .await;
-
-            match result {
-                Ok(response) => return Ok(response),
-                Err(error) => {
-                    if !retry::is_retryable(&error) || attempt >= max_retries {
-                        return Err(error);
-                    }
-                    last_error = Some(error);
-                    let delay = retry::backoff_delay(attempt + 1);
-                    tokio::select! {
-                        _ = cancel.cancelled() => return Err(anyhow::anyhow!("LLM request cancelled")),
-                        _ = tokio::time::sleep(delay) => {}
-                    }
-                }
-            }
-        }
-
-        Err(last_error.unwrap_or_else(|| anyhow::anyhow!("Max retries exceeded")))
-    }
-
-    pub(crate) async fn static_tool_names(&self) -> Result<Vec<String>> {
-        Ok(self
-            .tool_execution()
-            .discover_packages()
-            .await?
-            .into_iter()
-            .map(|manifest| manifest.name)
-            .collect())
-    }
-
-    pub(crate) fn default_tool_cwd(&self) -> Option<std::path::PathBuf> {
-        self.tool_execution()
-            .execution_binding()
-            .map(|binding| binding.cwd)
     }
 }
 

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/agent_files.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/agent_files.rs
@@ -163,6 +163,40 @@ impl NamespaceAgentFiles {
         write_request_record(&client, &self.agent_path, record).await
     }
 
+    pub(crate) async fn write_confirmation_request(
+        &self,
+        pending: &crate::approval::PendingConfirmation,
+    ) -> Result<String> {
+        let kind = crate::approval::runtime_confirmation_control_kind(&pending.checkpoint_type)
+            .unwrap_or("confirmation");
+        let options = serde_json::to_string(&serde_json::json!({
+            "checkpoint_id": pending.checkpoint_id.clone(),
+            "checkpoint_type": pending.checkpoint_type.clone(),
+            "details": pending.details.clone(),
+            "options": pending.options.clone(),
+        }))?;
+        self.write_request(
+            NamespaceRequestRecord::new(kind, pending.summary.clone()).with_options(options),
+        )
+        .await
+    }
+
+    pub(crate) async fn write_structured_input_request(
+        &self,
+        pending: &crate::approval::PendingStructuredInputRequest,
+    ) -> Result<String> {
+        let options = serde_json::to_string(&serde_json::json!({
+            "request_id": pending.request_id.clone(),
+            "title": pending.title.clone(),
+            "questions": pending.questions.clone(),
+        }))?;
+        self.write_request(
+            NamespaceRequestRecord::new("structured_input", pending.prompt.clone())
+                .with_options(options),
+        )
+        .await
+    }
+
     pub async fn write_action(&self, record: NamespaceActionRecord) -> Result<String> {
         let client = NamespaceClient::new(self.root.clone());
         write_action_record(&client, &self.agent_path, record).await

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/generation.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/generation.rs
@@ -77,6 +77,56 @@ impl NamespaceGeneration {
         Ok(response)
     }
 
+    pub(crate) async fn generate_once_with_cancel(
+        &self,
+        request: GenerationRequest,
+        cancel: &CancellationToken,
+        cancel_message: &'static str,
+    ) -> Result<GenerationResponse> {
+        match self.generate_controlled(&request, 0, cancel).await {
+            Err(_) if cancel.is_cancelled() => Err(anyhow::anyhow!(cancel_message)),
+            result => result,
+        }
+    }
+
+    pub(crate) async fn generate_response_with_retry(
+        &self,
+        request: GenerationRequest,
+        timeout_secs: u64,
+        cancel: &CancellationToken,
+    ) -> Result<GenerationResponse> {
+        let max_retries = crate::retry::DEFAULT_MAX_RETRIES;
+        let mut last_error = None;
+
+        for attempt in 0..=max_retries {
+            if cancel.is_cancelled() {
+                return Err(anyhow::anyhow!("LLM request cancelled"));
+            }
+
+            let result = self
+                .generate_controlled(&request, timeout_secs, cancel)
+                .await;
+            match result {
+                Ok(response) => return Ok(response),
+                Err(error) => {
+                    if !crate::retry::is_retryable(&error) || attempt >= max_retries {
+                        return Err(error);
+                    }
+                    last_error = Some(error);
+                    let delay = crate::retry::backoff_delay(attempt + 1);
+                    tokio::select! {
+                        _ = cancel.cancelled() => {
+                            return Err(anyhow::anyhow!("LLM request cancelled"));
+                        }
+                        _ = tokio::time::sleep(delay) => {}
+                    }
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| anyhow::anyhow!("Max retries exceeded")))
+    }
+
     pub async fn generate_with_text_events_controlled<E, F>(
         &self,
         request: &GenerationRequest,

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/tool_execution.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/tool_execution.rs
@@ -19,6 +19,19 @@ impl NamespaceToolExecution {
         context.tool_runner.process_binding(context.pid)
     }
 
+    pub(crate) fn default_cwd(&self) -> Option<std::path::PathBuf> {
+        self.execution_binding().map(|binding| binding.cwd)
+    }
+
+    pub(crate) async fn static_tool_names(&self) -> Result<Vec<String>> {
+        Ok(self
+            .discover_packages()
+            .await?
+            .into_iter()
+            .map(|manifest| manifest.name)
+            .collect())
+    }
+
     pub(crate) fn resolve_capability(
         &self,
         package: &ToolPackageManifest,

--- a/crates/agent-engine/src/runtime/transition/tests.rs
+++ b/crates/agent-engine/src/runtime/transition/tests.rs
@@ -506,13 +506,14 @@ impl LlmProvider for SequencedMockProvider {
 
 #[tokio::test]
 async fn namespace_generation_retries_transient_llmfs_errors() {
-    let mut state = runtime_state_with_provider(SequencedMockProvider::new(vec![
+    let state = runtime_state_with_provider(SequencedMockProvider::new(vec![
         SequencedStep::Error("503 unavailable".to_string()),
         SequencedStep::Success("recovered".to_string()),
     ]));
     let cancel = CancellationToken::new();
 
     let response = state
+        .namespace_generation()
         .generate_response_with_retry(
             GenerationRequest::new().with_user_message("hello"),
             0,
@@ -530,12 +531,13 @@ async fn namespace_generation_aborts_timed_out_generation_before_retry() {
     let (root, _procfs) =
         namespace_root_with_provider(TimeoutThenSucceedStreamProvider::new(Arc::clone(&attempts)));
     let shell = Shell::new(root.clone());
-    let mut state = runtime_state_with_environment(NamespaceRuntimeEnvironment::new(
+    let state = runtime_state_with_environment(NamespaceRuntimeEnvironment::new(
         root, "/agent/1", "default",
     ));
     let cancel = CancellationToken::new();
 
     let response = state
+        .namespace_generation()
         .generate_response_with_retry(
             GenerationRequest::new().with_user_message("hello"),
             1,

--- a/crates/agent-engine/src/runtime/virtual_tools.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools.rs
@@ -67,9 +67,9 @@ where
                 pending.details =
                     append_skill_permission_hints(pending.details, state.machine.active_skills());
                 let request_id = state
-                    .write_namespace_confirmation_request(&pending)
-                    .await?
-                    .unwrap_or_else(|| pending.checkpoint_id.clone());
+                    .agent_files()
+                    .write_confirmation_request(&pending)
+                    .await?;
                 let pending_payload = json!({
                     "status": "pending_confirmation",
                     "request_id": request_id.clone()
@@ -155,9 +155,9 @@ where
                 parse_structured_user_input_request(&tool_call.id, tool_arguments)
             {
                 let request_id = state
-                    .write_namespace_structured_input_request(&request)
-                    .await?
-                    .unwrap_or_else(|| request.request_id.clone());
+                    .agent_files()
+                    .write_structured_input_request(&request)
+                    .await?;
                 let pending_payload =
                     json!({"status": "pending_structured_input", "request_id": request_id.clone()});
                 emit(Event::ToolCallCompleted {

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -201,7 +201,12 @@ fn namespace_environment_reaches_capabilities_only_through_files() {
     ] {
         assert!(production.contains(required), "missing {required:?}");
     }
-    for required in ["write_agent_output", "{agent_path}/machine/tape"] {
+    for required in [
+        "write_agent_output",
+        "{agent_path}/machine/tape",
+        "write_confirmation_request",
+        "write_structured_input_request",
+    ] {
         assert!(
             agent_files.contains(required),
             "AgentFS file owner missing {required:?}"
@@ -215,6 +220,12 @@ fn namespace_environment_reaches_capabilities_only_through_files() {
         generation.contains("/mnt/llm/connections/{llm_connection}/clone"),
         "llmfs generation owner must clone through its file surface"
     );
+    for operation in ["generate_once_with_cancel", "generate_response_with_retry"] {
+        assert!(
+            generation.contains(operation),
+            "llmfs generation handle missing {operation}"
+        );
+    }
     assert!(
         !production.contains("/mnt/llm/connections/{llm_connection}/clone"),
         "namespace environment coordinator must leave llmfs protocol details to generation owner"
@@ -329,6 +340,24 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
         .expect("find end of turn_tool_definitions")];
     assert!(!tool_definitions.contains("RuntimeLoopState"));
     assert!(tool_definitions.contains("NamespaceToolExecution"));
+}
+
+#[test]
+fn runtime_loop_does_not_forward_narrow_handle_operations() {
+    let transition = read_runtime_source("transition.rs");
+    for operation in [
+        "write_namespace_confirmation_request",
+        "write_namespace_structured_input_request",
+        "generate_once_with_cancel",
+        "generate_response_with_retry",
+        "static_tool_names",
+        "default_tool_cwd",
+    ] {
+        assert!(
+            !transition.contains(operation),
+            "RuntimeLoopState retained forwarding operation {operation}"
+        );
+    }
 }
 
 #[test]
@@ -450,6 +479,12 @@ fn tool_workflows_use_only_the_narrow_tool_execution_handle() {
     let tool_operations = read_runtime_source("transition/namespace_environment/tool_execution.rs");
     assert!(tool_operations.contains("impl NamespaceToolExecution"));
     assert!(!tool_operations.contains("impl NamespaceRuntimeEnvironment"));
+    for operation in ["default_cwd", "static_tool_names"] {
+        assert!(
+            tool_operations.contains(operation),
+            "Tool execution handle missing {operation}"
+        );
+    }
 
     for path in [
         "tool_orchestrator.rs",


### PR DESCRIPTION
## Summary
- move confirmation and structured-input request writes onto NamespaceAgentFiles
- move controlled generation and retry behavior onto NamespaceGeneration
- move Tool cwd and mounted Tool-name queries onto NamespaceToolExecution
- delete the RuntimeLoopState forwarding methods and unreachable fallback paths
- enforce the handle ownership boundary with architecture absence checks

## Validation
- cargo test -p alan-agent-engine
- cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings
- repository commit quality gate