### PR TITLE
refactor(agent-engine): remove duplicate persona runtime state

### DIFF
--- a/crates/agent-engine/src/runtime/child_agents/tests.rs
+++ b/crates/agent-engine/src/runtime/child_agents/tests.rs
@@ -581,7 +581,6 @@ fn make_parent_state_with_capability_view(
             memory_store_backing: Some(memory_store),
             ..RuntimeConfig::default()
         },
-        definition_persona_dirs: Vec::new(),
         prompt_cache: super::super::prompt_cache::PromptAssemblyCache::with_fixed_capability_view(
             capability_view,
             Vec::new(),

--- a/crates/agent-engine/src/runtime/compaction.rs
+++ b/crates/agent-engine/src/runtime/compaction.rs
@@ -918,7 +918,6 @@ mod tests {
                 compaction_keep_last: 1,
                 ..RuntimeConfig::default()
             },
-            definition_persona_dirs: Vec::new(),
             prompt_cache: PromptAssemblyCache::new(Vec::new()),
         }
     }

--- a/crates/agent-engine/src/runtime/engine.rs
+++ b/crates/agent-engine/src/runtime/engine.rs
@@ -346,7 +346,6 @@ fn spawn_with_prepared_runtime_environment(
                 &runtime_config.governance,
             )
         };
-    let prompt_cache_persona_dirs = resolved_agent_definition.persona_dirs.clone();
     if core_config.memory.enabled
         && let Some(memory_dir) = core_config.memory.store_dir.as_deref()
         && let Err(err) = crate::prompts::ensure_memory_store_layout_at(memory_dir)
@@ -368,7 +367,7 @@ fn spawn_with_prepared_runtime_environment(
         super::prompt_cache::PromptAssemblyCache::with_fixed_capability_view_and_overrides(
             resolved_agent_definition.capability_view.clone(),
             resolved_agent_definition.skill_overrides.clone(),
-            prompt_cache_persona_dirs.clone(),
+            resolved_agent_definition.persona_dirs.clone(),
             host_capabilities,
         );
     prompt_cache.set_fixed_definition_persona_section(resolved_agent_definition.persona_context);
@@ -430,7 +429,6 @@ fn spawn_with_prepared_runtime_environment(
             environment,
             core_config,
             runtime_config,
-            definition_persona_dirs: prompt_cache_persona_dirs.clone(),
             prompt_cache,
         };
         match super::ui_surfaces::initialize(&state.agent_files()).await {

--- a/crates/agent-engine/src/runtime/engine_runtime_tests.rs
+++ b/crates/agent-engine/src/runtime/engine_runtime_tests.rs
@@ -409,7 +409,6 @@ async fn test_outer_idle_reads_answered_namespace_request_response() {
         environment: namespace_environment,
         core_config: crate::Config::default(),
         runtime_config: RuntimeConfig::default(),
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 

--- a/crates/agent-engine/src/runtime/engine_tests.rs
+++ b/crates/agent-engine/src/runtime/engine_tests.rs
@@ -69,7 +69,6 @@ fn make_deferred_action_for_test() -> DeferredRuntimeAction {
         environment: namespace_environment_for_test(),
         core_config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 

--- a/crates/agent-engine/src/runtime/memory_promotion/tests.rs
+++ b/crates/agent-engine/src/runtime/memory_promotion/tests.rs
@@ -433,7 +433,6 @@ async fn deferred_memory_promotion_uses_namespace_llmfs() {
         environment: NamespaceRuntimeEnvironment::new(root, "/agent/1", "default"),
         core_config: Config::default(),
         runtime_config: RuntimeConfig::default(),
-        definition_persona_dirs: Vec::new(),
         prompt_cache: PromptAssemblyCache::new(Vec::new()),
     };
     let job = TurnMemoryPromotionJob {

--- a/crates/agent-engine/src/runtime/memory_surfaces/tests.rs
+++ b/crates/agent-engine/src/runtime/memory_surfaces/tests.rs
@@ -370,7 +370,6 @@ async fn refresh_turn_memory_surfaces_writes_expected_files() {
             config
         },
         runtime_config: super::super::RuntimeConfig::default(),
-        definition_persona_dirs: Vec::new(),
         prompt_cache: super::super::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
@@ -411,7 +410,6 @@ async fn refresh_memory_surfaces_needs_no_model_request_or_llm_mount() {
             config
         },
         runtime_config: super::super::RuntimeConfig::default(),
-        definition_persona_dirs: Vec::new(),
         prompt_cache: super::super::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 

--- a/crates/agent-engine/src/runtime/prompt_cache.rs
+++ b/crates/agent-engine/src/runtime/prompt_cache.rs
@@ -133,13 +133,6 @@ impl PromptAssemblyCache {
         }
     }
 
-    pub(crate) fn rebind_paths(&mut self, definition_persona_dirs: Vec<PathBuf>) {
-        if self.definition_persona_dirs != definition_persona_dirs {
-            self.definition_persona_dirs = definition_persona_dirs;
-            self.definition_persona_snapshot = None;
-        }
-    }
-
     pub(crate) fn set_fixed_definition_persona_section(&mut self, section: Option<String>) {
         self.fixed_definition_persona_section = section;
     }

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/confirmation_and_mount_support.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/confirmation_and_mount_support.inc.rs
@@ -123,7 +123,6 @@
             environment: namespace_environment_for_test(),
             core_config: config,
             runtime_config,
-            definition_persona_dirs: Vec::new(),
             prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
         }
     }

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -74,7 +74,6 @@ pub(super) struct RuntimeLoopState {
     pub(super) environment: NamespaceRuntimeEnvironment,
     pub(super) core_config: Config,
     pub(super) runtime_config: RuntimeConfig,
-    pub(super) definition_persona_dirs: Vec<std::path::PathBuf>,
     pub(super) prompt_cache: super::prompt_cache::PromptAssemblyCache,
 }
 

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/tests.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/tests.rs
@@ -433,7 +433,6 @@ async fn answered_request_response_resumes_engine_pending_yield_from_files() {
         environment,
         core_config: crate::Config::default(),
         runtime_config: super::super::super::RuntimeConfig::default(),
-        definition_persona_dirs: Vec::new(),
         prompt_cache: super::super::super::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
     let cancel = tokio_util::sync::CancellationToken::new();

--- a/crates/agent-engine/src/runtime/transition/tests.rs
+++ b/crates/agent-engine/src/runtime/transition/tests.rs
@@ -165,7 +165,6 @@ fn runtime_state_with_environment(environment: NamespaceRuntimeEnvironment) -> R
         environment,
         core_config: Config::default(),
         runtime_config: super::RuntimeConfig::default(),
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     }
 }
@@ -364,7 +363,6 @@ fn create_replay_memory_test_state(
             config
         },
         runtime_config: super::RuntimeConfig::default(),
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     }
 }

--- a/crates/agent-engine/src/runtime/transition/tests/compaction_recovery.rs
+++ b/crates/agent-engine/src/runtime/transition/tests/compaction_recovery.rs
@@ -22,7 +22,6 @@ async fn test_manual_compaction_records_audit_fields() {
         )),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
@@ -110,7 +109,6 @@ async fn test_compaction_retry_result_is_audited_when_trimming_succeeds() {
         )),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
@@ -174,7 +172,6 @@ async fn test_compaction_generation_failure_uses_degraded_fallback_and_audits_it
         )),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
@@ -253,7 +250,6 @@ async fn test_degraded_compaction_rebases_active_turn_start() {
         )),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
@@ -330,7 +326,6 @@ async fn test_compaction_failure_without_fallback_escalates_warning_and_preserve
         )),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 

--- a/crates/agent-engine/src/runtime/transition/tests/compaction_thresholds.rs
+++ b/crates/agent-engine/src/runtime/transition/tests/compaction_thresholds.rs
@@ -12,7 +12,6 @@ async fn test_maybe_compact_context_no_compaction_needed() {
         )),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
@@ -54,7 +53,6 @@ async fn test_maybe_compact_context_with_mock_llm() {
         )),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
@@ -100,7 +98,6 @@ async fn test_maybe_compact_context_triggers_on_estimated_token_budget() {
         )),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
@@ -151,7 +148,6 @@ async fn test_maybe_compact_context_triggers_immediately_when_ratio_is_zero() {
         )),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
@@ -202,7 +198,6 @@ async fn test_maybe_compact_context_skips_when_context_window_budget_has_room() 
         )),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
@@ -257,7 +252,6 @@ async fn test_auto_pre_turn_soft_compaction_flushes_memory_before_compaction() {
         ])),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
@@ -348,7 +342,6 @@ async fn test_auto_pre_turn_soft_compaction_continues_after_memory_flush_failure
         ])),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
@@ -445,7 +438,6 @@ async fn test_auto_pre_turn_soft_compaction_skips_memory_flush_when_nothing_is_d
         ])),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
@@ -539,7 +531,6 @@ async fn test_auto_pre_turn_soft_compaction_records_already_flushed_cycle_skip()
         ])),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
@@ -630,7 +621,6 @@ async fn test_auto_pre_turn_hard_compaction_skips_memory_flush() {
         ])),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
@@ -692,7 +682,6 @@ async fn test_manual_compaction_bypasses_automatic_thresholds_without_memory_flu
         )),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
@@ -745,7 +734,6 @@ async fn test_maybe_compact_context_allows_mid_turn_emergency_near_hard_limit() 
         )),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 

--- a/crates/agent-engine/src/runtime/transition/tests/core_behaviors.rs
+++ b/crates/agent-engine/src/runtime/transition/tests/core_behaviors.rs
@@ -158,7 +158,6 @@ async fn test_cancel_current_task() {
         )),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
     state.machine.add_user_message("existing history");
@@ -336,7 +335,6 @@ fn test_transition_state_creation() {
         )),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 

--- a/crates/agent-engine/src/runtime/transition/tests/submissions.rs
+++ b/crates/agent-engine/src/runtime/transition/tests/submissions.rs
@@ -20,7 +20,6 @@ async fn test_handle_submission_cancel() {
         .await,
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 
@@ -102,7 +101,6 @@ async fn test_handle_submission_rollback() {
         )),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
 

--- a/crates/agent-engine/src/runtime/transition/tests/tool_batch/support_and_namespace_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/transition/tests/tool_batch/support_and_namespace_contract.inc.rs
@@ -375,7 +375,6 @@
             environment: NamespaceRuntimeEnvironment::new(root, "/agent/1", "default"),
             core_config: config,
             runtime_config,
-            definition_persona_dirs: Vec::new(),
             prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
         }
     }
@@ -461,7 +460,6 @@
             environment: NamespaceRuntimeEnvironment::new(root, "/agent/1", "default"),
             core_config: Config::default(),
             runtime_config: crate::runtime::RuntimeConfig::default(),
-            definition_persona_dirs: Vec::new(),
             prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
         };
         (state, shell)
@@ -649,7 +647,6 @@
                 .with_tool_process_context(alan_kernel::Pid(1), tool_runner),
             core_config: config,
             runtime_config: crate::runtime::RuntimeConfig::default(),
-            definition_persona_dirs: Vec::new(),
             prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
         }
     }

--- a/crates/agent-engine/src/runtime/turn_driver.rs
+++ b/crates/agent-engine/src/runtime/turn_driver.rs
@@ -467,7 +467,6 @@ mod tests {
             environment,
             core_config: crate::Config::default(),
             runtime_config: super::super::RuntimeConfig::default(),
-            definition_persona_dirs: Vec::new(),
             prompt_cache: super::super::prompt_cache::PromptAssemblyCache::new(Vec::new()),
         };
         let broker = TurnInputBroker::default();

--- a/crates/agent-engine/src/runtime/turn_executor.rs
+++ b/crates/agent-engine/src/runtime/turn_executor.rs
@@ -153,31 +153,14 @@ where
     }
 }
 
-fn resolve_definition_persona_dirs(state: &RuntimeLoopState) -> Vec<std::path::PathBuf> {
-    state.definition_persona_dirs.clone()
-}
-
 fn build_domain_prompt_with_skills(
-    state: &mut RuntimeLoopState,
+    prompt_cache: &mut super::prompt_cache::PromptAssemblyCache,
     user_input: Option<&[crate::tape::ContentPart]>,
     active_skills: Option<&[crate::skills::ActiveSkillEnvelope]>,
 ) -> super::prompt_cache::PromptAssemblyResult {
-    state
-        .prompt_cache
-        .rebind_paths(resolve_definition_persona_dirs(state));
-    state.prompt_cache.set_memory_store_dir(
-        state
-            .core_config
-            .memory
-            .enabled
-            .then(|| state.core_config.memory.store_dir.clone())
-            .flatten(),
-    );
     match active_skills {
-        Some(active_skills) => state
-            .prompt_cache
-            .build_with_active_skills(active_skills, user_input),
-        None => state.prompt_cache.build(user_input),
+        Some(active_skills) => prompt_cache.build_with_active_skills(active_skills, user_input),
+        None => prompt_cache.build(user_input),
     }
 }
 
@@ -275,7 +258,7 @@ where
         .then(|| state.machine.active_skills().to_vec())
         .filter(|active_skills| !active_skills.is_empty());
     let prompt_build = build_domain_prompt_with_skills(
-        state,
+        &mut state.prompt_cache,
         user_input_for_skills.as_deref(),
         resumed_active_skills.as_deref(),
     );

--- a/crates/agent-engine/src/runtime/turn_executor/tests.rs
+++ b/crates/agent-engine/src/runtime/turn_executor/tests.rs
@@ -933,7 +933,6 @@ fn create_test_state_with_provider_and_tools_and_shell<P: LlmProvider + 'static>
             .with_launch_context(launch_context),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
     (state, alan_shell::Shell::new(root))

--- a/crates/agent-engine/src/runtime/turn_executor/tests/prompt_and_tools.rs
+++ b/crates/agent-engine/src/runtime/turn_executor/tests/prompt_and_tools.rs
@@ -44,7 +44,7 @@ fn test_build_domain_prompt_with_skills_includes_mentioned_repo_skill_instructio
     state.prompt_cache = prompt_cache_for_definition_root(&definition_root, Vec::new());
 
     let user_input = vec![ContentPart::text("please use $my-skill for this task")];
-    let prompt = build_domain_prompt_with_skills(&mut state, Some(&user_input), None);
+    let prompt = build_domain_prompt_with_skills(&mut state.prompt_cache, Some(&user_input), None);
 
     assert!(prompt.system_prompt.contains("## Available Skills"));
     assert!(
@@ -62,18 +62,13 @@ fn test_build_domain_prompt_with_skills_uses_explicit_definition_persona() {
     let definition_root = temp.path().join("repo");
     let alan_dir = definition_root.join(".alan");
     let persona_dir = alan_dir.join("agents/default/persona");
-    let memory_dir = alan_dir.join("memory");
-    std::fs::create_dir_all(&memory_dir).unwrap();
     crate::prompts::ensure_definition_bootstrap_files_at(&persona_dir).unwrap();
     std::fs::write(persona_dir.join("SOUL.md"), "custom fallback persona").unwrap();
 
     let mut state = create_test_state_with_provider(ContentMockProvider::new("ok"));
-    state.core_config.memory.store_dir = Some(memory_dir);
-    state.definition_persona_dirs = vec![persona_dir];
-    state.prompt_cache =
-        prompt_cache_for_definition_root(&definition_root, state.definition_persona_dirs.clone());
+    state.prompt_cache = prompt_cache_for_definition_root(&definition_root, vec![persona_dir]);
 
-    let prompt = build_domain_prompt_with_skills(&mut state, None, None);
+    let prompt = build_domain_prompt_with_skills(&mut state.prompt_cache, None, None);
 
     assert!(prompt.system_prompt.contains("Agent Definition Persona"));
     assert!(prompt.system_prompt.contains("custom fallback persona"));
@@ -92,8 +87,16 @@ fn test_build_domain_prompt_with_skills_omits_memory_bootstrap_when_memory_disab
     state.core_config.memory.store_dir = Some(memory_dir);
     state.core_config.memory.enabled = false;
     state.prompt_cache = prompt_cache_for_definition_root(&definition_root, Vec::new());
+    state.prompt_cache.set_memory_store_dir(
+        state
+            .core_config
+            .memory
+            .enabled
+            .then(|| state.core_config.memory.store_dir.clone())
+            .flatten(),
+    );
 
-    let prompt = build_domain_prompt_with_skills(&mut state, None, None);
+    let prompt = build_domain_prompt_with_skills(&mut state.prompt_cache, None, None);
 
     assert!(!prompt.system_prompt.contains("Memory Store Bootstrap"));
     assert!(!prompt.system_prompt.contains("# User Memory"));

--- a/crates/agent-engine/src/runtime/virtual_tools_tests.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools_tests.rs
@@ -100,7 +100,6 @@ fn create_test_transition_state() -> super::super::transition::RuntimeLoopState 
             .with_launch_context(launch_context),
         core_config: config,
         runtime_config,
-        definition_persona_dirs: Vec::new(),
         prompt_cache,
     }
 }

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -69,7 +69,6 @@ fn runtime_state_and_handles_have_no_parallel_capability_or_event_authority() {
         "pub(super) environment: NamespaceRuntimeEnvironment",
         "pub(super) core_config: Config",
         "pub(super) runtime_config: RuntimeConfig",
-        "pub(super) definition_persona_dirs: Vec<std::path::PathBuf>",
         "pub(super) prompt_cache: super::prompt_cache::PromptAssemblyCache",
     ] {
         assert!(
@@ -82,9 +81,10 @@ fn runtime_state_and_handles_have_no_parallel_capability_or_event_authority() {
             .lines()
             .filter(|line| line.trim_start().starts_with("pub(super) "))
             .count(),
-        6,
-        "runtime loop aggregate must keep exactly its six cohesive fields"
+        5,
+        "runtime loop aggregate must keep exactly its five cohesive fields"
     );
+    assert!(!state.contains("definition_persona_dirs"));
     for displaced_state in [
         "current_submission",
         "turn_state",
@@ -361,6 +361,15 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
     }
 
     let executor = read_runtime_source("turn_executor.rs");
+    let prompt_build = &executor[executor
+        .find("fn build_domain_prompt_with_skills")
+        .expect("find prompt build")..];
+    let prompt_build = &prompt_build[..prompt_build
+        .find("/// Run a single agent turn")
+        .expect("find end of prompt build")];
+    assert!(!prompt_build.contains("RuntimeLoopState"));
+    assert!(prompt_build.contains("PromptAssemblyCache"));
+    assert!(!read_runtime_source("prompt_cache.rs").contains("rebind_paths"));
     let tool_definitions = &executor[executor
         .find("async fn turn_tool_definitions")
         .expect("find turn_tool_definitions")..];


### PR DESCRIPTION
## Summary
- make `PromptAssemblyCache` the sole owner of definition persona and memory prompt paths
- remove the parallel persona-path field from `RuntimeLoopState` and delete per-turn rebinding
- narrow prompt assembly to receive only the cache it needs
- enforce the five-field runtime aggregate and narrow prompt dependency with architecture tests

## Verification
- `cargo test -p alan-agent-engine` (1201 passed, 1 ignored; dependency boundary 17 passed)
- `cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings`
- `openspec validate deepen-agent-machine-transition-module --strict`
- `just quality`