### PR TITLE
refactor(agent-engine): confine virtual tool dispatch

### DIFF
--- a/crates/agent-engine/src/runtime/child_run_termination_tool_tests.rs
+++ b/crates/agent-engine/src/runtime/child_run_termination_tool_tests.rs
@@ -21,7 +21,7 @@ fn test_terminate_child_run_tool_definition() {
     );
 }
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_terminate_child_run_success() {
+async fn test_dispatch_virtual_tool_call_terminate_child_run_success() {
     let mut state = create_test_transition_state();
     let child_run_id = format!("child-run-{}", uuid::Uuid::new_v4());
     state
@@ -44,7 +44,7 @@ async fn test_try_handle_virtual_tool_call_terminate_child_run_success() {
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(
         result.unwrap(),
@@ -81,7 +81,7 @@ async fn test_try_handle_virtual_tool_call_terminate_child_run_success() {
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_terminate_child_run_unknown_child() {
+async fn test_dispatch_virtual_tool_call_terminate_child_run_unknown_child() {
     let mut state = create_test_transition_state();
     let child_run_id = format!("missing-child-run-{}", uuid::Uuid::new_v4());
 
@@ -101,7 +101,7 @@ async fn test_try_handle_virtual_tool_call_terminate_child_run_unknown_child() {
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(
         result.unwrap(),
@@ -121,7 +121,7 @@ async fn test_try_handle_virtual_tool_call_terminate_child_run_unknown_child() {
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_terminate_child_run_already_terminal() {
+async fn test_dispatch_virtual_tool_call_terminate_child_run_already_terminal() {
     let mut state = create_test_transition_state();
     let child_run_id = format!("child-run-{}", uuid::Uuid::new_v4());
     state
@@ -147,7 +147,7 @@ async fn test_try_handle_virtual_tool_call_terminate_child_run_already_terminal(
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(
         result.unwrap(),
@@ -174,7 +174,7 @@ async fn test_try_handle_virtual_tool_call_terminate_child_run_already_terminal(
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_terminate_child_run_escalates_under_escalating_policy() {
+async fn test_dispatch_virtual_tool_call_terminate_child_run_escalates_under_escalating_policy() {
     let mut state = create_test_transition_state();
     state.runtime_config.governance = alan_agent_protocol::GovernanceConfig {
         profile: alan_agent_protocol::GovernanceProfile::Autonomous,
@@ -202,7 +202,7 @@ async fn test_try_handle_virtual_tool_call_terminate_child_run_escalates_under_e
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(result.unwrap(), VirtualToolOutcome::PauseTurn));
     assert!(state.machine.pending_confirmation().is_some());
@@ -221,7 +221,7 @@ async fn test_try_handle_virtual_tool_call_terminate_child_run_escalates_under_e
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_terminate_child_run_denied_by_policy() {
+async fn test_dispatch_virtual_tool_call_terminate_child_run_denied_by_policy() {
     let mut state = create_test_transition_state();
     let temp = TempDir::new().unwrap();
     std::fs::write(
@@ -264,7 +264,7 @@ default_action: allow
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(
         result.unwrap(),

--- a/crates/agent-engine/src/runtime/delegated_skill_tool_tests.rs
+++ b/crates/agent-engine/src/runtime/delegated_skill_tool_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_invoke_delegated_skill() {
+async fn test_dispatch_virtual_tool_call_invoke_delegated_skill() {
     let mut state = create_test_transition_state();
     activate_test_delegated_skill(&mut state, "repo-review", "reviewer");
 
@@ -159,8 +159,7 @@ async fn test_delegated_capability_rejection_is_recorded_on_parent_tape() {
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_from_catalog_without_activation()
-{
+async fn test_dispatch_virtual_tool_call_invoke_delegated_skill_from_catalog_without_activation() {
     let temp = TempDir::new().unwrap();
     let package_store = temp.path().join("package-store");
     let skill_dir = package_store.join("repo-review");
@@ -251,7 +250,7 @@ Use this skill when asked.
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_rejects_when_runtime_support_is_disabled()
+async fn test_dispatch_virtual_tool_call_invoke_delegated_skill_rejects_when_runtime_support_is_disabled()
  {
     let temp = TempDir::new().unwrap();
     let package_store = temp.path().join("package-store");
@@ -350,7 +349,7 @@ Use this skill when asked.
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_records_successful_tool_call() {
+async fn test_dispatch_virtual_tool_call_invoke_delegated_skill_records_successful_tool_call() {
     let temp = TempDir::new().unwrap();
     let mut state = create_test_transition_state();
     state.machine = AgentMachine::new_with_recorder_in_dir("/proc/test", "gpt-5-mini", temp.path())
@@ -417,7 +416,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_records_succes
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_records_normalized_namespace_cwd() {
+async fn test_dispatch_virtual_tool_call_records_normalized_namespace_cwd() {
     let temp = TempDir::new().unwrap();
     let mut state = create_test_transition_state();
     state.machine = AgentMachine::new_with_recorder_in_dir("/proc/test", "gpt-5-mini", temp.path())
@@ -488,7 +487,7 @@ async fn test_try_handle_virtual_tool_call_records_normalized_namespace_cwd() {
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_bounds_preview_and_payload() {
+async fn test_dispatch_virtual_tool_call_invoke_delegated_skill_bounds_preview_and_payload() {
     let mut state = create_test_transition_state();
     let long_skill_id = format!("repo-review-{}", "x".repeat(150));
     let long_target = format!("reviewer-{}", "y".repeat(150));
@@ -620,7 +619,7 @@ async fn test_pre_cancelled_delegated_invocation_does_not_project_or_spawn_child
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_honors_interrupt() {
+async fn test_dispatch_virtual_tool_call_invoke_delegated_skill_honors_interrupt() {
     let mut state = create_test_transition_state();
     activate_test_delegated_skill(&mut state, "repo-review", "reviewer");
     state.machine.set_turn_activity(TurnActivityState::Running);
@@ -689,8 +688,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_honors_interru
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_honors_interrupt_during_startup()
-{
+async fn test_dispatch_virtual_tool_call_invoke_delegated_skill_honors_interrupt_during_startup() {
     let mut state = create_test_transition_state();
     activate_test_delegated_skill(&mut state, "repo-review", "reviewer");
     state.machine.set_turn_activity(TurnActivityState::Running);
@@ -747,7 +745,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_honors_interru
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_invalid_delegated_skill_request() {
+async fn test_dispatch_virtual_tool_call_invalid_delegated_skill_request() {
     let mut state = create_test_transition_state();
 
     let tool_call = NormalizedToolCall {
@@ -765,7 +763,7 @@ async fn test_try_handle_virtual_tool_call_invalid_delegated_skill_request() {
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(
         result.unwrap(),
@@ -785,7 +783,7 @@ async fn test_try_handle_virtual_tool_call_invalid_delegated_skill_request() {
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_rejects_target_mismatch() {
+async fn test_dispatch_virtual_tool_call_rejects_target_mismatch() {
     let mut state = create_test_transition_state();
     activate_test_delegated_skill(&mut state, "repo-review", "reviewer");
 

--- a/crates/agent-engine/src/runtime/interaction_tool_tests.rs
+++ b/crates/agent-engine/src/runtime/interaction_tool_tests.rs
@@ -358,9 +358,9 @@ fn test_parse_structured_user_input_request_fallback_request_id() {
     assert_eq!(result.unwrap().request_id, "fallback_id");
 }
 
-// Tests for try_handle_virtual_tool_call
+// Tests for dispatch_virtual_tool_call
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_request_confirmation() {
+async fn test_dispatch_virtual_tool_call_request_confirmation() {
     let mut state = create_test_transition_state();
 
     let tool_call = NormalizedToolCall {
@@ -379,7 +379,7 @@ async fn test_try_handle_virtual_tool_call_request_confirmation() {
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(result.unwrap(), VirtualToolOutcome::PauseTurn));
 
@@ -408,7 +408,7 @@ async fn namespace_request_confirmation_writes_request_file_and_waits_on_file_id
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit)
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit)
         .await
         .unwrap();
     assert!(matches!(result, VirtualToolOutcome::PauseTurn));
@@ -443,7 +443,7 @@ async fn namespace_request_confirmation_writes_request_file_and_waits_on_file_id
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_invalid_confirmation() {
+async fn test_dispatch_virtual_tool_call_invalid_confirmation() {
     let mut state = create_test_transition_state();
 
     let tool_call = NormalizedToolCall {
@@ -461,13 +461,13 @@ async fn test_try_handle_virtual_tool_call_invalid_confirmation() {
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(result.unwrap(), VirtualToolOutcome::EndTurn));
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_request_user_input() {
+async fn test_dispatch_virtual_tool_call_request_user_input() {
     let mut state = create_test_transition_state();
 
     let tool_call = NormalizedToolCall {
@@ -486,7 +486,7 @@ async fn test_try_handle_virtual_tool_call_request_user_input() {
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(result.unwrap(), VirtualToolOutcome::PauseTurn));
 
@@ -514,7 +514,7 @@ async fn namespace_request_user_input_writes_request_file_and_waits_on_file_id()
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit)
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit)
         .await
         .unwrap();
     assert!(matches!(result, VirtualToolOutcome::PauseTurn));
@@ -544,7 +544,7 @@ async fn namespace_request_user_input_writes_request_file_and_waits_on_file_id()
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_invalid_user_input() {
+async fn test_dispatch_virtual_tool_call_invalid_user_input() {
     let mut state = create_test_transition_state();
 
     let tool_call = NormalizedToolCall {
@@ -562,7 +562,7 @@ async fn test_try_handle_virtual_tool_call_invalid_user_input() {
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(result.unwrap(), VirtualToolOutcome::EndTurn));
 }

--- a/crates/agent-engine/src/runtime/mount_request_tool_tests.rs
+++ b/crates/agent-engine/src/runtime/mount_request_tool_tests.rs
@@ -198,7 +198,7 @@ fn test_parse_mount_request_rejects_invalid_fields() {
     }
 }
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_request_mount_escalates_even_when_allowed() {
+async fn test_dispatch_virtual_tool_call_request_mount_escalates_even_when_allowed() {
     let mut state = create_test_transition_state();
     state.runtime_config.policy_engine = crate::policy::PolicyEngine::allow_all();
     let temp = TempDir::new().unwrap();
@@ -222,7 +222,7 @@ async fn test_try_handle_virtual_tool_call_request_mount_escalates_even_when_all
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(result.unwrap(), VirtualToolOutcome::PauseTurn));
 
@@ -273,7 +273,7 @@ async fn test_try_handle_virtual_tool_call_request_mount_escalates_even_when_all
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_request_mount_does_not_probe_host_existence() {
+async fn test_dispatch_virtual_tool_call_request_mount_does_not_probe_host_existence() {
     let mut state = create_test_transition_state();
     state.runtime_config.policy_engine = crate::policy::PolicyEngine::allow_all();
     let missing_host_path = TempDir::new()
@@ -299,7 +299,7 @@ async fn test_try_handle_virtual_tool_call_request_mount_does_not_probe_host_exi
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(result.unwrap(), VirtualToolOutcome::PauseTurn));
 
@@ -320,7 +320,7 @@ async fn test_try_handle_virtual_tool_call_request_mount_does_not_probe_host_exi
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_request_mount_denied_by_policy() {
+async fn test_dispatch_virtual_tool_call_request_mount_denied_by_policy() {
     let mut state = create_test_transition_state();
     state.runtime_config.policy_engine = crate::policy::PolicyEngine::deny_all();
     let temp = TempDir::new().unwrap();
@@ -343,7 +343,7 @@ async fn test_try_handle_virtual_tool_call_request_mount_denied_by_policy() {
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(
         result.unwrap(),
@@ -371,7 +371,7 @@ async fn test_try_handle_virtual_tool_call_request_mount_denied_by_policy() {
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_request_mount_read_only_uses_read_policy() {
+async fn test_dispatch_virtual_tool_call_request_mount_read_only_uses_read_policy() {
     let mut state = create_test_transition_state();
     let temp = TempDir::new().unwrap();
     let host_dir = temp.path().join("ssh");
@@ -413,7 +413,7 @@ default_action: allow
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(
         result.unwrap(),
@@ -436,7 +436,7 @@ default_action: allow
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_request_mount_read_write_honors_read_denies() {
+async fn test_dispatch_virtual_tool_call_request_mount_read_write_honors_read_denies() {
     let mut state = create_test_transition_state();
     let temp = TempDir::new().unwrap();
     let host_dir = temp.path().join("ssh");
@@ -478,7 +478,7 @@ default_action: allow
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(
         result.unwrap(),
@@ -501,7 +501,7 @@ default_action: allow
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_request_mount_rejects_invalid_request() {
+async fn test_dispatch_virtual_tool_call_request_mount_rejects_invalid_request() {
     let mut state = create_test_transition_state();
 
     let tool_call = NormalizedToolCall {
@@ -521,7 +521,7 @@ async fn test_try_handle_virtual_tool_call_request_mount_rejects_invalid_request
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(
         result.unwrap(),

--- a/crates/agent-engine/src/runtime/plan_tool_tests.rs
+++ b/crates/agent-engine/src/runtime/plan_tool_tests.rs
@@ -123,7 +123,7 @@ fn test_parse_plan_status_invalid_values() {
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_update_plan() {
+async fn test_dispatch_virtual_tool_call_update_plan() {
     let mut state = create_test_transition_state();
     let expected_items = vec![alan_agent_protocol::PlanItem {
         id: "1".to_string(),
@@ -146,7 +146,7 @@ async fn test_try_handle_virtual_tool_call_update_plan() {
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(
         result.unwrap(),
@@ -177,7 +177,7 @@ async fn test_try_handle_virtual_tool_call_update_plan() {
 }
 
 #[tokio::test]
-async fn test_try_handle_virtual_tool_call_invalid_update_plan() {
+async fn test_dispatch_virtual_tool_call_invalid_update_plan() {
     let mut state = create_test_transition_state();
 
     let tool_call = NormalizedToolCall {
@@ -195,7 +195,7 @@ async fn test_try_handle_virtual_tool_call_invalid_update_plan() {
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(
         result.unwrap(),

--- a/crates/agent-engine/src/runtime/submission_handlers.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers.rs
@@ -581,7 +581,7 @@ fn validated_mount_escalation_request(
         .filter(|raw| !raw.is_empty())?
         .to_string();
     let mount_request = pending.details.get("mount_request")?;
-    let mount_request = super::virtual_tools::parse_mount_request(mount_request)
+    let mount_request = super::mount_request_tool::parse_mount_request(mount_request)
         .ok()?
         .payload();
     Some((tool_call_id, mount_request))

--- a/crates/agent-engine/src/runtime/tool_orchestrator.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator.rs
@@ -19,10 +19,10 @@ use super::tool_execution::{
 };
 #[cfg(test)]
 use super::tool_execution::{execute_tool_effect, tool_payload_for_tape};
-use super::transition::RuntimeLoopState;
+use super::transition::{RuntimeLoopState, dispatch_virtual_tool_call};
 use super::turn_driver::TurnInputBroker;
 use super::turn_support::tool_result_preview;
-use super::virtual_tools::{VirtualToolOutcome, try_handle_virtual_tool_call};
+use super::virtual_tool::VirtualToolOutcome;
 use crate::agent_machine::NormalizedToolCall;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -193,7 +193,7 @@ where
         return Ok(ToolOrchestratorOutcome::EndTurn);
     }
 
-    match try_handle_virtual_tool_call(
+    match dispatch_virtual_tool_call(
         state,
         tool_call,
         &tool_arguments,

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -26,10 +26,8 @@ use anyhow::Result;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
-#[cfg(test)]
-use crate::agent_machine::NormalizedToolCall;
 use crate::{
-    agent_machine::{AgentMachine, DeferredRuntimeAction, TurnActivityState},
+    agent_machine::{AgentMachine, DeferredRuntimeAction, NormalizedToolCall, TurnActivityState},
     config::Config,
     runtime::RuntimeConfig,
 };
@@ -226,6 +224,88 @@ pub(super) fn agent_interaction_runtime(
 ) -> super::interaction_tools::AgentInteractionRuntime<'_> {
     let agent_files = state.agent_files();
     super::interaction_tools::AgentInteractionRuntime::new(&mut state.machine, agent_files)
+}
+
+pub(super) async fn dispatch_virtual_tool_call<E, F>(
+    state: &mut RuntimeLoopState,
+    tool_call: &NormalizedToolCall,
+    tool_arguments: &serde_json::Value,
+    cancel: &CancellationToken,
+    allow_approved_tool_escalation_execution: bool,
+    emit: &mut E,
+) -> Result<super::virtual_tool::VirtualToolOutcome>
+where
+    E: FnMut(Event) -> F,
+    F: std::future::Future<Output = ()>,
+{
+    let agent_files = state.agent_files();
+    if cancel.is_cancelled()
+        && super::turn_support::check_turn_cancelled(&mut state.machine, &agent_files, emit, cancel)
+            .await?
+    {
+        return Ok(super::virtual_tool::VirtualToolOutcome::EndTurn);
+    }
+
+    match tool_call.name.as_str() {
+        "request_confirmation" => {
+            let runtime = agent_interaction_runtime(state);
+            super::interaction_tools::handle_request_confirmation(
+                runtime,
+                tool_call,
+                tool_arguments,
+                emit,
+            )
+            .await
+        }
+        "request_mount" => {
+            let runtime = mount_request_runtime(state);
+            super::mount_request_tool::handle_request_mount(
+                runtime,
+                tool_call,
+                tool_arguments,
+                emit,
+            )
+            .await
+        }
+        "request_user_input" => {
+            let runtime = agent_interaction_runtime(state);
+            super::interaction_tools::handle_request_user_input(
+                runtime,
+                tool_call,
+                tool_arguments,
+                emit,
+            )
+            .await
+        }
+        "update_plan" => {
+            let runtime = agent_interaction_runtime(state);
+            super::interaction_tools::handle_update_plan(runtime, tool_call, tool_arguments, emit)
+                .await
+        }
+        "invoke_delegated_skill" => {
+            let runtime = delegated_skill_runtime(state);
+            super::delegated_skill_tool::handle_invoke_delegated_skill(
+                runtime,
+                tool_call,
+                tool_arguments,
+                cancel,
+                emit,
+            )
+            .await
+        }
+        "terminate_child_run" => {
+            let runtime = child_run_termination_runtime(state);
+            super::child_run_termination_tool::handle_terminate_child_run(
+                runtime,
+                tool_call,
+                tool_arguments,
+                allow_approved_tool_escalation_execution,
+                emit,
+            )
+            .await
+        }
+        _ => Ok(super::virtual_tool::VirtualToolOutcome::NotVirtual),
+    }
 }
 
 pub(super) fn tool_authorization_runtime(

--- a/crates/agent-engine/src/runtime/virtual_tools.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools.rs
@@ -1,32 +1,12 @@
-use alan_agent_protocol::Event;
-use anyhow::Result;
-#[cfg(test)]
-use serde_json::json;
-use tokio_util::sync::CancellationToken;
+use crate::llm::ToolDefinition;
 
-use crate::{agent_machine::NormalizedToolCall, llm::ToolDefinition};
-
-use super::child_run_termination_tool::{
-    handle_terminate_child_run, terminate_child_run_tool_definition,
-};
-use super::delegated_skill_tool::{
-    handle_invoke_delegated_skill, invoke_delegated_skill_tool_definition,
-};
+use super::child_run_termination_tool::terminate_child_run_tool_definition;
+use super::delegated_skill_tool::invoke_delegated_skill_tool_definition;
 use super::interaction_tools::{
-    handle_request_confirmation, handle_request_user_input, handle_update_plan,
     request_confirmation_tool_definition, request_user_input_tool_definition,
     update_plan_tool_definition,
 };
-#[cfg(test)]
-use super::interaction_tools::{
-    parse_confirmation_request, parse_plan_status, parse_plan_update,
-    parse_structured_user_input_request,
-};
-pub(super) use super::mount_request_tool::parse_mount_request;
-use super::mount_request_tool::{handle_request_mount, request_mount_tool_definition};
-use super::transition::RuntimeLoopState;
-use super::turn_support::check_turn_cancelled;
-pub(super) use super::virtual_tool::VirtualToolOutcome;
+use super::mount_request_tool::request_mount_tool_definition;
 
 pub(super) fn virtual_tool_definitions(include_delegated_skill: bool) -> Vec<ToolDefinition> {
     let mut defs = vec![
@@ -40,61 +20,6 @@ pub(super) fn virtual_tool_definitions(include_delegated_skill: bool) -> Vec<Too
         defs.push(terminate_child_run_tool_definition());
     }
     defs
-}
-
-pub(super) async fn try_handle_virtual_tool_call<E, F>(
-    state: &mut RuntimeLoopState,
-    tool_call: &NormalizedToolCall,
-    tool_arguments: &serde_json::Value,
-    cancel: &CancellationToken,
-    allow_approved_tool_escalation_execution: bool,
-    emit: &mut E,
-) -> Result<VirtualToolOutcome>
-where
-    E: FnMut(Event) -> F,
-    F: std::future::Future<Output = ()>,
-{
-    let agent_files = state.agent_files();
-    if cancel.is_cancelled()
-        && check_turn_cancelled(&mut state.machine, &agent_files, emit, cancel).await?
-    {
-        return Ok(VirtualToolOutcome::EndTurn);
-    }
-
-    match tool_call.name.as_str() {
-        "request_confirmation" => {
-            let runtime = super::transition::agent_interaction_runtime(state);
-            handle_request_confirmation(runtime, tool_call, tool_arguments, emit).await
-        }
-        "request_mount" => {
-            let runtime = super::transition::mount_request_runtime(state);
-            handle_request_mount(runtime, tool_call, tool_arguments, emit).await
-        }
-        "request_user_input" => {
-            let runtime = super::transition::agent_interaction_runtime(state);
-            handle_request_user_input(runtime, tool_call, tool_arguments, emit).await
-        }
-        "update_plan" => {
-            let runtime = super::transition::agent_interaction_runtime(state);
-            handle_update_plan(runtime, tool_call, tool_arguments, emit).await
-        }
-        "invoke_delegated_skill" => {
-            let runtime = super::transition::delegated_skill_runtime(state);
-            handle_invoke_delegated_skill(runtime, tool_call, tool_arguments, cancel, emit).await
-        }
-        "terminate_child_run" => {
-            let runtime = super::transition::child_run_termination_runtime(state);
-            handle_terminate_child_run(
-                runtime,
-                tool_call,
-                tool_arguments,
-                allow_approved_tool_escalation_execution,
-                emit,
-            )
-            .await
-        }
-        _ => Ok(VirtualToolOutcome::NotVirtual),
-    }
 }
 
 #[cfg(test)]

--- a/crates/agent-engine/src/runtime/virtual_tools_tests.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    agent_machine::{AgentMachine, TurnActivityState},
+    agent_machine::{AgentMachine, NormalizedToolCall, TurnActivityState},
     config::Config,
     rollout::{RolloutItem, RolloutRecorder},
     runtime::{
@@ -16,8 +16,13 @@ use crate::{
             handle_invoke_delegated_skill_with_spawn as handle_invoke_delegated_skill_with_runtime,
         },
         delegation_capabilities::DelegatedSpawnRejected,
-        mount_request_tool::MountRequestAccess,
+        interaction_tools::{
+            parse_confirmation_request, parse_plan_status, parse_plan_update,
+            parse_structured_user_input_request,
+        },
+        mount_request_tool::{MountRequestAccess, parse_mount_request},
         transition::NamespaceActionRecord,
+        virtual_tool::VirtualToolOutcome,
     },
     skills::{
         ActiveSkillEnvelope, DelegatedSkillInvocationRecord, ResolvedCapabilityView,
@@ -26,11 +31,13 @@ use crate::{
     },
     tools::ToolRegistry,
 };
-use alan_agent_protocol::{SpawnHandle, SpawnSpec};
+use alan_agent_protocol::{Event, SpawnHandle, SpawnSpec};
 use alan_agentfs::AgentFs;
 use alan_ap::InProcessTransport;
 use alan_kernel::{Access, MountFs, Namespace};
 use alan_shell::Shell;
+use anyhow::Result;
+use serde_json::json;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
@@ -195,7 +202,7 @@ fn tool_result_text_for_call(
         .expect("expected tool result")
 }
 
-async fn try_handle_virtual_tool_call_for_test<E, F>(
+async fn dispatch_virtual_tool_call_for_test<E, F>(
     state: &mut super::super::transition::RuntimeLoopState,
     tool_call: &NormalizedToolCall,
     emit: &mut E,
@@ -205,7 +212,15 @@ where
     F: std::future::Future<Output = ()>,
 {
     let cancel = CancellationToken::new();
-    try_handle_virtual_tool_call(state, tool_call, &tool_call.arguments, &cancel, false, emit).await
+    super::super::transition::dispatch_virtual_tool_call(
+        state,
+        tool_call,
+        &tool_call.arguments,
+        &cancel,
+        false,
+        emit,
+    )
+    .await
 }
 
 async fn handle_invoke_delegated_skill_with_spawn<E, F, S>(
@@ -268,7 +283,7 @@ async fn test_try_handle_non_virtual_tool() {
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(result.unwrap(), VirtualToolOutcome::NotVirtual));
 }
@@ -289,7 +304,7 @@ async fn test_try_handle_unknown_tool() {
         async {}
     };
 
-    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
     assert!(result.is_ok());
     assert!(matches!(result.unwrap(), VirtualToolOutcome::NotVirtual));
 }

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -343,6 +343,7 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
         "tool_execution.rs",
         "tool_execution/runtime_inputs.rs",
         "turn_support.rs",
+        "virtual_tools.rs",
     ] {
         let source = read_runtime_source(path);
         assert!(
@@ -427,6 +428,11 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
     assert!(delegated_runtime.contains("ChildLaunchRuntime"));
     let transition = read_runtime_source("transition.rs");
     assert!(transition.contains("fn delegated_skill_runtime("));
+    assert!(transition.contains("async fn dispatch_virtual_tool_call"));
+    assert!(
+        !read_runtime_source("virtual_tools.rs").contains("dispatch_virtual_tool_call"),
+        "virtual Tool definitions must not regain full-state dispatch authority"
+    );
 
     let termination_runtime = read_runtime_source("child_run_termination_tool/runtime_inputs.rs");
     for forbidden in [


### PR DESCRIPTION
## Summary
- move full-state virtual Tool dispatch into the accepted-submission transition boundary
- keep each virtual Tool workflow on its existing narrow runtime projection
- reduce virtual_tools.rs to Tool definition assembly only
- remove the mount parser re-export and make tests import parsers from their real owners
- add an architecture guard preventing virtual_tools.rs from regaining RuntimeLoopState or dispatch authority

## Verification
- cargo test -p alan-agent-engine runtime::virtual_tools::tests (71 passed)
- cargo test -p alan-agent-engine runtime::tool_orchestrator::tests (35 passed)
- cargo test -p alan-agent-engine (1201 passed, 1 ignored)
- cargo test -p alan-agent-engine --test dependency_boundary (16 passed)
- cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings
- openspec validate deepen-agent-machine-transition-module --strict
- just quality

Part of deepen-agent-machine-transition-module.