### PR TITLE
refactor(agent-engine): narrow transition observers

### DIFF
--- a/crates/agent-engine/src/runtime/delegated_skill_evidence.rs
+++ b/crates/agent-engine/src/runtime/delegated_skill_evidence.rs
@@ -14,7 +14,7 @@ use super::delegated_skill_tool::{
     DelegatedSkillInvocationRequest, MAX_DELEGATED_PATH_CHARS, MAX_DELEGATED_SKILL_ID_CHARS,
     MAX_DELEGATED_TARGET_CHARS, MAX_DELEGATED_TASK_CHARS,
 };
-use super::transition::{NamespaceActionRecord, RuntimeLoopState};
+use super::transition::{NamespaceActionRecord, NamespaceAgentFiles};
 
 pub(super) const MAX_DELEGATED_STRUCTURED_OUTPUT_CHARS: usize = 4_000;
 pub(super) const MAX_DELEGATED_CHILD_RUN_METADATA_CHARS: usize = 2_000;
@@ -30,7 +30,7 @@ pub(super) struct DelegatedSkillRolloutRecord {
 }
 
 pub(super) async fn persist_delegated_child_evidence(
-    state: &RuntimeLoopState,
+    agent_files: &NamespaceAgentFiles,
     request: &DelegatedSkillInvocationRequest,
     result: &ChildRuntimeResult,
 ) -> Option<DelegatedSkillOutputRef> {
@@ -55,8 +55,7 @@ pub(super) async fn persist_delegated_child_evidence(
     {
         result_doc["child_agent_path"] = json!(agent_path);
     }
-    let action_id = state
-        .agent_files()
+    let action_id = agent_files
         .write_action(
             NamespaceActionRecord::new(
                 format!("delegate:{}", request.skill_id),
@@ -68,9 +67,7 @@ pub(super) async fn persist_delegated_child_evidence(
         )
         .await
         .ok()?;
-    let path = format!("{}/actions/{action_id}/output", state.agent_path());
-    let agent_files = state.agent_files();
-    let reference = agent_files.evidence_reference(path).await?;
+    let reference = agent_files.action_output_reference(&action_id).await?;
     agent_files
         .resolve_evidence_reference(&reference, None, result.child_run_value())
         .await

--- a/crates/agent-engine/src/runtime/delegated_skill_evidence_tests.rs
+++ b/crates/agent-engine/src/runtime/delegated_skill_evidence_tests.rs
@@ -25,7 +25,8 @@ async fn redaction_expansion_preserves_delegated_output_reference_and_child_path
     };
 
     assert!(result.output_text.chars().count() <= MAX_DELEGATED_RESULT_OUTPUT_INLINE_CHARS);
-    let output_ref = persist_delegated_child_evidence(&state, &request, &result)
+    let agent_files = state.agent_files();
+    let output_ref = persist_delegated_child_evidence(&agent_files, &request, &result)
         .await
         .expect("redaction-expanded child output should retain a reference");
     let delegated = result.delegated_result(Some(output_ref.clone()));
@@ -152,7 +153,8 @@ async fn failed_delegated_evidence_uses_namespace_refs_with_debug_rollout_paths(
             child_run: Some(test_child_run_record(&child_run_id, "parent-machine")),
         };
 
-        let output_ref = persist_delegated_child_evidence(&state, &request, &result)
+        let agent_files = state.agent_files();
+        let output_ref = persist_delegated_child_evidence(&agent_files, &request, &result)
             .await
             .expect("failed child output reference");
         assert!(output_ref.path.starts_with("/agent/1/actions/"));

--- a/crates/agent-engine/src/runtime/delegated_skill_tool.rs
+++ b/crates/agent-engine/src/runtime/delegated_skill_tool.rs
@@ -281,7 +281,8 @@ where
                         }
 
                         let output_reference =
-                            persist_delegated_child_evidence(state, &request, &child_result).await;
+                            persist_delegated_child_evidence(&agent_files, &request, &child_result)
+                                .await;
                         if let (Some(child_run_id), Some(reference)) = (
                             child_result.child_run_id.as_deref(),
                             output_reference.as_ref(),

--- a/crates/agent-engine/src/runtime/memory_surfaces.rs
+++ b/crates/agent-engine/src/runtime/memory_surfaces.rs
@@ -8,8 +8,6 @@ use tracing::warn;
 use crate::agent_machine::AgentMachine;
 use crate::tape::Message;
 
-use super::transition::RuntimeLoopState;
-
 const MAX_INLINE_TEXT_CHARS: usize = 280;
 const MAX_RECENT_MESSAGE_ITEMS: usize = 6;
 const MAX_PLAN_ITEMS_PER_SECTION: usize = 6;
@@ -27,12 +25,12 @@ struct RenderedMemorySurfaces {
     daily_entry: String,
 }
 
-pub(crate) async fn refresh_turn_memory_surfaces(state: &RuntimeLoopState) -> Result<()> {
-    if !state.core_config.memory.enabled {
-        return Ok(());
-    }
-
-    let Some(memory_dir) = state.core_config.memory.store_dir.as_deref() else {
+pub(crate) async fn refresh_turn_memory_surfaces(
+    machine: &AgentMachine,
+    memory_dir: Option<&Path>,
+    process_path: &str,
+) -> Result<()> {
+    let Some(memory_dir) = memory_dir else {
         return Ok(());
     };
 
@@ -40,9 +38,8 @@ pub(crate) async fn refresh_turn_memory_surfaces(state: &RuntimeLoopState) -> Re
         .with_context(|| format!("failed to ensure memory layout at {}", memory_dir.display()))?;
 
     let now = Utc::now();
-    let process_path = state.process_path();
-    let memory_record_id = state.machine.memory_record_id();
-    let rendered = render_memory_surfaces(&state.machine, &process_path, memory_record_id, now);
+    let memory_record_id = machine.memory_record_id();
+    let rendered = render_memory_surfaces(machine, process_path, memory_record_id, now);
 
     write_text_file(
         &working_memory_path(memory_dir, memory_record_id),
@@ -61,23 +58,27 @@ pub(crate) async fn refresh_turn_memory_surfaces(state: &RuntimeLoopState) -> Re
 }
 
 pub(crate) async fn refresh_turn_memory_surfaces_best_effort(
-    state: &RuntimeLoopState,
+    machine: &AgentMachine,
+    memory_dir: Option<&Path>,
+    process_path: &str,
     context: &'static str,
 ) {
-    if let Err(err) = refresh_turn_memory_surfaces(state).await {
+    if let Err(err) = refresh_turn_memory_surfaces(machine, memory_dir, process_path).await {
         warn!(error = %err, context, "Failed to refresh memory surfaces");
     }
 }
 
 pub(crate) async fn refresh_active_turn_memory_surfaces_best_effort(
-    state: &RuntimeLoopState,
+    machine: &AgentMachine,
+    memory_dir: Option<&Path>,
+    process_path: &str,
     context: &'static str,
 ) {
-    if state.machine.active_turn_message_start().is_none() {
+    if machine.active_turn_message_start().is_none() {
         return;
     }
 
-    refresh_turn_memory_surfaces_best_effort(state, context).await;
+    refresh_turn_memory_surfaces_best_effort(machine, memory_dir, process_path, context).await;
 }
 
 fn render_memory_surfaces(

--- a/crates/agent-engine/src/runtime/memory_surfaces/tests.rs
+++ b/crates/agent-engine/src/runtime/memory_surfaces/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::agent_machine::AgentMachine;
+use crate::runtime::transition::RuntimeLoopState;
 use std::sync::Arc;
 
 fn namespace_environment_for_test() -> crate::runtime::NamespaceRuntimeEnvironment {
@@ -373,7 +374,10 @@ async fn refresh_turn_memory_surfaces_writes_expected_files() {
         prompt_cache: super::super::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
-    refresh_turn_memory_surfaces(&state).await.unwrap();
+    let process_path = state.process_path();
+    refresh_turn_memory_surfaces(&state.machine, Some(&memory_dir), &process_path)
+        .await
+        .unwrap();
 
     assert!(working_memory_path(&memory_dir, state.machine.memory_record_id()).exists());
     assert!(latest_handoff_path(&memory_dir).exists());
@@ -411,7 +415,10 @@ async fn refresh_memory_surfaces_needs_no_model_request_or_llm_mount() {
         prompt_cache: super::super::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
-    refresh_turn_memory_surfaces(&state).await.unwrap();
+    let process_path = state.process_path();
+    refresh_turn_memory_surfaces(&state.machine, Some(&memory_dir), &process_path)
+        .await
+        .unwrap();
 
     assert_eq!(state.machine.messages().len(), message_count);
     let working = tokio::fs::read_to_string(working_memory_path(

--- a/crates/agent-engine/src/runtime/tool_orchestrator.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator.rs
@@ -21,7 +21,7 @@ use super::steering_queue::handle_queued_steering_inputs;
 use super::tool_effect_lifecycle::{EffectCategory, build_effect_identity};
 use super::tool_effect_lifecycle::{ToolEffectLifecycle, ToolEffectPlan};
 use super::tool_policy::{ToolPolicyDecision, evaluate_tool_policy};
-use super::transition::RuntimeLoopState;
+use super::transition::{NamespaceAgentFiles, RuntimeLoopState};
 use super::turn_driver::TurnInputBroker;
 use super::turn_support::{check_turn_cancelled, tool_result_preview};
 use super::virtual_tools::{VirtualToolOutcome, try_handle_virtual_tool_call};
@@ -245,7 +245,7 @@ fn namespace_tool_payload(
     Ok(payload)
 }
 
-async fn tool_payload_for_tape(state: &RuntimeLoopState, payload: &Value) -> Value {
+async fn tool_payload_for_tape(agent_files: &NamespaceAgentFiles, payload: &Value) -> Value {
     let redacted_payload = redact_evidence_payload(payload);
     if !payload_needs_projection(&redacted_payload) {
         return redacted_payload;
@@ -267,9 +267,7 @@ async fn tool_payload_for_tape(state: &RuntimeLoopState, payload: &Value) -> Val
             Some("reference_unresolvable".to_string()),
         );
     }
-    let path = format!("{}/actions/{action_id}/output", state.agent_path());
-    let agent_files = state.agent_files();
-    let reference = agent_files.evidence_reference(path).await;
+    let reference = agent_files.action_output_reference(action_id).await;
     let redactions = if let Some(reference) = reference.as_ref() {
         agent_files
             .resolve_evidence_reference(reference, None, None)
@@ -813,7 +811,7 @@ where
                     reason,
                 );
             }
-            let tape_value = tool_payload_for_tape(state, &value).await;
+            let tape_value = tool_payload_for_tape(&agent_files, &value).await;
             emit(Event::ToolCallCompleted {
                 presentation: super::tool_presentation::tool_presentation(
                     &tool_call.name,
@@ -971,8 +969,17 @@ where
             is_final: true,
         })
         .await;
+        let memory_dir = state
+            .core_config
+            .memory
+            .enabled
+            .then_some(state.core_config.memory.store_dir.as_deref())
+            .flatten();
+        let process_path = state.process_path();
         super::memory_surfaces::refresh_active_turn_memory_surfaces_best_effort(
-            state,
+            &state.machine,
+            memory_dir,
+            &process_path,
             "tool-loop-guard-ended-turn",
         )
         .await;

--- a/crates/agent-engine/src/runtime/tool_orchestrator/tests/namespace_and_batch_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator/tests/namespace_and_batch_contract.inc.rs
@@ -164,7 +164,7 @@
             "content": "x".repeat(crate::evidence::MAX_INLINE_EVIDENCE_BYTES + 1)
         });
 
-        let projected = tool_payload_for_tape(&state, &payload).await;
+        let projected = tool_payload_for_tape(&state.agent_files(), &payload).await;
 
         assert!(projected.get("reference").is_none());
         assert_eq!(

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -393,8 +393,17 @@ async fn finalize_replayed_tool_end_turn_best_effort(
 ) {
     if !cancel.is_cancelled() {
         if !surfaces_refreshed {
+            let memory_dir = state
+                .core_config
+                .memory
+                .enabled
+                .then_some(state.core_config.memory.store_dir.as_deref())
+                .flatten();
+            let process_path = state.process_path();
             super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(
-                state,
+                &state.machine,
+                memory_dir,
+                &process_path,
                 surfaces_context,
             )
             .await;

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/agent_files.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/agent_files.rs
@@ -290,6 +290,17 @@ impl NamespaceAgentFiles {
 
     /// Build a bounded reference only when the path currently resolves in this
     /// Agent Process namespace.
+    pub(crate) async fn action_output_reference(
+        &self,
+        action_id: &str,
+    ) -> Option<NamespaceEvidenceReference> {
+        validate_agent_file_id(action_id, "action id").ok()?;
+        self.evidence_reference(format!("{}/actions/{action_id}/output", self.agent_path))
+            .await
+    }
+
+    /// Build a bounded reference only when the path currently resolves in this
+    /// Agent Process namespace.
     pub(crate) async fn evidence_reference(
         &self,
         path: impl Into<String>,

--- a/crates/agent-engine/src/runtime/turn_executor.rs
+++ b/crates/agent-engine/src/runtime/turn_executor.rs
@@ -89,8 +89,20 @@ async fn finalize_turn_memory_best_effort(
     promotion_context: &'static str,
 ) {
     if !surfaces_refreshed {
-        super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(state, surfaces_context)
-            .await;
+        let memory_dir = state
+            .core_config
+            .memory
+            .enabled
+            .then_some(state.core_config.memory.store_dir.as_deref())
+            .flatten();
+        let process_path = state.process_path();
+        super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(
+            &state.machine,
+            memory_dir,
+            &process_path,
+            surfaces_context,
+        )
+        .await;
     }
 
     if let Some(job) =

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -324,6 +324,8 @@ fn turn_generation_uses_only_the_file_native_namespace_boundary() {
 #[test]
 fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
     for path in [
+        "delegated_skill_evidence.rs",
+        "memory_surfaces.rs",
         "response_guardrails.rs",
         "steering_queue.rs",
         "turn_support.rs",
@@ -344,6 +346,16 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
         .expect("find end of turn_tool_definitions")];
     assert!(!tool_definitions.contains("RuntimeLoopState"));
     assert!(tool_definitions.contains("NamespaceToolExecution"));
+
+    let tool_orchestrator = read_runtime_source("tool_orchestrator.rs");
+    let tool_evidence = &tool_orchestrator[tool_orchestrator
+        .find("async fn tool_payload_for_tape")
+        .expect("find tool_payload_for_tape")..];
+    let tool_evidence = &tool_evidence[..tool_evidence
+        .find("async fn execute_tool_effect")
+        .expect("find end of tool_payload_for_tape")];
+    assert!(!tool_evidence.contains("RuntimeLoopState"));
+    assert!(tool_evidence.contains("NamespaceAgentFiles"));
 }
 
 #[test]
@@ -389,6 +401,7 @@ fn agent_file_workflows_use_only_the_narrow_agent_files_handle() {
     let file_operations = read_runtime_source("transition/namespace_environment/agent_files.rs");
     assert!(file_operations.contains("impl NamespaceAgentFiles"));
     assert!(!file_operations.contains("impl NamespaceRuntimeEnvironment"));
+    assert!(file_operations.contains("action_output_reference"));
 
     let ui = read_runtime_source("ui_surfaces.rs");
     let ui_production = ui.split("\n#[cfg(test)]\nmod tests").next().unwrap();


### PR DESCRIPTION
## Summary
- give delegated-skill and tool evidence projection only the AgentFS handle they need
- make memory-surface refresh depend on Agent Machine, optional store root, and process path instead of RuntimeLoopState
- add architecture guards that keep observer workflows off the runtime aggregate

## Verification
- cargo test -p alan-agent-engine (1198 passed, 1 ignored)
- cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings
- repository commit quality gate