### PR TITLE
refactor(agent-engine): isolate turn memory finalization

### DIFF
--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -37,6 +37,7 @@ mod tool_resolution;
 mod transition;
 mod turn_driver;
 mod turn_executor;
+mod turn_memory;
 mod turn_support;
 mod ui_surfaces;
 mod virtual_tool;

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -50,6 +50,7 @@ use super::tool_resolution::{ToolResolutionOutcome, ToolResolutionRequest, resol
 use super::turn_driver::{TurnInputBroker, drive_turn_submission_with_cancel};
 pub(super) use super::turn_executor::run_turn_with_cancel;
 use super::turn_executor::{TurnExecutionOutcome, TurnRunKind};
+use super::turn_memory::{FinalizeTurnMemoryRequest, finalize_turn_memory_best_effort};
 #[allow(
     unused_imports,
     reason = "these helpers are imported here for the adjacent white-box test module"
@@ -353,6 +354,25 @@ pub(super) fn tool_execution_runtime(
         agent_files,
         tool_execution,
         process_path,
+    )
+}
+
+pub(super) fn turn_memory_runtime(
+    state: &mut RuntimeLoopState,
+) -> super::turn_memory::TurnMemoryRuntime<'_> {
+    let memory_dir = state
+        .core_config
+        .memory
+        .enabled
+        .then(|| state.core_config.memory.store_dir.clone())
+        .flatten();
+    let process_path = state.process_path();
+    let llm_request_timeout_secs = state.runtime_config.llm_request_timeout_secs;
+    super::turn_memory::TurnMemoryRuntime::new(
+        &mut state.machine,
+        memory_dir,
+        process_path,
+        llm_request_timeout_secs,
     )
 }
 
@@ -919,40 +939,16 @@ async fn finalize_replayed_tool_end_turn_best_effort(
     promotion_context: &'static str,
 ) {
     if !cancel.is_cancelled() {
-        if !surfaces_refreshed {
-            let memory_dir = state
-                .core_config
-                .memory
-                .enabled
-                .then_some(state.core_config.memory.store_dir.as_deref())
-                .flatten();
-            let process_path = state.process_path();
-            super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(
-                &state.machine,
-                memory_dir,
-                &process_path,
+        let memory_runtime = turn_memory_runtime(state);
+        finalize_turn_memory_best_effort(
+            memory_runtime,
+            FinalizeTurnMemoryRequest {
+                surfaces_refreshed,
                 surfaces_context,
-            )
-            .await;
-        }
-        let memory_dir = state
-            .core_config
-            .memory
-            .enabled
-            .then(|| state.core_config.memory.store_dir.clone())
-            .flatten();
-        let process_path = state.process_path();
-        if let Some(job) = super::memory_promotion::build_turn_memory_promotion_job(
-            &state.machine,
-            memory_dir,
-            process_path,
-            state.runtime_config.llm_request_timeout_secs,
-            promotion_context,
-        ) {
-            state
-                .machine
-                .push_deferred_runtime_action(DeferredRuntimeAction::TurnMemoryPromotion(job));
-        }
+                promotion_context,
+            },
+        )
+        .await;
     }
 
     state.machine.set_turn_activity(TurnActivityState::Idle);

--- a/crates/agent-engine/src/runtime/turn_executor.rs
+++ b/crates/agent-engine/src/runtime/turn_executor.rs
@@ -14,12 +14,12 @@ use super::response_guardrails::{
 use super::tool_batch::{ToolBatchOrchestratorOutcome, ToolOrchestratorInputs};
 use super::transition::{RuntimeLoopState, orchestrate_tool_batch};
 use super::turn_driver::TurnInputBroker;
+use super::turn_memory::{FinalizeTurnMemoryRequest, finalize_turn_memory_best_effort};
 use super::turn_support::{
     check_turn_cancelled, emit_streaming_chunks, emit_task_completed_success, emit_thinking_chunks,
     normalize_tool_calls,
 };
 use super::virtual_tools::virtual_tool_definitions;
-use crate::agent_machine::DeferredRuntimeAction;
 
 mod namespace_generation;
 
@@ -79,49 +79,6 @@ fn estimate_pending_turn_prompt_tokens(
             turn_recall_bundle,
             None,
         ))
-}
-
-async fn finalize_turn_memory_best_effort(
-    state: &mut RuntimeLoopState,
-    surfaces_refreshed: bool,
-    surfaces_context: &'static str,
-    promotion_context: &'static str,
-) {
-    if !surfaces_refreshed {
-        let memory_dir = state
-            .core_config
-            .memory
-            .enabled
-            .then_some(state.core_config.memory.store_dir.as_deref())
-            .flatten();
-        let process_path = state.process_path();
-        super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(
-            &state.machine,
-            memory_dir,
-            &process_path,
-            surfaces_context,
-        )
-        .await;
-    }
-
-    let memory_dir = state
-        .core_config
-        .memory
-        .enabled
-        .then(|| state.core_config.memory.store_dir.clone())
-        .flatten();
-    let process_path = state.process_path();
-    if let Some(job) = super::memory_promotion::build_turn_memory_promotion_job(
-        &state.machine,
-        memory_dir,
-        process_path,
-        state.runtime_config.llm_request_timeout_secs,
-        promotion_context,
-    ) {
-        state
-            .machine
-            .push_deferred_runtime_action(DeferredRuntimeAction::TurnMemoryPromotion(job));
-    }
 }
 
 async fn turn_tool_definitions(
@@ -643,11 +600,14 @@ where
                 ToolBatchOrchestratorOutcome::PauseTurn => return Ok(TurnExecutionOutcome::Paused),
                 ToolBatchOrchestratorOutcome::EndTurn { surfaces_refreshed } => {
                     if !cancel.is_cancelled() {
+                        let memory_runtime = super::transition::turn_memory_runtime(state);
                         finalize_turn_memory_best_effort(
-                            state,
-                            surfaces_refreshed,
-                            "turn-ended-after-tool-batch",
-                            "after tool-driven end turn",
+                            memory_runtime,
+                            FinalizeTurnMemoryRequest {
+                                surfaces_refreshed,
+                                surfaces_context: "turn-ended-after-tool-batch",
+                                promotion_context: "after tool-driven end turn",
+                            },
                         )
                         .await;
                     }
@@ -676,11 +636,14 @@ where
                 .write_turn_tape_state(namespace_input_text.as_deref(), fallback_text)
                 .await
                 .context("write namespace fallback turn tape state")?;
+            let memory_runtime = super::transition::turn_memory_runtime(state);
             finalize_turn_memory_best_effort(
-                state,
-                false,
-                "fallback-turn-completed",
-                "after fallback turn",
+                memory_runtime,
+                FinalizeTurnMemoryRequest {
+                    surfaces_refreshed: false,
+                    surfaces_context: "fallback-turn-completed",
+                    promotion_context: "after fallback turn",
+                },
             )
             .await;
             emit(Event::TextDelta {
@@ -698,8 +661,16 @@ where
             return Ok(TurnExecutionOutcome::Finished);
         }
 
-        finalize_turn_memory_best_effort(state, false, "turn-completed", "after completed turn")
-            .await;
+        let memory_runtime = super::transition::turn_memory_runtime(state);
+        finalize_turn_memory_best_effort(
+            memory_runtime,
+            FinalizeTurnMemoryRequest {
+                surfaces_refreshed: false,
+                surfaces_context: "turn-completed",
+                promotion_context: "after completed turn",
+            },
+        )
+        .await;
         emit_task_completed_success(&agent_files, emit, "Task completed").await?;
         return Ok(TurnExecutionOutcome::Finished);
     }

--- a/crates/agent-engine/src/runtime/turn_memory.rs
+++ b/crates/agent-engine/src/runtime/turn_memory.rs
@@ -1,0 +1,41 @@
+//! Memory Store surface finalization and deferred promotion for one completed turn.
+
+use crate::agent_machine::DeferredRuntimeAction;
+
+mod runtime_inputs;
+
+pub(super) use runtime_inputs::TurnMemoryRuntime;
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct FinalizeTurnMemoryRequest {
+    pub(super) surfaces_refreshed: bool,
+    pub(super) surfaces_context: &'static str,
+    pub(super) promotion_context: &'static str,
+}
+
+pub(super) async fn finalize_turn_memory_best_effort(
+    runtime: TurnMemoryRuntime<'_>,
+    request: FinalizeTurnMemoryRequest,
+) {
+    if !request.surfaces_refreshed {
+        super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(
+            runtime.machine,
+            runtime.memory_dir.as_deref(),
+            &runtime.process_path,
+            request.surfaces_context,
+        )
+        .await;
+    }
+
+    if let Some(job) = super::memory_promotion::build_turn_memory_promotion_job(
+        runtime.machine,
+        runtime.memory_dir,
+        runtime.process_path,
+        runtime.llm_request_timeout_secs,
+        request.promotion_context,
+    ) {
+        runtime
+            .machine
+            .push_deferred_runtime_action(DeferredRuntimeAction::TurnMemoryPromotion(job));
+    }
+}

--- a/crates/agent-engine/src/runtime/turn_memory/runtime_inputs.rs
+++ b/crates/agent-engine/src/runtime/turn_memory/runtime_inputs.rs
@@ -1,0 +1,27 @@
+use std::path::PathBuf;
+
+use crate::agent_machine::AgentMachine;
+
+/// Explicit inputs for finalizing one turn's Memory Store state.
+pub(crate) struct TurnMemoryRuntime<'a> {
+    pub(super) machine: &'a mut AgentMachine,
+    pub(super) memory_dir: Option<PathBuf>,
+    pub(super) process_path: String,
+    pub(super) llm_request_timeout_secs: u64,
+}
+
+impl<'a> TurnMemoryRuntime<'a> {
+    pub(crate) fn new(
+        machine: &'a mut AgentMachine,
+        memory_dir: Option<PathBuf>,
+        process_path: String,
+        llm_request_timeout_secs: u64,
+    ) -> Self {
+        Self {
+            machine,
+            memory_dir,
+            process_path,
+            llm_request_timeout_secs,
+        }
+    }
+}

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -1,5 +1,8 @@
 //! Absence guards for the namespace-native Agent Execution Engine boundary.
 
+#[path = "dependency_boundary/turn_memory.rs"]
+mod turn_memory;
+
 fn read_runtime_source(path: &str) -> String {
     std::fs::read_to_string(format!("{}/src/runtime/{path}", env!("CARGO_MANIFEST_DIR")))
         .unwrap_or_else(|error| panic!("read src/runtime/{path}: {error}"))
@@ -345,6 +348,8 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
         "tool_batch.rs",
         "tool_resolution.rs",
         "tool_resolution/runtime_inputs.rs",
+        "turn_memory.rs",
+        "turn_memory/runtime_inputs.rs",
         "turn_support.rs",
         "virtual_tools.rs",
     ] {

--- a/crates/agent-engine/tests/dependency_boundary/turn_memory.rs
+++ b/crates/agent-engine/tests/dependency_boundary/turn_memory.rs
@@ -1,0 +1,35 @@
+use super::read_runtime_source;
+
+#[test]
+fn turn_memory_finalization_uses_only_explicit_runtime_inputs() {
+    let runtime_inputs = read_runtime_source("turn_memory/runtime_inputs.rs");
+    for forbidden in [
+        "RuntimeLoopState",
+        "RuntimeConfig",
+        "NamespaceRuntimeEnvironment",
+    ] {
+        assert!(
+            !runtime_inputs.contains(forbidden),
+            "turn memory runtime must not regain {forbidden}"
+        );
+    }
+    assert!(runtime_inputs.contains("TurnMemoryRuntime"));
+
+    let transition = read_runtime_source("transition.rs");
+    assert!(transition.contains("fn turn_memory_runtime("));
+    let owner = read_runtime_source("turn_memory.rs");
+    assert!(owner.contains("finalize_turn_memory_best_effort"));
+
+    let executor = read_runtime_source("turn_executor.rs");
+    for (name, source) in [("turn executor", executor), ("transition", transition)] {
+        for displaced_operation in [
+            "build_turn_memory_promotion_job(",
+            "refresh_turn_memory_surfaces_best_effort(",
+        ] {
+            assert!(
+                !source.contains(displaced_operation),
+                "{name} must leave {displaced_operation} to the memory owner"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move Memory Store surface refresh and deferred turn-promotion scheduling into one `turn_memory` owner
- give that workflow only Agent Machine, Memory Store path, Process path, and timeout inputs projected by transition
- delete duplicated finalization logic from ordinary turn completion and approved Tool replay paths
- add a dedicated architecture guard module that prevents aggregate runtime state and displaced memory operations from returning

## Verification
- `cargo test -p alan-agent-engine` (1201 passed, 1 ignored)
- focused turn-memory tests (5 passed)
- focused replay-promotion tests (2 passed)
- dependency boundary tests (17 passed)
- `cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings`
- `openspec validate deepen-agent-machine-transition-module --strict`
- `just quality`