### PR TITLE
refactor(agent-engine): isolate delegated skill runtime inputs

### DIFF
--- a/crates/agent-engine/src/runtime/delegated_skill_tool.rs
+++ b/crates/agent-engine/src/runtime/delegated_skill_tool.rs
@@ -1,3 +1,5 @@
+mod runtime_inputs;
+
 use std::path::{Component, Path, PathBuf};
 use std::pin::Pin;
 
@@ -11,7 +13,7 @@ use tokio_util::sync::CancellationToken;
 use crate::llm::ToolDefinition;
 use crate::skills::{DelegatedSkillResult, DelegatedSkillResultStatus};
 
-use super::child_agents::spawn_child_runtime_cancellable;
+use super::child_agents::{ChildLaunchRuntime, spawn_child_runtime_cancellable};
 use super::delegated_child_run::ChildRuntimeResult;
 use super::delegated_skill_evidence::{
     build_bounded_delegated_invocation_persistence, persist_delegated_child_evidence,
@@ -19,10 +21,11 @@ use super::delegated_skill_evidence::{
 use super::delegation_capabilities::{
     DelegatedSpawnRejected, classify_delegated_task_requirements,
 };
-use super::transition::RuntimeLoopState;
 use super::turn_support::{check_turn_cancelled, tool_result_preview};
 use super::virtual_tool::VirtualToolOutcome;
 use crate::agent_machine::NormalizedToolCall;
+
+pub(crate) use runtime_inputs::{DelegatedChildRuntimeInputs, DelegatedSkillRuntime};
 
 pub(super) const MAX_DELEGATED_SKILL_ID_CHARS: usize = 120;
 pub(super) const MAX_DELEGATED_TARGET_CHARS: usize = 120;
@@ -148,7 +151,7 @@ pub(super) fn invoke_delegated_skill_tool_definition() -> ToolDefinition {
 }
 
 pub(super) async fn handle_invoke_delegated_skill<E, F>(
-    state: &mut RuntimeLoopState,
+    runtime: DelegatedSkillRuntime<'_>,
     tool_call: &NormalizedToolCall,
     tool_arguments: &serde_json::Value,
     cancel: &CancellationToken,
@@ -159,18 +162,18 @@ where
     F: std::future::Future<Output = ()>,
 {
     handle_invoke_delegated_skill_with_spawn(
-        state,
+        runtime,
         tool_call,
         tool_arguments,
         cancel,
         emit,
-        |state, spec, cancel| Box::pin(spawn_and_join_delegated_child(state, spec, cancel)),
+        |runtime, spec, cancel| Box::pin(spawn_and_join_delegated_child(runtime, spec, cancel)),
     )
     .await
 }
 
 pub(super) async fn handle_invoke_delegated_skill_with_spawn<E, F, S>(
-    state: &mut RuntimeLoopState,
+    mut runtime: DelegatedSkillRuntime<'_>,
     tool_call: &NormalizedToolCall,
     tool_arguments: &serde_json::Value,
     cancel: &CancellationToken,
@@ -181,7 +184,7 @@ where
     E: FnMut(Event) -> F,
     F: std::future::Future<Output = ()>,
     S: for<'a> FnOnce(
-        &'a RuntimeLoopState,
+        ChildLaunchRuntime,
         SpawnSpec,
         &'a CancellationToken,
     ) -> Pin<
@@ -210,13 +213,13 @@ where
             audit: None,
         })
         .await;
-        state.machine.record_tool_call(
+        runtime.machine.record_tool_call(
             &tool_call.name,
             tool_arguments.clone(),
             error_payload.clone(),
             false,
         );
-        state
+        runtime
             .machine
             .add_tool_message(&tool_call.id, &tool_call.name, error_payload.clone());
         emit(Event::Error {
@@ -229,7 +232,7 @@ where
         });
     };
 
-    if !state.prompt_cache.supports_delegated_skill_invocation() {
+    if !runtime.prompt_cache.supports_delegated_skill_invocation() {
         let error_payload = json!({
             "status": "delegated_invocation_unavailable",
             "error": "Delegated skill invocation is not available in this runtime."
@@ -243,13 +246,13 @@ where
             audit: None,
         })
         .await;
-        state.machine.record_tool_call(
+        runtime.machine.record_tool_call(
             &tool_call.name,
             tool_arguments.clone(),
             error_payload.clone(),
             false,
         );
-        state
+        runtime
             .machine
             .add_tool_message(&tool_call.id, &tool_call.name, error_payload);
         emit(Event::Error {
@@ -262,35 +265,48 @@ where
         });
     }
 
-    let agent_files = state.agent_files();
     let (persisted_request, result, child_run) =
-        match resolve_delegated_skill_invocation(state, &request) {
+        match resolve_delegated_skill_invocation(&mut runtime, &request) {
             Ok(spec) => {
                 let persisted_request = request.with_effective_launch_inputs(
                     spec.launch.cwd.clone(),
                     spec.launch.timeout_secs,
                 );
-                match spawn_child(state, spec, cancel).await {
+                let child_result = if cancel.is_cancelled() {
+                    Ok(ChildRuntimeResult::cancelled_before_launch())
+                } else {
+                    let child_runtime = runtime.child_launch_runtime(&spec);
+                    spawn_child(child_runtime, spec, cancel).await
+                };
+                match child_result {
                     Ok(mut child_result) => {
                         if cancel.is_cancelled()
                             && child_result.is_cancelled()
-                            && check_turn_cancelled(&mut state.machine, &agent_files, emit, cancel)
-                                .await?
+                            && check_turn_cancelled(
+                                &mut *runtime.machine,
+                                &runtime.agent_files,
+                                emit,
+                                cancel,
+                            )
+                            .await?
                         {
                             return Ok(VirtualToolOutcome::EndTurn);
                         }
 
-                        let output_reference =
-                            persist_delegated_child_evidence(&agent_files, &request, &child_result)
-                                .await;
+                        let output_reference = persist_delegated_child_evidence(
+                            &runtime.agent_files,
+                            &request,
+                            &child_result,
+                        )
+                        .await;
                         if let (Some(child_run_id), Some(reference)) = (
                             child_result.child_run_id.as_deref(),
                             output_reference.as_ref(),
                         ) {
-                            state
+                            runtime
                                 .child_run_registry()
                                 .set_state_ref(child_run_id, reference.clone());
-                            child_result.child_run = state.child_run_registry().get(child_run_id);
+                            child_result.child_run = runtime.child_run_registry().get(child_run_id);
                         }
                         (
                             persisted_request,
@@ -300,8 +316,13 @@ where
                     }
                     Err(err) => {
                         if cancel.is_cancelled()
-                            && check_turn_cancelled(&mut state.machine, &agent_files, emit, cancel)
-                                .await?
+                            && check_turn_cancelled(
+                                &mut *runtime.machine,
+                                &runtime.agent_files,
+                                emit,
+                                cancel,
+                            )
+                            .await?
                         {
                             return Ok(VirtualToolOutcome::EndTurn);
                         }
@@ -356,13 +377,13 @@ where
         audit: None,
     })
     .await;
-    state.machine.record_tool_call(
+    runtime.machine.record_tool_call(
         &tool_call.name,
         persisted_arguments,
         rollout_payload,
         invocation_succeeded,
     );
-    state
+    runtime
         .machine
         .add_tool_message(&tool_call.id, &tool_call.name, tape_payload);
     Ok(VirtualToolOutcome::Continue {
@@ -371,7 +392,7 @@ where
 }
 
 async fn spawn_and_join_delegated_child(
-    state: &RuntimeLoopState,
+    runtime: ChildLaunchRuntime,
     spec: SpawnSpec,
     cancel: &CancellationToken,
 ) -> Result<ChildRuntimeResult> {
@@ -379,16 +400,15 @@ async fn spawn_and_join_delegated_child(
         return Ok(ChildRuntimeResult::cancelled_before_launch());
     }
 
-    let runtime = super::transition::child_launch_runtime(state, &spec);
     let controller = spawn_child_runtime_cancellable(runtime, spec, cancel).await?;
     controller.join_until_cancelled(cancel).await
 }
 
 fn resolve_delegated_skill_invocation(
-    state: &mut RuntimeLoopState,
+    runtime: &mut DelegatedSkillRuntime<'_>,
     request: &DelegatedSkillInvocationRequest,
 ) -> DelegatedSkillSpawnResult<SpawnSpec> {
-    let active_skill = state
+    let active_skill = runtime
         .machine
         .active_skills()
         .iter()
@@ -410,7 +430,7 @@ fn resolve_delegated_skill_invocation(
         }
         skill.metadata
     } else {
-        match state
+        match runtime
             .prompt_cache
             .resolve_listed_skill_metadata(request.skill_id.as_str())
         {
@@ -477,16 +497,15 @@ fn resolve_delegated_skill_invocation(
         )));
     };
 
-    build_delegated_spawn_spec(state, request, spawn_target)
+    build_delegated_spawn_spec(runtime, request, spawn_target)
 }
 
 fn build_delegated_spawn_spec(
-    state: &RuntimeLoopState,
+    runtime: &DelegatedSkillRuntime<'_>,
     request: &DelegatedSkillInvocationRequest,
     target: alan_agent_protocol::SpawnTarget,
 ) -> DelegatedSkillSpawnResult<SpawnSpec> {
-    let child_launch = state.child_launch();
-    let launch_context = child_launch.launch_context();
+    let launch_context = runtime.child_launch_context();
     let parent_namespace_cwd = launch_context.map(|context| Path::new(&context.cwd));
     let cwd = request
         .cwd

--- a/crates/agent-engine/src/runtime/delegated_skill_tool/runtime_inputs.rs
+++ b/crates/agent-engine/src/runtime/delegated_skill_tool/runtime_inputs.rs
@@ -1,0 +1,93 @@
+use crate::{
+    agent_machine::AgentMachine,
+    runtime::{
+        child_agents::{ChildLaunchRuntime, project_child_task_context},
+        child_runs::ChildRunRegistry,
+        launch_config::AgentConfig,
+        prompt_cache::PromptAssemblyCache,
+        transition::{NamespaceAgentFiles, NamespaceChildLaunch, NamespaceToolExecution},
+    },
+};
+use alan_agent_protocol::SpawnSpec;
+
+/// Explicit inputs for one delegated-skill Tool transition.
+pub(crate) struct DelegatedSkillRuntime<'a> {
+    pub(super) machine: &'a mut AgentMachine,
+    pub(super) prompt_cache: &'a mut PromptAssemblyCache,
+    pub(super) agent_files: NamespaceAgentFiles,
+    child_runtime_inputs: DelegatedChildRuntimeInputs,
+}
+
+/// Owned inputs that can produce one real child-launch handle after the spawn spec is resolved.
+pub(crate) struct DelegatedChildRuntimeInputs {
+    base_agent_config: AgentConfig,
+    child_launch: NamespaceChildLaunch,
+    tool_execution: NamespaceToolExecution,
+    child_run_registry: ChildRunRegistry,
+    parent_process_path: String,
+}
+
+impl<'a> DelegatedSkillRuntime<'a> {
+    pub(crate) fn new(
+        machine: &'a mut AgentMachine,
+        prompt_cache: &'a mut PromptAssemblyCache,
+        agent_files: NamespaceAgentFiles,
+        child_runtime_inputs: DelegatedChildRuntimeInputs,
+    ) -> Self {
+        Self {
+            machine,
+            prompt_cache,
+            agent_files,
+            child_runtime_inputs,
+        }
+    }
+
+    pub(super) fn child_launch_context(&self) -> Option<&crate::ProcessLaunchContext> {
+        self.child_runtime_inputs.child_launch.launch_context()
+    }
+
+    pub(super) fn child_run_registry(&self) -> &ChildRunRegistry {
+        &self.child_runtime_inputs.child_run_registry
+    }
+
+    pub(super) fn child_launch_runtime(&self, spec: &SpawnSpec) -> ChildLaunchRuntime {
+        let (plan_explanation, plan_items) = match self.machine.plan_snapshot() {
+            Some(snapshot) => (snapshot.explanation.as_deref(), snapshot.items.as_slice()),
+            None => (None, &[][..]),
+        };
+        let task_context = project_child_task_context(
+            self.machine.tape_summary(),
+            self.machine.messages(),
+            plan_explanation,
+            plan_items,
+            spec,
+        );
+        ChildLaunchRuntime::new(
+            self.child_runtime_inputs.base_agent_config.clone(),
+            self.child_runtime_inputs.child_launch.clone(),
+            self.child_runtime_inputs.tool_execution.clone(),
+            self.child_runtime_inputs.child_run_registry.clone(),
+            self.child_runtime_inputs.parent_process_path.clone(),
+            self.prompt_cache.capability_view().cloned(),
+            task_context,
+        )
+    }
+}
+
+impl DelegatedChildRuntimeInputs {
+    pub(crate) fn new(
+        base_agent_config: AgentConfig,
+        child_launch: NamespaceChildLaunch,
+        tool_execution: NamespaceToolExecution,
+        child_run_registry: ChildRunRegistry,
+        parent_process_path: String,
+    ) -> Self {
+        Self {
+            base_agent_config,
+            child_launch,
+            tool_execution,
+            child_run_registry,
+            parent_process_path,
+        }
+    }
+}

--- a/crates/agent-engine/src/runtime/delegated_skill_tool_tests.rs
+++ b/crates/agent-engine/src/runtime/delegated_skill_tool_tests.rs
@@ -586,6 +586,40 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_bounds_preview
 }
 
 #[tokio::test]
+async fn test_pre_cancelled_delegated_invocation_does_not_project_or_spawn_child_runtime() {
+    let mut state = create_test_transition_state();
+    activate_test_delegated_skill(&mut state, "repo-review", "reviewer");
+    state.machine.set_turn_activity(TurnActivityState::Running);
+    let tool_call = NormalizedToolCall {
+        id: "call_pre_cancelled".to_string(),
+        name: "invoke_delegated_skill".to_string(),
+        arguments: json!({
+            "skill_id": "repo-review",
+            "target": "reviewer",
+            "task": "Review the current diff."
+        }),
+    };
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+    let mut emit = |_event: Event| async {};
+
+    let outcome = handle_invoke_delegated_skill_with_spawn(
+        &mut state,
+        &tool_call,
+        &tool_call.arguments,
+        &cancel,
+        &mut emit,
+        |_runtime, _spec, _cancel| {
+            Box::pin(async { panic!("pre-cancelled launch must not reach the spawn boundary") })
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome, VirtualToolOutcome::EndTurn);
+}
+
+#[tokio::test]
 async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_honors_interrupt() {
     let mut state = create_test_transition_state();
     activate_test_delegated_skill(&mut state, "repo-review", "reviewer");

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -137,12 +137,12 @@ pub(super) fn compaction_runtime(
     )
 }
 
+#[cfg(test)]
 pub(super) fn child_launch_runtime(
     state: &RuntimeLoopState,
     spec: &alan_agent_protocol::SpawnSpec,
 ) -> super::child_agents::ChildLaunchRuntime {
-    let mut base_agent_config = super::launch_config::AgentConfig::from(state.core_config.clone());
-    base_agent_config.runtime_config = state.runtime_config.clone();
+    let base_agent_config = child_launch_base_agent_config(state);
     let (plan_explanation, plan_items) = match state.machine.plan_snapshot() {
         Some(snapshot) => (snapshot.explanation.as_deref(), snapshot.items.as_slice()),
         None => (None, &[][..]),
@@ -163,6 +163,36 @@ pub(super) fn child_launch_runtime(
         state.prompt_cache.capability_view().cloned(),
         task_context,
     )
+}
+
+pub(super) fn delegated_skill_runtime(
+    state: &mut RuntimeLoopState,
+) -> super::delegated_skill_tool::DelegatedSkillRuntime<'_> {
+    let agent_files = state.agent_files();
+    let child_run_registry = state.child_run_registry().clone();
+    let child_launch = state.child_launch();
+    let base_agent_config = child_launch_base_agent_config(state);
+    let tool_execution = state.tool_execution();
+    let parent_process_path = state.process_path();
+    let child_runtime_inputs = super::delegated_skill_tool::DelegatedChildRuntimeInputs::new(
+        base_agent_config,
+        child_launch,
+        tool_execution,
+        child_run_registry,
+        parent_process_path,
+    );
+    super::delegated_skill_tool::DelegatedSkillRuntime::new(
+        &mut state.machine,
+        &mut state.prompt_cache,
+        agent_files,
+        child_runtime_inputs,
+    )
+}
+
+fn child_launch_base_agent_config(state: &RuntimeLoopState) -> super::launch_config::AgentConfig {
+    let mut config = super::launch_config::AgentConfig::from(state.core_config.clone());
+    config.runtime_config = state.runtime_config.clone();
+    config
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/agent-engine/src/runtime/virtual_tools.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools.rs
@@ -308,7 +308,8 @@ where
             }
         }
         "invoke_delegated_skill" => {
-            handle_invoke_delegated_skill(state, tool_call, tool_arguments, cancel, emit).await
+            let runtime = super::transition::delegated_skill_runtime(state);
+            handle_invoke_delegated_skill(runtime, tool_call, tool_arguments, cancel, emit).await
         }
         "terminate_child_run" => {
             handle_terminate_child_run(

--- a/crates/agent-engine/src/runtime/virtual_tools_tests.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools_tests.rs
@@ -13,7 +13,7 @@ use crate::{
         delegated_skill_tool::{
             DEFAULT_DELEGATED_TIMEOUT_SECS, DelegatedSkillInvocationRequest,
             MAX_DELEGATED_SKILL_ID_CHARS, MAX_DELEGATED_TARGET_CHARS, MAX_DELEGATED_TASK_CHARS,
-            handle_invoke_delegated_skill_with_spawn,
+            handle_invoke_delegated_skill_with_spawn as handle_invoke_delegated_skill_with_runtime,
         },
         delegation_capabilities::DelegatedSpawnRejected,
         mount_request_tool::MountRequestAccess,
@@ -26,7 +26,7 @@ use crate::{
     },
     tools::ToolRegistry,
 };
-use alan_agent_protocol::SpawnHandle;
+use alan_agent_protocol::{SpawnHandle, SpawnSpec};
 use alan_agentfs::AgentFs;
 use alan_ap::InProcessTransport;
 use alan_kernel::{Access, MountFs, Namespace};
@@ -206,6 +206,37 @@ where
 {
     let cancel = CancellationToken::new();
     try_handle_virtual_tool_call(state, tool_call, &tool_call.arguments, &cancel, false, emit).await
+}
+
+async fn handle_invoke_delegated_skill_with_spawn<E, F, S>(
+    state: &mut super::super::transition::RuntimeLoopState,
+    tool_call: &NormalizedToolCall,
+    tool_arguments: &serde_json::Value,
+    cancel: &CancellationToken,
+    emit: &mut E,
+    spawn_child: S,
+) -> Result<VirtualToolOutcome>
+where
+    E: FnMut(Event) -> F,
+    F: std::future::Future<Output = ()>,
+    S: for<'a> FnOnce(
+        super::super::child_agents::ChildLaunchRuntime,
+        SpawnSpec,
+        &'a CancellationToken,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<ChildRuntimeResult>> + Send + 'a>,
+    >,
+{
+    let runtime = super::super::transition::delegated_skill_runtime(state);
+    handle_invoke_delegated_skill_with_runtime(
+        runtime,
+        tool_call,
+        tool_arguments,
+        cancel,
+        emit,
+        spawn_child,
+    )
+    .await
 }
 
 #[path = "child_run_termination_tool_tests.rs"]

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -324,6 +324,8 @@ fn turn_generation_uses_only_the_file_native_namespace_boundary() {
 #[test]
 fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
     for path in [
+        "delegated_skill_tool.rs",
+        "delegated_skill_tool/runtime_inputs.rs",
         "delegated_skill_evidence.rs",
         "memory_flush.rs",
         "memory_promotion.rs",
@@ -397,6 +399,23 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
     assert!(child_launch_inputs.contains("ChildTaskContext"));
     let child_task_context = read_runtime_source("child_agents/task_context.rs");
     assert!(child_task_context.contains("spec.has_handle(SpawnHandle::ToolResults)"));
+
+    let delegated_runtime = read_runtime_source("delegated_skill_tool/runtime_inputs.rs");
+    for forbidden in [
+        "RuntimeLoopState",
+        "RuntimeConfig",
+        "NamespaceRuntimeEnvironment",
+    ] {
+        assert!(
+            !delegated_runtime.contains(forbidden),
+            "delegated skill runtime must not regain {forbidden}"
+        );
+    }
+    assert!(delegated_runtime.contains("DelegatedSkillRuntime"));
+    assert!(delegated_runtime.contains("DelegatedChildRuntimeInputs"));
+    assert!(delegated_runtime.contains("ChildLaunchRuntime"));
+    let transition = read_runtime_source("transition.rs");
+    assert!(transition.contains("fn delegated_skill_runtime("));
 
     for marker in [
         "fn compaction_submission_id",


### PR DESCRIPTION
## Summary

- replace delegated-skill production access to the complete runtime-loop aggregate with an explicit DelegatedSkillRuntime
- project child launch configuration and namespace handles only at the accepted transition boundary, then pass a real ChildLaunchRuntime into the spawn seam
- preserve cancellation ordering so a pre-cancelled invocation neither projects nor spawns a child runtime
- add architecture absence guards that prevent delegated-skill code from regaining RuntimeLoopState, RuntimeConfig, or NamespaceRuntimeEnvironment

## Verification

- cargo test -p alan-agent-engine (1200 passed, 1 ignored)
- cargo test -p alan-agent-engine --test dependency_boundary (16 passed)
- cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings
- openspec validate deepen-agent-machine-transition-module --strict
- just quality

Part of deepen-agent-machine-transition-module.