### PR TITLE
refactor(agent-engine): narrow turn lifecycle helpers

### DIFF
--- a/crates/agent-engine/src/runtime/delegated_skill_tool.rs
+++ b/crates/agent-engine/src/runtime/delegated_skill_tool.rs
@@ -262,6 +262,7 @@ where
         });
     }
 
+    let agent_files = state.agent_files();
     let (persisted_request, result, child_run) =
         match resolve_delegated_skill_invocation(state, &request) {
             Ok(spec) => {
@@ -273,7 +274,8 @@ where
                     Ok(mut child_result) => {
                         if cancel.is_cancelled()
                             && child_result.is_cancelled()
-                            && check_turn_cancelled(state, emit, cancel).await?
+                            && check_turn_cancelled(&mut state.machine, &agent_files, emit, cancel)
+                                .await?
                         {
                             return Ok(VirtualToolOutcome::EndTurn);
                         }
@@ -297,7 +299,8 @@ where
                     }
                     Err(err) => {
                         if cancel.is_cancelled()
-                            && check_turn_cancelled(state, emit, cancel).await?
+                            && check_turn_cancelled(&mut state.machine, &agent_files, emit, cancel)
+                                .await?
                         {
                             return Ok(VirtualToolOutcome::EndTurn);
                         }

--- a/crates/agent-engine/src/runtime/submission_handlers.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers.rs
@@ -95,7 +95,8 @@ where
             .await;
         }
         Op::Interrupt => {
-            cancel_current_task(state, emit).await?;
+            let agent_files = state.agent_files();
+            cancel_current_task(&mut state.machine, &agent_files, emit).await?;
         }
 
         // ====================================================================

--- a/crates/agent-engine/src/runtime/tool_orchestrator.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator.rs
@@ -784,7 +784,10 @@ where
         tool_timeout_secs,
     )
     .await;
-    if inputs.cancel.is_cancelled() && check_turn_cancelled(state, emit, inputs.cancel).await? {
+    let agent_files = state.agent_files();
+    if inputs.cancel.is_cancelled()
+        && check_turn_cancelled(&mut state.machine, &agent_files, emit, inputs.cancel).await?
+    {
         return Ok(ToolOrchestratorOutcome::EndTurn);
     }
 

--- a/crates/agent-engine/src/runtime/transition/tests/core_behaviors.rs
+++ b/crates/agent-engine/src/runtime/transition/tests/core_behaviors.rs
@@ -170,7 +170,8 @@ async fn test_cancel_current_task() {
         async {}
     };
 
-    let result = cancel_current_task(&mut state, &mut emit).await;
+    let agent_files = state.agent_files();
+    let result = cancel_current_task(&mut state.machine, &agent_files, &mut emit).await;
 
     assert!(result.is_ok());
     assert!(state.machine.pending_confirmation().is_none());

--- a/crates/agent-engine/src/runtime/turn_driver.rs
+++ b/crates/agent-engine/src/runtime/turn_driver.rs
@@ -171,7 +171,8 @@ where
                         // Report and clear buffered in-turn submissions before cancel_current_task
                         // resets Machine turn state, otherwise the drop count under-reports.
                         emit_dropped_in_turn_submissions(emit, &mut state.machine, broker).await;
-                        cancel_current_task(state, emit).await?;
+                        let agent_files = state.agent_files();
+                        cancel_current_task(&mut state.machine, &agent_files, emit).await?;
                         return Ok(None);
                     }
                     emit_dropped_in_turn_submissions(emit, &mut state.machine, broker).await;

--- a/crates/agent-engine/src/runtime/turn_executor.rs
+++ b/crates/agent-engine/src/runtime/turn_executor.rs
@@ -276,7 +276,7 @@ where
             warn!("Context compaction timeout - continuing without compaction");
         }
     }
-    if check_turn_cancelled(state, emit, cancel).await? {
+    if check_turn_cancelled(&mut state.machine, &agent_files, emit, cancel).await? {
         return Ok(TurnExecutionOutcome::Finished);
     }
 
@@ -361,7 +361,7 @@ where
     let mut response_guardrails = ResponseGuardrails::default();
     let mut pending_guardrail_instruction: Option<String> = None;
     loop {
-        if check_turn_cancelled(state, emit, cancel).await? {
+        if check_turn_cancelled(&mut state.machine, &agent_files, emit, cancel).await? {
             return Ok(TurnExecutionOutcome::Finished);
         }
         let provider = generation.provider();
@@ -439,7 +439,9 @@ where
         {
             Ok(response) => response,
             Err(error) => {
-                if cancel.is_cancelled() && check_turn_cancelled(state, emit, cancel).await? {
+                if cancel.is_cancelled()
+                    && check_turn_cancelled(&mut state.machine, &agent_files, emit, cancel).await?
+                {
                     return Ok(TurnExecutionOutcome::Finished);
                 }
                 log_generation_failure(request_start, &error);
@@ -509,7 +511,7 @@ where
                     ),
                 )
                 .await?;
-                if check_turn_cancelled(state, emit, cancel).await? {
+                if check_turn_cancelled(&mut state.machine, &agent_files, emit, cancel).await? {
                     return Ok(TurnExecutionOutcome::Finished);
                 }
                 continue;
@@ -611,7 +613,7 @@ where
                         ),
                     )
                     .await?;
-                    if check_turn_cancelled(state, emit, cancel).await? {
+                    if check_turn_cancelled(&mut state.machine, &agent_files, emit, cancel).await? {
                         return Ok(TurnExecutionOutcome::Finished);
                     }
                 }
@@ -675,7 +677,7 @@ where
 
         finalize_turn_memory_best_effort(state, false, "turn-completed", "after completed turn")
             .await;
-        emit_task_completed_success(state, emit, "Task completed").await?;
+        emit_task_completed_success(&agent_files, emit, "Task completed").await?;
         return Ok(TurnExecutionOutcome::Finished);
     }
 }

--- a/crates/agent-engine/src/runtime/turn_support.rs
+++ b/crates/agent-engine/src/runtime/turn_support.rs
@@ -4,11 +4,12 @@ use tokio_util::sync::CancellationToken;
 use tracing::warn;
 use uuid::Uuid;
 
-use super::transition::RuntimeLoopState;
-use crate::agent_machine::NormalizedToolCall;
+use super::transition::NamespaceAgentFiles;
+use crate::agent_machine::{AgentMachine, NormalizedToolCall};
 
 pub(super) async fn cancel_current_task<E, F>(
-    state: &mut RuntimeLoopState,
+    machine: &mut AgentMachine,
+    agent_files: &NamespaceAgentFiles,
     emit: &mut E,
 ) -> Result<()>
 where
@@ -18,10 +19,10 @@ where
     warn!("Cancelling current task");
     // Clear turn-scoped pending state, but preserve machine history so the user can
     // continue the same conversation after an interrupt/cancel.
-    state.machine.reset_turn();
-    state.machine.clear_plan_snapshot();
-    state.machine.clear_active_task();
-    super::ui_surfaces::turn_completed(&state.agent_files(), true).await?;
+    machine.reset_turn();
+    machine.clear_plan_snapshot();
+    machine.clear_active_task();
+    super::ui_surfaces::turn_completed(agent_files, true).await?;
     emit(Event::TurnCompleted {
         summary: Some("Task cancelled by user".to_string()),
     })
@@ -30,7 +31,7 @@ where
 }
 
 pub(super) async fn emit_task_completed_success<E, F>(
-    state: &RuntimeLoopState,
+    agent_files: &NamespaceAgentFiles,
     emit: &mut E,
     summary: impl Into<String>,
 ) -> Result<()>
@@ -39,7 +40,7 @@ where
     F: std::future::Future<Output = ()>,
 {
     let summary = summary.into();
-    super::ui_surfaces::turn_completed(&state.agent_files(), false).await?;
+    super::ui_surfaces::turn_completed(agent_files, false).await?;
     emit(Event::TurnCompleted {
         summary: Some(summary),
     })
@@ -173,7 +174,8 @@ where
 }
 
 pub(super) async fn check_turn_cancelled<E, F>(
-    state: &mut RuntimeLoopState,
+    machine: &mut AgentMachine,
+    agent_files: &NamespaceAgentFiles,
     emit: &mut E,
     cancel: &CancellationToken,
 ) -> Result<bool>
@@ -184,7 +186,7 @@ where
     if !cancel.is_cancelled() {
         return Ok(false);
     }
-    if !state.machine.is_turn_active() && !state.machine.has_pending_interaction() {
+    if !machine.is_turn_active() && !machine.has_pending_interaction() {
         emit(Event::Error {
             message: "No active turn to cancel.".to_string(),
             recoverable: true,
@@ -192,6 +194,6 @@ where
         .await;
         return Ok(false);
     }
-    cancel_current_task(state, emit).await?;
+    cancel_current_task(machine, agent_files, emit).await?;
     Ok(true)
 }

--- a/crates/agent-engine/src/runtime/virtual_tools.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools.rs
@@ -49,7 +49,10 @@ where
     E: FnMut(Event) -> F,
     F: std::future::Future<Output = ()>,
 {
-    if cancel.is_cancelled() && check_turn_cancelled(state, emit, cancel).await? {
+    let agent_files = state.agent_files();
+    if cancel.is_cancelled()
+        && check_turn_cancelled(&mut state.machine, &agent_files, emit, cancel).await?
+    {
         return Ok(VirtualToolOutcome::EndTurn);
     }
 

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -323,7 +323,11 @@ fn turn_generation_uses_only_the_file_native_namespace_boundary() {
 
 #[test]
 fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
-    for path in ["response_guardrails.rs", "steering_queue.rs"] {
+    for path in [
+        "response_guardrails.rs",
+        "steering_queue.rs",
+        "turn_support.rs",
+    ] {
         let source = read_runtime_source(path);
         assert!(
             !source.contains("RuntimeLoopState"),


### PR DESCRIPTION
## Summary
- make turn cancellation consume AgentMachine and NamespaceAgentFiles directly
- make successful turn completion consume only NamespaceAgentFiles
- update transition callers to resolve the file handle at their owning boundary
- extend the architecture absence guard so turn_support cannot regain RuntimeLoopState

## Validation
- cargo test -p alan-agent-engine
- cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings
- repository commit quality gate