### PR TITLE
refactor(agent-engine): isolate submission runtime inputs

### DIFF
--- a/crates/agent-engine/src/runtime/child_agents/tests.rs
+++ b/crates/agent-engine/src/runtime/child_agents/tests.rs
@@ -22,7 +22,28 @@ use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
 
 fn child_launch_runtime(parent: &RuntimeLoopState, spec: &SpawnSpec) -> ChildLaunchRuntime {
-    super::super::transition::child_launch_runtime(parent, spec)
+    let mut base_agent_config = AgentConfig::from(parent.core_config.clone());
+    base_agent_config.runtime_config = parent.runtime_config.clone();
+    let (plan_explanation, plan_items) = match parent.machine.plan_snapshot() {
+        Some(snapshot) => (snapshot.explanation.as_deref(), snapshot.items.as_slice()),
+        None => (None, &[][..]),
+    };
+    let task_context = super::project_child_task_context(
+        parent.machine.tape_summary(),
+        parent.machine.messages(),
+        plan_explanation,
+        plan_items,
+        spec,
+    );
+    ChildLaunchRuntime::new(
+        base_agent_config,
+        parent.child_launch(),
+        parent.tool_execution(),
+        parent.child_run_registry().clone(),
+        parent.process_path(),
+        parent.prompt_cache.capability_view().cloned(),
+        task_context,
+    )
 }
 
 async fn spawn_child_runtime(

--- a/crates/agent-engine/src/runtime/submission_handlers.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers.rs
@@ -1,7 +1,6 @@
 use alan_agent_protocol::{Event, InputMode, Op, Submission};
 use anyhow::Result;
 use serde_json::json;
-use tokio_util::sync::CancellationToken;
 
 use crate::ROLLBACK_NON_DURABLE_WARNING;
 use crate::approval::{
@@ -11,13 +10,16 @@ use crate::approval::{
 };
 use crate::tape::ContentPart;
 
-use super::compaction::{CompactionRequest, maybe_compact_context_for_request};
 use super::transition::{
-    ApprovedMountGrant, ApprovedMountGrantAccess, NamespaceMountApplication, RuntimeLoopState,
+    ApprovedMountGrant, ApprovedMountGrantAccess, NamespaceAgentFiles, NamespaceMountApplication,
 };
 use super::turn_executor::TurnRunKind;
 use super::turn_support::cancel_current_task;
-use crate::agent_machine::{NormalizedToolCall, PendingYield};
+use crate::agent_machine::{AgentMachine, NormalizedToolCall, PendingYield};
+
+mod runtime_inputs;
+
+pub(crate) use runtime_inputs::SubmissionRuntime;
 
 #[derive(Debug, Clone)]
 pub(super) enum RuntimeOpAction {
@@ -39,21 +41,18 @@ pub(super) enum RuntimeOpAction {
     },
 }
 
-pub(super) async fn handle_runtime_op_with_cancel<E, F>(
-    state: &mut RuntimeLoopState,
+pub(super) async fn handle_non_compaction_runtime_op<E, F>(
+    mut runtime: SubmissionRuntime<'_>,
     op: Op,
     emit: &mut E,
-    _cancel: &CancellationToken,
 ) -> Result<RuntimeOpAction>
 where
     E: FnMut(Event) -> F,
     F: std::future::Future<Output = ()>,
 {
     match op {
-        Op::CompactWithOptions { focus } => {
-            let runtime = super::transition::compaction_runtime(state);
-            maybe_compact_context_for_request(runtime, emit, CompactionRequest::manual(focus))
-                .await?;
+        Op::CompactWithOptions { .. } => {
+            anyhow::bail!("manual compaction must enter through the accepted-submission transition")
         }
         Op::Rollback { turns } => {
             if turns == 0 {
@@ -64,10 +63,10 @@ where
                 .await;
                 return Ok(RuntimeOpAction::NoTurn);
             }
-            let rollback = state.machine.rollback_last_turns(turns);
-            state.machine.clear_plan_snapshot();
-            super::ui_surfaces::plan_updated(&state.agent_files(), None, Vec::new()).await?;
-            super::ui_surfaces::rollback(&state.agent_files(), rollback.removed_turns).await?;
+            let rollback = runtime.machine.rollback_last_turns(turns);
+            runtime.machine.clear_plan_snapshot();
+            super::ui_surfaces::plan_updated(&runtime.agent_files, None, Vec::new()).await?;
+            super::ui_surfaces::rollback(&runtime.agent_files, rollback.removed_turns).await?;
             emit(Event::MachineRolledBack {
                 turns: rollback.removed_turns,
                 removed_messages: rollback.removed_messages,
@@ -89,15 +88,14 @@ where
                 is_final: true,
             })
             .await;
-            super::ui_surfaces::warning(&state.agent_files(), ROLLBACK_NON_DURABLE_WARNING).await?;
+            super::ui_surfaces::warning(&runtime.agent_files, ROLLBACK_NON_DURABLE_WARNING).await?;
             emit(Event::Warning {
                 message: ROLLBACK_NON_DURABLE_WARNING.to_string(),
             })
             .await;
         }
         Op::Interrupt => {
-            let agent_files = state.agent_files();
-            cancel_current_task(&mut state.machine, &agent_files, emit).await?;
+            cancel_current_task(runtime.machine, &runtime.agent_files, emit).await?;
         }
 
         // ====================================================================
@@ -106,7 +104,7 @@ where
         Op::Turn { parts, context } => {
             let reasoning_effort = context.as_ref().and_then(|c| c.reasoning_effort);
 
-            let queued_next_turn_inputs = state.machine.drain_next_turn_inputs();
+            let queued_next_turn_inputs = runtime.machine.drain_next_turn_inputs();
             let queued_next_turn_count = queued_next_turn_inputs.len();
             let mut merged_parts = Vec::new();
             for queued_parts in queued_next_turn_inputs {
@@ -114,8 +112,8 @@ where
             }
             merged_parts.extend(parts);
 
-            state.machine.reset_turn();
-            state.machine.set_active_turn_request_control_intent(
+            runtime.machine.reset_turn();
+            runtime.machine.set_active_turn_request_control_intent(
                 crate::RequestControlIntent::reasoning_effort(reasoning_effort),
             );
 
@@ -123,7 +121,7 @@ where
                 let message = format!(
                     "Applied {queued_next_turn_count} queued next_turn input(s) to this turn."
                 );
-                super::ui_surfaces::warning(&state.agent_files(), message.clone()).await?;
+                super::ui_surfaces::warning(&runtime.agent_files, message.clone()).await?;
                 emit(Event::Warning { message }).await;
             }
 
@@ -137,7 +135,8 @@ where
         Op::Input { parts, mode } => {
             match mode {
                 InputMode::Steer => {
-                    if !(state.machine.is_turn_active() || state.machine.has_pending_interaction())
+                    if !(runtime.machine.is_turn_active()
+                        || runtime.machine.has_pending_interaction())
                     {
                         emit(Event::Error {
                             message: "Input(mode=steer) requires an active or pending turn. Use Op::Turn to start a new turn.".to_string(),
@@ -154,10 +153,11 @@ where
                     });
                 }
                 InputMode::FollowUp => {
-                    if state.machine.is_turn_active() || state.machine.has_pending_interaction() {
+                    if runtime.machine.is_turn_active() || runtime.machine.has_pending_interaction()
+                    {
                         // In normal runtime flow this path should be handled by in-band queueing in
                         // turn_driver. Keep this as a safe fallback.
-                        state
+                        runtime
                             .machine
                             .push_buffered_inband_submission(Submission::new(Op::Input {
                                 parts,
@@ -165,12 +165,12 @@ where
                             }));
                         let message =
                             "Queued follow_up input for execution after current turn.".to_string();
-                        super::ui_surfaces::warning(&state.agent_files(), message.clone()).await?;
+                        super::ui_surfaces::warning(&runtime.agent_files, message.clone()).await?;
                         emit(Event::Warning { message }).await;
                         return Ok(RuntimeOpAction::NoTurn);
                     }
 
-                    state.machine.reset_turn();
+                    runtime.machine.reset_turn();
                     return Ok(RuntimeOpAction::RunTurn {
                         turn_kind: TurnRunKind::NewTurn,
                         user_input: Some(parts),
@@ -178,13 +178,13 @@ where
                     });
                 }
                 InputMode::NextTurn => {
-                    let queued_size = state.machine.queue_next_turn_input(parts);
+                    let queued_size = runtime.machine.queue_next_turn_input(parts);
                     match queued_size {
                         Some(size) => {
                             let message = format!(
                                 "Queued next_turn input (queue_size={size}); it will apply to the next explicit turn."
                             );
-                            super::ui_surfaces::warning(&state.agent_files(), message.clone())
+                            super::ui_surfaces::warning(&runtime.agent_files, message.clone())
                                 .await?;
                             emit(Event::Warning { message }).await;
                         }
@@ -207,7 +207,7 @@ where
             content,
         } => {
             let result = resume_content_to_value(&content);
-            match state.machine.take_pending(&request_id) {
+            match runtime.machine.take_pending(&request_id) {
                 Some(PendingYield::Confirmation(pending)) => {
                     let choice = result
                         .get("choice")
@@ -223,7 +223,7 @@ where
                         .map(String::from);
 
                     return handle_confirmation_resolution(
-                        state,
+                        &mut runtime,
                         pending,
                         choice_str,
                         modifications,
@@ -231,7 +231,7 @@ where
                     .await;
                 }
                 Some(PendingYield::StructuredInput(pending)) => {
-                    state.machine.add_tool_message(
+                    runtime.machine.add_tool_message(
                         &pending.request_id,
                         "request_user_input",
                         result,
@@ -315,11 +315,12 @@ fn checkpoint_choice_for_rollout(choice_str: &str) -> &str {
 }
 
 async fn persist_runtime_confirmation_checkpoint(
-    state: &RuntimeLoopState,
+    machine: &mut AgentMachine,
+    agent_files: &NamespaceAgentFiles,
     pending: &crate::approval::PendingConfirmation,
     choice_str: &str,
 ) {
-    let knowledge_root = match state.agent_files().current_tape_checkpoint().await {
+    let knowledge_root = match agent_files.current_tape_checkpoint().await {
         Ok(root) => {
             let trimmed = root.trim();
             if trimmed.is_empty() { None } else { Some(root) }
@@ -334,25 +335,25 @@ async fn persist_runtime_confirmation_checkpoint(
             None
         }
     };
-    state
-        .machine
-        .record_checkpoint_with_optional_knowledge_root(
-            &pending.checkpoint_id,
-            &pending.checkpoint_type,
-            &pending.summary,
-            Some(checkpoint_choice_for_rollout(choice_str)),
-            knowledge_root.as_deref(),
-        );
+    machine.record_checkpoint_with_optional_knowledge_root(
+        &pending.checkpoint_id,
+        &pending.checkpoint_type,
+        &pending.summary,
+        Some(checkpoint_choice_for_rollout(choice_str)),
+        knowledge_root.as_deref(),
+    );
 }
 
 async fn handle_confirmation_resolution(
-    state: &mut RuntimeLoopState,
+    runtime: &mut SubmissionRuntime<'_>,
     pending: crate::approval::PendingConfirmation,
     choice_str: &str,
     modifications: Option<String>,
 ) -> Result<RuntimeOpAction> {
     let replay_tool_batch = if replays_tool_calls(&pending.checkpoint_type) {
-        state.machine.take_tool_replay_batch(&pending.checkpoint_id)
+        runtime
+            .machine
+            .take_tool_replay_batch(&pending.checkpoint_id)
     } else {
         None
     };
@@ -369,7 +370,7 @@ async fn handle_confirmation_resolution(
 
     if pending.checkpoint_type == MOUNT_ESCALATION_CHECKPOINT_TYPE {
         return Ok(handle_mount_escalation_resolution(
-            state, pending, choice_str,
+            runtime, pending, choice_str,
         ));
     }
 
@@ -379,12 +380,18 @@ async fn handle_confirmation_resolution(
             "version": RUNTIME_CONFIRMATION_CONTROL_VERSION,
             "source": RUNTIME_CONFIRMATION_CONTROL_SOURCE
         });
-        state
+        runtime
             .machine
             .add_user_control_message_parts(vec![ContentPart::structured(payload)]);
-        persist_runtime_confirmation_checkpoint(state, &pending, choice_str).await;
+        persist_runtime_confirmation_checkpoint(
+            runtime.machine,
+            &runtime.agent_files,
+            &pending,
+            choice_str,
+        )
+        .await;
     } else {
-        state
+        runtime
             .machine
             .add_tool_message(&pending.checkpoint_id, "request_confirmation", payload);
     }
@@ -438,7 +445,7 @@ async fn handle_confirmation_resolution(
 }
 
 fn handle_mount_escalation_resolution(
-    state: &mut RuntimeLoopState,
+    runtime: &mut SubmissionRuntime<'_>,
     pending: crate::approval::PendingConfirmation,
     choice_str: &str,
 ) -> RuntimeOpAction {
@@ -447,12 +454,12 @@ fn handle_mount_escalation_resolution(
             "status": "invalid_mount_escalation_checkpoint",
             "approved": false,
             "live_applied": false,
-            "checkpoint_id": pending.checkpoint_id.clone(),
-            "checkpoint_type": pending.checkpoint_type.clone(),
+            "checkpoint_id": pending.checkpoint_id,
+            "checkpoint_type": pending.checkpoint_type,
             "choice": choice_str,
             "error": "Invalid mount escalation checkpoint.",
         });
-        state
+        runtime
             .machine
             .add_tool_message(&pending.checkpoint_id, "request_mount", result);
         return RuntimeOpAction::RunTurn {
@@ -467,8 +474,8 @@ fn handle_mount_escalation_resolution(
         grant
             .as_ref()
             .map(|grant| {
-                state
-                    .mount_control()
+                runtime
+                    .mount_control
                     .apply_approved_grant(&grant.approved_mount_grant())
             })
             .unwrap_or_else(|| {
@@ -492,28 +499,21 @@ fn handle_mount_escalation_resolution(
         .ok()
     });
     let namespace_applied = approved && namespace_application.namespace_applied;
-    let scratch_dir = state
-        .tool_execution()
+    let scratch_dir = runtime
+        .tool_execution
         .execution_binding()
         .map(|binding| binding.scratch_dir)
-        .or_else(|| {
-            state
-                .runtime_config
-                .store_bindings
-                .as_ref()
-                .map(|stores| stores.tmp.clone())
-        });
+        .or_else(|| runtime.runtime_scratch_dir.clone());
     let tool_sandbox_projection_changed = namespace_applied
         && native_grant.as_ref().is_some_and(|grant| {
-            let mut mount_control = state.mount_control();
-            mount_control.retain_host_mount(grant.clone());
+            runtime.mount_control.retain_host_mount(grant.clone());
             scratch_dir
                 .clone()
-                .is_some_and(|scratch| mount_control.sync_tool_binding(scratch))
+                .is_some_and(|scratch| runtime.mount_control.sync_tool_binding(scratch))
         });
     let tool_sandbox_applied = namespace_applied
         && grant.as_ref().is_some_and(|grant| {
-            let binding = state.tool_execution().execution_binding();
+            let binding = runtime.tool_execution.execution_binding();
             binding.is_some_and(|binding| {
                 binding.host_mounts.iter().any(|mounted| {
                     mounted.namespace_path == grant.namespace_path
@@ -531,19 +531,19 @@ fn handle_mount_escalation_resolution(
         "namespace_error": namespace_application.namespace_error,
         "tool_sandbox_applied": tool_sandbox_applied,
         "tool_sandbox_projection_changed": tool_sandbox_projection_changed,
-        "checkpoint_id": pending.checkpoint_id.clone(),
-        "checkpoint_type": pending.checkpoint_type.clone(),
+        "checkpoint_id": pending.checkpoint_id,
+        "checkpoint_type": pending.checkpoint_type,
         "choice": choice_str,
         "mount_request": mount_request,
     });
 
     if approved {
-        state.machine.record_event(
+        runtime.machine.record_event(
             "host_mount_grant",
             host_mount_grant_event_payload(&pending.details, &result),
         );
     }
-    state
+    runtime
         .machine
         .add_tool_message(&tool_call_id, "request_mount", result);
 

--- a/crates/agent-engine/src/runtime/submission_handlers/runtime_inputs.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/runtime_inputs.rs
@@ -1,0 +1,33 @@
+use std::path::PathBuf;
+
+use crate::{
+    agent_machine::AgentMachine,
+    runtime::transition::{NamespaceAgentFiles, NamespaceMountControl, NamespaceToolExecution},
+};
+
+/// Explicit inputs for classifying and applying one non-compaction runtime operation.
+pub(crate) struct SubmissionRuntime<'a> {
+    pub(super) machine: &'a mut AgentMachine,
+    pub(super) agent_files: NamespaceAgentFiles,
+    pub(super) mount_control: NamespaceMountControl<'a>,
+    pub(super) tool_execution: NamespaceToolExecution,
+    pub(super) runtime_scratch_dir: Option<PathBuf>,
+}
+
+impl<'a> SubmissionRuntime<'a> {
+    pub(crate) fn new(
+        machine: &'a mut AgentMachine,
+        agent_files: NamespaceAgentFiles,
+        mount_control: NamespaceMountControl<'a>,
+        tool_execution: NamespaceToolExecution,
+        runtime_scratch_dir: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            machine,
+            agent_files,
+            mount_control,
+            tool_execution,
+            runtime_scratch_dir,
+        }
+    }
+}

--- a/crates/agent-engine/src/runtime/submission_handlers/tests.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests.rs
@@ -1,3 +1,18 @@
+use tokio_util::sync::CancellationToken;
+
+async fn handle_runtime_op_with_cancel<E, F>(
+    state: &mut super::super::transition::RuntimeLoopState,
+    op: alan_agent_protocol::Op,
+    emit: &mut E,
+    _cancel: &CancellationToken,
+) -> anyhow::Result<super::RuntimeOpAction>
+where
+    E: FnMut(alan_agent_protocol::Event) -> F,
+    F: std::future::Future<Output = ()>,
+{
+    super::super::transition::handle_runtime_op(state, op, emit).await
+}
+
 include!("tests/confirmation_and_mount_support.inc.rs");
 include!("tests/mount_and_user_input_contract.inc.rs");
 include!("tests/runtime_ops_and_replay_contract.inc.rs");

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/confirmation_and_mount_support.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/confirmation_and_mount_support.inc.rs
@@ -9,6 +9,7 @@
         tape::ContentPart,
         tools::ToolRegistry,
     };
+    use crate::runtime::transition::RuntimeLoopState;
     use alan_ap::InProcessTransport;
     use alan_kernel::{Access, MountFs, Namespace, ProcFs};
     use alan_shell::Shell;

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -35,7 +35,9 @@ use crate::{
 
 use super::loop_guard::ToolLoopGuard;
 use super::steering_queue::handle_queued_steering_inputs;
-use super::submission_handlers::{RuntimeOpAction, handle_runtime_op_with_cancel};
+use super::submission_handlers::{
+    RuntimeOpAction, SubmissionRuntime, handle_non_compaction_runtime_op,
+};
 use super::tool_authorization::{
     ToolAuthorizationOutcome, ToolAuthorizationRequest, authorize_tool_call,
 };
@@ -110,10 +112,6 @@ impl RuntimeLoopState {
         self.environment.child_launch()
     }
 
-    pub(crate) fn mount_control(&mut self) -> NamespaceMountControl<'_> {
-        self.environment.mount_control()
-    }
-
     pub(crate) fn tool_execution(&self) -> NamespaceToolExecution {
         self.environment.tool_execution()
     }
@@ -143,34 +141,6 @@ pub(super) fn compaction_runtime(
         agent_files,
         settings,
         memory,
-    )
-}
-
-#[cfg(test)]
-pub(super) fn child_launch_runtime(
-    state: &RuntimeLoopState,
-    spec: &alan_agent_protocol::SpawnSpec,
-) -> super::child_agents::ChildLaunchRuntime {
-    let base_agent_config = child_launch_base_agent_config(state);
-    let (plan_explanation, plan_items) = match state.machine.plan_snapshot() {
-        Some(snapshot) => (snapshot.explanation.as_deref(), snapshot.items.as_slice()),
-        None => (None, &[][..]),
-    };
-    let task_context = super::child_agents::project_child_task_context(
-        state.machine.tape_summary(),
-        state.machine.messages(),
-        plan_explanation,
-        plan_items,
-        spec,
-    );
-    super::child_agents::ChildLaunchRuntime::new(
-        base_agent_config,
-        state.child_launch(),
-        state.tool_execution(),
-        state.child_run_registry().clone(),
-        state.process_path(),
-        state.prompt_cache.capability_view().cloned(),
-        task_context,
     )
 }
 
@@ -656,6 +626,53 @@ fn child_launch_base_agent_config(state: &RuntimeLoopState) -> super::launch_con
     config
 }
 
+fn submission_runtime(state: &mut RuntimeLoopState) -> SubmissionRuntime<'_> {
+    let RuntimeLoopState {
+        machine,
+        environment,
+        runtime_config,
+        ..
+    } = state;
+    let agent_files = environment.agent_files();
+    let tool_execution = environment.tool_execution();
+    let runtime_scratch_dir = runtime_config
+        .store_bindings
+        .as_ref()
+        .map(|stores| stores.tmp.clone());
+    let mount_control = environment.mount_control();
+    SubmissionRuntime::new(
+        machine,
+        agent_files,
+        mount_control,
+        tool_execution,
+        runtime_scratch_dir,
+    )
+}
+
+pub(super) async fn handle_runtime_op<E, F>(
+    state: &mut RuntimeLoopState,
+    op: Op,
+    emit: &mut E,
+) -> Result<RuntimeOpAction>
+where
+    E: FnMut(Event) -> F,
+    F: std::future::Future<Output = ()>,
+{
+    match op {
+        Op::CompactWithOptions { focus } => {
+            let runtime = compaction_runtime(state);
+            super::compaction::maybe_compact_context_for_request(
+                runtime,
+                emit,
+                super::compaction::CompactionRequest::manual(focus),
+            )
+            .await?;
+            Ok(RuntimeOpAction::NoTurn)
+        }
+        op => handle_non_compaction_runtime_op(submission_runtime(state), op, emit).await,
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TransitionCompletion {
     Completed,
@@ -712,27 +729,6 @@ pub(crate) async fn advance_accepted_submission(
     }
 }
 
-/// Handle a single submission
-#[cfg_attr(
-    not(test),
-    allow(
-        dead_code,
-        reason = "submission entrypoint remains available to the adjacent white-box test seam"
-    )
-)]
-pub async fn handle_submission<E, F>(
-    state: &mut RuntimeLoopState,
-    submission: Submission,
-    emit: &mut E,
-) -> Result<()>
-where
-    E: FnMut(Event) -> F,
-    F: std::future::Future<Output = ()>,
-{
-    let cancel = CancellationToken::new();
-    handle_submission_with_cancel(state, submission, emit, &cancel).await
-}
-
 pub(crate) async fn handle_submission_with_cancel<E, F>(
     state: &mut RuntimeLoopState,
     submission: Submission,
@@ -759,7 +755,7 @@ where
 {
     let op = submission.op;
 
-    match handle_runtime_op_with_cancel(state, op, emit, cancel).await? {
+    match handle_runtime_op(state, op, emit).await? {
         RuntimeOpAction::NoTurn => Ok(()),
         RuntimeOpAction::RunTurn {
             turn_kind,

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/tests.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/tests.rs
@@ -435,21 +435,15 @@ async fn answered_request_response_resumes_engine_pending_yield_from_files() {
         runtime_config: super::super::super::RuntimeConfig::default(),
         prompt_cache: super::super::super::prompt_cache::PromptAssemblyCache::new(Vec::new()),
     };
-    let cancel = tokio_util::sync::CancellationToken::new();
     let mut events = Vec::new();
     let mut emit = |event| {
         events.push(event);
         async {}
     };
 
-    let action = super::super::super::submission_handlers::handle_runtime_op_with_cancel(
-        &mut state,
-        submission.op,
-        &mut emit,
-        &cancel,
-    )
-    .await
-    .unwrap();
+    let action = super::super::handle_runtime_op(&mut state, submission.op, &mut emit)
+        .await
+        .unwrap();
 
     assert!(
         matches!(

--- a/crates/agent-engine/src/runtime/transition/tests/submissions.rs
+++ b/crates/agent-engine/src/runtime/transition/tests/submissions.rs
@@ -1,4 +1,4 @@
-// Tests for handle_submission
+// Tests for direct submission handling
 #[tokio::test]
 #[allow(
     clippy::field_reassign_with_default,
@@ -31,7 +31,8 @@ async fn test_handle_submission_cancel() {
 
     let submission = Submission::new(alan_agent_protocol::Op::Interrupt);
 
-    let result = handle_submission(&mut state, submission, &mut emit).await;
+    let cancel = CancellationToken::new();
+    let result = handle_submission_with_cancel(&mut state, submission, &mut emit, &cancel).await;
 
     assert!(result.is_ok(), "interrupt should succeed: {result:?}");
     assert_eq!(events.len(), 1);
@@ -112,7 +113,8 @@ async fn test_handle_submission_rollback() {
 
     let submission = Submission::new(alan_agent_protocol::Op::Rollback { turns: 1 });
 
-    let result = handle_submission(&mut state, submission, &mut emit).await;
+    let cancel = CancellationToken::new();
+    let result = handle_submission_with_cancel(&mut state, submission, &mut emit, &cancel).await;
 
     assert!(result.is_ok());
     assert_eq!(state.machine.messages().len(), 2);

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -1,5 +1,7 @@
 //! Absence guards for the namespace-native Agent Execution Engine boundary.
 
+#[path = "dependency_boundary/submission_runtime.rs"]
+mod submission_runtime;
 #[path = "dependency_boundary/turn_memory.rs"]
 mod turn_memory;
 
@@ -341,6 +343,8 @@ fn transition_leaf_workflows_do_not_receive_the_runtime_loop_aggregate() {
         "mount_request_tool/runtime_inputs.rs",
         "response_guardrails.rs",
         "steering_queue.rs",
+        "submission_handlers.rs",
+        "submission_handlers/runtime_inputs.rs",
         "tool_authorization.rs",
         "tool_authorization/runtime_inputs.rs",
         "tool_execution.rs",
@@ -835,10 +839,6 @@ fn mount_changes_use_only_the_narrow_namespace_mount_control() {
             "complete namespace environment retained displaced mount operation {displaced}"
         );
     }
-
-    let submission_handlers = read_runtime_source("submission_handlers.rs");
-    assert!(submission_handlers.contains(".mount_control()"));
-    assert!(!submission_handlers.contains("state.environment"));
 
     let transition = read_runtime_source("transition.rs");
     let engine = read_runtime_source("engine.rs");

--- a/crates/agent-engine/tests/dependency_boundary/submission_runtime.rs
+++ b/crates/agent-engine/tests/dependency_boundary/submission_runtime.rs
@@ -1,0 +1,25 @@
+#[test]
+fn submission_handling_uses_only_explicit_runtime_inputs() {
+    let transition = super::read_runtime_source("transition.rs");
+    let handlers = super::read_runtime_source("submission_handlers.rs");
+    let runtime = super::read_runtime_source("submission_handlers/runtime_inputs.rs");
+
+    for forbidden in [
+        "RuntimeLoopState",
+        "RuntimeConfig",
+        "NamespaceRuntimeEnvironment",
+    ] {
+        assert!(
+            !runtime.contains(forbidden),
+            "submission runtime must not regain {forbidden}"
+        );
+    }
+    assert!(runtime.contains("SubmissionRuntime"));
+    assert!(transition.contains("fn submission_runtime("));
+    assert!(transition.contains("async fn handle_runtime_op"));
+    assert!(transition.contains("Op::CompactWithOptions"));
+    assert!(handlers.contains("handle_non_compaction_runtime_op"));
+    assert!(handlers.contains("runtime.mount_control"));
+    assert!(!handlers.contains("state.mount_control()"));
+    assert!(!handlers.contains("state.environment"));
+}


### PR DESCRIPTION
## Summary
- keep manual compaction at the accepted-submission transition boundary
- give non-compaction submission handling only explicit Machine, AgentFS, mount-control, Tool, and scratch-path inputs
- remove the displaced `RuntimeLoopState::mount_control` forwarder and unused cancellation parameter
- move test-only child launch assembly out of production transition code and add a dedicated submission dependency guard

## Verification
- `cargo test -p alan-agent-engine` (1201 passed, 1 ignored; dependency boundary 18 passed)
- `cargo clippy -p alan-agent-engine --all-targets --all-features -- -D warnings`
- `openspec validate deepen-agent-machine-transition-module --strict`
- `just quality`