### PR TITLE
refactor(agent-engine): isolate tool execution runtime inputs

### DIFF
--- a/crates/agent-engine/src/approval.rs
+++ b/crates/agent-engine/src/approval.rs
@@ -1,5 +1,7 @@
 //! Pending interactive request types and checkpoint taxonomy.
 
+use alan_agent_protocol::{AdaptivePresentationHint, ConfirmationYieldPayload};
+
 use crate::skills::ActiveSkillEnvelope;
 
 pub const TOOL_ESCALATION_CHECKPOINT_TYPE: &str = "tool_escalation";
@@ -62,6 +64,31 @@ pub struct PendingConfirmation {
     pub summary: String,
     pub details: serde_json::Value,
     pub options: Vec<String>,
+}
+
+/// Builds the protocol payload for a runtime-owned confirmation checkpoint.
+pub fn runtime_confirmation_yield_payload(
+    pending: &PendingConfirmation,
+) -> ConfirmationYieldPayload {
+    let default_option = pending
+        .options
+        .iter()
+        .find(|option| option.as_str() == "approve")
+        .cloned()
+        .or_else(|| pending.options.first().cloned());
+
+    ConfirmationYieldPayload {
+        checkpoint_type: pending.checkpoint_type.clone(),
+        summary: pending.summary.clone(),
+        details: Some(pending.details.clone()),
+        options: pending.options.clone(),
+        default_option,
+        presentation_hints: if is_runtime_confirmation_checkpoint_type(&pending.checkpoint_type) {
+            vec![AdaptivePresentationHint::Dangerous]
+        } else {
+            vec![]
+        },
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
@@ -188,6 +215,25 @@ mod tests {
         assert_eq!(pending.checkpoint_id, "chk-123");
         assert_eq!(pending.checkpoint_type, TOOL_ESCALATION_CHECKPOINT_TYPE);
         assert_eq!(pending.options.len(), 2);
+    }
+
+    #[test]
+    fn runtime_confirmation_yield_payload_is_dangerous_and_defaults_to_approve() {
+        let pending = PendingConfirmation {
+            checkpoint_id: "tool_escalation_call-1".to_string(),
+            checkpoint_type: TOOL_ESCALATION_CHECKPOINT_TYPE.to_string(),
+            summary: "Approve Tool execution".to_string(),
+            details: serde_json::json!({"tool": "bash"}),
+            options: vec!["approve".to_string(), "reject".to_string()],
+        };
+
+        let payload = runtime_confirmation_yield_payload(&pending);
+
+        assert_eq!(payload.default_option.as_deref(), Some("approve"));
+        assert_eq!(
+            payload.presentation_hints,
+            vec![AdaptivePresentationHint::Dangerous]
+        );
     }
 
     #[test]

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -27,6 +27,7 @@ mod response_guardrails;
 mod steering_queue;
 mod submission_handlers;
 mod tool_effect_lifecycle;
+mod tool_execution;
 mod tool_orchestrator;
 mod tool_packages;
 mod tool_policy;

--- a/crates/agent-engine/src/runtime/tool_effect_lifecycle.rs
+++ b/crates/agent-engine/src/runtime/tool_effect_lifecycle.rs
@@ -43,7 +43,8 @@ pub(super) struct EffectCheckpointFailure {
 }
 
 /// Owns one effectful Tool call from stable identity through its terminal durable record.
-/// Policy evaluation and physical Tool Process execution stay with the orchestrator.
+/// Policy evaluation stays with the orchestrator; physical execution is driven by the narrow
+/// Tool execution transition owner.
 #[derive(Debug, Clone)]
 pub(super) struct ToolEffectLifecycle {
     identity: EffectIdentity,

--- a/crates/agent-engine/src/runtime/tool_execution.rs
+++ b/crates/agent-engine/src/runtime/tool_execution.rs
@@ -1,0 +1,415 @@
+use alan_agent_protocol::{Event, ToolCapability, ToolDecisionAudit};
+use anyhow::{Context, Result};
+use serde_json::{Value, json};
+use std::time::Instant;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+use crate::{
+    agent_machine::NormalizedToolCall,
+    approval::{
+        EFFECT_REPLAY_CHECKPOINT_PREFIX, EFFECT_REPLAY_CHECKPOINT_TYPE, PendingConfirmation,
+        append_skill_permission_hints, runtime_confirmation_yield_payload,
+    },
+    evidence::{
+        payload_needs_projection, project_evidence_payload, redact_evidence_payload,
+        redaction_markers_in_text,
+    },
+};
+
+use super::{
+    tool_effect_lifecycle::{ToolEffectLifecycle, ToolEffectPlan},
+    transition::{NamespaceAgentFiles, NamespaceToolActionOutput, NamespaceToolExecution},
+    turn_support::{check_turn_cancelled, tool_result_preview},
+};
+
+mod runtime_inputs;
+
+pub(super) use runtime_inputs::ToolExecutionRuntime;
+
+pub(super) struct ToolExecutionRequest<'a> {
+    pub(super) tool_call: &'a NormalizedToolCall,
+    pub(super) tool_arguments: &'a Value,
+    pub(super) tool_timeout_secs: usize,
+    pub(super) tool_capability: ToolCapability,
+    pub(super) tool_audit: Option<ToolDecisionAudit>,
+    pub(super) allow_approved_unknown_effect_execution: bool,
+    pub(super) cancel: &'a CancellationToken,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ToolExecutionOutcome {
+    Completed,
+    PauseTurn,
+    EndTurn,
+}
+
+pub(super) async fn execute_allowed_tool_call<E, F>(
+    runtime: ToolExecutionRuntime<'_>,
+    request: ToolExecutionRequest<'_>,
+    emit: &mut E,
+) -> Result<ToolExecutionOutcome>
+where
+    E: FnMut(Event) -> F,
+    F: std::future::Future<Output = ()>,
+{
+    let ToolExecutionRequest {
+        tool_call,
+        tool_arguments,
+        tool_timeout_secs,
+        tool_capability,
+        tool_audit,
+        allow_approved_unknown_effect_execution,
+        cancel,
+    } = request;
+    let effect_lifecycle = ToolEffectLifecycle::for_call(
+        runtime.machine,
+        &runtime.process_path,
+        tool_call.id.clone(),
+        tool_call.name.clone(),
+        tool_arguments,
+        tool_capability,
+    );
+    let effect_plan = effect_lifecycle
+        .as_ref()
+        .map(|effect| effect.plan(runtime.machine, allow_approved_unknown_effect_execution));
+
+    if matches!(effect_plan.as_ref(), Some(ToolEffectPlan::ConfirmUnknown)) {
+        let effect = effect_lifecycle
+            .as_ref()
+            .expect("effect plan requires a lifecycle");
+        let escalation_reason =
+            "Previous side effect attempt has unknown status; explicit confirmation required";
+        effect.record_unknown_confirmation(runtime.machine, escalation_reason);
+
+        let pending = PendingConfirmation {
+            checkpoint_id: format!("{EFFECT_REPLAY_CHECKPOINT_PREFIX}{}", tool_call.id),
+            checkpoint_type: EFFECT_REPLAY_CHECKPOINT_TYPE.to_string(),
+            summary: "Potential duplicate side effect requires confirmation".to_string(),
+            details: append_skill_permission_hints(
+                json!({
+                    "reason": escalation_reason,
+                    "effect_status": "unknown",
+                    "effect_type": effect.effect_type(),
+                    "idempotency_key": effect.idempotency_key(),
+                    "request_fingerprint": effect.request_fingerprint(),
+                    "replay_tool_call": {
+                        "call_id": tool_call.id,
+                        "tool_name": tool_call.name,
+                        "arguments": tool_arguments,
+                    }
+                }),
+                runtime.machine.active_skills(),
+            ),
+            options: vec!["approve".to_string(), "reject".to_string()],
+        };
+        let request_id = runtime
+            .agent_files
+            .write_confirmation_request(&pending)
+            .await?;
+        runtime.machine.record_tool_call_with_audit(
+            &tool_call.name,
+            tool_arguments.clone(),
+            json!({
+                "status": "escalation_required",
+                "reason": escalation_reason,
+                "idempotency_key": effect.idempotency_key(),
+                "effect_status": "unknown",
+                "request_id": request_id.clone()
+            }),
+            true,
+            tool_audit.clone(),
+        );
+        runtime
+            .machine
+            .set_confirmation_for_request(request_id.clone(), pending.clone());
+        super::ui_surfaces::paused(&runtime.agent_files).await?;
+        emit(Event::Yield {
+            request_id,
+            kind: alan_agent_protocol::YieldKind::Confirmation,
+            payload: serde_json::to_value(runtime_confirmation_yield_payload(&pending))
+                .unwrap_or_else(|_| json!({})),
+        })
+        .await;
+        return Ok(ToolExecutionOutcome::PauseTurn);
+    }
+
+    emit(Event::ToolCallStarted {
+        title: super::tool_presentation::tool_title(&tool_call.name, tool_arguments),
+        id: tool_call.id.clone(),
+        name: tool_call.name.clone(),
+        audit: tool_audit.clone(),
+    })
+    .await;
+
+    if let Some(ToolEffectPlan::ReplayApplied {
+        payload: replay_payload,
+    }) = effect_plan
+    {
+        let dedupe_reason = "Matching applied side effect found; skipped physical execution";
+        emit(Event::ToolCallCompleted {
+            presentation: None,
+            id: tool_call.id.clone(),
+            name: Some(tool_call.name.clone()),
+            success: Some(true),
+            result_preview: tool_result_preview(&replay_payload),
+            audit: tool_audit.clone(),
+        })
+        .await;
+        runtime.machine.record_tool_call_with_audit(
+            &tool_call.name,
+            tool_arguments.clone(),
+            replay_payload.clone(),
+            true,
+            tool_audit,
+        );
+        runtime
+            .machine
+            .add_tool_message(&tool_call.id, &tool_call.name, replay_payload.clone());
+        effect_lifecycle
+            .as_ref()
+            .expect("replay plan requires a lifecycle")
+            .commit_replay(runtime.machine, &replay_payload, dedupe_reason);
+        return Ok(ToolExecutionOutcome::Completed);
+    }
+
+    let effect_start = if let Some(effect) = effect_lifecycle.as_ref() {
+        effect.record_execute_decision(runtime.machine, "No applied effect record found");
+        match effect.begin(runtime.machine).await {
+            Ok(record) => Some(record),
+            Err(failure) => {
+                emit(Event::Error {
+                    message: failure.message.clone(),
+                    recoverable: true,
+                })
+                .await;
+                emit(Event::ToolCallCompleted {
+                    presentation: None,
+                    id: tool_call.id.clone(),
+                    name: Some(tool_call.name.clone()),
+                    success: Some(false),
+                    result_preview: tool_result_preview(&failure.payload),
+                    audit: tool_audit.clone(),
+                })
+                .await;
+                runtime.machine.record_tool_call_with_audit(
+                    &tool_call.name,
+                    tool_arguments.clone(),
+                    failure.payload.clone(),
+                    false,
+                    tool_audit,
+                );
+                runtime
+                    .machine
+                    .add_tool_message(&tool_call.id, &tool_call.name, failure.payload);
+                return Ok(ToolExecutionOutcome::Completed);
+            }
+        }
+    } else {
+        None
+    };
+
+    let tool_start = Instant::now();
+    let tool_result = execute_tool_effect(
+        runtime.tool_execution,
+        &tool_call.name,
+        tool_arguments.clone(),
+        cancel,
+        tool_timeout_secs,
+    )
+    .await;
+    if cancel.is_cancelled()
+        && check_turn_cancelled(runtime.machine, &runtime.agent_files, emit, cancel).await?
+    {
+        return Ok(ToolExecutionOutcome::EndTurn);
+    }
+
+    match tool_result {
+        Ok(value) => {
+            // `Ok` is only the transport result — the Tool may report a logical
+            // failure in its payload. Derive effect and completion status from it.
+            let payload_success = value.get("success").and_then(Value::as_bool) != Some(false);
+            if let (Some(effect), Some(effect_start)) =
+                (effect_lifecycle.as_ref(), effect_start.as_ref())
+            {
+                let reason =
+                    (!payload_success).then(|| "tool reported failure in payload".to_string());
+                effect.complete(
+                    runtime.machine,
+                    effect_start,
+                    &value,
+                    payload_success,
+                    reason,
+                );
+            }
+            let tape_value = tool_payload_for_tape(&runtime.agent_files, &value).await;
+            emit(Event::ToolCallCompleted {
+                presentation: super::tool_presentation::tool_presentation(
+                    &tool_call.name,
+                    tool_arguments,
+                    &value,
+                ),
+                id: tool_call.id.clone(),
+                name: Some(tool_call.name.clone()),
+                success: Some(payload_success),
+                result_preview: tool_result_preview(&value),
+                audit: tool_audit.clone(),
+            })
+            .await;
+            runtime.machine.record_tool_call_with_audit(
+                &tool_call.name,
+                tool_arguments.clone(),
+                value.clone(),
+                payload_success,
+                tool_audit.clone(),
+            );
+            runtime
+                .machine
+                .add_tool_message(&tool_call.id, &tool_call.name, tape_value);
+            info!(
+                tool_name = %tool_call.name,
+                elapsed_ms = tool_start.elapsed().as_millis(),
+                success = payload_success,
+                "Tool done"
+            );
+            Ok(ToolExecutionOutcome::Completed)
+        }
+        Err(err) => {
+            let error_payload = json!({"error": err.to_string()});
+            if let (Some(effect), Some(effect_start)) =
+                (effect_lifecycle.as_ref(), effect_start.as_ref())
+            {
+                effect.complete(
+                    runtime.machine,
+                    effect_start,
+                    &error_payload,
+                    false,
+                    Some(err.to_string()),
+                );
+            }
+            emit(Event::ToolCallCompleted {
+                presentation: None,
+                id: tool_call.id.clone(),
+                name: Some(tool_call.name.clone()),
+                success: Some(false),
+                result_preview: tool_result_preview(&error_payload),
+                audit: tool_audit.clone(),
+            })
+            .await;
+            runtime.machine.record_tool_call_with_audit(
+                &tool_call.name,
+                tool_arguments.clone(),
+                error_payload.clone(),
+                false,
+                tool_audit,
+            );
+            runtime
+                .machine
+                .add_tool_message(&tool_call.id, &tool_call.name, error_payload);
+            info!(
+                tool_name = %tool_call.name,
+                elapsed_ms = tool_start.elapsed().as_millis(),
+                success = false,
+                error = %err,
+                "Tool done"
+            );
+            Ok(ToolExecutionOutcome::Completed)
+        }
+    }
+}
+
+pub(super) fn namespace_tool_payload(tool: NamespaceToolActionOutput) -> Result<Value> {
+    let trimmed = tool.output.trim();
+    let mut payload = if trimmed.is_empty() {
+        json!({})
+    } else {
+        serde_json::from_str::<Value>(trimmed)
+            .unwrap_or_else(|_| json!({ "output": tool.output.clone() }))
+    };
+    let process = format!("/proc/{}", tool.pid);
+    match &mut payload {
+        Value::Object(object) => {
+            object
+                .entry("success")
+                .or_insert(Value::Bool(tool.exit_code == 0));
+            object.entry("exit_code").or_insert(json!(tool.exit_code));
+            object.entry("process").or_insert(json!(process));
+            object.insert("action_id".to_string(), json!(tool.action_id));
+        }
+        other => {
+            payload = json!({
+                "success": tool.exit_code == 0,
+                "exit_code": tool.exit_code,
+                "output": other.clone(),
+                "process": process,
+                "action_id": tool.action_id,
+            });
+        }
+    }
+    Ok(payload)
+}
+
+pub(super) async fn tool_payload_for_tape(
+    agent_files: &NamespaceAgentFiles,
+    payload: &Value,
+) -> Value {
+    let redacted_payload = redact_evidence_payload(payload);
+    if !payload_needs_projection(&redacted_payload) {
+        return redacted_payload;
+    }
+
+    let Some(action_id) = payload.get("action_id").and_then(Value::as_str) else {
+        return project_evidence_payload(
+            payload,
+            None,
+            Vec::new(),
+            Some("reference_unresolvable".to_string()),
+        );
+    };
+    if action_id.is_empty() || action_id.contains('/') {
+        return project_evidence_payload(
+            payload,
+            None,
+            Vec::new(),
+            Some("reference_unresolvable".to_string()),
+        );
+    }
+    let reference = agent_files.action_output_reference(action_id).await;
+    let redactions = if let Some(reference) = reference.as_ref() {
+        agent_files
+            .resolve_evidence_reference(reference, None, None)
+            .await
+            .ok()
+            .and_then(|bytes| String::from_utf8(bytes).ok())
+            .map(|text| redaction_markers_in_text(&text))
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    let fallback_reason = reference
+        .is_none()
+        .then(|| "reference_unresolvable".to_string());
+    project_evidence_payload(payload, reference, redactions, fallback_reason)
+}
+
+pub(super) async fn execute_tool_effect(
+    tools: NamespaceToolExecution,
+    tool_name: &str,
+    tool_arguments: Value,
+    cancel: &CancellationToken,
+    timeout_secs: usize,
+) -> Result<Value> {
+    let executable = format!("/bin/{tool_name}");
+    let arguments_doc =
+        serde_json::to_string(&tool_arguments).context("serialize tool arguments")?;
+    let tool = tools
+        .run_action_with_cancel_and_timeout(
+            tool_name,
+            &executable,
+            [arguments_doc],
+            cancel,
+            timeout_secs,
+        )
+        .await?;
+    namespace_tool_payload(tool)
+}

--- a/crates/agent-engine/src/runtime/tool_execution/runtime_inputs.rs
+++ b/crates/agent-engine/src/runtime/tool_execution/runtime_inputs.rs
@@ -1,0 +1,28 @@
+use crate::{
+    agent_machine::AgentMachine,
+    runtime::transition::{NamespaceAgentFiles, NamespaceToolExecution},
+};
+
+/// Explicit inputs for one policy-approved Tool Process execution transition.
+pub(crate) struct ToolExecutionRuntime<'a> {
+    pub(super) machine: &'a mut AgentMachine,
+    pub(super) agent_files: NamespaceAgentFiles,
+    pub(super) tool_execution: NamespaceToolExecution,
+    pub(super) process_path: String,
+}
+
+impl<'a> ToolExecutionRuntime<'a> {
+    pub(crate) fn new(
+        machine: &'a mut AgentMachine,
+        agent_files: NamespaceAgentFiles,
+        tool_execution: NamespaceToolExecution,
+        process_path: String,
+    ) -> Self {
+        Self {
+            machine,
+            agent_files,
+            tool_execution,
+            process_path,
+        }
+    }
+}

--- a/crates/agent-engine/src/runtime/tool_orchestrator.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator.rs
@@ -1,29 +1,28 @@
-use alan_agent_protocol::{AdaptivePresentationHint, ConfirmationYieldPayload, Event};
-use anyhow::{Context, Result};
-use serde_json::{Value, json};
-use std::time::Instant;
+use alan_agent_protocol::Event;
+use anyhow::Result;
+#[cfg(test)]
+use serde_json::Value;
+use serde_json::json;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
 
 use crate::approval::{
-    EFFECT_REPLAY_CHECKPOINT_PREFIX, EFFECT_REPLAY_CHECKPOINT_TYPE, PendingConfirmation,
-    TOOL_ESCALATION_CHECKPOINT_PREFIX, TOOL_ESCALATION_CHECKPOINT_TYPE,
-    append_skill_permission_hints, is_runtime_confirmation_checkpoint_type, replays_tool_calls,
-};
-use crate::evidence::{
-    payload_needs_projection, project_evidence_payload, redact_evidence_payload,
-    redaction_markers_in_text,
+    PendingConfirmation, TOOL_ESCALATION_CHECKPOINT_PREFIX, TOOL_ESCALATION_CHECKPOINT_TYPE,
+    append_skill_permission_hints, replays_tool_calls, runtime_confirmation_yield_payload,
 };
 
 use super::loop_guard::ToolLoopGuard;
 use super::steering_queue::handle_queued_steering_inputs;
 #[cfg(test)]
 use super::tool_effect_lifecycle::{EffectCategory, build_effect_identity};
-use super::tool_effect_lifecycle::{ToolEffectLifecycle, ToolEffectPlan};
+use super::tool_execution::{
+    ToolExecutionOutcome, ToolExecutionRequest, execute_allowed_tool_call,
+};
+#[cfg(test)]
+use super::tool_execution::{execute_tool_effect, tool_payload_for_tape};
 use super::tool_policy::{ToolPolicyDecision, evaluate_tool_policy};
-use super::transition::{NamespaceAgentFiles, RuntimeLoopState};
+use super::transition::RuntimeLoopState;
 use super::turn_driver::TurnInputBroker;
-use super::turn_support::{check_turn_cancelled, tool_result_preview};
+use super::turn_support::tool_result_preview;
 use super::virtual_tools::{VirtualToolOutcome, try_handle_virtual_tool_call};
 use crate::agent_machine::NormalizedToolCall;
 
@@ -39,34 +38,6 @@ pub(super) enum ToolBatchOrchestratorOutcome {
     ContinueTurnLoop { refresh_context: bool },
     PauseTurn,
     EndTurn { surfaces_refreshed: bool },
-}
-
-fn confirmation_payload(
-    checkpoint_type: String,
-    summary: String,
-    details: Value,
-    options: Vec<String>,
-) -> ConfirmationYieldPayload {
-    let presentation_hints = if is_runtime_confirmation_checkpoint_type(&checkpoint_type) {
-        vec![AdaptivePresentationHint::Dangerous]
-    } else {
-        vec![]
-    };
-
-    let default_option = options
-        .iter()
-        .find(|option| option.as_str() == "approve")
-        .cloned()
-        .or_else(|| options.first().cloned());
-
-    ConfirmationYieldPayload {
-        checkpoint_type,
-        summary,
-        details: Some(details),
-        options,
-        default_option,
-        presentation_hints,
-    }
 }
 
 pub(super) struct ToolTurnOrchestrator {
@@ -210,101 +181,6 @@ fn maybe_allow_approved_tool_escalation_replay(
         }
         other => other,
     }
-}
-
-fn namespace_tool_payload(
-    tool: crate::runtime::NamespaceToolActionOutput,
-) -> Result<serde_json::Value> {
-    let trimmed = tool.output.trim();
-    let mut payload = if trimmed.is_empty() {
-        json!({})
-    } else {
-        serde_json::from_str::<Value>(trimmed)
-            .unwrap_or_else(|_| json!({ "output": tool.output.clone() }))
-    };
-    let process = format!("/proc/{}", tool.pid);
-    match &mut payload {
-        Value::Object(object) => {
-            object
-                .entry("success")
-                .or_insert(Value::Bool(tool.exit_code == 0));
-            object.entry("exit_code").or_insert(json!(tool.exit_code));
-            object.entry("process").or_insert(json!(process));
-            object.insert("action_id".to_string(), json!(tool.action_id));
-        }
-        other => {
-            payload = json!({
-                "success": tool.exit_code == 0,
-                "exit_code": tool.exit_code,
-                "output": other.clone(),
-                "process": process,
-                "action_id": tool.action_id,
-            });
-        }
-    }
-    Ok(payload)
-}
-
-async fn tool_payload_for_tape(agent_files: &NamespaceAgentFiles, payload: &Value) -> Value {
-    let redacted_payload = redact_evidence_payload(payload);
-    if !payload_needs_projection(&redacted_payload) {
-        return redacted_payload;
-    }
-
-    let Some(action_id) = payload.get("action_id").and_then(Value::as_str) else {
-        return project_evidence_payload(
-            payload,
-            None,
-            Vec::new(),
-            Some("reference_unresolvable".to_string()),
-        );
-    };
-    if action_id.is_empty() || action_id.contains('/') {
-        return project_evidence_payload(
-            payload,
-            None,
-            Vec::new(),
-            Some("reference_unresolvable".to_string()),
-        );
-    }
-    let reference = agent_files.action_output_reference(action_id).await;
-    let redactions = if let Some(reference) = reference.as_ref() {
-        agent_files
-            .resolve_evidence_reference(reference, None, None)
-            .await
-            .ok()
-            .and_then(|bytes| String::from_utf8(bytes).ok())
-            .map(|text| redaction_markers_in_text(&text))
-            .unwrap_or_default()
-    } else {
-        Vec::new()
-    };
-    let fallback_reason = reference
-        .is_none()
-        .then(|| "reference_unresolvable".to_string());
-    project_evidence_payload(payload, reference, redactions, fallback_reason)
-}
-
-async fn execute_tool_effect(
-    tools: crate::runtime::transition::NamespaceToolExecution,
-    tool_name: &str,
-    tool_arguments: Value,
-    cancel: &CancellationToken,
-    timeout_secs: usize,
-) -> Result<Value> {
-    let executable = format!("/bin/{tool_name}");
-    let arguments_doc =
-        serde_json::to_string(&tool_arguments).context("serialize tool arguments")?;
-    let tool = tools
-        .run_action_with_cancel_and_timeout(
-            tool_name,
-            &executable,
-            [arguments_doc],
-            cancel,
-            timeout_secs,
-        )
-        .await?;
-    namespace_tool_payload(tool)
 }
 
 async fn orchestrate_tool_call_with_guard<E, F>(
@@ -562,13 +438,8 @@ where
                 emit(Event::Yield {
                     request_id,
                     kind: alan_agent_protocol::YieldKind::Confirmation,
-                    payload: serde_json::to_value(confirmation_payload(
-                        pending.checkpoint_type.clone(),
-                        pending.summary.clone(),
-                        pending.details.clone(),
-                        pending.options.clone(),
-                    ))
-                    .unwrap_or_else(|_| json!({})),
+                    payload: serde_json::to_value(runtime_confirmation_yield_payload(&pending))
+                        .unwrap_or_else(|_| json!({})),
                 })
                 .await;
                 return Ok(ToolOrchestratorOutcome::PauseTurn);
@@ -615,279 +486,22 @@ where
         }
     };
 
-    let effect_lifecycle = ToolEffectLifecycle::for_call(
-        &state.machine,
-        state.process_path(),
-        tool_call.id.clone(),
-        tool_call.name.clone(),
-        &tool_arguments,
+    let runtime = super::transition::tool_execution_runtime(state);
+    let request = ToolExecutionRequest {
+        tool_call,
+        tool_arguments: &tool_arguments,
+        tool_timeout_secs: tool_package.timeout_secs,
         tool_capability,
-    );
-    let effect_plan = effect_lifecycle
-        .as_ref()
-        .map(|effect| effect.plan(&state.machine, allow_approved_unknown_effect_execution));
-
-    if matches!(effect_plan.as_ref(), Some(ToolEffectPlan::ConfirmUnknown)) {
-        let effect = effect_lifecycle
-            .as_ref()
-            .expect("effect plan requires a lifecycle");
-        let escalation_reason =
-            "Previous side effect attempt has unknown status; explicit confirmation required";
-        effect.record_unknown_confirmation(&mut state.machine, escalation_reason);
-
-        let pending = PendingConfirmation {
-            checkpoint_id: format!("{EFFECT_REPLAY_CHECKPOINT_PREFIX}{}", tool_call.id),
-            checkpoint_type: EFFECT_REPLAY_CHECKPOINT_TYPE.to_string(),
-            summary: "Potential duplicate side effect requires confirmation".to_string(),
-            details: append_skill_permission_hints(
-                json!({
-                    "reason": escalation_reason,
-                    "effect_status": "unknown",
-                    "effect_type": effect.effect_type(),
-                    "idempotency_key": effect.idempotency_key(),
-                    "request_fingerprint": effect.request_fingerprint(),
-                    "replay_tool_call": {
-                        "call_id": tool_call.id,
-                        "tool_name": tool_call.name,
-                        "arguments": tool_arguments,
-                    }
-                }),
-                state.machine.active_skills(),
-            ),
-            options: vec!["approve".to_string(), "reject".to_string()],
-        };
-        let request_id = state
-            .agent_files()
-            .write_confirmation_request(&pending)
-            .await?;
-        state.machine.record_tool_call_with_audit(
-            &tool_call.name,
-            tool_arguments.clone(),
-            json!({
-                "status": "escalation_required",
-                "reason": escalation_reason,
-                "idempotency_key": effect.idempotency_key(),
-                "effect_status": "unknown",
-                "request_id": request_id.clone()
-            }),
-            true,
-            tool_audit.clone(),
-        );
-        state
-            .machine
-            .set_confirmation_for_request(request_id.clone(), pending.clone());
-        super::ui_surfaces::paused(&state.agent_files()).await?;
-        emit(Event::Yield {
-            request_id,
-            kind: alan_agent_protocol::YieldKind::Confirmation,
-            payload: serde_json::to_value(confirmation_payload(
-                pending.checkpoint_type.clone(),
-                pending.summary.clone(),
-                pending.details.clone(),
-                pending.options.clone(),
-            ))
-            .unwrap_or_else(|_| json!({})),
-        })
-        .await;
-        return Ok(ToolOrchestratorOutcome::PauseTurn);
-    }
-
-    emit(Event::ToolCallStarted {
-        title: super::tool_presentation::tool_title(&tool_call.name, &tool_arguments),
-        id: tool_call.id.clone(),
-        name: tool_call.name.clone(),
-        audit: tool_audit.clone(),
-    })
-    .await;
-
-    if let Some(ToolEffectPlan::ReplayApplied {
-        payload: replay_payload,
-    }) = effect_plan
-    {
-        let dedupe_reason = "Matching applied side effect found; skipped physical execution";
-        emit(Event::ToolCallCompleted {
-            presentation: None,
-            id: tool_call.id.clone(),
-            name: Some(tool_call.name.clone()),
-            success: Some(true),
-            result_preview: tool_result_preview(&replay_payload),
-            audit: tool_audit.clone(),
-        })
-        .await;
-        state.machine.record_tool_call_with_audit(
-            &tool_call.name,
-            tool_arguments.clone(),
-            replay_payload.clone(),
-            true,
-            tool_audit,
-        );
-        state
-            .machine
-            .add_tool_message(&tool_call.id, &tool_call.name, replay_payload.clone());
-        effect_lifecycle
-            .as_ref()
-            .expect("replay plan requires a lifecycle")
-            .commit_replay(&mut state.machine, &replay_payload, dedupe_reason);
-        return Ok(ToolOrchestratorOutcome::ContinueToolBatch {
-            refresh_context: false,
-        });
-    }
-
-    let effect_start = if let Some(effect) = effect_lifecycle.as_ref() {
-        effect.record_execute_decision(&mut state.machine, "No applied effect record found");
-        match effect.begin(&mut state.machine).await {
-            Ok(record) => Some(record),
-            Err(failure) => {
-                emit(Event::Error {
-                    message: failure.message.clone(),
-                    recoverable: true,
-                })
-                .await;
-                emit(Event::ToolCallCompleted {
-                    presentation: None,
-                    id: tool_call.id.clone(),
-                    name: Some(tool_call.name.clone()),
-                    success: Some(false),
-                    result_preview: tool_result_preview(&failure.payload),
-                    audit: tool_audit.clone(),
-                })
-                .await;
-                state.machine.record_tool_call_with_audit(
-                    &tool_call.name,
-                    tool_arguments.clone(),
-                    failure.payload.clone(),
-                    false,
-                    tool_audit,
-                );
-                state
-                    .machine
-                    .add_tool_message(&tool_call.id, &tool_call.name, failure.payload);
-                return Ok(ToolOrchestratorOutcome::ContinueToolBatch {
-                    refresh_context: false,
-                });
-            }
-        }
-    } else {
-        None
+        tool_audit,
+        allow_approved_unknown_effect_execution,
+        cancel: inputs.cancel,
     };
-
-    let execution_target = state.tool_execution();
-    let tool_start = Instant::now();
-    let tool_timeout_secs = tool_package.timeout_secs;
-    let tool_result = execute_tool_effect(
-        execution_target,
-        &tool_call.name,
-        tool_arguments.clone(),
-        inputs.cancel,
-        tool_timeout_secs,
-    )
-    .await;
-    let agent_files = state.agent_files();
-    if inputs.cancel.is_cancelled()
-        && check_turn_cancelled(&mut state.machine, &agent_files, emit, inputs.cancel).await?
-    {
-        return Ok(ToolOrchestratorOutcome::EndTurn);
-    }
-
-    match tool_result {
-        Ok(value) => {
-            // `Ok` is only the transport result — the tool may report a logical
-            // failure in its payload (e.g. bash `{ "success": false, "exit_code": 1
-            // }`). Derive completion + effect status from that, so a failed
-            // side-effecting command is not cached as `Applied` (which would make a
-            // retry skip physical execution) and is not rendered as a success.
-            let payload_success =
-                value.get("success").and_then(serde_json::Value::as_bool) != Some(false);
-            if let (Some(effect), Some(effect_start)) =
-                (effect_lifecycle.as_ref(), effect_start.as_ref())
-            {
-                let reason =
-                    (!payload_success).then(|| "tool reported failure in payload".to_string());
-                effect.complete(
-                    &mut state.machine,
-                    effect_start,
-                    &value,
-                    payload_success,
-                    reason,
-                );
-            }
-            let tape_value = tool_payload_for_tape(&agent_files, &value).await;
-            emit(Event::ToolCallCompleted {
-                presentation: super::tool_presentation::tool_presentation(
-                    &tool_call.name,
-                    &tool_arguments,
-                    &value,
-                ),
-                id: tool_call.id.clone(),
-                name: Some(tool_call.name.clone()),
-                success: Some(payload_success),
-                result_preview: tool_result_preview(&value),
-                audit: tool_audit.clone(),
-            })
-            .await;
-            state.machine.record_tool_call_with_audit(
-                &tool_call.name,
-                tool_arguments.clone(),
-                value.clone(),
-                payload_success,
-                tool_audit.clone(),
-            );
-            state
-                .machine
-                .add_tool_message(&tool_call.id, &tool_call.name, tape_value);
-            info!(
-                tool_name = %tool_call.name,
-                elapsed_ms = tool_start.elapsed().as_millis(),
-                success = payload_success,
-                "Tool done"
-            );
-            Ok(ToolOrchestratorOutcome::ContinueToolBatch {
-                refresh_context: false,
-            })
-        }
-        Err(err) => {
-            let error_payload = json!({"error": err.to_string()});
-            if let (Some(effect), Some(effect_start)) =
-                (effect_lifecycle.as_ref(), effect_start.as_ref())
-            {
-                effect.complete(
-                    &mut state.machine,
-                    effect_start,
-                    &error_payload,
-                    false,
-                    Some(err.to_string()),
-                );
-            }
-            emit(Event::ToolCallCompleted {
-                presentation: None,
-                id: tool_call.id.clone(),
-                name: Some(tool_call.name.clone()),
-                success: Some(false),
-                result_preview: tool_result_preview(&error_payload),
-                audit: tool_audit.clone(),
-            })
-            .await;
-            state.machine.record_tool_call_with_audit(
-                &tool_call.name,
-                tool_arguments.clone(),
-                error_payload.clone(),
-                false,
-                tool_audit,
-            );
-            state
-                .machine
-                .add_tool_message(&tool_call.id, &tool_call.name, error_payload);
-            info!(
-                tool_name = %tool_call.name,
-                elapsed_ms = tool_start.elapsed().as_millis(),
-                success = false,
-                error = %err,
-                "Tool done"
-            );
-            Ok(ToolOrchestratorOutcome::ContinueToolBatch {
-                refresh_context: false,
-            })
-        }
+    match execute_allowed_tool_call(runtime, request, emit).await? {
+        ToolExecutionOutcome::Completed => Ok(ToolOrchestratorOutcome::ContinueToolBatch {
+            refresh_context: false,
+        }),
+        ToolExecutionOutcome::PauseTurn => Ok(ToolOrchestratorOutcome::PauseTurn),
+        ToolExecutionOutcome::EndTurn => Ok(ToolOrchestratorOutcome::EndTurn),
     }
 }
 

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -228,6 +228,20 @@ pub(super) fn agent_interaction_runtime(
     super::interaction_tools::AgentInteractionRuntime::new(&mut state.machine, agent_files)
 }
 
+pub(super) fn tool_execution_runtime(
+    state: &mut RuntimeLoopState,
+) -> super::tool_execution::ToolExecutionRuntime<'_> {
+    let agent_files = state.agent_files();
+    let tool_execution = state.tool_execution();
+    let process_path = state.process_path();
+    super::tool_execution::ToolExecutionRuntime::new(
+        &mut state.machine,
+        agent_files,
+        tool_execution,
+        process_path,
+    )
+}
+
 fn child_launch_base_agent_config(state: &RuntimeLoopState) -> super::launch_config::AgentConfig {
     let mut config = super::launch_config::AgentConfig::from(state.core_config.clone());
     config.runtime_config = state.runtime_config.clone();

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -338,6 +338,8 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
         "mount_request_tool/runtime_inputs.rs",
         "response_guardrails.rs",
         "steering_queue.rs",
+        "tool_execution.rs",
+        "tool_execution/runtime_inputs.rs",
         "turn_support.rs",
     ] {
         let source = read_runtime_source(path);
@@ -358,7 +360,8 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
     assert!(tool_definitions.contains("NamespaceToolExecution"));
 
     let tool_orchestrator = read_runtime_source("tool_orchestrator.rs");
-    let tool_evidence = &tool_orchestrator[tool_orchestrator
+    let tool_execution_source = read_runtime_source("tool_execution.rs");
+    let tool_evidence = &tool_execution_source[tool_execution_source
         .find("async fn tool_payload_for_tape")
         .expect("find tool_payload_for_tape")..];
     let tool_evidence = &tool_evidence[..tool_evidence
@@ -464,6 +467,22 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
     }
     assert!(interaction_runtime.contains("AgentInteractionRuntime"));
     assert!(transition.contains("fn agent_interaction_runtime("));
+
+    let tool_execution_runtime = read_runtime_source("tool_execution/runtime_inputs.rs");
+    for forbidden in [
+        "RuntimeLoopState",
+        "RuntimeConfig",
+        "NamespaceRuntimeEnvironment",
+    ] {
+        assert!(
+            !tool_execution_runtime.contains(forbidden),
+            "Tool execution runtime must not regain {forbidden}"
+        );
+    }
+    assert!(tool_execution_runtime.contains("ToolExecutionRuntime"));
+    assert!(transition.contains("fn tool_execution_runtime("));
+    assert!(read_runtime_source("tool_execution.rs").contains("execute_allowed_tool_call"));
+    assert!(!tool_orchestrator.contains("ToolEffectLifecycle"));
 
     for marker in [
         "fn compaction_submission_id",


### PR DESCRIPTION
## Summary
- move policy-approved Tool execution into a narrow `ToolExecutionRuntime` owner
- keep effect confirmation, dedupe replay, durable start, Tool Process execution, cancellation, evidence projection, and Machine recording on one path
- leave virtual Tool dispatch, policy evaluation, and guardian review in the orchestrator
- centralize runtime confirmation Yield payload construction with its dangerous presentation contract
- add dependency guards against `RuntimeLoopState`, `RuntimeConfig`, and `NamespaceRuntimeEnvironment`

## Verification
- `cargo test -p alan-agent-engine runtime::tool_orchestrator::tests` (35 passed)
- `cargo test -p alan-agent-engine tool_effect` (6 passed)
- `cargo test -p alan-agent-engine approval::tests` (7 passed)
- `cargo test -p alan-agent-engine` (1201 passed, 1 ignored)
- `cargo test -p alan-agent-engine --test dependency_boundary` (16 passed)
- `cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings`
- `openspec validate deepen-agent-machine-transition-module --strict`
- `just quality`

Part of `deepen-agent-machine-transition-module`.