### PR TITLE
refactor(agent-engine): isolate child termination runtime inputs

### DIFF
--- a/crates/agent-engine/src/runtime/child_run_termination_tool.rs
+++ b/crates/agent-engine/src/runtime/child_run_termination_tool.rs
@@ -1,3 +1,5 @@
+mod runtime_inputs;
+
 use alan_agent_protocol::{AdaptivePresentationHint, ConfirmationYieldPayload, Event, YieldKind};
 use anyhow::Result;
 use serde_json::json;
@@ -10,13 +12,14 @@ use crate::llm::ToolDefinition;
 
 use super::child_runs::{ChildRunRegistryError, ChildRunTerminationMode};
 use super::tool_policy::{ToolPolicyDecision, evaluate_tool_policy};
-use super::transition::RuntimeLoopState;
 use super::turn_support::tool_result_preview;
 use super::virtual_tool::VirtualToolOutcome;
 use crate::agent_machine::NormalizedToolCall;
 
+pub(crate) use runtime_inputs::ChildRunTerminationRuntime;
+
 pub(super) async fn handle_terminate_child_run<E, F>(
-    state: &mut RuntimeLoopState,
+    mut runtime: ChildRunTerminationRuntime<'_>,
     tool_call: &NormalizedToolCall,
     tool_arguments: &serde_json::Value,
     allow_approved_tool_escalation_execution: bool,
@@ -42,14 +45,14 @@ where
             audit: Some(audit.clone()),
         })
         .await;
-        state.machine.record_tool_call_with_audit(
+        runtime.machine.record_tool_call_with_audit(
             &tool_call.name,
             tool_arguments.clone(),
             payload.clone(),
             false,
             Some(audit),
         );
-        state
+        runtime
             .machine
             .add_tool_message(&tool_call.id, &tool_call.name, payload);
         return Ok(VirtualToolOutcome::Continue {
@@ -58,7 +61,7 @@ where
     };
 
     let audit = match evaluate_terminate_child_run_policy(
-        state,
+        &mut runtime,
         tool_call,
         tool_arguments,
         allow_approved_tool_escalation_execution,
@@ -81,8 +84,8 @@ where
     })
     .await;
 
-    let result = state.child_run_registry().request_termination(
-        &state.process_path(),
+    let result = runtime.child_run_registry.request_termination(
+        &runtime.parent_process_path,
         &child_run_id,
         "parent_runtime",
         mode,
@@ -122,14 +125,14 @@ where
         audit: Some(audit.clone()),
     })
     .await;
-    state.machine.record_tool_call_with_audit(
+    runtime.machine.record_tool_call_with_audit(
         &tool_call.name,
         tool_arguments.clone(),
         payload.clone(),
         success,
         Some(audit),
     );
-    state
+    runtime
         .machine
         .add_tool_message(&tool_call.id, &tool_call.name, payload);
     Ok(VirtualToolOutcome::Continue {
@@ -156,7 +159,7 @@ enum TerminateChildRunPolicyOutcome {
 }
 
 async fn evaluate_terminate_child_run_policy<E, F>(
-    state: &mut RuntimeLoopState,
+    runtime: &mut ChildRunTerminationRuntime<'_>,
     tool_call: &NormalizedToolCall,
     tool_arguments: &serde_json::Value,
     allow_approved_tool_escalation_execution: bool,
@@ -168,12 +171,12 @@ where
 {
     let policy_decision = maybe_allow_approved_virtual_tool_escalation_replay(
         evaluate_tool_policy(
-            &state.runtime_config.policy_engine,
-            &state.runtime_config.governance,
+            runtime.policy_engine,
+            runtime.governance,
             &tool_call.name,
             tool_arguments,
             alan_agent_protocol::ToolCapability::Write,
-            state.tool_execution().default_cwd().as_deref(),
+            runtime.tool_execution.default_cwd().as_deref(),
             super::tool_policy::SandboxConfinement::detect(),
         ),
         allow_approved_tool_escalation_execution,
@@ -183,7 +186,7 @@ where
         | ToolPolicyDecision::Escalate { audit, .. }
         | ToolPolicyDecision::Forbidden { audit, .. } => audit.clone(),
     };
-    state.machine.record_event(
+    runtime.machine.record_event(
         "tool_policy_decision",
         json!({
             "tool_call_id": tool_call.id,
@@ -211,7 +214,7 @@ where
                 "tool_name": tool_call.name,
                 "arguments": tool_arguments,
             });
-            details = append_skill_permission_hints(details, state.machine.active_skills());
+            details = append_skill_permission_hints(details, runtime.machine.active_skills());
             let pending = PendingConfirmation {
                 checkpoint_id: format!("{TOOL_ESCALATION_CHECKPOINT_PREFIX}{}", tool_call.id),
                 checkpoint_type: TOOL_ESCALATION_CHECKPOINT_TYPE.to_string(),
@@ -219,21 +222,21 @@ where
                 details,
                 options: vec!["approve".to_string(), "reject".to_string()],
             };
-            state.machine.record_tool_call_with_audit(
+            runtime.machine.record_tool_call_with_audit(
                 &tool_call.name,
                 tool_arguments.clone(),
                 json!({"status":"escalation_required"}),
                 true,
                 Some(audit),
             );
-            let request_id = state
-                .agent_files()
+            let request_id = runtime
+                .agent_files
                 .write_confirmation_request(&pending)
                 .await?;
-            state
+            runtime
                 .machine
                 .set_confirmation_for_request(request_id.clone(), pending.clone());
-            super::ui_surfaces::paused(&state.agent_files()).await?;
+            super::ui_surfaces::paused(&runtime.agent_files).await?;
             emit(Event::Yield {
                 request_id,
                 kind: YieldKind::Confirmation,
@@ -272,14 +275,14 @@ where
                 audit: Some(audit.clone()),
             })
             .await;
-            state.machine.record_tool_call_with_audit(
+            runtime.machine.record_tool_call_with_audit(
                 &tool_call.name,
                 tool_arguments.clone(),
                 blocked_payload.clone(),
                 false,
                 Some(audit),
             );
-            state
+            runtime
                 .machine
                 .add_tool_message(&tool_call.id, &tool_call.name, blocked_payload);
             Ok(TerminateChildRunPolicyOutcome::Continue {

--- a/crates/agent-engine/src/runtime/child_run_termination_tool/runtime_inputs.rs
+++ b/crates/agent-engine/src/runtime/child_run_termination_tool/runtime_inputs.rs
@@ -1,0 +1,41 @@
+use crate::{
+    agent_machine::AgentMachine,
+    policy::PolicyEngine,
+    runtime::{
+        child_runs::ChildRunRegistry,
+        transition::{NamespaceAgentFiles, NamespaceToolExecution},
+    },
+};
+
+/// Explicit inputs for one child-run termination Tool transition.
+pub(crate) struct ChildRunTerminationRuntime<'a> {
+    pub(super) machine: &'a mut AgentMachine,
+    pub(super) policy_engine: &'a PolicyEngine,
+    pub(super) governance: &'a alan_agent_protocol::GovernanceConfig,
+    pub(super) agent_files: NamespaceAgentFiles,
+    pub(super) tool_execution: NamespaceToolExecution,
+    pub(super) child_run_registry: ChildRunRegistry,
+    pub(super) parent_process_path: String,
+}
+
+impl<'a> ChildRunTerminationRuntime<'a> {
+    pub(crate) fn new(
+        machine: &'a mut AgentMachine,
+        policy_engine: &'a PolicyEngine,
+        governance: &'a alan_agent_protocol::GovernanceConfig,
+        agent_files: NamespaceAgentFiles,
+        tool_execution: NamespaceToolExecution,
+        child_run_registry: ChildRunRegistry,
+        parent_process_path: String,
+    ) -> Self {
+        Self {
+            machine,
+            policy_engine,
+            governance,
+            agent_files,
+            tool_execution,
+            child_run_registry,
+            parent_process_path,
+        }
+    }
+}

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -189,6 +189,24 @@ pub(super) fn delegated_skill_runtime(
     )
 }
 
+pub(super) fn child_run_termination_runtime(
+    state: &mut RuntimeLoopState,
+) -> super::child_run_termination_tool::ChildRunTerminationRuntime<'_> {
+    let agent_files = state.agent_files();
+    let tool_execution = state.tool_execution();
+    let child_run_registry = state.child_run_registry().clone();
+    let parent_process_path = state.process_path();
+    super::child_run_termination_tool::ChildRunTerminationRuntime::new(
+        &mut state.machine,
+        &state.runtime_config.policy_engine,
+        &state.runtime_config.governance,
+        agent_files,
+        tool_execution,
+        child_run_registry,
+        parent_process_path,
+    )
+}
+
 fn child_launch_base_agent_config(state: &RuntimeLoopState) -> super::launch_config::AgentConfig {
     let mut config = super::launch_config::AgentConfig::from(state.core_config.clone());
     config.runtime_config = state.runtime_config.clone();

--- a/crates/agent-engine/src/runtime/virtual_tools.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools.rs
@@ -312,8 +312,9 @@ where
             handle_invoke_delegated_skill(runtime, tool_call, tool_arguments, cancel, emit).await
         }
         "terminate_child_run" => {
+            let runtime = super::transition::child_run_termination_runtime(state);
             handle_terminate_child_run(
-                state,
+                runtime,
                 tool_call,
                 tool_arguments,
                 allow_approved_tool_escalation_execution,

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -324,6 +324,8 @@ fn turn_generation_uses_only_the_file_native_namespace_boundary() {
 #[test]
 fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
     for path in [
+        "child_run_termination_tool.rs",
+        "child_run_termination_tool/runtime_inputs.rs",
         "delegated_skill_tool.rs",
         "delegated_skill_tool/runtime_inputs.rs",
         "delegated_skill_evidence.rs",
@@ -416,6 +418,20 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
     assert!(delegated_runtime.contains("ChildLaunchRuntime"));
     let transition = read_runtime_source("transition.rs");
     assert!(transition.contains("fn delegated_skill_runtime("));
+
+    let termination_runtime = read_runtime_source("child_run_termination_tool/runtime_inputs.rs");
+    for forbidden in [
+        "RuntimeLoopState",
+        "RuntimeConfig",
+        "NamespaceRuntimeEnvironment",
+    ] {
+        assert!(
+            !termination_runtime.contains(forbidden),
+            "child-run termination runtime must not regain {forbidden}"
+        );
+    }
+    assert!(termination_runtime.contains("ChildRunTerminationRuntime"));
+    assert!(transition.contains("fn child_run_termination_runtime("));
 
     for marker in [
         "fn compaction_submission_id",


### PR DESCRIPTION
## Summary

- replace child-run termination access to the complete runtime-loop aggregate with an explicit ChildRunTerminationRuntime
- project Machine, policy, AgentFS, Tool namespace, child registry, and parent Process path only at the transition boundary
- preserve policy allow, escalation, approved replay, denial, and child-registry behavior
- add architecture absence guards against RuntimeLoopState, RuntimeConfig, and NamespaceRuntimeEnvironment regressions

## Verification

- cargo test -p alan-agent-engine (1200 passed, 1 ignored)
- cargo test -p alan-agent-engine --test dependency_boundary (16 passed)
- cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings
- openspec validate deepen-agent-machine-transition-module --strict
- just quality

Part of deepen-agent-machine-transition-module.