### PR TITLE
refactor(agent-engine): isolate tool authorization runtime inputs

### DIFF
--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -26,6 +26,7 @@ mod prompt_cache;
 mod response_guardrails;
 mod steering_queue;
 mod submission_handlers;
+mod tool_authorization;
 mod tool_effect_lifecycle;
 mod tool_execution;
 mod tool_orchestrator;

--- a/crates/agent-engine/src/runtime/tool_authorization.rs
+++ b/crates/agent-engine/src/runtime/tool_authorization.rs
@@ -1,0 +1,312 @@
+//! Policy, guardian-review, and human-approval transition for one Tool call.
+
+use std::path::Path;
+
+use alan_agent_protocol::{Event, ToolCapability, ToolDecisionAudit};
+use anyhow::Result;
+use serde_json::{Value, json};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    agent_machine::NormalizedToolCall,
+    approval::{
+        PendingConfirmation, TOOL_ESCALATION_CHECKPOINT_PREFIX, TOOL_ESCALATION_CHECKPOINT_TYPE,
+        append_skill_permission_hints, runtime_confirmation_yield_payload,
+    },
+};
+
+use super::{
+    guardian::{
+        DEFAULT_REVIEWER_POLICY, ReviewContext, ReviewOutcome, build_review_request,
+        build_transcript, review_generation_result,
+    },
+    tool_policy::{EscalationRoute, SandboxConfinement, ToolPolicyDecision, evaluate_tool_policy},
+    turn_support::tool_result_preview,
+};
+
+mod runtime_inputs;
+
+pub(super) use runtime_inputs::ToolAuthorizationRuntime;
+
+pub(super) struct ToolAuthorizationRequest<'a> {
+    pub(super) tool_call: &'a NormalizedToolCall,
+    pub(super) tool_arguments: &'a Value,
+    pub(super) tool_capability: ToolCapability,
+    pub(super) current_tool_cwd: Option<&'a Path>,
+    pub(super) allow_approved_tool_escalation_execution: bool,
+    pub(super) cancel: &'a CancellationToken,
+}
+
+#[derive(Debug)]
+pub(super) enum ToolAuthorizationOutcome {
+    Authorized { audit: ToolDecisionAudit },
+    Completed,
+    PauseTurn,
+}
+
+pub(super) async fn authorize_tool_call<E, F>(
+    mut runtime: ToolAuthorizationRuntime<'_>,
+    request: ToolAuthorizationRequest<'_>,
+    emit: &mut E,
+) -> Result<ToolAuthorizationOutcome>
+where
+    E: FnMut(Event) -> F,
+    F: std::future::Future<Output = ()>,
+{
+    let ToolAuthorizationRequest {
+        tool_call,
+        tool_arguments,
+        tool_capability,
+        current_tool_cwd,
+        allow_approved_tool_escalation_execution,
+        cancel,
+    } = request;
+    let policy_decision = maybe_allow_approved_tool_escalation_replay(
+        evaluate_tool_policy(
+            runtime.policy_engine,
+            runtime.governance,
+            &tool_call.name,
+            tool_arguments,
+            tool_capability,
+            current_tool_cwd,
+            SandboxConfinement::detect(),
+        ),
+        allow_approved_tool_escalation_execution,
+    );
+    record_policy_decision(runtime.machine, tool_call, &policy_decision);
+
+    match policy_decision {
+        ToolPolicyDecision::Allow { audit } => Ok(ToolAuthorizationOutcome::Authorized { audit }),
+        ToolPolicyDecision::Escalate {
+            summary,
+            mut details,
+            audit,
+            route,
+        } => {
+            details["escalation_route"] = json!(match route {
+                EscalationRoute::Reviewer => "reviewer",
+                EscalationRoute::AlwaysHuman => "always_human",
+            });
+            details["replay_tool_call"] = json!({
+                "call_id": tool_call.id,
+                "tool_name": tool_call.name,
+                "arguments": tool_arguments,
+            });
+            details = append_skill_permission_hints(details, runtime.machine.active_skills());
+
+            if matches!(route, EscalationRoute::Reviewer) {
+                match review_escalation(
+                    &mut runtime,
+                    tool_call,
+                    tool_arguments,
+                    &details,
+                    &audit,
+                    cancel,
+                    emit,
+                )
+                .await?
+                {
+                    EscalationReviewOutcome::Authorized => {
+                        return Ok(ToolAuthorizationOutcome::Authorized { audit });
+                    }
+                    EscalationReviewOutcome::Completed => {
+                        return Ok(ToolAuthorizationOutcome::Completed);
+                    }
+                    EscalationReviewOutcome::Human => {}
+                }
+            }
+
+            let pending = PendingConfirmation {
+                checkpoint_id: format!("{TOOL_ESCALATION_CHECKPOINT_PREFIX}{}", tool_call.id),
+                checkpoint_type: TOOL_ESCALATION_CHECKPOINT_TYPE.to_string(),
+                summary,
+                details,
+                options: vec!["approve".to_string(), "reject".to_string()],
+            };
+            let request_id = runtime
+                .agent_files
+                .write_confirmation_request(&pending)
+                .await?;
+            runtime.machine.record_tool_call_with_audit(
+                &tool_call.name,
+                tool_arguments.clone(),
+                json!({"status":"escalation_required","request_id": request_id.clone()}),
+                true,
+                Some(audit),
+            );
+            runtime
+                .machine
+                .set_confirmation_for_request(request_id.clone(), pending.clone());
+            super::ui_surfaces::paused(&runtime.agent_files).await?;
+            emit(Event::Yield {
+                request_id,
+                kind: alan_agent_protocol::YieldKind::Confirmation,
+                payload: serde_json::to_value(runtime_confirmation_yield_payload(&pending))
+                    .unwrap_or_else(|_| json!({})),
+            })
+            .await;
+            Ok(ToolAuthorizationOutcome::PauseTurn)
+        }
+        ToolPolicyDecision::Forbidden { reason, audit } => {
+            let blocked_payload = json!({
+                "error": reason,
+                "status": "blocked_by_policy"
+            });
+            emit(Event::Error {
+                message: blocked_payload["error"]
+                    .as_str()
+                    .unwrap_or("Tool blocked by policy")
+                    .to_string(),
+                recoverable: true,
+            })
+            .await;
+            emit(Event::ToolCallCompleted {
+                presentation: None,
+                id: tool_call.id.clone(),
+                name: Some(tool_call.name.clone()),
+                success: Some(false),
+                result_preview: tool_result_preview(&blocked_payload),
+                audit: Some(audit.clone()),
+            })
+            .await;
+            runtime.machine.record_tool_call_with_audit(
+                &tool_call.name,
+                tool_arguments.clone(),
+                blocked_payload.clone(),
+                false,
+                Some(audit),
+            );
+            runtime
+                .machine
+                .add_tool_message(&tool_call.id, &tool_call.name, blocked_payload);
+            Ok(ToolAuthorizationOutcome::Completed)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EscalationReviewOutcome {
+    Authorized,
+    Completed,
+    Human,
+}
+
+async fn review_escalation<E, F>(
+    runtime: &mut ToolAuthorizationRuntime<'_>,
+    tool_call: &NormalizedToolCall,
+    tool_arguments: &Value,
+    details: &Value,
+    audit: &ToolDecisionAudit,
+    cancel: &CancellationToken,
+    emit: &mut E,
+) -> Result<EscalationReviewOutcome>
+where
+    E: FnMut(Event) -> F,
+    F: std::future::Future<Output = ()>,
+{
+    let transcript = build_transcript(runtime.machine.messages());
+    let review_context = ReviewContext {
+        policy: DEFAULT_REVIEWER_POLICY,
+        transcript: &transcript,
+        approval_request: details,
+    };
+    let request = build_review_request(&review_context);
+    let result = runtime
+        .generation
+        .generate_response_with_retry(request, runtime.llm_request_timeout_secs, cancel)
+        .await;
+
+    match review_generation_result(result) {
+        ReviewOutcome::Allow => {
+            runtime.machine.record_guardian_review(false);
+            Ok(EscalationReviewOutcome::Authorized)
+        }
+        ReviewOutcome::Deny { rationale } => {
+            let tripped = runtime.machine.record_guardian_review(true);
+            let message = format!("auto-review denied: {rationale}");
+            super::ui_surfaces::warning(&runtime.agent_files, message.clone()).await?;
+            emit(Event::Warning { message }).await;
+            if tripped {
+                let message = "auto-review circuit breaker tripped; pausing for you".to_string();
+                super::ui_surfaces::warning(&runtime.agent_files, message.clone()).await?;
+                emit(Event::Warning { message }).await;
+                Ok(EscalationReviewOutcome::Human)
+            } else {
+                let denied_payload = json!({
+                    "status": "denied_by_reviewer",
+                    "reason": rationale,
+                    "instruction": "Do not work around this denial. Pursue a materially safer \
+                        alternative, or stop and ask the user."
+                });
+                emit(Event::ToolCallCompleted {
+                    presentation: None,
+                    id: tool_call.id.clone(),
+                    name: Some(tool_call.name.clone()),
+                    success: Some(false),
+                    result_preview: tool_result_preview(&denied_payload),
+                    audit: Some(audit.clone()),
+                })
+                .await;
+                runtime.machine.record_tool_call_with_audit(
+                    &tool_call.name,
+                    tool_arguments.clone(),
+                    denied_payload.clone(),
+                    false,
+                    Some(audit.clone()),
+                );
+                runtime
+                    .machine
+                    .add_tool_message(&tool_call.id, &tool_call.name, denied_payload);
+                Ok(EscalationReviewOutcome::Completed)
+            }
+        }
+        ReviewOutcome::Unavailable { reason } => {
+            tracing::warn!(%reason, "auto-review unavailable; pausing for human");
+            Ok(EscalationReviewOutcome::Human)
+        }
+    }
+}
+
+fn record_policy_decision(
+    machine: &mut crate::agent_machine::AgentMachine,
+    tool_call: &NormalizedToolCall,
+    decision: &ToolPolicyDecision,
+) {
+    let audit = match decision {
+        ToolPolicyDecision::Allow { audit }
+        | ToolPolicyDecision::Escalate { audit, .. }
+        | ToolPolicyDecision::Forbidden { audit, .. } => audit,
+    };
+    machine.record_event(
+        "tool_policy_decision",
+        json!({
+            "tool_call_id": tool_call.id,
+            "tool_name": tool_call.name,
+            "policy_source": audit.policy_source,
+            "rule_id": audit.rule_id,
+            "action": audit.action,
+            "reason": audit.reason,
+            "capability": audit.capability,
+            "sandbox_backend": audit.sandbox_backend,
+            "path_mode": audit.path_mode,
+        }),
+    );
+}
+
+fn maybe_allow_approved_tool_escalation_replay(
+    policy_decision: ToolPolicyDecision,
+    allow_approved_tool_escalation_execution: bool,
+) -> ToolPolicyDecision {
+    match policy_decision {
+        ToolPolicyDecision::Escalate { audit, .. } if allow_approved_tool_escalation_execution => {
+            ToolPolicyDecision::Allow {
+                audit: ToolDecisionAudit {
+                    action: "allow".to_string(),
+                    reason: Some("approved tool escalation replay".to_string()),
+                    ..audit
+                },
+            }
+        }
+        other => other,
+    }
+}

--- a/crates/agent-engine/src/runtime/tool_authorization/runtime_inputs.rs
+++ b/crates/agent-engine/src/runtime/tool_authorization/runtime_inputs.rs
@@ -1,0 +1,35 @@
+use crate::{
+    agent_machine::AgentMachine,
+    policy::PolicyEngine,
+    runtime::transition::{NamespaceAgentFiles, NamespaceGeneration},
+};
+
+/// Explicit inputs for one Tool policy and approval transition.
+pub(crate) struct ToolAuthorizationRuntime<'a> {
+    pub(super) machine: &'a mut AgentMachine,
+    pub(super) policy_engine: &'a PolicyEngine,
+    pub(super) governance: &'a alan_agent_protocol::GovernanceConfig,
+    pub(super) generation: NamespaceGeneration,
+    pub(super) agent_files: NamespaceAgentFiles,
+    pub(super) llm_request_timeout_secs: u64,
+}
+
+impl<'a> ToolAuthorizationRuntime<'a> {
+    pub(crate) fn new(
+        machine: &'a mut AgentMachine,
+        policy_engine: &'a PolicyEngine,
+        governance: &'a alan_agent_protocol::GovernanceConfig,
+        generation: NamespaceGeneration,
+        agent_files: NamespaceAgentFiles,
+        llm_request_timeout_secs: u64,
+    ) -> Self {
+        Self {
+            machine,
+            policy_engine,
+            governance,
+            generation,
+            agent_files,
+            llm_request_timeout_secs,
+        }
+    }
+}

--- a/crates/agent-engine/src/runtime/tool_orchestrator.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator.rs
@@ -5,13 +5,13 @@ use serde_json::Value;
 use serde_json::json;
 use tokio_util::sync::CancellationToken;
 
-use crate::approval::{
-    PendingConfirmation, TOOL_ESCALATION_CHECKPOINT_PREFIX, TOOL_ESCALATION_CHECKPOINT_TYPE,
-    append_skill_permission_hints, replays_tool_calls, runtime_confirmation_yield_payload,
-};
+use crate::approval::replays_tool_calls;
 
 use super::loop_guard::ToolLoopGuard;
 use super::steering_queue::handle_queued_steering_inputs;
+use super::tool_authorization::{
+    ToolAuthorizationOutcome, ToolAuthorizationRequest, authorize_tool_call,
+};
 #[cfg(test)]
 use super::tool_effect_lifecycle::{EffectCategory, build_effect_identity};
 use super::tool_execution::{
@@ -19,7 +19,6 @@ use super::tool_execution::{
 };
 #[cfg(test)]
 use super::tool_execution::{execute_tool_effect, tool_payload_for_tape};
-use super::tool_policy::{ToolPolicyDecision, evaluate_tool_policy};
 use super::transition::RuntimeLoopState;
 use super::turn_driver::TurnInputBroker;
 use super::turn_support::tool_result_preview;
@@ -165,24 +164,6 @@ pub(super) struct ToolOrchestratorInputs<'a> {
     pub steering_broker: Option<&'a TurnInputBroker>,
 }
 
-fn maybe_allow_approved_tool_escalation_replay(
-    policy_decision: ToolPolicyDecision,
-    allow_approved_tool_escalation_execution: bool,
-) -> ToolPolicyDecision {
-    match policy_decision {
-        ToolPolicyDecision::Escalate { audit, .. } if allow_approved_tool_escalation_execution => {
-            ToolPolicyDecision::Allow {
-                audit: alan_agent_protocol::ToolDecisionAudit {
-                    action: "allow".to_string(),
-                    reason: Some("approved tool escalation replay".to_string()),
-                    ..audit
-                },
-            }
-        }
-        other => other,
-    }
-}
-
 async fn orchestrate_tool_call_with_guard<E, F>(
     state: &mut RuntimeLoopState,
     loop_guard: &mut ToolLoopGuard,
@@ -277,214 +258,27 @@ where
         .tool_execution()
         .resolve_capability(&tool_package, &tool_arguments);
     let current_tool_cwd = state.tool_execution().default_cwd();
-    let policy_decision = maybe_allow_approved_tool_escalation_replay(
-        evaluate_tool_policy(
-            &state.runtime_config.policy_engine,
-            &state.runtime_config.governance,
-            &tool_call.name,
-            &tool_arguments,
-            tool_capability,
-            current_tool_cwd.as_deref(),
-            super::tool_policy::SandboxConfinement::detect(),
-        ),
+    let authorization_runtime = super::transition::tool_authorization_runtime(state);
+    let authorization_request = ToolAuthorizationRequest {
+        tool_call,
+        tool_arguments: &tool_arguments,
+        tool_capability,
+        current_tool_cwd: current_tool_cwd.as_deref(),
         allow_approved_tool_escalation_execution,
-    );
-    let policy_audit = match &policy_decision {
-        ToolPolicyDecision::Allow { audit }
-        | ToolPolicyDecision::Escalate { audit, .. }
-        | ToolPolicyDecision::Forbidden { audit, .. } => audit.clone(),
+        cancel: inputs.cancel,
     };
-    state.machine.record_event(
-        "tool_policy_decision",
-        json!({
-            "tool_call_id": tool_call.id,
-            "tool_name": tool_call.name,
-            "policy_source": policy_audit.policy_source,
-            "rule_id": policy_audit.rule_id,
-            "action": policy_audit.action,
-            "reason": policy_audit.reason,
-            "capability": policy_audit.capability,
-            "sandbox_backend": policy_audit.sandbox_backend,
-            "path_mode": policy_audit.path_mode,
-        }),
-    );
-
-    let tool_audit = match policy_decision {
-        ToolPolicyDecision::Allow { audit } => Some(audit),
-        ToolPolicyDecision::Escalate {
-            summary,
-            mut details,
-            audit,
-            route,
-        } => {
-            details["escalation_route"] = json!(match route {
-                super::tool_policy::EscalationRoute::Reviewer => "reviewer",
-                super::tool_policy::EscalationRoute::AlwaysHuman => "always_human",
-            });
-            details["replay_tool_call"] = json!({
-                "call_id": tool_call.id,
-                "tool_name": tool_call.name,
-                "arguments": tool_arguments,
-            });
-            details = append_skill_permission_hints(details, state.machine.active_skills());
-
-            // Reviewer-routed escalations consult the guardian before pausing for
-            // a human. The sandbox + the deterministic red line remain the
-            // boundary; the reviewer only decides whether to bother the human.
-            let go_human = if matches!(route, super::tool_policy::EscalationRoute::Reviewer) {
-                let transcript = super::guardian::build_transcript(state.machine.messages());
-                let outcome = {
-                    let review_ctx = super::guardian::ReviewContext {
-                        policy: super::guardian::DEFAULT_REVIEWER_POLICY,
-                        transcript: &transcript,
-                        approval_request: &details,
-                    };
-                    let llm_request_timeout_secs = state.runtime_config.llm_request_timeout_secs;
-                    let request = super::guardian::build_review_request(&review_ctx);
-                    let result = state
-                        .namespace_generation()
-                        .generate_response_with_retry(
-                            request,
-                            llm_request_timeout_secs,
-                            inputs.cancel,
-                        )
-                        .await;
-                    super::guardian::review_generation_result(result)
-                };
-                match outcome {
-                    super::guardian::ReviewOutcome::Allow => {
-                        state.machine.record_guardian_review(false);
-                        false
-                    }
-                    super::guardian::ReviewOutcome::Deny { rationale } => {
-                        let tripped = state.machine.record_guardian_review(true);
-                        let message = format!("auto-review denied: {rationale}");
-                        super::ui_surfaces::warning(&state.agent_files(), message.clone()).await?;
-                        emit(Event::Warning { message }).await;
-                        if tripped {
-                            let message =
-                                "auto-review circuit breaker tripped; pausing for you".to_string();
-                            super::ui_surfaces::warning(&state.agent_files(), message.clone())
-                                .await?;
-                            emit(Event::Warning { message }).await;
-                            true
-                        } else {
-                            // Self-correction: feed the denial back to the agent.
-                            let denied_payload = json!({
-                                "status": "denied_by_reviewer",
-                                "reason": rationale,
-                                "instruction": "Do not work around this denial. Pursue a \
-                                 materially safer alternative, or stop and ask the user."
-                            });
-                            emit(Event::ToolCallCompleted {
-                                presentation: None,
-                                id: tool_call.id.clone(),
-                                name: Some(tool_call.name.clone()),
-                                success: Some(false),
-                                result_preview: tool_result_preview(&denied_payload),
-                                audit: Some(audit.clone()),
-                            })
-                            .await;
-                            state.machine.record_tool_call_with_audit(
-                                &tool_call.name,
-                                tool_arguments.clone(),
-                                denied_payload.clone(),
-                                false,
-                                Some(audit),
-                            );
-                            state.machine.add_tool_message(
-                                &tool_call.id,
-                                &tool_call.name,
-                                denied_payload,
-                            );
-                            return Ok(ToolOrchestratorOutcome::ContinueToolBatch {
-                                refresh_context: false,
-                            });
-                        }
-                    }
-                    super::guardian::ReviewOutcome::Unavailable { reason } => {
-                        tracing::warn!(%reason, "auto-review unavailable; pausing for human");
-                        true
-                    }
-                }
-            } else {
-                // Always-human red line.
-                true
-            };
-
-            if go_human {
-                let pending = PendingConfirmation {
-                    checkpoint_id: format!("{TOOL_ESCALATION_CHECKPOINT_PREFIX}{}", tool_call.id),
-                    checkpoint_type: TOOL_ESCALATION_CHECKPOINT_TYPE.to_string(),
-                    summary,
-                    details,
-                    options: vec!["approve".to_string(), "reject".to_string()],
-                };
-                let request_id = state
-                    .agent_files()
-                    .write_confirmation_request(&pending)
-                    .await?;
-                state.machine.record_tool_call_with_audit(
-                    &tool_call.name,
-                    tool_arguments.clone(),
-                    json!({"status":"escalation_required","request_id": request_id.clone()}),
-                    true,
-                    Some(audit),
-                );
-                state
-                    .machine
-                    .set_confirmation_for_request(request_id.clone(), pending.clone());
-                super::ui_surfaces::paused(&state.agent_files()).await?;
-                emit(Event::Yield {
-                    request_id,
-                    kind: alan_agent_protocol::YieldKind::Confirmation,
-                    payload: serde_json::to_value(runtime_confirmation_yield_payload(&pending))
-                        .unwrap_or_else(|_| json!({})),
-                })
-                .await;
+    let tool_audit =
+        match authorize_tool_call(authorization_runtime, authorization_request, emit).await? {
+            ToolAuthorizationOutcome::Authorized { audit } => Some(audit),
+            ToolAuthorizationOutcome::Completed => {
+                return Ok(ToolOrchestratorOutcome::ContinueToolBatch {
+                    refresh_context: false,
+                });
+            }
+            ToolAuthorizationOutcome::PauseTurn => {
                 return Ok(ToolOrchestratorOutcome::PauseTurn);
             }
-
-            // Reviewer approved — proceed to execute (still sandboxed).
-            Some(audit)
-        }
-        ToolPolicyDecision::Forbidden { reason, audit } => {
-            let blocked_payload = json!({
-                "error": reason,
-                "status": "blocked_by_policy"
-            });
-            emit(Event::Error {
-                message: blocked_payload["error"]
-                    .as_str()
-                    .unwrap_or("Tool blocked by policy")
-                    .to_string(),
-                recoverable: true,
-            })
-            .await;
-            emit(Event::ToolCallCompleted {
-                presentation: None,
-                id: tool_call.id.clone(),
-                name: Some(tool_call.name.clone()),
-                success: Some(false),
-                result_preview: tool_result_preview(&blocked_payload),
-                audit: Some(audit.clone()),
-            })
-            .await;
-            state.machine.record_tool_call_with_audit(
-                &tool_call.name,
-                tool_arguments.clone(),
-                blocked_payload.clone(),
-                false,
-                Some(audit),
-            );
-            state
-                .machine
-                .add_tool_message(&tool_call.id, &tool_call.name, blocked_payload);
-            return Ok(ToolOrchestratorOutcome::ContinueToolBatch {
-                refresh_context: false,
-            });
-        }
-    };
+        };
 
     let runtime = super::transition::tool_execution_runtime(state);
     let request = ToolExecutionRequest {

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -228,6 +228,22 @@ pub(super) fn agent_interaction_runtime(
     super::interaction_tools::AgentInteractionRuntime::new(&mut state.machine, agent_files)
 }
 
+pub(super) fn tool_authorization_runtime(
+    state: &mut RuntimeLoopState,
+) -> super::tool_authorization::ToolAuthorizationRuntime<'_> {
+    let generation = state.namespace_generation();
+    let agent_files = state.agent_files();
+    let llm_request_timeout_secs = state.runtime_config.llm_request_timeout_secs;
+    super::tool_authorization::ToolAuthorizationRuntime::new(
+        &mut state.machine,
+        &state.runtime_config.policy_engine,
+        &state.runtime_config.governance,
+        generation,
+        agent_files,
+        llm_request_timeout_secs,
+    )
+}
+
 pub(super) fn tool_execution_runtime(
     state: &mut RuntimeLoopState,
 ) -> super::tool_execution::ToolExecutionRuntime<'_> {

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -338,6 +338,8 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
         "mount_request_tool/runtime_inputs.rs",
         "response_guardrails.rs",
         "steering_queue.rs",
+        "tool_authorization.rs",
+        "tool_authorization/runtime_inputs.rs",
         "tool_execution.rs",
         "tool_execution/runtime_inputs.rs",
         "turn_support.rs",
@@ -467,6 +469,33 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
     }
     assert!(interaction_runtime.contains("AgentInteractionRuntime"));
     assert!(transition.contains("fn agent_interaction_runtime("));
+
+    let tool_authorization_runtime = read_runtime_source("tool_authorization/runtime_inputs.rs");
+    for forbidden in [
+        "RuntimeLoopState",
+        "RuntimeConfig",
+        "NamespaceRuntimeEnvironment",
+    ] {
+        assert!(
+            !tool_authorization_runtime.contains(forbidden),
+            "Tool authorization runtime must not regain {forbidden}"
+        );
+    }
+    assert!(tool_authorization_runtime.contains("ToolAuthorizationRuntime"));
+    assert!(transition.contains("fn tool_authorization_runtime("));
+    let tool_authorization = read_runtime_source("tool_authorization.rs");
+    assert!(tool_authorization.contains("authorize_tool_call"));
+    for displaced_owner in [
+        "evaluate_tool_policy(",
+        "ReviewOutcome::",
+        "write_confirmation_request(",
+        "record_guardian_review(",
+    ] {
+        assert!(
+            !tool_orchestrator.contains(displaced_owner),
+            "Tool orchestrator must leave {displaced_owner} to the authorization owner"
+        );
+    }
 
     let tool_execution_runtime = read_runtime_source("tool_execution/runtime_inputs.rs");
     for forbidden in [


### PR DESCRIPTION
## Summary
- move Tool policy evaluation, guardian review, human escalation, and policy denial into one narrow ToolAuthorizationRuntime owner
- pass only Agent Machine, policy/governance, namespace generation, AgentFS, and the existing request timeout into the workflow
- keep Tool discovery, virtual dispatch, batch control, and physical Tool Process execution in their existing owners
- delete the displaced policy and approval path from the Tool orchestrator
- add dependency guards against broad runtime and namespace-environment reach-through

## Verification
- cargo test -p alan-agent-engine runtime::tool_orchestrator::tests (35 passed)
- cargo test -p alan-agent-engine (1201 passed, 1 ignored)
- cargo test -p alan-agent-engine --test dependency_boundary (16 passed)
- cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings
- openspec validate deepen-agent-machine-transition-module --strict
- just quality

Part of deepen-agent-machine-transition-module.