### PR TITLE
refactor(agent-engine): isolate tool resolution runtime inputs

### DIFF
--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -33,6 +33,7 @@ mod tool_orchestrator;
 mod tool_packages;
 mod tool_policy;
 mod tool_presentation;
+mod tool_resolution;
 mod transition;
 mod turn_driver;
 mod turn_executor;

--- a/crates/agent-engine/src/runtime/tool_orchestrator.rs
+++ b/crates/agent-engine/src/runtime/tool_orchestrator.rs
@@ -1,8 +1,7 @@
 use alan_agent_protocol::Event;
 use anyhow::Result;
 #[cfg(test)]
-use serde_json::Value;
-use serde_json::json;
+use serde_json::{Value, json};
 use tokio_util::sync::CancellationToken;
 
 use crate::approval::replays_tool_calls;
@@ -19,9 +18,9 @@ use super::tool_execution::{
 };
 #[cfg(test)]
 use super::tool_execution::{execute_tool_effect, tool_payload_for_tape};
+use super::tool_resolution::{ToolResolutionOutcome, ToolResolutionRequest, resolve_tool_call};
 use super::transition::{RuntimeLoopState, dispatch_virtual_tool_call};
 use super::turn_driver::TurnInputBroker;
-use super::turn_support::tool_result_preview;
 use super::virtual_tool::VirtualToolOutcome;
 use crate::agent_machine::NormalizedToolCall;
 
@@ -211,59 +210,26 @@ where
         VirtualToolOutcome::EndTurn => return Ok(ToolOrchestratorOutcome::EndTurn),
     }
 
-    let tool_package = state
-        .tool_execution()
-        .discover_packages()
-        .await?
-        .into_iter()
-        .find(|package| package.name == tool_call.name);
-    let Some(tool_package) = tool_package else {
-        let payload = json!({
-            "success": false,
-            "error": format!(
-                "Tool '{}' is unavailable because its executable and valid manifest are not both mounted",
-                tool_call.name
-            )
-        });
-        emit(Event::ToolCallStarted {
-            title: None,
-            id: tool_call.id.clone(),
-            name: tool_call.name.clone(),
-            audit: None,
-        })
-        .await;
-        emit(Event::ToolCallCompleted {
-            presentation: None,
-            id: tool_call.id.clone(),
-            name: Some(tool_call.name.clone()),
-            success: Some(false),
-            result_preview: tool_result_preview(&payload),
-            audit: None,
-        })
-        .await;
-        state.machine.record_tool_call(
-            &tool_call.name,
-            tool_arguments.clone(),
-            payload.clone(),
-            false,
-        );
-        state
-            .machine
-            .add_tool_message(&tool_call.id, &tool_call.name, payload);
-        return Ok(ToolOrchestratorOutcome::ContinueToolBatch {
-            refresh_context: false,
-        });
+    let resolution_runtime = super::transition::tool_resolution_runtime(state);
+    let resolution_request = ToolResolutionRequest {
+        tool_call,
+        tool_arguments: &tool_arguments,
     };
-    let tool_capability = state
-        .tool_execution()
-        .resolve_capability(&tool_package, &tool_arguments);
-    let current_tool_cwd = state.tool_execution().default_cwd();
+    let resolved_tool =
+        match resolve_tool_call(resolution_runtime, resolution_request, emit).await? {
+            ToolResolutionOutcome::Resolved(resolved) => resolved,
+            ToolResolutionOutcome::Unavailable => {
+                return Ok(ToolOrchestratorOutcome::ContinueToolBatch {
+                    refresh_context: false,
+                });
+            }
+        };
     let authorization_runtime = super::transition::tool_authorization_runtime(state);
     let authorization_request = ToolAuthorizationRequest {
         tool_call,
         tool_arguments: &tool_arguments,
-        tool_capability,
-        current_tool_cwd: current_tool_cwd.as_deref(),
+        tool_capability: resolved_tool.capability,
+        current_tool_cwd: resolved_tool.current_cwd.as_deref(),
         allow_approved_tool_escalation_execution,
         cancel: inputs.cancel,
     };
@@ -284,8 +250,8 @@ where
     let request = ToolExecutionRequest {
         tool_call,
         tool_arguments: &tool_arguments,
-        tool_timeout_secs: tool_package.timeout_secs,
-        tool_capability,
+        tool_timeout_secs: resolved_tool.timeout_secs,
+        tool_capability: resolved_tool.capability,
         tool_audit,
         allow_approved_unknown_effect_execution,
         cancel: inputs.cancel,

--- a/crates/agent-engine/src/runtime/tool_resolution.rs
+++ b/crates/agent-engine/src/runtime/tool_resolution.rs
@@ -1,0 +1,98 @@
+//! Mounted-package resolution and unavailable-Tool recording for one Tool call.
+
+use std::path::PathBuf;
+
+use alan_agent_protocol::{Event, ToolCapability};
+use anyhow::Result;
+use serde_json::{Value, json};
+
+use crate::agent_machine::NormalizedToolCall;
+
+use super::turn_support::tool_result_preview;
+
+mod runtime_inputs;
+
+pub(super) use runtime_inputs::ToolResolutionRuntime;
+
+pub(super) struct ToolResolutionRequest<'a> {
+    pub(super) tool_call: &'a NormalizedToolCall,
+    pub(super) tool_arguments: &'a Value,
+}
+
+#[derive(Debug)]
+pub(super) struct ResolvedToolCall {
+    pub(super) timeout_secs: usize,
+    pub(super) capability: ToolCapability,
+    pub(super) current_cwd: Option<PathBuf>,
+}
+
+#[derive(Debug)]
+pub(super) enum ToolResolutionOutcome {
+    Resolved(ResolvedToolCall),
+    Unavailable,
+}
+
+pub(super) async fn resolve_tool_call<E, F>(
+    runtime: ToolResolutionRuntime<'_>,
+    request: ToolResolutionRequest<'_>,
+    emit: &mut E,
+) -> Result<ToolResolutionOutcome>
+where
+    E: FnMut(Event) -> F,
+    F: std::future::Future<Output = ()>,
+{
+    let ToolResolutionRequest {
+        tool_call,
+        tool_arguments,
+    } = request;
+    let tool_package = runtime
+        .tool_execution
+        .discover_packages()
+        .await?
+        .into_iter()
+        .find(|package| package.name == tool_call.name);
+    let Some(tool_package) = tool_package else {
+        let payload = json!({
+            "success": false,
+            "error": format!(
+                "Tool '{}' is unavailable because its executable and valid manifest are not both mounted",
+                tool_call.name
+            )
+        });
+        emit(Event::ToolCallStarted {
+            title: None,
+            id: tool_call.id.clone(),
+            name: tool_call.name.clone(),
+            audit: None,
+        })
+        .await;
+        emit(Event::ToolCallCompleted {
+            presentation: None,
+            id: tool_call.id.clone(),
+            name: Some(tool_call.name.clone()),
+            success: Some(false),
+            result_preview: tool_result_preview(&payload),
+            audit: None,
+        })
+        .await;
+        runtime.machine.record_tool_call(
+            &tool_call.name,
+            tool_arguments.clone(),
+            payload.clone(),
+            false,
+        );
+        runtime
+            .machine
+            .add_tool_message(&tool_call.id, &tool_call.name, payload);
+        return Ok(ToolResolutionOutcome::Unavailable);
+    };
+
+    let capability = runtime
+        .tool_execution
+        .resolve_capability(&tool_package, tool_arguments);
+    Ok(ToolResolutionOutcome::Resolved(ResolvedToolCall {
+        timeout_secs: tool_package.timeout_secs,
+        capability,
+        current_cwd: runtime.tool_execution.default_cwd(),
+    }))
+}

--- a/crates/agent-engine/src/runtime/tool_resolution/runtime_inputs.rs
+++ b/crates/agent-engine/src/runtime/tool_resolution/runtime_inputs.rs
@@ -1,0 +1,19 @@
+use crate::{agent_machine::AgentMachine, runtime::transition::NamespaceToolExecution};
+
+/// Explicit inputs for resolving one mounted Tool package for execution.
+pub(crate) struct ToolResolutionRuntime<'a> {
+    pub(super) machine: &'a mut AgentMachine,
+    pub(super) tool_execution: NamespaceToolExecution,
+}
+
+impl<'a> ToolResolutionRuntime<'a> {
+    pub(crate) fn new(
+        machine: &'a mut AgentMachine,
+        tool_execution: NamespaceToolExecution,
+    ) -> Self {
+        Self {
+            machine,
+            tool_execution,
+        }
+    }
+}

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -308,6 +308,13 @@ where
     }
 }
 
+pub(super) fn tool_resolution_runtime(
+    state: &mut RuntimeLoopState,
+) -> super::tool_resolution::ToolResolutionRuntime<'_> {
+    let tool_execution = state.tool_execution();
+    super::tool_resolution::ToolResolutionRuntime::new(&mut state.machine, tool_execution)
+}
+
 pub(super) fn tool_authorization_runtime(
     state: &mut RuntimeLoopState,
 ) -> super::tool_authorization::ToolAuthorizationRuntime<'_> {

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -342,6 +342,8 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
         "tool_authorization/runtime_inputs.rs",
         "tool_execution.rs",
         "tool_execution/runtime_inputs.rs",
+        "tool_resolution.rs",
+        "tool_resolution/runtime_inputs.rs",
         "turn_support.rs",
         "virtual_tools.rs",
     ] {
@@ -500,6 +502,32 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
         assert!(
             !tool_orchestrator.contains(displaced_owner),
             "Tool orchestrator must leave {displaced_owner} to the authorization owner"
+        );
+    }
+
+    let tool_resolution_runtime = read_runtime_source("tool_resolution/runtime_inputs.rs");
+    for forbidden in [
+        "RuntimeLoopState",
+        "RuntimeConfig",
+        "NamespaceRuntimeEnvironment",
+    ] {
+        assert!(
+            !tool_resolution_runtime.contains(forbidden),
+            "Tool resolution runtime must not regain {forbidden}"
+        );
+    }
+    assert!(tool_resolution_runtime.contains("ToolResolutionRuntime"));
+    assert!(transition.contains("fn tool_resolution_runtime("));
+    assert!(read_runtime_source("tool_resolution.rs").contains("resolve_tool_call"));
+    for displaced_operation in [
+        "discover_packages(",
+        "resolve_capability(",
+        "default_cwd(",
+        ".tool_execution()",
+    ] {
+        assert!(
+            !tool_orchestrator.contains(displaced_operation),
+            "Tool orchestrator must leave {displaced_operation} to the resolution owner"
         );
     }
 


### PR DESCRIPTION
## Summary
- move mounted Tool package discovery, capability resolution, cwd capture, and unavailable-Tool recording into `ToolResolutionRuntime`
- give the resolution workflow only explicit Agent Machine and namespace Tool execution inputs
- keep the Tool orchestrator responsible for ordering virtual dispatch, resolution, authorization, and execution while deleting its old direct resolution path
- add dependency guards that prevent the new owner from regaining the aggregate runtime state

## Verification
- `cargo test -p alan-agent-engine` (1201 passed, 1 ignored)
- `openspec validate deepen-agent-machine-transition-module --strict`
- `just quality`