### PR TITLE
docs(openspec): sync agent machine transition contract

### DIFF
--- a/openspec/changes/deepen-agent-machine-transition-module/tasks.md
+++ b/openspec/changes/deepen-agent-machine-transition-module/tasks.md
@@ -4,10 +4,10 @@
   `NamespaceRuntimeEnvironment` access in the accepted-submission path and assign
   each value to Process-loop control, Agent Machine state, or a narrow
   transition dependency.
-- [ ] 1.2 Add focused characterization checks for submission acceptance,
+- [x] 1.2 Add focused characterization checks for submission acceptance,
   generation completion, Yield/resume, Tool replay, compaction, deferred
   actions, persistence/recovery, cancellation, and failure evidence.
-- [ ] 1.3 Confirm current AgentFS, `/proc`, rollout, and checkpoint observations
+- [x] 1.3 Confirm current AgentFS, `/proc`, rollout, and checkpoint observations
   before moving ownership.
 
 ## 2. Make Agent Machine The State Owner
@@ -17,7 +17,7 @@
   operations.
 - [x] 2.2 Make Tape, recorder, flags, and transition state private; remove the
   public Agent Machine re-export and replace direct field access.
-- [ ] 2.3 Keep or delete the private `RuntimeLoopState` according to whether it
+- [x] 2.3 Keep or delete the private `RuntimeLoopState` according to whether it
   still groups cohesive Machine state; do not preserve it as a shared field bag.
 - [x] 2.4 Add adjacent white-box tests for private Machine transitions and keep
   supported external tests at file boundaries.
@@ -28,30 +28,30 @@
   transition module with a compact outcome for the outer loop.
 - [x] 3.2 Keep input polling, channel closure, shutdown, cancellation, and
   heartbeat in `engine.rs` and verify they do not become Machine state.
-- [ ] 3.3 Restrict complete namespace-environment access to the transition
+- [x] 3.3 Restrict complete namespace-environment access to the transition
   boundary and pass narrow concrete inputs to generation, Tool, policy, memory,
   and evidence workflows.
-- [ ] 3.4 Delete displaced forwarding helpers, broad environment parameters,
+- [x] 3.4 Delete displaced forwarding helpers, broad environment parameters,
   direct Machine field access, and any temporary dual transition path.
 
 ## 4. Verify And Deliver The Stack
 
-- [ ] 4.1 Run focused `alan-agent-engine` tests, workspace formatting, Clippy,
+- [x] 4.1 Run focused `alan-agent-engine` tests, workspace formatting, Clippy,
   the canonical repository quality gate, and strict OpenSpec validation.
-- [ ] 4.2 Verify AgentFS, `/proc`, aP, Yield, Tool, compaction, memory,
+- [x] 4.2 Verify AgentFS, `/proc`, aP, Yield, Tool, compaction, memory,
   persistence, recovery, and child-process behavior remains unchanged.
-- [ ] 4.3 Deliver focused stacked PRs in dependency order; each PR must move one
+- [x] 4.3 Deliver focused stacked PRs in dependency order; each PR must move one
   complete owner and delete its old path rather than add scaffolding or a
   compatibility layer.
-- [ ] 4.4 For every PR, resolve all actionable Codex Review comments, rerun CI on
+- [x] 4.4 For every PR, resolve all actionable Codex Review comments, rerun CI on
   the current HEAD, wait through a follow-up review window, and merge only when
   no unresolved or new issue remains.
 
 ## 5. Sync And Archive
 
-- [ ] 5.1 After all implementation PRs merge, sync the delta requirement into
+- [x] 5.1 After all implementation PRs merge, sync the delta requirement into
   canonical `agent-namespace-runtime` and run strict OpenSpec validation.
-- [ ] 5.2 Confirm the merged code and canonical spec contain no retired public
+- [x] 5.2 Confirm the merged code and canonical spec contain no retired public
   Machine surface or dual transition owner.
 - [ ] 5.3 Archive the change only after implementation, review, verification,
   and canonical spec sync are complete.

--- a/openspec/specs/agent-namespace-runtime/spec.md
+++ b/openspec/specs/agent-namespace-runtime/spec.md
@@ -132,6 +132,74 @@ projector.
 - **THEN** every live use is a file-record schema or transition-local value
 - **AND** the type does not carry a publish/subscribe runtime transport
 
+### Requirement: Agent Machine owns transition-local state
+Agent Execution Engine SHALL keep Tape, the current accepted submission, turn
+state, pending Yield, Tool replay state, active-task state, and deferred
+transition action inside one Agent Machine owner. Those values MUST NOT be
+independently mutable through a shared runtime field bag, and Agent Machine
+internals MUST NOT be a public cross-crate integration surface.
+
+#### Scenario: A submission starts a transition
+- **WHEN** the outer Process loop accepts a `Submission`
+- **THEN** Agent Machine records and advances all state local to that transition
+- **AND** sibling runtime modules cannot mutate its Tape or turn state directly
+
+#### Scenario: Engine API visibility is inspected
+- **WHEN** repository validation inspects `alan-agent-engine` exports and field
+  visibility
+- **THEN** Agent Machine state is private to the engine implementation
+- **AND** supported observation remains AgentFS, `/proc`, rollout, and checkpoint
+  files
+
+#### Scenario: A pending transition resumes
+- **WHEN** Agent Runtime Service restores a Yield, Tool replay, or deferred action
+  from durable files
+- **THEN** Agent Machine resumes from that restored transition state
+- **AND** no parallel runtime field bag must be reconciled with it
+
+### Requirement: Process-loop control is separate from transition execution
+Agent Execution Engine SHALL keep input polling, channel closure, shutdown,
+cancellation, and heartbeat control in its outer Process loop. A concrete
+transition module SHALL own execution after a `Submission` is accepted and
+SHALL return only the compact outcome required for the outer loop to continue.
+
+#### Scenario: No submission is available
+- **WHEN** the outer Process loop is polling input or handling heartbeat and
+  shutdown state
+- **THEN** it does not enter or mutate an Agent Machine transition
+
+#### Scenario: An accepted submission completes or yields
+- **WHEN** the transition module advances an accepted submission to completion,
+  Yield, or deferred continuation
+- **THEN** it updates Agent Machine and the owning file surfaces
+- **AND** it returns a compact control outcome rather than transferring Machine
+  state ownership to the outer loop
+
+#### Scenario: A Process is cancelled
+- **WHEN** Process lifecycle control cancels an Agent Process
+- **THEN** the outer loop applies cancellation to the active transition
+- **AND** cancellation does not become a second Agent Machine state owner
+
+### Requirement: Transition dependencies are narrow and concrete
+The accepted-submission transition boundary SHALL receive the one concrete
+namespace-backed runtime environment. Its child modules SHALL receive only the
+specific paths, handles, records, or operations required by their workflow and
+MUST NOT accept the complete runtime environment or a new one-implementation
+abstraction for convenience.
+
+#### Scenario: A transition child operation is added
+- **WHEN** a child module needs a namespace capability during a transition
+- **THEN** the transition owner resolves or passes the narrow concrete input
+  required by that operation
+- **AND** the child module does not gain the complete environment field bag
+
+#### Scenario: The ownership refactor is verified
+- **WHEN** the transition module refactor completes
+- **THEN** existing AgentFS, `/proc`, aP, Tool, Yield, compaction, persistence,
+  recovery, memory, and child-process contract tests remain unchanged in
+  behavior
+- **AND** no compatibility transition path remains
+
 ### Requirement: An agent is a process with a spawner-assembled namespace
 An agent SHALL run as an ordinary `Process` created via `/proc/clone` whose exec
 spec assembles the child's namespace. The mounted set — the LLM connection, the


### PR DESCRIPTION
## Summary
- sync the completed Agent Machine transition ownership requirements into the canonical `agent-namespace-runtime` spec
- record completion of characterization, ownership, narrow-dependency, verification, and review tasks
- leave only the post-merge archive task open

## Verification
- `cargo test -p alan-agent-engine --test dependency_boundary` (20 passed)
- `just quality`
- `openspec validate deepen-agent-machine-transition-module --strict`
- `openspec validate --all --strict` (88 passed)