### PR TITLE
refactor(agent-engine): narrow memory promotion inputs

### DIFF
--- a/crates/agent-engine/src/runtime/engine_tests.rs
+++ b/crates/agent-engine/src/runtime/engine_tests.rs
@@ -73,9 +73,15 @@ fn make_deferred_action_for_test() -> DeferredRuntimeAction {
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
-    memory_promotion::build_turn_memory_promotion_job(&state, "queue ordering test")
-        .map(DeferredRuntimeAction::TurnMemoryPromotion)
-        .expect("build deferred memory promotion job")
+    memory_promotion::build_turn_memory_promotion_job(
+        &state.machine,
+        state.core_config.memory.store_dir.clone(),
+        state.process_path(),
+        state.runtime_config.llm_request_timeout_secs,
+        "queue ordering test",
+    )
+    .map(DeferredRuntimeAction::TurnMemoryPromotion)
+    .expect("build deferred memory promotion job")
 }
 
 fn queue_item_kinds(queue: &VecDeque<QueuedRuntimeItem>) -> Vec<&'static str> {

--- a/crates/agent-engine/src/runtime/memory_promotion.rs
+++ b/crates/agent-engine/src/runtime/memory_promotion.rs
@@ -10,7 +10,6 @@ use chrono::{DateTime, Datelike, Utc};
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 
-#[cfg(test)]
 use crate::agent_machine::AgentMachine;
 #[cfg(test)]
 use crate::llm::LlmClient;
@@ -21,7 +20,7 @@ use crate::prompts::{
 };
 use crate::tape::Message;
 
-use super::transition::RuntimeLoopState;
+use super::transition::NamespaceGeneration;
 
 const DEFAULT_PROMOTED_FACTS_HEADER: &str = "## Promoted Facts";
 const DEFAULT_TOPIC_SUMMARY: &str = "Promoted from inbox entries.";
@@ -258,27 +257,24 @@ pub(crate) struct TurnMemoryPromotionJob {
 }
 
 pub(crate) fn build_turn_memory_promotion_job(
-    state: &RuntimeLoopState,
+    machine: &AgentMachine,
+    memory_dir: Option<PathBuf>,
+    process_path: String,
+    llm_request_timeout_secs: u64,
     warning_context: &'static str,
 ) -> Option<TurnMemoryPromotionJob> {
-    if !state.core_config.memory.enabled {
-        return None;
-    }
-
-    let memory_dir = state.core_config.memory.store_dir.clone()?;
-    let active_turn_user_messages = active_turn_user_messages(
-        state.machine.messages(),
-        state.machine.active_turn_message_start(),
-    );
+    let memory_dir = memory_dir?;
+    let active_turn_user_messages =
+        active_turn_user_messages(machine.messages(), machine.active_turn_message_start());
     if active_turn_user_messages.is_empty() {
         return None;
     }
 
     Some(TurnMemoryPromotionJob {
         memory_dir,
-        process_path: state.process_path(),
+        process_path,
         active_turn_user_messages,
-        llm_request_timeout_secs: state.runtime_config.llm_request_timeout_secs,
+        llm_request_timeout_secs,
         warning_context,
     })
 }
@@ -301,13 +297,12 @@ pub(crate) async fn run_turn_memory_promotion_job_with_cancel(
 }
 
 pub(crate) async fn run_turn_memory_promotion_job_for_runtime_with_cancel(
-    state: &mut RuntimeLoopState,
+    generation: &NamespaceGeneration,
     job: &TurnMemoryPromotionJob,
     cancel: &CancellationToken,
 ) -> Result<()> {
     let request = build_memory_promotion_request(job.active_turn_user_messages.clone());
-    let response = state
-        .namespace_generation()
+    let response = generation
         .generate_response_with_retry(request, job.llm_request_timeout_secs, cancel)
         .await
         .context("generate turn-end memory promotion plan")?;

--- a/crates/agent-engine/src/runtime/memory_promotion/tests.rs
+++ b/crates/agent-engine/src/runtime/memory_promotion/tests.rs
@@ -428,7 +428,7 @@ async fn deferred_memory_promotion_uses_namespace_llmfs() {
         Access::ReadWrite,
     );
     let root = InProcessTransport::new(Arc::new(MountFs::new(namespace)));
-    let mut state = RuntimeLoopState {
+    let state = RuntimeLoopState {
         machine: AgentMachine::new(),
         environment: NamespaceRuntimeEnvironment::new(root, "/agent/1", "default"),
         core_config: Config::default(),
@@ -444,8 +444,9 @@ async fn deferred_memory_promotion_uses_namespace_llmfs() {
         warning_context: "test",
     };
 
+    let generation = state.namespace_generation();
     run_turn_memory_promotion_job_for_runtime_with_cancel(
-        &mut state,
+        &generation,
         &job,
         &CancellationToken::new(),
     )

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -408,9 +408,20 @@ async fn finalize_replayed_tool_end_turn_best_effort(
             )
             .await;
         }
-        if let Some(job) =
-            super::memory_promotion::build_turn_memory_promotion_job(state, promotion_context)
-        {
+        let memory_dir = state
+            .core_config
+            .memory
+            .enabled
+            .then(|| state.core_config.memory.store_dir.clone())
+            .flatten();
+        let process_path = state.process_path();
+        if let Some(job) = super::memory_promotion::build_turn_memory_promotion_job(
+            &state.machine,
+            memory_dir,
+            process_path,
+            state.runtime_config.llm_request_timeout_secs,
+            promotion_context,
+        ) {
             state
                 .machine
                 .push_deferred_runtime_action(DeferredRuntimeAction::TurnMemoryPromotion(job));
@@ -427,8 +438,11 @@ pub(super) async fn run_deferred_runtime_action_with_cancel(
 ) -> DeferredRuntimeActionExit {
     match action {
         DeferredRuntimeAction::TurnMemoryPromotion(job) => {
+            let generation = state.namespace_generation();
             match super::memory_promotion::run_turn_memory_promotion_job_for_runtime_with_cancel(
-                state, &job, cancel,
+                &generation,
+                &job,
+                cancel,
             )
             .await
             {

--- a/crates/agent-engine/src/runtime/turn_executor.rs
+++ b/crates/agent-engine/src/runtime/turn_executor.rs
@@ -105,9 +105,20 @@ async fn finalize_turn_memory_best_effort(
         .await;
     }
 
-    if let Some(job) =
-        super::memory_promotion::build_turn_memory_promotion_job(state, promotion_context)
-    {
+    let memory_dir = state
+        .core_config
+        .memory
+        .enabled
+        .then(|| state.core_config.memory.store_dir.clone())
+        .flatten();
+    let process_path = state.process_path();
+    if let Some(job) = super::memory_promotion::build_turn_memory_promotion_job(
+        &state.machine,
+        memory_dir,
+        process_path,
+        state.runtime_config.llm_request_timeout_secs,
+        promotion_context,
+    ) {
         state
             .machine
             .push_deferred_runtime_action(DeferredRuntimeAction::TurnMemoryPromotion(job));

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -325,6 +325,7 @@ fn turn_generation_uses_only_the_file_native_namespace_boundary() {
 fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
     for path in [
         "delegated_skill_evidence.rs",
+        "memory_promotion.rs",
         "memory_surfaces.rs",
         "response_guardrails.rs",
         "steering_queue.rs",


### PR DESCRIPTION
## Summary
- build turn-end promotion jobs from explicit Agent Machine, Memory Store, Process path, and timeout inputs
- execute promotion generation through the narrow namespace generation handle
- prevent memory promotion from regaining RuntimeLoopState access

## Verification
- cargo test -p alan-agent-engine (1198 passed, 1 ignored)
- cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings
- repository commit quality gate