### PR TITLE
refactor(agent-engine): isolate child launch runtime inputs

### DIFF
--- a/crates/agent-engine/src/runtime/child_agents.rs
+++ b/crates/agent-engine/src/runtime/child_agents.rs
@@ -1,5 +1,6 @@
 mod delegated_launch;
 mod launch_context;
+mod runtime_inputs;
 mod runtime_startup;
 mod task_context;
 #[cfg(test)]
@@ -13,7 +14,6 @@ use super::delegated_child_run::ChildRuntimeStatus;
 use super::delegated_child_run::{DelegatedChildRunSupervision, DelegatedChildRunSupervisor};
 use super::engine::{runtime_host_capabilities_for_tools, spawn_with_namespace_environment};
 use super::launch_config::{AgentProcessConfig, effective_core_config_for_runtime};
-use super::transition::RuntimeLoopState;
 #[cfg(test)]
 use crate::llm::LlmClient;
 use crate::tape::ContentPart;
@@ -46,6 +46,9 @@ use test_namespace::{
     spawn_child_namespace_runtime_environment,
 };
 use tokio_util::sync::CancellationToken;
+
+pub(crate) use runtime_inputs::{ChildLaunchRuntime, ChildTaskContext};
+pub(crate) use task_context::project_child_task_context;
 
 const ROUTE_MOUNT_PATH: &str = "/mnt/route";
 #[cfg(test)]
@@ -85,7 +88,7 @@ impl LlmProvider for ChildLlmProvider {
 
 #[cfg(test)]
 pub(crate) async fn spawn_child_runtime(
-    parent: &RuntimeLoopState,
+    parent: ChildLaunchRuntime,
     spec: SpawnSpec,
 ) -> Result<DelegatedChildRunSupervisor> {
     spawn_child_runtime_with_optional_cancel(parent, spec, None).await
@@ -96,7 +99,7 @@ pub(crate) async fn spawn_child_runtime(
     reason = "cancellable adapter remains available to focused child-runtime tests"
 )]
 pub(crate) async fn spawn_child_runtime_cancellable(
-    parent: &RuntimeLoopState,
+    parent: ChildLaunchRuntime,
     spec: SpawnSpec,
     cancel: &CancellationToken,
 ) -> Result<DelegatedChildRunSupervisor> {
@@ -104,7 +107,7 @@ pub(crate) async fn spawn_child_runtime_cancellable(
 }
 
 async fn spawn_child_runtime_with_optional_cancel(
-    parent: &RuntimeLoopState,
+    parent: ChildLaunchRuntime,
     spec: SpawnSpec,
     cancel: Option<&CancellationToken>,
 ) -> Result<DelegatedChildRunSupervisor> {
@@ -120,7 +123,7 @@ async fn spawn_child_runtime_with_optional_cancel(
 
 #[cfg(test)]
 async fn spawn_child_runtime_with_client_factory<F>(
-    parent: &RuntimeLoopState,
+    parent: ChildLaunchRuntime,
     spec: SpawnSpec,
     llm_client_factory: F,
 ) -> Result<DelegatedChildRunSupervisor>
@@ -135,7 +138,7 @@ type TestChildLlmClientFactory<'a> =
     Box<dyn FnOnce(&crate::Config) -> Result<LlmClient> + Send + 'a>;
 
 async fn spawn_child_runtime_inner(
-    parent: &RuntimeLoopState,
+    parent: ChildLaunchRuntime,
     mut spec: SpawnSpec,
     #[cfg(test)] llm_client_factory: Option<TestChildLlmClientFactory<'_>>,
     cancel: Option<&CancellationToken>,
@@ -145,10 +148,10 @@ async fn spawn_child_runtime_inner(
     }
 
     let child_cwd = validate_child_launch_contract(&spec)?;
-    let launch_root_dir = resolve_launch_root_dir(parent, &spec.target)?;
-    let child_agent_config = build_child_agent_config(parent, &spec);
+    let launch_root_dir = resolve_launch_root_dir(&parent, &spec.target)?;
+    let child_agent_config = build_child_agent_config(&parent, &spec);
     let parent_launch_context = parent
-        .child_launch()
+        .child_launch
         .launch_context()
         .cloned()
         .unwrap_or_else(crate::ProcessLaunchContext::root);
@@ -166,10 +169,20 @@ async fn spawn_child_runtime_inner(
         // parent's effective config as a terminal env override.
         core_config_source: crate::ConfigSourceKind::Default,
         launch_context,
-        store_bindings: parent.runtime_config.store_bindings.clone(),
+        store_bindings: parent
+            .base_agent_config
+            .runtime_config
+            .store_bindings
+            .clone(),
         memory_store_backing: spec
             .has_handle(SpawnHandle::Memory)
-            .then(|| parent.runtime_config.memory_store_backing.clone())
+            .then(|| {
+                parent
+                    .base_agent_config
+                    .runtime_config
+                    .memory_store_backing
+                    .clone()
+            })
             .flatten(),
         recovery_rollout_path: None,
     };
@@ -186,8 +199,12 @@ async fn spawn_child_runtime_inner(
         .apply_to_agent_config(&child_agent_config)
         .context("Failed to resolve effective child Agent Process config")?;
     if spec.has_handle(SpawnHandle::Memory) {
-        resolved_child_agent_config.core_config.memory.store_dir =
-            parent.core_config.memory.store_dir.clone();
+        resolved_child_agent_config.core_config.memory.store_dir = parent
+            .base_agent_config
+            .core_config
+            .memory
+            .store_dir
+            .clone();
     } else {
         resolved_child_agent_config.core_config.memory.store_dir = None;
     }
@@ -196,7 +213,7 @@ async fn spawn_child_runtime_inner(
     let effective_child_core_config = effective_core_config_for_runtime(&child_config)
         .context("Failed to resolve effective child Agent Process runtime config")?;
     let child_namespace_plan = build_child_namespace_assembly_plan(
-        parent,
+        &parent,
         &spec,
         &effective_child_core_config,
         child_config.launch_context.clone(),
@@ -204,9 +221,9 @@ async fn spawn_child_runtime_inner(
     .await
     .context("Failed to assemble child Agent Process namespace plan")?;
     let child_connection = child_namespace_plan.llm_connection_name()?;
-    ensure_child_connection_is_passed(parent, &child_connection)?;
+    ensure_child_connection_is_passed(&parent, &child_connection)?;
     let delegation_capability_decision =
-        evaluate_delegated_launch_capabilities(parent, &mut spec, &child_namespace_plan).await?;
+        evaluate_delegated_launch_capabilities(&parent, &mut spec, &child_namespace_plan).await?;
     #[cfg(test)]
     let test_llm = if let Some(factory) = llm_client_factory {
         let client = factory(&effective_child_core_config)
@@ -221,7 +238,7 @@ async fn spawn_child_runtime_inner(
         None
     };
     let assembler = parent
-        .child_launch()
+        .child_launch
         .assembler()
         .context("parent Agent Process has no Agent Runtime Service child assembly capability")?;
     let assembly = assembler
@@ -269,11 +286,11 @@ async fn spawn_child_runtime_inner(
             return Err(err);
         }
     };
-    let child_run_registry = parent.child_run_registry().clone();
+    let child_run_registry = parent.child_run_registry.clone();
     let child_run_id = uuid::Uuid::new_v4().to_string();
     let mut child_run_record = ChildRunRecord::new(
         child_run_id.clone(),
-        parent.process_path(),
+        parent.parent_process_path.clone(),
         startup_metadata.process_path.clone(),
         Some(startup_metadata.agent_path.clone()),
         Some(format!("{:?}", spec.target)),
@@ -284,7 +301,8 @@ async fn spawn_child_runtime_inner(
     child_run_registry.register(child_run_record);
     let submission = Submission::new(Op::Turn {
         parts: vec![ContentPart::text(task_context::build_child_task_text(
-            parent, &spec,
+            &parent.task_context,
+            &spec,
         ))],
         context: None,
     });
@@ -317,7 +335,7 @@ async fn spawn_child_runtime_inner(
 type ChildNamespaceAssemblyPlan = super::ChildAgentProcessAssemblyPlan;
 
 async fn build_child_namespace_assembly_plan(
-    parent: &RuntimeLoopState,
+    parent: &ChildLaunchRuntime,
     spec: &SpawnSpec,
     child_core_config: &crate::Config,
     launch_context: crate::ProcessLaunchContext,
@@ -343,7 +361,7 @@ async fn build_child_namespace_assembly_plan(
         launch_context,
     };
 
-    let packages = parent.tool_execution().discover_packages().await?;
+    let packages = parent.tool_execution.discover_packages().await?;
     plan.tool_packages = if let Some(profile) = spec.runtime_overrides.tool_profile.as_ref() {
         let available = packages
             .iter()

--- a/crates/agent-engine/src/runtime/child_agents/delegated_launch.rs
+++ b/crates/agent-engine/src/runtime/child_agents/delegated_launch.rs
@@ -1,14 +1,14 @@
 use super::{ChildNamespaceAssemblyPlan, ROUTE_MOUNT_PATH};
+use crate::runtime::child_agents::ChildLaunchRuntime;
 use crate::runtime::delegation_capabilities::{
     DelegatedSpawnRejected, evaluate_delegated_namespace, namespace_summary_from_bindings,
 };
-use crate::runtime::transition::RuntimeLoopState;
 use alan_agent_protocol::{DelegatedCapabilityDecision, DelegatedCapabilityRecovery, SpawnSpec};
 use anyhow::Result;
 use std::path::PathBuf;
 
 pub(super) async fn evaluate_delegated_launch_capabilities(
-    parent: &RuntimeLoopState,
+    parent: &ChildLaunchRuntime,
     spec: &mut SpawnSpec,
     plan: &ChildNamespaceAssemblyPlan,
 ) -> Result<Option<DelegatedCapabilityDecision>> {
@@ -65,10 +65,9 @@ fn namespace_summary_from_child_plan(
 }
 
 async fn namespace_summary_from_parent(
-    parent: &RuntimeLoopState,
+    parent: &ChildLaunchRuntime,
 ) -> Result<alan_agent_protocol::DelegatedNamespaceSummary> {
-    let child_launch = parent.child_launch();
-    let launch_context = child_launch.launch_context();
+    let launch_context = parent.child_launch.launch_context();
     let mut described = launch_context
         .map(|context| context.namespace.describe())
         .unwrap_or_default();
@@ -87,7 +86,7 @@ async fn namespace_summary_from_parent(
             .map(|(path, _)| path.clone())
             .collect(),
         parent
-            .tool_execution()
+            .tool_execution
             .static_tool_names()
             .await?
             .into_iter()
@@ -96,6 +95,7 @@ async fn namespace_summary_from_parent(
         cwd,
         Some(
             parent
+                .base_agent_config
                 .core_config
                 .connection_profile
                 .clone()

--- a/crates/agent-engine/src/runtime/child_agents/launch_context.rs
+++ b/crates/agent-engine/src/runtime/child_agents/launch_context.rs
@@ -1,15 +1,14 @@
+use crate::runtime::child_agents::ChildLaunchRuntime;
 use crate::runtime::launch_config::AgentConfig;
-use crate::runtime::transition::RuntimeLoopState;
 use alan_agent_protocol::{GovernanceConfig, SpawnHandle, SpawnSpec, SpawnTarget};
 use anyhow::{Context, Result, bail};
 use std::path::PathBuf;
 
 pub(super) fn ensure_child_connection_is_passed(
-    parent: &RuntimeLoopState,
+    parent: &ChildLaunchRuntime,
     requested: &str,
 ) -> Result<()> {
-    let child_launch = parent.child_launch();
-    let passed = child_launch.connection_name();
+    let passed = parent.child_launch.connection_name();
     if requested != passed {
         bail!(
             "Connection '{requested}' was not passed to the child Agent Process by the parent Process; available Connection is '{passed}'."
@@ -157,13 +156,12 @@ pub(super) fn validate_child_launch_contract(spec: &SpawnSpec) -> Result<Option<
 }
 
 pub(super) fn resolve_launch_root_dir(
-    parent: &RuntimeLoopState,
+    parent: &ChildLaunchRuntime,
     target: &SpawnTarget,
 ) -> Result<Option<ResolvedLaunchRoot>> {
     match target {
         SpawnTarget::DefinitionDescriptor { descriptor } => {
-            let child_launch = parent.child_launch();
-            let launch_context = child_launch.launch_context();
+            let launch_context = parent.child_launch.launch_context();
             let descriptor = launch_context
                 .and_then(|context| context.descriptor(descriptor))
                 .with_context(|| format!("parent Process has no `{descriptor}` descriptor"))?;
@@ -186,8 +184,8 @@ pub(super) fn resolve_launch_root_dir(
         }
         SpawnTarget::PackageChildAgent { .. } => {
             let export = parent
-                .prompt_cache
-                .capability_view()
+                .capability_view
+                .as_ref()
                 .map(crate::skills::ResolvedCapabilityView::refresh)
                 .and_then(|view| view.resolve_child_agent_export(target).cloned())
                 .ok_or_else(|| {
@@ -206,16 +204,19 @@ pub(super) struct ResolvedLaunchRoot {
     pub(super) file_tree: Option<crate::ProcessFileTree>,
 }
 
-pub(super) fn build_child_agent_config(parent: &RuntimeLoopState, spec: &SpawnSpec) -> AgentConfig {
-    let mut child_agent_config = AgentConfig::from(parent.core_config.clone());
-    child_agent_config.runtime_config = parent.runtime_config.clone();
+pub(super) fn build_child_agent_config(
+    parent: &ChildLaunchRuntime,
+    spec: &SpawnSpec,
+) -> AgentConfig {
+    let mut child_agent_config = parent.base_agent_config.clone();
 
     if !spec.has_handle(SpawnHandle::Memory) {
         child_agent_config.core_config.memory.store_dir = None;
     }
 
     if spec.has_handle(SpawnHandle::ApprovalScope) {
-        child_agent_config.runtime_config.governance = parent.runtime_config.governance.clone();
+        child_agent_config.runtime_config.governance =
+            parent.base_agent_config.runtime_config.governance.clone();
     } else {
         child_agent_config.runtime_config.governance = GovernanceConfig::default();
     }

--- a/crates/agent-engine/src/runtime/child_agents/runtime_inputs.rs
+++ b/crates/agent-engine/src/runtime/child_agents/runtime_inputs.rs
@@ -1,0 +1,60 @@
+use crate::{
+    runtime::{
+        child_runs::ChildRunRegistry,
+        launch_config::AgentConfig,
+        transition::{NamespaceChildLaunch, NamespaceToolExecution},
+    },
+    skills::ResolvedCapabilityView,
+};
+
+pub(crate) struct ChildTaskContext {
+    pub(super) conversation_snapshot: Option<String>,
+    pub(super) plan_snapshot: Option<String>,
+    pub(super) tool_results_snapshot: Option<String>,
+}
+
+impl ChildTaskContext {
+    pub(crate) fn new(
+        conversation_snapshot: Option<String>,
+        plan_snapshot: Option<String>,
+        tool_results_snapshot: Option<String>,
+    ) -> Self {
+        Self {
+            conversation_snapshot,
+            plan_snapshot,
+            tool_results_snapshot,
+        }
+    }
+}
+
+pub(crate) struct ChildLaunchRuntime {
+    pub(super) base_agent_config: AgentConfig,
+    pub(super) child_launch: NamespaceChildLaunch,
+    pub(super) tool_execution: NamespaceToolExecution,
+    pub(super) child_run_registry: ChildRunRegistry,
+    pub(super) parent_process_path: String,
+    pub(super) capability_view: Option<ResolvedCapabilityView>,
+    pub(super) task_context: ChildTaskContext,
+}
+
+impl ChildLaunchRuntime {
+    pub(crate) fn new(
+        base_agent_config: AgentConfig,
+        child_launch: NamespaceChildLaunch,
+        tool_execution: NamespaceToolExecution,
+        child_run_registry: ChildRunRegistry,
+        parent_process_path: String,
+        capability_view: Option<ResolvedCapabilityView>,
+        task_context: ChildTaskContext,
+    ) -> Self {
+        Self {
+            base_agent_config,
+            child_launch,
+            tool_execution,
+            child_run_registry,
+            parent_process_path,
+            capability_view,
+            task_context,
+        }
+    }
+}

--- a/crates/agent-engine/src/runtime/child_agents/task_context.rs
+++ b/crates/agent-engine/src/runtime/child_agents/task_context.rs
@@ -1,6 +1,6 @@
-use crate::runtime::transition::RuntimeLoopState;
+use crate::runtime::child_agents::ChildTaskContext;
 use crate::tape::Message;
-use alan_agent_protocol::{SpawnHandle, SpawnSpec};
+use alan_agent_protocol::{PlanItem, SpawnHandle, SpawnSpec};
 
 const MAX_CHILD_CONVERSATION_MESSAGES: usize = 8;
 const MAX_CHILD_CONVERSATION_CHARS: usize = 4_000;
@@ -9,26 +9,40 @@ const MAX_CHILD_PLAN_ITEM_CHARS: usize = 240;
 const MAX_CHILD_TOOL_RESULTS: usize = 6;
 const MAX_CHILD_TOOL_RESULT_CHARS: usize = 1_200;
 
-pub(super) fn build_child_task_text(parent: &RuntimeLoopState, spec: &SpawnSpec) -> String {
+pub(crate) fn project_child_task_context(
+    tape_summary: Option<&str>,
+    messages: &[Message],
+    plan_explanation: Option<&str>,
+    plan_items: &[PlanItem],
+    spec: &SpawnSpec,
+) -> ChildTaskContext {
+    ChildTaskContext::new(
+        spec.has_handle(SpawnHandle::ConversationSnapshot)
+            .then(|| render_conversation_snapshot(tape_summary, messages))
+            .flatten(),
+        spec.has_handle(SpawnHandle::Plan)
+            .then(|| render_plan_snapshot(plan_explanation, plan_items))
+            .flatten(),
+        spec.has_handle(SpawnHandle::ToolResults)
+            .then(|| render_tool_results_snapshot(messages))
+            .flatten(),
+    )
+}
+
+pub(super) fn build_child_task_text(parent: &ChildTaskContext, spec: &SpawnSpec) -> String {
     let mut sections = vec![spec.launch.task.trim().to_string()];
 
     if let Some(metadata) = render_launch_metadata(spec) {
         sections.push(metadata);
     }
-    if spec.has_handle(SpawnHandle::ConversationSnapshot)
-        && let Some(snapshot) = render_conversation_snapshot(parent)
-    {
-        sections.push(snapshot);
+    if let Some(snapshot) = parent.conversation_snapshot.as_ref() {
+        sections.push(snapshot.clone());
     }
-    if spec.has_handle(SpawnHandle::Plan)
-        && let Some(snapshot) = render_plan_snapshot(parent)
-    {
-        sections.push(snapshot);
+    if let Some(snapshot) = parent.plan_snapshot.as_ref() {
+        sections.push(snapshot.clone());
     }
-    if spec.has_handle(SpawnHandle::ToolResults)
-        && let Some(snapshot) = render_tool_results_snapshot(parent)
-    {
-        sections.push(snapshot);
+    if let Some(snapshot) = parent.tool_results_snapshot.as_ref() {
+        sections.push(snapshot.clone());
     }
 
     sections
@@ -50,34 +64,33 @@ fn render_launch_metadata(spec: &SpawnSpec) -> Option<String> {
     (!lines.is_empty()).then(|| format!("Execution Context\n{}", lines.join("\n")))
 }
 
-fn render_conversation_snapshot(parent: &RuntimeLoopState) -> Option<String> {
+fn render_conversation_snapshot(
+    tape_summary: Option<&str>,
+    messages: &[Message],
+) -> Option<String> {
     let mut lines = Vec::new();
-    if let Some(summary) = parent.machine.tape_summary() {
+    if let Some(summary) = tape_summary {
         lines.push("Summary:".to_string());
         lines.push(truncate_chars(summary.trim(), MAX_CHILD_CONVERSATION_CHARS));
     }
 
-    let recent_messages = parent
-        .machine
-        .messages()
+    let recent_messages = messages
         .iter()
         .rev()
         .filter(|message| matches!(message, Message::User { .. } | Message::Assistant { .. }))
         .take(MAX_CHILD_CONVERSATION_MESSAGES)
-        .cloned()
         .collect::<Vec<_>>();
-
     if !recent_messages.is_empty() {
         lines.push("Recent Messages:".to_string());
         for message in recent_messages.into_iter().rev() {
-            let role = match &message {
+            let role = match message {
                 Message::User { .. } => "user",
                 Message::Assistant { .. } => "assistant",
                 Message::Tool { .. } => unreachable!("tool messages are filtered out above"),
                 Message::System { .. } => "system",
                 Message::Context { .. } => "context",
             };
-            let text = match &message {
+            let text = match message {
                 Message::Assistant { .. } => message.non_thinking_text_content(),
                 _ => message.text_content(),
             };
@@ -93,10 +106,9 @@ fn render_conversation_snapshot(parent: &RuntimeLoopState) -> Option<String> {
     (!lines.is_empty()).then(|| format!("Parent Conversation Snapshot\n{}", lines.join("\n")))
 }
 
-fn render_plan_snapshot(parent: &RuntimeLoopState) -> Option<String> {
-    let plan_snapshot = parent.machine.plan_snapshot()?;
+fn render_plan_snapshot(plan_explanation: Option<&str>, plan_items: &[PlanItem]) -> Option<String> {
     let mut lines = Vec::new();
-    if let Some(explanation) = plan_snapshot.explanation.as_deref()
+    if let Some(explanation) = plan_explanation
         && !explanation.trim().is_empty()
     {
         lines.push(format!(
@@ -104,7 +116,7 @@ fn render_plan_snapshot(parent: &RuntimeLoopState) -> Option<String> {
             truncate_chars(explanation.trim(), MAX_CHILD_PLAN_ITEM_CHARS)
         ));
     }
-    for item in plan_snapshot.items.iter().take(MAX_CHILD_PLAN_ITEMS) {
+    for item in plan_items.iter().take(MAX_CHILD_PLAN_ITEMS) {
         lines.push(format!(
             "- [{}] {}",
             match item.status {
@@ -119,11 +131,9 @@ fn render_plan_snapshot(parent: &RuntimeLoopState) -> Option<String> {
     (!lines.is_empty()).then(|| format!("Parent Plan Snapshot\n{}", lines.join("\n")))
 }
 
-fn render_tool_results_snapshot(parent: &RuntimeLoopState) -> Option<String> {
+fn render_tool_results_snapshot(messages: &[Message]) -> Option<String> {
     let mut lines = Vec::new();
-    for message in parent
-        .machine
-        .messages()
+    for message in messages
         .iter()
         .rev()
         .filter(|message| matches!(message, Message::Tool { .. }))
@@ -147,5 +157,58 @@ fn truncate_chars(text: &str, limit: usize) -> String {
         truncated
     } else {
         format!("{truncated}...")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alan_agent_protocol::{SpawnLaunchInputs, SpawnRuntimeOverrides, SpawnTarget};
+
+    fn spawn_spec(handles: Vec<SpawnHandle>) -> SpawnSpec {
+        SpawnSpec {
+            target: SpawnTarget::DefinitionDescriptor {
+                descriptor: "test-agent".to_string(),
+            },
+            launch: SpawnLaunchInputs {
+                task: "test child task".to_string(),
+                cwd: None,
+                timeout_secs: None,
+                output_dir: None,
+            },
+            handles,
+            runtime_overrides: SpawnRuntimeOverrides::default(),
+            delegated: None,
+        }
+    }
+
+    #[test]
+    fn tool_result_projection_is_handle_gated_and_bounded_before_storage() {
+        let messages = vec![Message::tool_text(
+            "large-tool-call",
+            "x".repeat(MAX_CHILD_TOOL_RESULT_CHARS * 4),
+        )];
+        let without_tool_results =
+            project_child_task_context(None, &messages, None, &[], &spawn_spec(Vec::new()));
+        assert!(without_tool_results.tool_results_snapshot.is_none());
+
+        let with_tool_results = project_child_task_context(
+            None,
+            &messages,
+            None,
+            &[],
+            &spawn_spec(vec![SpawnHandle::ToolResults]),
+        );
+        let snapshot = with_tool_results
+            .tool_results_snapshot
+            .expect("ToolResults handle should project bounded text");
+        assert!(snapshot.starts_with("Parent Tool Results\n- large-tool-call: "));
+        assert!(snapshot.ends_with("..."));
+        assert!(
+            snapshot.chars().count()
+                <= "Parent Tool Results\n- large-tool-call: ".chars().count()
+                    + MAX_CHILD_TOOL_RESULT_CHARS
+                    + 3
+        );
     }
 }

--- a/crates/agent-engine/src/runtime/child_agents/tests.rs
+++ b/crates/agent-engine/src/runtime/child_agents/tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::llm::{GenerationRequest, GenerationResponse, StreamChunk, TokenUsage};
 use crate::runtime::controller::RuntimeStartupMetadata;
+use crate::runtime::launch_config::AgentConfig;
+use crate::runtime::transition::RuntimeLoopState;
 use crate::runtime::{
     ApprovedMountGrant, ApprovedMountGrantAccess, MountGrantApplicator,
     MountGrantApplicatorFactory, NamespaceRuntimeEnvironment, RuntimeConfig,
@@ -18,6 +20,64 @@ use alan_llm::LlmProvider;
 use serde_json::json;
 use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
+
+fn child_launch_runtime(parent: &RuntimeLoopState, spec: &SpawnSpec) -> ChildLaunchRuntime {
+    super::super::transition::child_launch_runtime(parent, spec)
+}
+
+async fn spawn_child_runtime(
+    parent: &RuntimeLoopState,
+    spec: SpawnSpec,
+) -> Result<DelegatedChildRunSupervisor> {
+    let runtime = child_launch_runtime(parent, &spec);
+    super::spawn_child_runtime(runtime, spec).await
+}
+
+async fn spawn_child_runtime_cancellable(
+    parent: &RuntimeLoopState,
+    spec: SpawnSpec,
+    cancel: &CancellationToken,
+) -> Result<DelegatedChildRunSupervisor> {
+    let runtime = child_launch_runtime(parent, &spec);
+    super::spawn_child_runtime_cancellable(runtime, spec, cancel).await
+}
+
+async fn spawn_child_runtime_with_client_factory<F>(
+    parent: &RuntimeLoopState,
+    spec: SpawnSpec,
+    llm_client_factory: F,
+) -> Result<DelegatedChildRunSupervisor>
+where
+    F: FnOnce(&crate::Config) -> Result<LlmClient> + Send,
+{
+    let runtime = child_launch_runtime(parent, &spec);
+    super::spawn_child_runtime_with_client_factory(runtime, spec, llm_client_factory).await
+}
+
+async fn build_child_namespace_assembly_plan(
+    parent: &RuntimeLoopState,
+    spec: &SpawnSpec,
+    child_core_config: &crate::Config,
+    launch_context: crate::ProcessLaunchContext,
+) -> Result<ChildNamespaceAssemblyPlan> {
+    let runtime = child_launch_runtime(parent, spec);
+    super::build_child_namespace_assembly_plan(&runtime, spec, child_core_config, launch_context)
+        .await
+}
+
+async fn evaluate_delegated_launch_capabilities(
+    parent: &RuntimeLoopState,
+    spec: &mut SpawnSpec,
+    plan: &ChildNamespaceAssemblyPlan,
+) -> Result<Option<alan_agent_protocol::DelegatedCapabilityDecision>> {
+    let runtime = child_launch_runtime(parent, spec);
+    super::evaluate_delegated_launch_capabilities(&runtime, spec, plan).await
+}
+
+fn build_child_agent_config(parent: &RuntimeLoopState, spec: &SpawnSpec) -> AgentConfig {
+    let runtime = child_launch_runtime(parent, spec);
+    super::build_child_agent_config(&runtime, spec)
+}
 
 fn test_startup_metadata(
     process_path: impl Into<String>,

--- a/crates/agent-engine/src/runtime/delegated_skill_tool.rs
+++ b/crates/agent-engine/src/runtime/delegated_skill_tool.rs
@@ -379,7 +379,8 @@ async fn spawn_and_join_delegated_child(
         return Ok(ChildRuntimeResult::cancelled_before_launch());
     }
 
-    let controller = spawn_child_runtime_cancellable(state, spec, cancel).await?;
+    let runtime = super::transition::child_launch_runtime(state, &spec);
+    let controller = spawn_child_runtime_cancellable(runtime, spec, cancel).await?;
     controller.join_until_cancelled(cancel).await
 }
 

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -137,6 +137,34 @@ pub(super) fn compaction_runtime(
     )
 }
 
+pub(super) fn child_launch_runtime(
+    state: &RuntimeLoopState,
+    spec: &alan_agent_protocol::SpawnSpec,
+) -> super::child_agents::ChildLaunchRuntime {
+    let mut base_agent_config = super::launch_config::AgentConfig::from(state.core_config.clone());
+    base_agent_config.runtime_config = state.runtime_config.clone();
+    let (plan_explanation, plan_items) = match state.machine.plan_snapshot() {
+        Some(snapshot) => (snapshot.explanation.as_deref(), snapshot.items.as_slice()),
+        None => (None, &[][..]),
+    };
+    let task_context = super::child_agents::project_child_task_context(
+        state.machine.tape_summary(),
+        state.machine.messages(),
+        plan_explanation,
+        plan_items,
+        spec,
+    );
+    super::child_agents::ChildLaunchRuntime::new(
+        base_agent_config,
+        state.child_launch(),
+        state.tool_execution(),
+        state.child_run_registry().clone(),
+        state.process_path(),
+        state.prompt_cache.capability_view().cloned(),
+        task_context,
+    )
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TransitionCompletion {
     Completed,

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -374,6 +374,30 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
     ] {
         assert!(!compaction_inputs.contains(forbidden));
     }
+
+    for path in [
+        "child_agents.rs",
+        "child_agents/delegated_launch.rs",
+        "child_agents/launch_context.rs",
+        "child_agents/runtime_inputs.rs",
+        "child_agents/task_context.rs",
+    ] {
+        let source = read_runtime_source(path);
+        for forbidden in ["RuntimeLoopState", "NamespaceRuntimeEnvironment"] {
+            assert!(
+                !source.contains(forbidden),
+                "{path} must receive only child-launch configuration, snapshots, and namespace handles"
+            );
+        }
+    }
+    let child_launch_inputs = read_runtime_source("child_agents/runtime_inputs.rs");
+    assert!(!child_launch_inputs.contains("RuntimeConfig"));
+    assert!(!child_launch_inputs.contains("Vec<Message>"));
+    assert!(child_launch_inputs.contains("ChildLaunchRuntime"));
+    assert!(child_launch_inputs.contains("ChildTaskContext"));
+    let child_task_context = read_runtime_source("child_agents/task_context.rs");
+    assert!(child_task_context.contains("spec.has_handle(SpawnHandle::ToolResults)"));
+
     for marker in [
         "fn compaction_submission_id",
         "async fn record_and_emit_compaction_attempt",
@@ -694,7 +718,8 @@ fn engine_has_no_host_connection_store_or_provider_factory_authority() {
         );
     }
     assert!(child.contains("ensure_child_connection_is_passed"));
-    assert!(child.contains(".child_launch()"));
+    assert!(child.contains("ChildLaunchRuntime"));
+    assert!(child.contains(".child_launch"));
     assert!(child.contains(".assembler()"));
     assert!(child.contains("Agent Runtime Service child assembly capability"));
 }

--- a/crates/service-manager/tests/agent_runtime_ownership.rs
+++ b/crates/service-manager/tests/agent_runtime_ownership.rs
@@ -58,7 +58,8 @@ fn runtime_assembly_call_paths_have_explicit_owners() {
 
     let child_runtime = include_str!("../../agent-engine/src/runtime/child_agents.rs");
     let live_child_launch = rust_item_body(child_runtime, "async fn spawn_child_runtime_inner");
-    assert!(live_child_launch.contains(".child_launch()"));
+    assert!(child_runtime.contains("ChildLaunchRuntime"));
+    assert!(live_child_launch.contains(".child_launch"));
     assert!(live_child_launch.contains(".assembler()"));
     for displaced in [
         "child_process_assembler()",


### PR DESCRIPTION
## Summary

- project child-launch configuration, Process handles, capability view, registry, and bounded Machine task snapshots at the transition boundary
- remove RuntimeLoopState and NamespaceRuntimeEnvironment from child launch, launch-context, task-context, and delegation-capability workflows
- preserve test coverage through the real transition projection and enforce the narrow dependency boundary

## Verification

- cargo check -p alan-agent-engine --all-targets
- cargo test -p alan-agent-engine
- cargo test -p alan-agent-engine runtime::child_agents::tests
- cargo test -p alan-agent-engine --test dependency_boundary
- cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings
- repository commit quality gate