### PR TITLE
refactor(agent-engine): isolate mount request runtime inputs

### DIFF
--- a/crates/agent-engine/src/runtime/mount_request_tool.rs
+++ b/crates/agent-engine/src/runtime/mount_request_tool.rs
@@ -1,3 +1,5 @@
+mod runtime_inputs;
+
 use alan_agent_protocol::{AdaptivePresentationHint, ConfirmationYieldPayload, Event, YieldKind};
 use anyhow::Result;
 use serde::Serialize;
@@ -11,10 +13,11 @@ use crate::approval::{
 use crate::llm::ToolDefinition;
 
 use super::tool_policy::{ToolPolicyDecision, evaluate_tool_policy};
-use super::transition::RuntimeLoopState;
 use super::turn_support::tool_result_preview;
 use super::virtual_tool::VirtualToolOutcome;
 use crate::agent_machine::NormalizedToolCall;
+
+pub(crate) use runtime_inputs::MountRequestRuntime;
 
 const RESERVED_MOUNT_NAMESPACE_ROOTS: &[&str] = &["llm", "mem", "route"];
 
@@ -61,7 +64,7 @@ impl MountRequest {
 }
 
 pub(super) async fn handle_request_mount<E, F>(
-    state: &mut RuntimeLoopState,
+    runtime: MountRequestRuntime<'_>,
     tool_call: &NormalizedToolCall,
     tool_arguments: &serde_json::Value,
     emit: &mut E,
@@ -94,13 +97,13 @@ where
                 audit: None,
             })
             .await;
-            state.machine.record_tool_call(
+            runtime.machine.record_tool_call(
                 &tool_call.name,
                 tool_arguments.clone(),
                 payload.clone(),
                 false,
             );
-            state
+            runtime
                 .machine
                 .add_tool_message(&tool_call.id, &tool_call.name, payload);
             return Ok(VirtualToolOutcome::Continue {
@@ -112,22 +115,22 @@ where
     let sandbox_confinement = super::tool_policy::SandboxConfinement::detect();
 
     let mut decision = evaluate_tool_policy(
-        &state.runtime_config.policy_engine,
-        &state.runtime_config.governance,
+        runtime.policy_engine,
+        runtime.governance,
         &tool_call.name,
         &mount_payload,
         mount_request.access.policy_capability(),
-        state.tool_execution().default_cwd().as_deref(),
+        runtime.tool_execution.default_cwd().as_deref(),
         sandbox_confinement,
     );
     if mount_request.access == MountRequestAccess::ReadWrite {
         let read_decision = evaluate_tool_policy(
-            &state.runtime_config.policy_engine,
-            &state.runtime_config.governance,
+            runtime.policy_engine,
+            runtime.governance,
             &tool_call.name,
             &mount_payload,
             alan_agent_protocol::ToolCapability::Read,
-            state.tool_execution().default_cwd().as_deref(),
+            runtime.tool_execution.default_cwd().as_deref(),
             sandbox_confinement,
         );
         decision = merge_mount_policy_decision(decision, read_decision);
@@ -144,7 +147,7 @@ where
             "error": reason,
             "mount_request": mount_payload,
         });
-        state.machine.record_event(
+        runtime.machine.record_event(
             "tool_policy_decision",
             json!({
                 "tool_call_id": tool_call.id,
@@ -175,14 +178,14 @@ where
             audit: Some(audit.clone()),
         })
         .await;
-        state.machine.record_tool_call_with_audit(
+        runtime.machine.record_tool_call_with_audit(
             &tool_call.name,
             tool_arguments.clone(),
             payload.clone(),
             false,
             Some(audit),
         );
-        state
+        runtime
             .machine
             .add_tool_message(&tool_call.id, &tool_call.name, payload);
         return Ok(VirtualToolOutcome::Continue {
@@ -202,7 +205,7 @@ where
         sandbox_backend: decision_audit.sandbox_backend.clone(),
         path_mode: decision_audit.path_mode.clone(),
     };
-    state.machine.record_event(
+    runtime.machine.record_event(
         "tool_policy_decision",
         json!({
             "tool_call_id": tool_call.id,
@@ -234,7 +237,7 @@ where
         },
         "live_applied": false,
     });
-    details = append_skill_permission_hints(details, state.machine.active_skills());
+    details = append_skill_permission_hints(details, runtime.machine.active_skills());
 
     let pending = PendingConfirmation {
         checkpoint_id: format!("{MOUNT_ESCALATION_CHECKPOINT_PREFIX}{}", tool_call.id),
@@ -248,8 +251,8 @@ where
         options: vec!["approve".to_string(), "reject".to_string()],
     };
 
-    let request_id = state
-        .agent_files()
+    let request_id = runtime
+        .agent_files
         .write_confirmation_request(&pending)
         .await?;
     let payload = json!({
@@ -267,17 +270,17 @@ where
         audit: Some(escalation_audit.clone()),
     })
     .await;
-    state.machine.record_tool_call_with_audit(
+    runtime.machine.record_tool_call_with_audit(
         &tool_call.name,
         tool_arguments.clone(),
         payload.clone(),
         true,
         Some(escalation_audit),
     );
-    state
+    runtime
         .machine
         .set_confirmation_for_request(request_id.clone(), pending.clone());
-    super::ui_surfaces::paused(&state.agent_files()).await?;
+    super::ui_surfaces::paused(&runtime.agent_files).await?;
     emit(Event::Yield {
         request_id,
         kind: YieldKind::Confirmation,

--- a/crates/agent-engine/src/runtime/mount_request_tool/runtime_inputs.rs
+++ b/crates/agent-engine/src/runtime/mount_request_tool/runtime_inputs.rs
@@ -1,0 +1,32 @@
+use crate::{
+    agent_machine::AgentMachine,
+    policy::PolicyEngine,
+    runtime::transition::{NamespaceAgentFiles, NamespaceToolExecution},
+};
+
+/// Explicit inputs for one approval-gated mount-request Tool transition.
+pub(crate) struct MountRequestRuntime<'a> {
+    pub(super) machine: &'a mut AgentMachine,
+    pub(super) policy_engine: &'a PolicyEngine,
+    pub(super) governance: &'a alan_agent_protocol::GovernanceConfig,
+    pub(super) agent_files: NamespaceAgentFiles,
+    pub(super) tool_execution: NamespaceToolExecution,
+}
+
+impl<'a> MountRequestRuntime<'a> {
+    pub(crate) fn new(
+        machine: &'a mut AgentMachine,
+        policy_engine: &'a PolicyEngine,
+        governance: &'a alan_agent_protocol::GovernanceConfig,
+        agent_files: NamespaceAgentFiles,
+        tool_execution: NamespaceToolExecution,
+    ) -> Self {
+        Self {
+            machine,
+            policy_engine,
+            governance,
+            agent_files,
+            tool_execution,
+        }
+    }
+}

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -207,6 +207,20 @@ pub(super) fn child_run_termination_runtime(
     )
 }
 
+pub(super) fn mount_request_runtime(
+    state: &mut RuntimeLoopState,
+) -> super::mount_request_tool::MountRequestRuntime<'_> {
+    let agent_files = state.agent_files();
+    let tool_execution = state.tool_execution();
+    super::mount_request_tool::MountRequestRuntime::new(
+        &mut state.machine,
+        &state.runtime_config.policy_engine,
+        &state.runtime_config.governance,
+        agent_files,
+        tool_execution,
+    )
+}
+
 fn child_launch_base_agent_config(state: &RuntimeLoopState) -> super::launch_config::AgentConfig {
     let mut config = super::launch_config::AgentConfig::from(state.core_config.clone());
     config.runtime_config = state.runtime_config.clone();

--- a/crates/agent-engine/src/runtime/virtual_tools.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools.rs
@@ -144,7 +144,10 @@ where
             }
             Ok(VirtualToolOutcome::PauseTurn)
         }
-        "request_mount" => handle_request_mount(state, tool_call, tool_arguments, emit).await,
+        "request_mount" => {
+            let runtime = super::transition::mount_request_runtime(state);
+            handle_request_mount(runtime, tool_call, tool_arguments, emit).await
+        }
         "request_user_input" => {
             emit(Event::ToolCallStarted {
                 title: None,

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -332,6 +332,8 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
         "memory_flush.rs",
         "memory_promotion.rs",
         "memory_surfaces.rs",
+        "mount_request_tool.rs",
+        "mount_request_tool/runtime_inputs.rs",
         "response_guardrails.rs",
         "steering_queue.rs",
         "turn_support.rs",
@@ -432,6 +434,20 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
     }
     assert!(termination_runtime.contains("ChildRunTerminationRuntime"));
     assert!(transition.contains("fn child_run_termination_runtime("));
+
+    let mount_runtime = read_runtime_source("mount_request_tool/runtime_inputs.rs");
+    for forbidden in [
+        "RuntimeLoopState",
+        "RuntimeConfig",
+        "NamespaceRuntimeEnvironment",
+    ] {
+        assert!(
+            !mount_runtime.contains(forbidden),
+            "mount request runtime must not regain {forbidden}"
+        );
+    }
+    assert!(mount_runtime.contains("MountRequestRuntime"));
+    assert!(transition.contains("fn mount_request_runtime("));
 
     for marker in [
         "fn compaction_submission_id",


### PR DESCRIPTION
## Summary
- replace mount-request access to the complete runtime-loop aggregate with explicit `MountRequestRuntime` inputs
- project Machine, policy, AgentFS, and Tool namespace only at the transition boundary
- preserve read/read-write policy merge, denial, approval escalation, pending confirmation, and Yield behavior
- add dependency guards against `RuntimeLoopState`, `RuntimeConfig`, and `NamespaceRuntimeEnvironment`

## Verification
- `cargo test -p alan-agent-engine` (1200 passed, 1 ignored)
- `cargo test -p alan-agent-engine --test dependency_boundary` (16 passed)
- `cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings`
- `openspec validate deepen-agent-machine-transition-module --strict`
- `just quality`

Part of `deepen-agent-machine-transition-module`.