### PR TITLE
Replace Host Mount requests with logical file protocol

### DIFF
--- a/clients/apple/alan-macos/Services/AlanOS/AlanOSAttachmentService.swift
+++ b/clients/apple/alan-macos/Services/AlanOS/AlanOSAttachmentService.swift
@@ -770,9 +770,23 @@ final class AlanOSNativeCapabilityAdapter {
     }
 
     private func pollHostMounts(session: AlanOSAttachmentSession) async {
-        guard let data = try? await session.cat("/mnt/host-mount/request"),
-              let requests = try? JSONDecoder().decode([AlanHostMountNativeRequest].self, from: data)
-        else { return }
+        guard let entries = try? await session.list("/mnt/host-mount/requests") else { return }
+        var requests: [AlanHostMountNativeRequest] = []
+        for requestID in entries where requestID != "clone" && requestID != "events" {
+            let base = "/mnt/host-mount/requests/\(requestID)"
+            guard let statusData = try? await session.cat("\(base)/status"),
+                  String(decoding: statusData, as: UTF8.self)
+                    .trimmingCharacters(in: .whitespacesAndNewlines) == "pending",
+                  let requestData = try? await session.cat("\(base)/request"),
+                  let request = try? JSONDecoder().decode(
+                    AlanHostMountNativeRequest.self,
+                    from: requestData
+                  ),
+                  request.id == requestID
+            else { continue }
+            requests.append(request)
+        }
+        requests.sort { alanAgentFileIDPrecedes($0.id, $1.id) }
         let pendingIDs = Set(requests.map(\.id))
         dismissedMountRequests.formIntersection(pendingIDs)
         guard let request = requests.first(where: {

--- a/clients/apple/alan-macos/Services/AlanOS/AlanOSAttachmentService.swift
+++ b/clients/apple/alan-macos/Services/AlanOS/AlanOSAttachmentService.swift
@@ -738,7 +738,6 @@ final class AlanOSNativeCapabilityAdapter {
 
     private var observationTask: Task<Void, Never>?
     private var inFlight = Set<String>()
-    private var dismissedMountRequests = Set<String>()
     private var securityScopedDirectories: [String: URL] = [:]
 
     func start(attachment: AlanOSAttachmentController) {
@@ -757,7 +756,6 @@ final class AlanOSNativeCapabilityAdapter {
         observationTask?.cancel()
         observationTask = nil
         inFlight.removeAll()
-        dismissedMountRequests.removeAll()
         for url in securityScopedDirectories.values {
             url.stopAccessingSecurityScopedResource()
         }
@@ -787,10 +785,8 @@ final class AlanOSNativeCapabilityAdapter {
             requests.append(request)
         }
         requests.sort { alanAgentFileIDPrecedes($0.id, $1.id) }
-        let pendingIDs = Set(requests.map(\.id))
-        dismissedMountRequests.formIntersection(pendingIDs)
         guard let request = requests.first(where: {
-            !inFlight.contains("mount:\($0.id)") && !dismissedMountRequests.contains($0.id)
+            !inFlight.contains("mount:\($0.id)")
         }) else { return }
         let key = "mount:\(request.id)"
         inFlight.insert(key)
@@ -804,7 +800,14 @@ final class AlanOSNativeCapabilityAdapter {
         panel.canChooseFiles = false
         panel.allowsMultipleSelection = false
         guard panel.runModal() == .OK, let directory = panel.url else {
-            dismissedMountRequests.insert(request.id)
+            do {
+                try AlanOSHostCommandClient.cancelHostMount(
+                    status: session.status,
+                    requestID: request.id
+                )
+            } catch {
+                presentNativeError(title: "Directory access cancellation failed", error: error)
+            }
             return
         }
         let scoped = directory.startAccessingSecurityScopedResource()
@@ -1040,13 +1043,42 @@ private enum AlanOSHostCommandClient {
         request: AlanHostMountNativeRequest,
         directory: URL
     ) throws {
-        let descriptor = try connectUnixSocket(path: status.socket)
-        defer { Darwin.close(descriptor) }
         let command: [String: Any] = [
             "op": "approve_host_mount",
             "request_id": request.id,
             "host_path": directory.path,
         ]
+        let response = try send(status: status, command: command)
+        guard response["host_path"] == nil,
+              let grant = response["grant"] as? [String: Any],
+              grant["host_path"] == nil,
+              grant["id"] as? String == request.id,
+              grant["namespace_path"] as? String == request.namespacePath,
+              grant["access"] as? String == request.access,
+              grant["active"] as? Bool == true
+        else {
+            throw AlanOSAttachmentError.protocolFailure("Host Mount response was unbounded or mismatched.")
+        }
+    }
+
+    static func cancelHostMount(status: AlanOSHostStatus, requestID: String) throws {
+        let response = try send(status: status, command: [
+            "op": "cancel_host_mount",
+            "request_id": requestID,
+        ])
+        guard response["host_path"] == nil,
+              response["grant"] == nil || response["grant"] is NSNull
+        else {
+            throw AlanOSAttachmentError.protocolFailure("Host Mount cancellation returned authority.")
+        }
+    }
+
+    private static func send(
+        status: AlanOSHostStatus,
+        command: [String: Any]
+    ) throws -> [String: Any] {
+        let descriptor = try connectUnixSocket(path: status.socket)
+        defer { Darwin.close(descriptor) }
         let payload = try JSONSerialization.data(withJSONObject: command)
         var length = UInt32(payload.count).bigEndian
         var frame = Data(bytes: &length, count: MemoryLayout<UInt32>.size)
@@ -1068,16 +1100,7 @@ private enum AlanOSHostCommandClient {
         if let error = response["error"] as? String {
             throw AlanOSAttachmentError.hostUnavailable(error)
         }
-        guard response["host_path"] == nil,
-              let grant = response["grant"] as? [String: Any],
-              grant["host_path"] == nil,
-              grant["id"] as? String == request.id,
-              grant["namespace_path"] as? String == request.namespacePath,
-              grant["access"] as? String == request.access,
-              grant["active"] as? Bool == true
-        else {
-            throw AlanOSAttachmentError.protocolFailure("Host Mount response was unbounded or mismatched.")
-        }
+        return response
     }
 }
 

--- a/clients/apple/scripts/test-alan-os-attachment.sh
+++ b/clients/apple/scripts/test-alan-os-attachment.sh
@@ -39,6 +39,11 @@ if grep -Fq 'session.cat("/mnt/host-mount/request")' "$ATTACHMENT_SOURCE"; then
 fi
 grep -q 'let panel = NSOpenPanel()' "$ATTACHMENT_SOURCE"
 grep -q 'approveHostMount(' "$ATTACHMENT_SOURCE"
+grep -q 'cancelHostMount(' "$ATTACHMENT_SOURCE"
+if grep -q 'dismissedMountRequests' "$ATTACHMENT_SOURCE"; then
+    echo "Dismissed native Host Mount panels must settle the service request." >&2
+    exit 1
+fi
 grep -Fq 'session.cat("/mnt/connections/native-requests")' "$ATTACHMENT_SOURCE"
 grep -Fq 'host-keychain:\(channel):\(credentialID)' "$ATTACHMENT_SOURCE"
 grep -q 'ALAN_NATIVE_CONNECTION_REQUEST_ID' "$ATTACHMENT_SOURCE"

--- a/clients/apple/scripts/test-alan-os-attachment.sh
+++ b/clients/apple/scripts/test-alan-os-attachment.sh
@@ -32,7 +32,11 @@ grep -Fq 'writeDocument("/proc/\(reference.pid)/ctl"' "$ATTACHMENT_SOURCE"
 grep -Fq 'writeDocument("/agent/\(reference.pid)/machine/ctl"' "$ATTACHMENT_SOURCE"
 grep -Fq '.alert("Stop Agent Process?"' "$AGENT_CONTENT_SOURCE"
 grep -Fq 'Closing this view only detaches.' "$AGENT_CONTENT_SOURCE"
-grep -Fq 'session.cat("/mnt/host-mount/request")' "$ATTACHMENT_SOURCE"
+grep -Fq 'session.list("/mnt/host-mount/requests")' "$ATTACHMENT_SOURCE"
+if grep -Fq 'session.cat("/mnt/host-mount/request")' "$ATTACHMENT_SOURCE"; then
+    echo "Alan for macOS must not poll the retired Host Mount request file." >&2
+    exit 1
+fi
 grep -q 'let panel = NSOpenPanel()' "$ATTACHMENT_SOURCE"
 grep -q 'approveHostMount(' "$ATTACHMENT_SOURCE"
 grep -Fq 'session.cat("/mnt/connections/native-requests")' "$ATTACHMENT_SOURCE"

--- a/crates/agent-engine/src/agent_machine.rs
+++ b/crates/agent-engine/src/agent_machine.rs
@@ -20,8 +20,9 @@ mod transition_state;
 use runtime_control::{ResponsesContinuationState, RollbackOutcome};
 use transition_state::MachineTransitionState;
 pub(crate) use transition_state::{
-    DeferredRuntimeAction, NormalizedToolCall, PendingYield, TurnActivityState,
-    is_auto_mid_turn_compaction_emergency,
+    DeferredRuntimeAction, HOST_MOUNT_REQUEST_TERMINAL_EVENT_TYPE,
+    HOST_MOUNT_REQUEST_WAITING_EVENT_TYPE, NormalizedToolCall, PendingHostMountRequest,
+    PendingYield, TurnActivityState, is_auto_mid_turn_compaction_emergency,
 };
 
 pub use recovery::{

--- a/crates/agent-engine/src/agent_machine.rs
+++ b/crates/agent-engine/src/agent_machine.rs
@@ -21,8 +21,9 @@ use runtime_control::{ResponsesContinuationState, RollbackOutcome};
 use transition_state::MachineTransitionState;
 pub(crate) use transition_state::{
     DeferredRuntimeAction, HOST_MOUNT_REQUEST_TERMINAL_EVENT_TYPE,
-    HOST_MOUNT_REQUEST_WAITING_EVENT_TYPE, NormalizedToolCall, PendingHostMountRequest,
-    PendingYield, TurnActivityState, is_auto_mid_turn_compaction_emergency,
+    HOST_MOUNT_REQUEST_WAIT_CLEARED_EVENT_TYPE, HOST_MOUNT_REQUEST_WAITING_EVENT_TYPE,
+    NormalizedToolCall, PendingHostMountRequest, PendingYield, TurnActivityState,
+    is_auto_mid_turn_compaction_emergency,
 };
 
 pub use recovery::{

--- a/crates/agent-engine/src/agent_machine/recovery.rs
+++ b/crates/agent-engine/src/agent_machine/recovery.rs
@@ -5,7 +5,8 @@ use alan_agent_protocol::{CompactionAttemptSnapshot, MemoryFlushAttemptSnapshot}
 use tracing::error;
 
 use super::{
-    AgentMachine, HOST_MOUNT_REQUEST_TERMINAL_EVENT_TYPE, HOST_MOUNT_REQUEST_WAITING_EVENT_TYPE,
+    AgentMachine, HOST_MOUNT_REQUEST_TERMINAL_EVENT_TYPE,
+    HOST_MOUNT_REQUEST_WAIT_CLEARED_EVENT_TYPE, HOST_MOUNT_REQUEST_WAITING_EVENT_TYPE,
     PendingHostMountRequest, ResponsesContinuationState, runtime_control,
 };
 use crate::rollout::{CompactedItem, EffectRecord, EventRecord, RolloutItem, RolloutRecorder};
@@ -25,7 +26,8 @@ impl AgentMachine {
                         pending.insert(request.request_id.clone(), request);
                     }
                 }
-                HOST_MOUNT_REQUEST_TERMINAL_EVENT_TYPE => {
+                HOST_MOUNT_REQUEST_TERMINAL_EVENT_TYPE
+                | HOST_MOUNT_REQUEST_WAIT_CLEARED_EVENT_TYPE => {
                     if let Some(request_id) = event
                         .payload
                         .get("request_id")

--- a/crates/agent-engine/src/agent_machine/recovery.rs
+++ b/crates/agent-engine/src/agent_machine/recovery.rs
@@ -1,14 +1,45 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 use alan_agent_protocol::{CompactionAttemptSnapshot, MemoryFlushAttemptSnapshot};
 use tracing::error;
 
-use super::{AgentMachine, ResponsesContinuationState, runtime_control};
+use super::{
+    AgentMachine, HOST_MOUNT_REQUEST_TERMINAL_EVENT_TYPE, HOST_MOUNT_REQUEST_WAITING_EVENT_TYPE,
+    PendingHostMountRequest, ResponsesContinuationState, runtime_control,
+};
 use crate::rollout::{CompactedItem, EffectRecord, EventRecord, RolloutItem, RolloutRecorder};
 use crate::tape::ContextItem;
 
 impl AgentMachine {
+    fn pending_host_mounts_from_event_records(
+        event_records: &[EventRecord],
+    ) -> Vec<PendingHostMountRequest> {
+        let mut pending = BTreeMap::new();
+        for event in event_records {
+            match event.event_type.as_str() {
+                HOST_MOUNT_REQUEST_WAITING_EVENT_TYPE => {
+                    if let Ok(request) =
+                        serde_json::from_value::<PendingHostMountRequest>(event.payload.clone())
+                    {
+                        pending.insert(request.request_id.clone(), request);
+                    }
+                }
+                HOST_MOUNT_REQUEST_TERMINAL_EVENT_TYPE => {
+                    if let Some(request_id) = event
+                        .payload
+                        .get("request_id")
+                        .and_then(serde_json::Value::as_str)
+                    {
+                        pending.remove(request_id);
+                    }
+                }
+                _ => {}
+            }
+        }
+        pending.into_values().collect()
+    }
+
     fn responses_continuation_from_event_records(
         event_records: &[EventRecord],
     ) -> Option<ResponsesContinuationState> {
@@ -295,6 +326,9 @@ impl AgentMachine {
         machine.latest_memory_flush_attempt = recovered_latest_memory_flush_attempt;
         machine.responses_continuation =
             Self::responses_continuation_from_event_records(&event_records);
+        for pending in Self::pending_host_mounts_from_event_records(&event_records) {
+            machine.set_host_mount_request(pending);
+        }
 
         for effect in &effect_records {
             machine

--- a/crates/agent-engine/src/agent_machine/transition_state.rs
+++ b/crates/agent-engine/src/agent_machine/transition_state.rs
@@ -5,10 +5,14 @@ use crate::approval::{PendingConfirmation, PendingStructuredInputRequest};
 use crate::skills::ActiveSkillEnvelope;
 use crate::tape::ContentPart;
 use alan_agent_protocol::{PlanItem, Submission};
+use serde::{Deserialize, Serialize};
 
 const MAX_QUEUED_NEXT_TURN_INPUTS: usize = 16;
 const AUTO_MID_TURN_COMPACTION_LIMIT: u32 = 2;
 const AUTO_MID_TURN_COMPACTION_MIN_GROWTH_TOKENS: usize = 256;
+
+pub(crate) const HOST_MOUNT_REQUEST_WAITING_EVENT_TYPE: &str = "host_mount_request_waiting";
+pub(crate) const HOST_MOUNT_REQUEST_TERMINAL_EVENT_TYPE: &str = "host_mount_request_terminal";
 
 pub(crate) fn is_auto_mid_turn_compaction_emergency(
     estimated_prompt_tokens: usize,
@@ -23,6 +27,21 @@ pub(crate) fn is_auto_mid_turn_compaction_emergency(
 pub(crate) enum PendingYield {
     Confirmation(PendingConfirmation),
     StructuredInput(PendingStructuredInputRequest),
+    HostMount(PendingHostMountRequest),
+}
+
+/// Durable logical wait state for one Host Mount Service request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PendingHostMountRequest {
+    pub(crate) request_id: String,
+    pub(crate) tool_call_id: String,
+    pub(crate) namespace_path: String,
+    pub(crate) access: String,
+    pub(crate) reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) label: Option<String>,
+    #[serde(default)]
+    pub(crate) request_events_offset: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -485,6 +504,21 @@ impl AgentMachine {
             .pending
             .insert(key.clone(), PendingYield::StructuredInput(pending));
         push_latest_key(&mut self.transition_state.pending_order, key);
+    }
+
+    pub(crate) fn set_host_mount_request(&mut self, pending: PendingHostMountRequest) {
+        let key = pending.request_id.clone();
+        self.transition_state
+            .pending
+            .insert(key.clone(), PendingYield::HostMount(pending));
+        push_latest_key(&mut self.transition_state.pending_order, key);
+    }
+
+    pub(crate) fn pending_host_mount(&self, request_id: &str) -> Option<PendingHostMountRequest> {
+        match self.transition_state.pending.get(request_id) {
+            Some(PendingYield::HostMount(pending)) => Some(pending.clone()),
+            _ => None,
+        }
     }
 
     /// Unified lookup: take any pending item by request_id.

--- a/crates/agent-engine/src/agent_machine/transition_state.rs
+++ b/crates/agent-engine/src/agent_machine/transition_state.rs
@@ -12,6 +12,8 @@ const AUTO_MID_TURN_COMPACTION_LIMIT: u32 = 2;
 const AUTO_MID_TURN_COMPACTION_MIN_GROWTH_TOKENS: usize = 256;
 
 pub(crate) const HOST_MOUNT_REQUEST_WAITING_EVENT_TYPE: &str = "host_mount_request_waiting";
+pub(crate) const HOST_MOUNT_REQUEST_WAIT_CLEARED_EVENT_TYPE: &str =
+    "host_mount_request_wait_cleared";
 pub(crate) const HOST_MOUNT_REQUEST_TERMINAL_EVENT_TYPE: &str = "host_mount_request_terminal";
 
 pub(crate) fn is_auto_mid_turn_compaction_emergency(
@@ -165,6 +167,24 @@ impl AgentMachine {
     }
 
     pub(crate) fn reset_turn(&mut self) {
+        let cleared_host_mount_requests = self
+            .transition_state
+            .pending
+            .values()
+            .filter_map(|pending| match pending {
+                PendingYield::HostMount(pending) => Some(pending.request_id.clone()),
+                PendingYield::Confirmation(_) | PendingYield::StructuredInput(_) => None,
+            })
+            .collect::<Vec<_>>();
+        for request_id in cleared_host_mount_requests {
+            self.record_event(
+                HOST_MOUNT_REQUEST_WAIT_CLEARED_EVENT_TYPE,
+                serde_json::json!({
+                    "request_id": request_id,
+                    "reason": "turn_reset",
+                }),
+            );
+        }
         self.transition_state.pending.clear();
         self.transition_state.pending_tool_replay_batches.clear();
         self.transition_state.pending_order.clear();

--- a/crates/agent-engine/src/agent_machine_persistence_tests.rs
+++ b/crates/agent-engine/src/agent_machine_persistence_tests.rs
@@ -522,6 +522,51 @@ async fn test_flush_waits_for_queued_rollout_writes() {
 }
 
 #[tokio::test]
+async fn test_reset_turn_persists_host_mount_wait_clear_after_waiting_event() {
+    let temp_dir = TempDir::new_in(std::env::temp_dir()).unwrap();
+    let mut machine =
+        AgentMachine::new_with_recorder_in_dir("/proc/test", "test-model", temp_dir.path())
+            .await
+            .unwrap();
+    let pending = PendingHostMountRequest {
+        request_id: "request-42".to_string(),
+        tool_call_id: "call-mount".to_string(),
+        namespace_path: "/mnt/project".to_string(),
+        access: "read_only".to_string(),
+        reason: "Read project files".to_string(),
+        label: Some("Project".to_string()),
+        request_events_offset: 0,
+    };
+    machine.record_event(
+        HOST_MOUNT_REQUEST_WAITING_EVENT_TYPE,
+        serde_json::to_value(&pending).unwrap(),
+    );
+    machine.set_host_mount_request(pending);
+
+    machine.reset_turn();
+    machine.flush().await;
+
+    let items = RolloutRecorder::load_history(machine.rollout_path().unwrap())
+        .await
+        .unwrap();
+    let events = items
+        .into_iter()
+        .filter_map(|item| match item {
+            RolloutItem::Event(event) => Some(event),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].event_type, HOST_MOUNT_REQUEST_WAITING_EVENT_TYPE);
+    assert_eq!(
+        events[1].event_type,
+        HOST_MOUNT_REQUEST_WAIT_CLEARED_EVENT_TYPE
+    );
+    assert_eq!(events[1].payload["request_id"], "request-42");
+    assert_eq!(events[1].payload["reason"], "turn_reset");
+}
+
+#[tokio::test]
 async fn test_rollback_records_non_durable_audit_marker() {
     let temp_dir = TempDir::new_in(std::env::temp_dir()).unwrap();
 

--- a/crates/agent-engine/src/agent_machine_recovery_tests.rs
+++ b/crates/agent-engine/src/agent_machine_recovery_tests.rs
@@ -89,6 +89,38 @@ fn test_load_from_rollout_recovers_only_unsettled_logical_host_mount_waits() {
         .unwrap();
         assert!(settled.pending_host_mount("request-42").is_none());
         assert!(!settled.has_pending_interaction());
+
+        items.pop();
+        items.push(RolloutItem::Event(EventRecord {
+            event_type: HOST_MOUNT_REQUEST_WAIT_CLEARED_EVENT_TYPE.to_string(),
+            payload: serde_json::json!({
+                "request_id": "request-42",
+                "reason": "turn_reset"
+            }),
+            timestamp: "2026-07-19T00:00:02Z".to_string(),
+        }));
+        tokio::fs::write(
+            &rollout_path,
+            items
+                .iter()
+                .map(serde_json::to_string)
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+                .join("\n")
+                + "\n",
+        )
+        .await
+        .unwrap();
+        let cleared = AgentMachine::load_from_rollout_in_dir(
+            &rollout_path,
+            "/proc/restarted-after-turn-reset",
+            "test-model",
+            temp_dir.path(),
+        )
+        .await
+        .unwrap();
+        assert!(cleared.pending_host_mount("request-42").is_none());
+        assert!(!cleared.has_pending_interaction());
     });
 }
 

--- a/crates/agent-engine/src/agent_machine_recovery_tests.rs
+++ b/crates/agent-engine/src/agent_machine_recovery_tests.rs
@@ -1,6 +1,98 @@
 use super::*;
 
 #[test]
+fn test_load_from_rollout_recovers_only_unsettled_logical_host_mount_waits() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let temp_dir = TempDir::new_in(std::env::temp_dir()).unwrap();
+        let rollout_path = temp_dir.path().join("rollout-host-mount-wait.jsonl");
+        let pending = PendingHostMountRequest {
+            request_id: "request-42".to_string(),
+            tool_call_id: "call-mount".to_string(),
+            namespace_path: "/mnt/project".to_string(),
+            access: "read_only".to_string(),
+            reason: "Read project files".to_string(),
+            label: Some("Project".to_string()),
+            request_events_offset: 137,
+        };
+        let mut items = vec![
+            RolloutItem::AgentMachineMeta(AgentMachineMeta {
+                rollout_id: "test-host-mount-wait".to_string(),
+                process_path: "/proc/test".to_string(),
+                started_at: "2026-07-19T00:00:00Z".to_string(),
+                cwd: "/mnt/project".to_string(),
+                model: "test-model".to_string(),
+                reasoning_effort: None,
+            }),
+            RolloutItem::Event(EventRecord {
+                event_type: HOST_MOUNT_REQUEST_WAITING_EVENT_TYPE.to_string(),
+                payload: serde_json::to_value(&pending).unwrap(),
+                timestamp: "2026-07-19T00:00:01Z".to_string(),
+            }),
+        ];
+        let waiting_payload = serde_json::to_string(&items[1]).unwrap();
+        assert!(!waiting_payload.contains("host_path"));
+        tokio::fs::write(
+            &rollout_path,
+            items
+                .iter()
+                .map(serde_json::to_string)
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+                .join("\n")
+                + "\n",
+        )
+        .await
+        .unwrap();
+
+        let recovered = AgentMachine::load_from_rollout_in_dir(
+            &rollout_path,
+            "/proc/restarted",
+            "test-model",
+            temp_dir.path(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            recovered.pending_host_mount("request-42"),
+            Some(pending.clone())
+        );
+
+        items.push(RolloutItem::Event(EventRecord {
+            event_type: HOST_MOUNT_REQUEST_TERMINAL_EVENT_TYPE.to_string(),
+            payload: serde_json::json!({
+                "request_id": "request-42",
+                "status": "rejected",
+                "error": "User declined"
+            }),
+            timestamp: "2026-07-19T00:00:02Z".to_string(),
+        }));
+        tokio::fs::write(
+            &rollout_path,
+            items
+                .iter()
+                .map(serde_json::to_string)
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+                .join("\n")
+                + "\n",
+        )
+        .await
+        .unwrap();
+        let settled = AgentMachine::load_from_rollout_in_dir(
+            &rollout_path,
+            "/proc/restarted-again",
+            "test-model",
+            temp_dir.path(),
+        )
+        .await
+        .unwrap();
+        assert!(settled.pending_host_mount("request-42").is_none());
+        assert!(!settled.has_pending_interaction());
+    });
+}
+
+#[test]
 fn test_load_from_rollout_prefers_rich_message_payload_when_available() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async {

--- a/crates/agent-engine/src/approval.rs
+++ b/crates/agent-engine/src/approval.rs
@@ -12,9 +12,6 @@ pub const EFFECT_REPLAY_CHECKPOINT_TYPE: &str = "effect_replay_confirmation";
 pub const EFFECT_REPLAY_CHECKPOINT_PREFIX: &str = "effect_replay_";
 pub const EFFECT_REPLAY_CONTROL_KIND: &str = "effect_replay_confirmation";
 
-pub const MOUNT_ESCALATION_CHECKPOINT_TYPE: &str = "mount_escalation";
-pub const MOUNT_ESCALATION_CHECKPOINT_PREFIX: &str = "mount_escalation_";
-
 pub const RUNTIME_CONFIRMATION_CONTROL_SOURCE: &str = "runtime/submission_handlers";
 pub const RUNTIME_CONFIRMATION_CONTROL_VERSION: u64 = 1;
 

--- a/crates/agent-engine/src/policy.rs
+++ b/crates/agent-engine/src/policy.rs
@@ -502,14 +502,7 @@ fn collect_path_candidates(
     arguments: &serde_json::Value,
     current_cwd: Option<&Path>,
 ) -> Vec<NormalizedPathMatchValue> {
-    const PATH_KEYS: &[&str] = &[
-        "path",
-        "paths",
-        "directory",
-        "cwd",
-        "host_path",
-        "namespace_path",
-    ];
+    const PATH_KEYS: &[&str] = &["path", "paths", "directory", "cwd", "namespace_path"];
     const BASE_PATH_KEYS: &[&str] = &["directory", "cwd"];
 
     let Some(object) = arguments.as_object() else {

--- a/crates/agent-engine/src/policy/tests.rs
+++ b/crates/agent-engine/src/policy/tests.rs
@@ -75,7 +75,6 @@ fn auto_approve_boundary_matches_human_in_the_end_posture() {
         tool_name: "request_mount",
         arguments: &serde_json::json!({
             "namespace_path": "/mnt/project",
-            "host_path": "/Users/morris/Developer/alan",
             "access": "read_only",
             "reason": "Need project files"
         }),
@@ -248,38 +247,6 @@ fn policy_rule_match_path_prefix_matches_absolute_write_path() {
 }
 
 #[test]
-fn policy_rule_match_path_prefix_matches_request_mount_host_path() {
-    let engine = PolicyEngine {
-        rules: vec![PolicyRule {
-            id: Some("deny-private-mount".to_string()),
-            tool: Some("request_mount".to_string()),
-            capability: Some("write".to_string()),
-            match_command: None,
-            match_path_prefix: Some("/Users/me/private".to_string()),
-            action: PolicyAction::Deny,
-            reason: Some("private host mounts are not allowed".to_string()),
-        }],
-        default_action: PolicyAction::Allow,
-        source: "test",
-    };
-
-    let decision = engine.evaluate(PolicyContext {
-        tool_name: "request_mount",
-        arguments: &json!({
-            "namespace_path": "/mnt/private",
-            "host_path": "/Users/me/private/project",
-            "access": "read_only",
-            "reason": "Need files"
-        }),
-        capability: alan_agent_protocol::ToolCapability::Write,
-        cwd: None,
-    });
-
-    assert_eq!(decision.action, PolicyAction::Deny);
-    assert_eq!(decision.rule_id.as_deref(), Some("deny-private-mount"));
-}
-
-#[test]
 fn policy_rule_match_path_prefix_matches_request_mount_namespace_path() {
     let engine = PolicyEngine {
         rules: vec![PolicyRule {
@@ -299,7 +266,6 @@ fn policy_rule_match_path_prefix_matches_request_mount_namespace_path() {
         tool_name: "request_mount",
         arguments: &json!({
             "namespace_path": "/mnt/private/project",
-            "host_path": "/Users/me/project",
             "access": "read_only",
             "reason": "Need files"
         }),

--- a/crates/agent-engine/src/process_launch.rs
+++ b/crates/agent-engine/src/process_launch.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use alan_ap::InProcessTransport;
-use alan_kernel::{Access, Credentials, Namespace};
+use alan_kernel::{Access, Credentials, LiveNamespace, Namespace};
 use anyhow::{Result, ensure};
 
 use crate::skills::{
@@ -224,7 +224,15 @@ pub struct ProcessLaunchContext {
     pub package_references: Vec<ProcessPackageReference>,
     pub credentials: Credentials,
     pub cwd: String,
+    projected_host_mounts: Vec<ProjectedHostMount>,
+    live_namespace: Option<LiveNamespace>,
     retained_authorities: Vec<Arc<dyn Any + Send + Sync>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ProjectedHostMount {
+    namespace_path: String,
+    access: Access,
 }
 
 impl std::fmt::Debug for ProcessLaunchContext {
@@ -237,6 +245,8 @@ impl std::fmt::Debug for ProcessLaunchContext {
             .field("package_references", &self.package_references)
             .field("credentials", &self.credentials)
             .field("cwd", &self.cwd)
+            .field("projected_host_mounts", &self.projected_host_mounts)
+            .field("live_namespace", &self.live_namespace.is_some())
             .field("retained_authorities", &self.retained_authorities.len())
             .finish()
     }
@@ -255,6 +265,8 @@ impl ProcessLaunchContext {
             package_references: Vec::new(),
             credentials,
             cwd: normalize_namespace_path(&cwd.into())?,
+            projected_host_mounts: Vec::new(),
+            live_namespace: None,
             retained_authorities: Vec::new(),
         })
     }
@@ -289,6 +301,57 @@ impl ProcessLaunchContext {
 
     pub fn add_package_reference(&mut self, reference: ProcessPackageReference) {
         self.package_references.push(reference);
+    }
+
+    /// Record one Host-Mount-Service-owned projection without retaining Host backing.
+    pub(crate) fn record_projected_host_mount(&mut self, namespace_path: String, access: Access) {
+        if let Some(existing) = self
+            .projected_host_mounts
+            .iter_mut()
+            .find(|mount| mount.namespace_path == namespace_path)
+        {
+            existing.access = access;
+        } else {
+            self.projected_host_mounts.push(ProjectedHostMount {
+                namespace_path,
+                access,
+            });
+        }
+    }
+
+    /// Logical Host Mount paths whose actual authority is retained by namespace handles.
+    pub fn host_mount_namespace_paths(&self) -> Vec<String> {
+        let mut paths = self
+            .host_mounts
+            .iter()
+            .map(|grant| grant.namespace_path.clone())
+            .chain(
+                self.projected_host_mounts
+                    .iter()
+                    .map(|mount| mount.namespace_path.clone()),
+            )
+            .collect::<Vec<_>>();
+        paths.sort();
+        paths.dedup();
+        paths
+    }
+
+    pub fn projected_host_mounts(&self) -> Vec<(String, Access)> {
+        self.projected_host_mounts
+            .iter()
+            .map(|mount| (mount.namespace_path.clone(), mount.access))
+            .collect()
+    }
+
+    pub fn has_host_mounts(&self) -> bool {
+        !self.host_mounts.is_empty() || !self.projected_host_mounts.is_empty()
+    }
+
+    pub(crate) fn take_projected_host_mount_paths(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.projected_host_mounts)
+            .into_iter()
+            .map(|mount| mount.namespace_path)
+            .collect()
     }
 
     /// Retain an opaque owner-issued authority for the lifetime of this Process context.
@@ -350,12 +413,18 @@ impl ProcessLaunchContext {
 
     pub fn child(&self) -> Self {
         Self {
-            namespace: self.namespace.child(),
+            namespace: self
+                .live_namespace
+                .as_ref()
+                .map(LiveNamespace::snapshot)
+                .unwrap_or_else(|| self.namespace.child()),
             host_mounts: self.host_mounts.clone(),
             descriptors: self.descriptors.clone(),
             package_references: self.package_references.clone(),
             credentials: self.credentials.clone(),
             cwd: self.cwd.clone(),
+            projected_host_mounts: self.projected_host_mounts.clone(),
+            live_namespace: None,
             retained_authorities: self.retained_authorities.clone(),
         }
     }
@@ -369,6 +438,23 @@ impl ProcessLaunchContext {
             package_references: self.package_references.clone(),
             credentials,
             cwd: self.cwd.clone(),
+            projected_host_mounts: self.projected_host_mounts.clone(),
+            live_namespace: None,
+            retained_authorities: self.retained_authorities.clone(),
+        }
+    }
+
+    /// Rebind inherited Process authority to the live namespace owned by its Process.
+    pub fn rebound_live(&self, namespace: LiveNamespace, credentials: Credentials) -> Self {
+        Self {
+            namespace: namespace.snapshot(),
+            host_mounts: self.host_mounts.clone(),
+            descriptors: self.descriptors.clone(),
+            package_references: self.package_references.clone(),
+            credentials,
+            cwd: self.cwd.clone(),
+            projected_host_mounts: self.projected_host_mounts.clone(),
+            live_namespace: Some(namespace),
             retained_authorities: self.retained_authorities.clone(),
         }
     }

--- a/crates/agent-engine/src/process_launch.rs
+++ b/crates/agent-engine/src/process_launch.rs
@@ -231,6 +231,7 @@ pub struct ProcessLaunchContext {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct ProjectedHostMount {
+    grant_reference: String,
     namespace_path: String,
     access: Access,
 }
@@ -304,36 +305,37 @@ impl ProcessLaunchContext {
     }
 
     /// Record one Host-Mount-Service-owned projection without retaining Host backing.
-    pub(crate) fn record_projected_host_mount(&mut self, namespace_path: String, access: Access) {
+    pub(crate) fn record_projected_host_mount(
+        &mut self,
+        grant_reference: String,
+        namespace_path: String,
+        access: Access,
+    ) {
         if let Some(existing) = self
             .projected_host_mounts
             .iter_mut()
             .find(|mount| mount.namespace_path == namespace_path)
         {
+            existing.grant_reference = grant_reference;
             existing.access = access;
         } else {
             self.projected_host_mounts.push(ProjectedHostMount {
+                grant_reference,
                 namespace_path,
                 access,
             });
         }
     }
 
-    /// Logical Host Mount paths whose actual authority is retained by namespace handles.
-    pub fn host_mount_namespace_paths(&self) -> Vec<String> {
-        let mut paths = self
-            .host_mounts
+    /// Opaque Host Mount references selected for explicit child delegation.
+    ///
+    /// References are metadata, not authority: Host Mount Service must also prove that the
+    /// spawning Process currently holds the corresponding namespace projection.
+    pub fn projected_host_mount_references(&self) -> Vec<String> {
+        self.projected_host_mounts
             .iter()
-            .map(|grant| grant.namespace_path.clone())
-            .chain(
-                self.projected_host_mounts
-                    .iter()
-                    .map(|mount| mount.namespace_path.clone()),
-            )
-            .collect::<Vec<_>>();
-        paths.sort();
-        paths.dedup();
-        paths
+            .map(|mount| mount.grant_reference.clone())
+            .collect()
     }
 
     pub fn projected_host_mounts(&self) -> Vec<(String, Access)> {
@@ -413,11 +415,7 @@ impl ProcessLaunchContext {
 
     pub fn child(&self) -> Self {
         Self {
-            namespace: self
-                .live_namespace
-                .as_ref()
-                .map(LiveNamespace::snapshot)
-                .unwrap_or_else(|| self.namespace.child()),
+            namespace: self.namespace_snapshot(),
             host_mounts: self.host_mounts.clone(),
             descriptors: self.descriptors.clone(),
             package_references: self.package_references.clone(),
@@ -427,6 +425,14 @@ impl ProcessLaunchContext {
             live_namespace: None,
             retained_authorities: self.retained_authorities.clone(),
         }
+    }
+
+    /// Snapshot the current Process namespace, including live mount and revocation changes.
+    pub fn namespace_snapshot(&self) -> Namespace {
+        self.live_namespace
+            .as_ref()
+            .map(LiveNamespace::snapshot)
+            .unwrap_or_else(|| self.namespace.child())
     }
 
     /// Rebind inherited Process authority to a concrete live namespace and credentials.
@@ -548,6 +554,30 @@ mod tests {
         assert_eq!(child.host_mounts, context.host_mounts);
         assert_eq!(child.namespace.describe(), context.namespace.describe());
         assert_eq!(child.cwd, "/");
+    }
+
+    #[test]
+    fn latest_projected_grant_reference_replaces_the_same_namespace_path() {
+        let mut context = ProcessLaunchContext::root();
+        context.record_projected_host_mount(
+            "grant-old".to_string(),
+            "/mnt/project".to_string(),
+            Access::ReadOnly,
+        );
+        context.record_projected_host_mount(
+            "grant-latest".to_string(),
+            "/mnt/project".to_string(),
+            Access::ReadWrite,
+        );
+
+        assert_eq!(
+            context.projected_host_mount_references(),
+            vec!["grant-latest".to_string()]
+        );
+        assert_eq!(
+            context.projected_host_mounts(),
+            vec![("/mnt/project".to_string(), Access::ReadWrite)]
+        );
     }
 
     #[test]

--- a/crates/agent-engine/src/runtime/child_agents/launch_context.rs
+++ b/crates/agent-engine/src/runtime/child_agents/launch_context.rs
@@ -32,19 +32,26 @@ pub(super) fn build_child_launch_context(
 
     if !spec.has_handle(SpawnHandle::HostMounts) {
         let inherited_mounts = std::mem::take(&mut launch_context.host_mounts);
+        let projected_mount_paths = launch_context.take_projected_host_mount_paths();
         if let Some(cwd) = child_cwd.as_deref()
-            && inherited_mounts
+            && (inherited_mounts
                 .iter()
                 .any(|grant| grant.resolve_host_path(cwd).is_some())
+                || projected_mount_paths
+                    .iter()
+                    .any(|path| namespace_path_is_within(cwd, path)))
         {
             bail!(
                 "Child Agent Process launch cwd '{cwd}' requires the explicit host_mounts handle."
             );
         }
         if child_cwd.is_none()
-            && inherited_mounts
+            && (inherited_mounts
                 .iter()
                 .any(|grant| grant.resolve_host_path(&launch_context.cwd).is_some())
+                || projected_mount_paths
+                    .iter()
+                    .any(|path| namespace_path_is_within(&launch_context.cwd, path)))
         {
             launch_context.cwd = "/".to_string();
         }
@@ -54,6 +61,9 @@ pub(super) fn build_child_launch_context(
                 continue;
             }
             launch_context.namespace.unmount(&grant.namespace_path);
+        }
+        for path in projected_mount_paths {
+            launch_context.namespace.unmount(&path);
         }
     }
 
@@ -118,6 +128,13 @@ pub(super) fn build_child_launch_context(
             );
     }
     Ok(launch_context)
+}
+
+fn namespace_path_is_within(path: &str, mount: &str) -> bool {
+    path == mount
+        || path
+            .strip_prefix(mount)
+            .is_some_and(|suffix| suffix.starts_with('/'))
 }
 
 pub(super) fn validate_child_launch_contract(spec: &SpawnSpec) -> Result<Option<String>> {

--- a/crates/agent-engine/src/runtime/child_agents/tests.rs
+++ b/crates/agent-engine/src/runtime/child_agents/tests.rs
@@ -407,7 +407,7 @@ impl MountGrantApplicatorFactory for RecordingMountGrantApplicatorFactory {
         &self,
         _pid: alan_kernel::Pid,
         live_namespace: alan_kernel::LiveNamespace,
-        _inherited_mount_paths: &[String],
+        _inherited_mount_references: &[String],
     ) -> Arc<dyn MountGrantApplicator> {
         *self
             .created

--- a/crates/agent-engine/src/runtime/child_agents/tests/launch_contract.rs
+++ b/crates/agent-engine/src/runtime/child_agents/tests/launch_contract.rs
@@ -572,7 +572,11 @@ fn child_launch_context_tracks_live_service_mounts_and_revocation() {
         alan_ap::InProcessTransport::new(std::sync::Arc::new(alan_ap::reference::MemFs::new())),
         alan_kernel::Access::ReadOnly,
     );
-    parent.record_projected_host_mount("/mnt/docs".to_string(), alan_kernel::Access::ReadOnly);
+    parent.record_projected_host_mount(
+        "grant-docs".to_string(),
+        "/mnt/docs".to_string(),
+        alan_kernel::Access::ReadOnly,
+    );
     parent = parent.rebound_live(live.clone(), parent.credentials.clone());
 
     let definition = host_launch_root(definition);
@@ -587,6 +591,10 @@ fn child_launch_context_tracks_live_service_mounts_and_revocation() {
     assert_eq!(
         child.projected_host_mounts(),
         vec![("/mnt/docs".to_string(), alan_kernel::Access::ReadOnly)]
+    );
+    assert_eq!(
+        child.projected_host_mount_references(),
+        vec!["grant-docs".to_string()]
     );
 
     live.unmount("/mnt/docs");
@@ -615,7 +623,11 @@ fn child_launch_context_removes_unpassed_live_service_mount() {
         alan_ap::InProcessTransport::new(std::sync::Arc::new(alan_ap::reference::MemFs::new())),
         alan_kernel::Access::ReadOnly,
     );
-    parent.record_projected_host_mount("/mnt/docs".to_string(), alan_kernel::Access::ReadOnly);
+    parent.record_projected_host_mount(
+        "grant-docs".to_string(),
+        "/mnt/docs".to_string(),
+        alan_kernel::Access::ReadOnly,
+    );
     parent = parent.rebound_live(live, parent.credentials.clone());
     let mut spec = launch_spec(temp.path().join("child-definition"));
     spec.handles.clear();

--- a/crates/agent-engine/src/runtime/child_agents/tests/launch_contract.rs
+++ b/crates/agent-engine/src/runtime/child_agents/tests/launch_contract.rs
@@ -557,6 +557,76 @@ fn child_launch_context_passes_parent_host_mounts_only_with_explicit_handle() {
 }
 
 #[test]
+fn child_launch_context_tracks_live_service_mounts_and_revocation() {
+    let temp = TempDir::new().unwrap();
+    let definition = temp.path().join("child-definition");
+    let mut parent = crate::ProcessLaunchContext::new(
+        alan_kernel::Namespace::new(),
+        alan_kernel::Credentials::user("parent"),
+        "/mnt/docs",
+    )
+    .unwrap();
+    let live = alan_kernel::LiveNamespace::new(parent.namespace.child());
+    live.mount(
+        "/mnt/docs",
+        alan_ap::InProcessTransport::new(std::sync::Arc::new(alan_ap::reference::MemFs::new())),
+        alan_kernel::Access::ReadOnly,
+    );
+    parent.record_projected_host_mount("/mnt/docs".to_string(), alan_kernel::Access::ReadOnly);
+    parent = parent.rebound_live(live.clone(), parent.credentials.clone());
+
+    let definition = host_launch_root(definition);
+    let child = build_child_launch_context(
+        &parent,
+        &launch_spec(temp.path().join("child-definition")),
+        None,
+        Some(&definition),
+    )
+    .unwrap();
+    assert!(child.namespace.resolve("/mnt/docs").is_ok());
+    assert_eq!(
+        child.projected_host_mounts(),
+        vec![("/mnt/docs".to_string(), alan_kernel::Access::ReadOnly)]
+    );
+
+    live.unmount("/mnt/docs");
+    let revoked_child = build_child_launch_context(
+        &parent,
+        &launch_spec(temp.path().join("child-definition")),
+        None,
+        Some(&definition),
+    )
+    .unwrap();
+    assert!(revoked_child.namespace.resolve("/mnt/docs").is_err());
+}
+
+#[test]
+fn child_launch_context_removes_unpassed_live_service_mount() {
+    let temp = TempDir::new().unwrap();
+    let mut parent = crate::ProcessLaunchContext::new(
+        alan_kernel::Namespace::new(),
+        alan_kernel::Credentials::user("parent"),
+        "/",
+    )
+    .unwrap();
+    let live = alan_kernel::LiveNamespace::new(parent.namespace.child());
+    live.mount(
+        "/mnt/docs",
+        alan_ap::InProcessTransport::new(std::sync::Arc::new(alan_ap::reference::MemFs::new())),
+        alan_kernel::Access::ReadOnly,
+    );
+    parent.record_projected_host_mount("/mnt/docs".to_string(), alan_kernel::Access::ReadOnly);
+    parent = parent.rebound_live(live, parent.credentials.clone());
+    let mut spec = launch_spec(temp.path().join("child-definition"));
+    spec.handles.clear();
+
+    let definition = host_launch_root(temp.path().join("child-definition"));
+    let child = build_child_launch_context(&parent, &spec, None, Some(&definition)).unwrap();
+    assert!(child.namespace.resolve("/mnt/docs").is_err());
+    assert!(child.projected_host_mounts().is_empty());
+}
+
+#[test]
 fn child_launch_rejects_cwd_inside_an_unpassed_host_mount() {
     let temp = TempDir::new().unwrap();
     let parent = make_parent_state(

--- a/crates/agent-engine/src/runtime/delegated_skill_tool.rs
+++ b/crates/agent-engine/src/runtime/delegated_skill_tool.rs
@@ -285,6 +285,7 @@ where
                             && check_turn_cancelled(
                                 &mut *runtime.machine,
                                 &runtime.agent_files,
+                                &runtime.host_mount_requests,
                                 emit,
                                 cancel,
                             )
@@ -319,6 +320,7 @@ where
                             && check_turn_cancelled(
                                 &mut *runtime.machine,
                                 &runtime.agent_files,
+                                &runtime.host_mount_requests,
                                 emit,
                                 cancel,
                             )

--- a/crates/agent-engine/src/runtime/delegated_skill_tool/runtime_inputs.rs
+++ b/crates/agent-engine/src/runtime/delegated_skill_tool/runtime_inputs.rs
@@ -5,7 +5,10 @@ use crate::{
         child_runs::ChildRunRegistry,
         launch_config::AgentConfig,
         prompt_cache::PromptAssemblyCache,
-        transition::{NamespaceAgentFiles, NamespaceChildLaunch, NamespaceToolExecution},
+        transition::{
+            NamespaceAgentFiles, NamespaceChildLaunch, NamespaceHostMountRequests,
+            NamespaceToolExecution,
+        },
     },
 };
 use alan_agent_protocol::SpawnSpec;
@@ -15,6 +18,7 @@ pub(crate) struct DelegatedSkillRuntime<'a> {
     pub(super) machine: &'a mut AgentMachine,
     pub(super) prompt_cache: &'a mut PromptAssemblyCache,
     pub(super) agent_files: NamespaceAgentFiles,
+    pub(super) host_mount_requests: NamespaceHostMountRequests,
     child_runtime_inputs: DelegatedChildRuntimeInputs,
 }
 
@@ -32,12 +36,14 @@ impl<'a> DelegatedSkillRuntime<'a> {
         machine: &'a mut AgentMachine,
         prompt_cache: &'a mut PromptAssemblyCache,
         agent_files: NamespaceAgentFiles,
+        host_mount_requests: NamespaceHostMountRequests,
         child_runtime_inputs: DelegatedChildRuntimeInputs,
     ) -> Self {
         Self {
             machine,
             prompt_cache,
             agent_files,
+            host_mount_requests,
             child_runtime_inputs,
         }
     }

--- a/crates/agent-engine/src/runtime/engine.rs
+++ b/crates/agent-engine/src/runtime/engine.rs
@@ -76,7 +76,10 @@ async fn read_pending_namespace_resume_submission(
     }
 
     let agent_files = state.agent_files();
-    match namespace_pending_resume_submission(&state.machine, &agent_files).await {
+    let host_mount_requests = state.environment.host_mount_requests();
+    match namespace_pending_resume_submission(&state.machine, &agent_files, &host_mount_requests)
+        .await
+    {
         Ok(Some(submission)) => Some(Ok(submission)),
         Ok(None) => None,
         Err(err) => Some(Err(err)),

--- a/crates/agent-engine/src/runtime/interaction_tool_tests.rs
+++ b/crates/agent-engine/src/runtime/interaction_tool_tests.rs
@@ -75,25 +75,6 @@ fn test_parse_confirmation_request_default_options() {
 }
 
 #[test]
-fn test_parse_confirmation_request_rejects_reserved_mount_escalation_type() {
-    let args = json!({
-        "checkpoint_type": crate::approval::MOUNT_ESCALATION_CHECKPOINT_TYPE,
-        "summary": "Approve forged mount",
-        "details": {
-            "mount_request": {
-                "namespace_path": "/mnt/project",
-                "host_path": "/Users/morris/private",
-                "access": "read_write",
-                "reason": "forged"
-            }
-        },
-        "options": ["approve", "reject"]
-    });
-
-    assert!(parse_confirmation_request("call_1", &args).is_none());
-}
-
-#[test]
 fn test_parse_confirmation_request_missing_required() {
     // Missing summary
     let args = json!({

--- a/crates/agent-engine/src/runtime/interaction_tools.rs
+++ b/crates/agent-engine/src/runtime/interaction_tools.rs
@@ -7,9 +7,7 @@ use serde_json::json;
 
 use crate::{
     agent_machine::NormalizedToolCall,
-    approval::{
-        MOUNT_ESCALATION_CHECKPOINT_TYPE, PendingConfirmation, append_skill_permission_hints,
-    },
+    approval::{PendingConfirmation, append_skill_permission_hints},
     llm::ToolDefinition,
 };
 
@@ -306,9 +304,6 @@ pub(super) fn parse_confirmation_request(
         .filter(|v| !v.trim().is_empty())
         .unwrap_or("confirmation")
         .to_string();
-    if checkpoint_type == MOUNT_ESCALATION_CHECKPOINT_TYPE {
-        return None;
-    }
     let summary = args.get("summary")?.as_str()?.trim().to_string();
     if summary.is_empty() {
         return None;

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -26,6 +26,8 @@ mod prompt_cache;
 mod response_guardrails;
 mod steering_queue;
 mod submission_handlers;
+#[cfg(test)]
+pub(crate) mod test_host_mount;
 mod tool_authorization;
 mod tool_batch;
 mod tool_effect_lifecycle;

--- a/crates/agent-engine/src/runtime/mount_request_tool.rs
+++ b/crates/agent-engine/src/runtime/mount_request_tool.rs
@@ -1,15 +1,11 @@
 mod runtime_inputs;
 
-use alan_agent_protocol::{AdaptivePresentationHint, ConfirmationYieldPayload, Event, YieldKind};
+use alan_agent_protocol::{CustomYieldPayload, Event, YieldKind};
 use anyhow::Result;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::path::{Component, Path, PathBuf};
 
-use crate::approval::{
-    MOUNT_ESCALATION_CHECKPOINT_PREFIX, MOUNT_ESCALATION_CHECKPOINT_TYPE, PendingConfirmation,
-    append_skill_permission_hints,
-};
+use crate::agent_machine::{HOST_MOUNT_REQUEST_WAITING_EVENT_TYPE, PendingHostMountRequest};
 use crate::llm::ToolDefinition;
 
 use super::tool_policy::{ToolPolicyDecision, evaluate_tool_policy};
@@ -19,7 +15,15 @@ use crate::agent_machine::NormalizedToolCall;
 
 pub(crate) use runtime_inputs::MountRequestRuntime;
 
-const RESERVED_MOUNT_NAMESPACE_ROOTS: &[&str] = &["llm", "mem", "route"];
+const RESERVED_MOUNT_NAMESPACE_ROOTS: &[&str] = &[
+    "connections",
+    "host-mount",
+    "llm",
+    "mem",
+    "package",
+    "route",
+    "service-manager",
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -47,20 +51,29 @@ impl MountRequestAccess {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(super) struct MountRequest {
     pub namespace_path: String,
-    pub host_path: PathBuf,
     pub access: MountRequestAccess,
     pub reason: String,
+    pub label: Option<String>,
 }
 
 impl MountRequest {
     pub(super) fn payload(&self) -> serde_json::Value {
         json!({
             "namespace_path": &self.namespace_path,
-            "host_path": self.host_path.display().to_string(),
             "access": self.access.as_str(),
             "reason": &self.reason,
+            "label": &self.label,
         })
     }
+}
+
+/// Return the only `request_mount` arguments allowed to enter Machine or rollout evidence.
+/// Invalid documents may contain Host-owned locations or other unknown data, so their values are
+/// intentionally discarded instead of being persisted as part of the rejection record.
+pub(super) fn durable_mount_request_arguments(args: &serde_json::Value) -> serde_json::Value {
+    parse_mount_request(args)
+        .map(|request| request.payload())
+        .unwrap_or_else(|_| json!({ "invalid_request": true }))
 }
 
 pub(super) async fn handle_request_mount<E, F>(
@@ -99,7 +112,7 @@ where
             .await;
             runtime.machine.record_tool_call(
                 &tool_call.name,
-                tool_arguments.clone(),
+                durable_mount_request_arguments(tool_arguments),
                 payload.clone(),
                 false,
             );
@@ -180,7 +193,7 @@ where
         .await;
         runtime.machine.record_tool_call_with_audit(
             &tool_call.name,
-            tool_arguments.clone(),
+            mount_payload.clone(),
             payload.clone(),
             false,
             Some(audit),
@@ -221,45 +234,57 @@ where
         }),
     );
 
-    let mut details = json!({
-        "kind": "mount_escalation",
-        "tool_call_id": tool_call.id,
-        "tool_name": tool_call.name,
-        "mount_request": mount_payload,
-        "policy": {
-            "policy_source": escalation_audit.policy_source,
-            "rule_id": escalation_audit.rule_id,
-            "action": escalation_audit.action,
-            "reason": escalation_audit.reason,
-            "capability": escalation_audit.capability,
-            "sandbox_backend": escalation_audit.sandbox_backend,
-            "path_mode": escalation_audit.path_mode,
-        },
-        "live_applied": false,
-    });
-    details = append_skill_permission_hints(details, runtime.machine.active_skills());
-
-    let pending = PendingConfirmation {
-        checkpoint_id: format!("{MOUNT_ESCALATION_CHECKPOINT_PREFIX}{}", tool_call.id),
-        checkpoint_type: MOUNT_ESCALATION_CHECKPOINT_TYPE.to_string(),
-        summary: format!(
-            "Approve host mount {} at {}?",
-            mount_request.host_path.display(),
-            mount_request.namespace_path
-        ),
-        details,
-        options: vec!["approve".to_string(), "reject".to_string()],
+    let request_document = serde_json::to_vec(&mount_payload)?;
+    let request_id = match runtime.host_mount_requests.create(&request_document).await {
+        Ok(request_id) => request_id,
+        Err(error) => {
+            let payload = json!({
+                "status": "request_service_unavailable",
+                "error": "Host Mount Service did not accept the logical request",
+                "mount_request": mount_payload,
+            });
+            emit(Event::Error {
+                message: format!("Host Mount Service request failed: {error}"),
+                recoverable: true,
+            })
+            .await;
+            emit(Event::ToolCallCompleted {
+                presentation: None,
+                id: tool_call.id.clone(),
+                name: Some(tool_call.name.clone()),
+                success: Some(false),
+                result_preview: tool_result_preview(&payload),
+                audit: Some(escalation_audit.clone()),
+            })
+            .await;
+            runtime.machine.record_tool_call_with_audit(
+                &tool_call.name,
+                mount_payload.clone(),
+                payload.clone(),
+                false,
+                Some(escalation_audit),
+            );
+            runtime
+                .machine
+                .add_tool_message(&tool_call.id, &tool_call.name, payload);
+            return Ok(VirtualToolOutcome::Continue {
+                refresh_context: false,
+            });
+        }
     };
-
-    let request_id = runtime
-        .agent_files
-        .write_confirmation_request(&pending)
-        .await?;
+    let pending = PendingHostMountRequest {
+        request_id: request_id.clone(),
+        tool_call_id: tool_call.id.clone(),
+        namespace_path: mount_request.namespace_path.clone(),
+        access: mount_request.access.as_str().to_string(),
+        reason: mount_request.reason.clone(),
+        label: mount_request.label.clone(),
+        request_events_offset: 0,
+    };
     let payload = json!({
-        "status": "pending_mount_approval",
-        "request_id": request_id.clone(),
+        "status": "pending_authorization",
+        "request_reference": request_id.clone(),
         "mount_request": mount_payload,
-        "live_applied": false,
     });
     emit(Event::ToolCallCompleted {
         presentation: None,
@@ -272,25 +297,32 @@ where
     .await;
     runtime.machine.record_tool_call_with_audit(
         &tool_call.name,
-        tool_arguments.clone(),
+        mount_payload,
         payload.clone(),
         true,
         Some(escalation_audit),
     );
-    runtime
-        .machine
-        .set_confirmation_for_request(request_id.clone(), pending.clone());
+    runtime.machine.record_event(
+        HOST_MOUNT_REQUEST_WAITING_EVENT_TYPE,
+        serde_json::to_value(&pending).unwrap_or_else(|_| json!({})),
+    );
+    runtime.machine.set_host_mount_request(pending.clone());
     super::ui_surfaces::paused(&runtime.agent_files).await?;
     emit(Event::Yield {
         request_id,
-        kind: YieldKind::Confirmation,
-        payload: serde_json::to_value(ConfirmationYieldPayload {
-            checkpoint_type: pending.checkpoint_type.clone(),
-            summary: pending.summary.clone(),
-            details: Some(pending.details.clone()),
-            options: pending.options.clone(),
-            default_option: Some("reject".to_string()),
-            presentation_hints: vec![AdaptivePresentationHint::Dangerous],
+        kind: YieldKind::Custom("authorization_wait".to_string()),
+        payload: serde_json::to_value(CustomYieldPayload {
+            title: Some("Waiting for Host Mount authorization".to_string()),
+            prompt: None,
+            details: Some(json!({
+                "request_reference": pending.request_id,
+                "namespace_path": pending.namespace_path,
+                "access": pending.access,
+                "reason": pending.reason,
+                "label": pending.label,
+                "status": "pending",
+            })),
+            form: None,
         })
         .unwrap_or_else(|_| json!({})),
     })
@@ -314,30 +346,47 @@ fn merge_mount_policy_decision(
 pub(super) fn parse_mount_request(
     args: &serde_json::Value,
 ) -> std::result::Result<MountRequest, String> {
-    let namespace_path = parse_mount_namespace_path(required_string(args, "namespace_path")?)?;
-    let host_path = parse_mount_host_path(required_string(args, "host_path")?)?;
-    let access = parse_mount_access(required_string(args, "access")?)?;
-    let reason = required_string(args, "reason")?;
+    const ALLOWED_FIELDS: &[&str] = &["namespace_path", "access", "reason", "label"];
+
+    #[derive(Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct Document {
+        namespace_path: String,
+        access: String,
+        reason: String,
+        #[serde(default)]
+        label: Option<String>,
+    }
+
+    let object = args
+        .as_object()
+        .ok_or_else(|| "request_mount arguments must be an object".to_string())?;
+    if object
+        .keys()
+        .any(|field| !ALLOWED_FIELDS.contains(&field.as_str()))
+    {
+        return Err("request_mount arguments contain unsupported fields".to_string());
+    }
+    let document: Document =
+        serde_json::from_value(args.clone()).map_err(|error| error.to_string())?;
+    let namespace_path = parse_mount_namespace_path(&document.namespace_path)?;
+    let access = parse_mount_access(&document.access)?;
+    let reason = document.reason.trim();
 
     if reason.trim().is_empty() {
         return Err("reason must be a non-empty string".to_string());
     }
+    let label = document.label.map(|label| label.trim().to_string());
+    if label.as_deref() == Some("") {
+        return Err("label must be a non-empty string when provided".to_string());
+    }
 
     Ok(MountRequest {
         namespace_path,
-        host_path,
         access,
-        reason: reason.trim().to_string(),
+        reason: reason.to_string(),
+        label,
     })
-}
-
-fn required_string<'a>(
-    args: &'a serde_json::Value,
-    field: &str,
-) -> std::result::Result<&'a str, String> {
-    args.get(field)
-        .and_then(serde_json::Value::as_str)
-        .ok_or_else(|| format!("{field} must be a string"))
 }
 
 fn parse_mount_namespace_path(raw: &str) -> std::result::Result<String, String> {
@@ -368,79 +417,6 @@ fn parse_mount_namespace_path(raw: &str) -> std::result::Result<String, String> 
     Ok(format!("/{}", components.join("/")))
 }
 
-fn parse_mount_host_path(raw: &str) -> std::result::Result<PathBuf, String> {
-    let trimmed = raw.trim();
-    let path = Path::new(trimmed);
-    if is_windows_filesystem_root_path(trimmed) || path == Path::new("/") {
-        return Err("host_path must not be the host filesystem root".to_string());
-    }
-    if !path.is_absolute() {
-        return Err("host_path must be absolute".to_string());
-    }
-    if has_invalid_raw_host_path_segment(trimmed)
-        || path
-            .components()
-            .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
-    {
-        return Err("host_path must not contain '.', '..', or empty components".to_string());
-    }
-    let normalized =
-        dunce::canonicalize(path).unwrap_or_else(|_| dunce::simplified(path).to_path_buf());
-    if let Some(component) = crate::tools::protected_path_component(&normalized) {
-        return Err(format!(
-            "host_path must not directly target protected `{component}` state"
-        ));
-    }
-    Ok(path.to_path_buf())
-}
-
-fn is_windows_filesystem_root_path(path: &str) -> bool {
-    let normalized = path.replace('\\', "/");
-    is_windows_drive_root_path(normalized.as_str())
-        || normalized
-            .strip_prefix("//?/")
-            .is_some_and(is_windows_drive_root_path)
-        || normalized
-            .strip_prefix("//./")
-            .is_some_and(is_windows_drive_root_path)
-        || normalized
-            .strip_prefix("//?/UNC/")
-            .is_some_and(is_windows_unc_share_root_path)
-        || normalized
-            .strip_prefix("//./UNC/")
-            .is_some_and(is_windows_unc_share_root_path)
-        || normalized
-            .strip_prefix("//")
-            .is_some_and(is_windows_unc_share_root_path)
-}
-
-fn is_windows_drive_root_path(path: &str) -> bool {
-    let bytes = path.as_bytes();
-    bytes.len() >= 3
-        && bytes[0].is_ascii_alphabetic()
-        && bytes[1] == b':'
-        && bytes[2..].iter().all(|byte| *byte == b'/')
-}
-
-fn is_windows_unc_share_root_path(path: &str) -> bool {
-    let parts = path
-        .split('/')
-        .filter(|component| !component.is_empty())
-        .collect::<Vec<_>>();
-    parts.len() == 2
-}
-
-fn has_invalid_raw_host_path_segment(path: &str) -> bool {
-    let mut segments = path.split('/');
-    let Some(first) = segments.next() else {
-        return true;
-    };
-    if !first.is_empty() {
-        return false;
-    }
-    segments.any(|segment| segment.is_empty() || segment == "." || segment == "..")
-}
-
 fn parse_mount_access(raw: &str) -> std::result::Result<MountRequestAccess, String> {
     match raw.trim() {
         "read_only" => Ok(MountRequestAccess::ReadOnly),
@@ -455,14 +431,11 @@ pub(super) fn request_mount_tool_definition() -> ToolDefinition {
         description: "Request an approval-gated host directory mount under /mnt. This asks the host to authorize a mount grant; it does not apply the mount directly.".to_string(),
         parameters: serde_json::json!({
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "namespace_path": {
                     "type": "string",
                     "description": "Absolute Alan OS namespace path under /mnt/<name>, without '.', '..', or empty path components."
-                },
-                "host_path": {
-                    "type": "string",
-                    "description": "Absolute host directory path to request access to."
                 },
                 "access": {
                     "type": "string",
@@ -472,22 +445,13 @@ pub(super) fn request_mount_tool_definition() -> ToolDefinition {
                 "reason": {
                     "type": "string",
                     "description": "Non-empty explanation of why this mount is needed."
+                },
+                "label": {
+                    "type": "string",
+                    "description": "Optional human-readable label for the requested mount."
                 }
             },
-            "required": ["namespace_path", "host_path", "access", "reason"]
+            "required": ["namespace_path", "access", "reason"]
         }),
-    }
-}
-
-#[cfg(all(test, unix))]
-mod tests {
-    use super::parse_mount_host_path;
-
-    #[test]
-    fn rejects_protected_host_state_root() {
-        let error = parse_mount_host_path("/tmp/project/.git")
-            .expect_err("a protected Host state root must not become a direct mount");
-
-        assert!(error.contains("protected `.git` state"));
     }
 }

--- a/crates/agent-engine/src/runtime/mount_request_tool/runtime_inputs.rs
+++ b/crates/agent-engine/src/runtime/mount_request_tool/runtime_inputs.rs
@@ -1,7 +1,9 @@
 use crate::{
     agent_machine::AgentMachine,
     policy::PolicyEngine,
-    runtime::transition::{NamespaceAgentFiles, NamespaceToolExecution},
+    runtime::transition::{
+        NamespaceAgentFiles, NamespaceHostMountRequests, NamespaceToolExecution,
+    },
 };
 
 /// Explicit inputs for one approval-gated mount-request Tool transition.
@@ -10,6 +12,7 @@ pub(crate) struct MountRequestRuntime<'a> {
     pub(super) policy_engine: &'a PolicyEngine,
     pub(super) governance: &'a alan_agent_protocol::GovernanceConfig,
     pub(super) agent_files: NamespaceAgentFiles,
+    pub(super) host_mount_requests: NamespaceHostMountRequests,
     pub(super) tool_execution: NamespaceToolExecution,
 }
 
@@ -19,6 +22,7 @@ impl<'a> MountRequestRuntime<'a> {
         policy_engine: &'a PolicyEngine,
         governance: &'a alan_agent_protocol::GovernanceConfig,
         agent_files: NamespaceAgentFiles,
+        host_mount_requests: NamespaceHostMountRequests,
         tool_execution: NamespaceToolExecution,
     ) -> Self {
         Self {
@@ -26,6 +30,7 @@ impl<'a> MountRequestRuntime<'a> {
             policy_engine,
             governance,
             agent_files,
+            host_mount_requests,
             tool_execution,
         }
     }

--- a/crates/agent-engine/src/runtime/mount_request_tool_tests.rs
+++ b/crates/agent-engine/src/runtime/mount_request_tool_tests.rs
@@ -1,552 +1,297 @@
 use super::*;
 
 #[test]
-fn test_request_mount_tool_definition() {
-    let def = request_mount_tool_definition();
-    assert_eq!(def.name, "request_mount");
-    assert!(def.description.contains("host directory mount"));
-    assert_eq!(def.parameters["type"], "object");
+fn request_mount_schema_accepts_only_logical_intent() {
+    let definition = request_mount_tool_definition();
+    assert_eq!(definition.name, "request_mount");
+    assert_eq!(definition.parameters["type"], "object");
+    assert_eq!(definition.parameters["additionalProperties"], false);
+    assert!(
+        definition.parameters["properties"]
+            .get("host_path")
+            .is_none()
+    );
     assert_eq!(
-        def.parameters["properties"]["namespace_path"]["type"],
+        definition.parameters["properties"]["label"]["type"],
         "string"
     );
-    assert_eq!(def.parameters["properties"]["host_path"]["type"], "string");
     assert_eq!(
-        def.parameters["properties"]["access"]["enum"],
-        json!(["read_only", "read_write"])
-    );
-    assert_eq!(
-        def.parameters["required"],
-        json!(["namespace_path", "host_path", "access", "reason"])
+        definition.parameters["required"],
+        json!(["namespace_path", "access", "reason"])
     );
 }
+
 #[test]
-fn test_parse_mount_request_valid() {
+fn parse_mount_request_normalizes_logical_document() {
     let request = parse_mount_request(&json!({
         "namespace_path": "/mnt/project",
-        "host_path": "/Users/morris/Developer/alan",
         "access": "read_only",
-        "reason": "Read project docs"
+        "reason": "  Read project docs  ",
+        "label": "  Project  "
     }))
-    .expect("valid mount request");
+    .expect("valid logical mount request");
 
     assert_eq!(request.namespace_path, "/mnt/project");
-    assert_eq!(
-        request.host_path,
-        PathBuf::from("/Users/morris/Developer/alan")
-    );
     assert_eq!(request.access, MountRequestAccess::ReadOnly);
     assert_eq!(request.reason, "Read project docs");
-    assert_eq!(request.payload()["access"], "read_only");
+    assert_eq!(request.label.as_deref(), Some("Project"));
+    assert_eq!(
+        request.payload(),
+        json!({
+            "namespace_path": "/mnt/project",
+            "access": "read_only",
+            "reason": "Read project docs",
+            "label": "Project"
+        })
+    );
 }
 
 #[test]
-fn test_parse_mount_request_rejects_invalid_fields() {
+fn parse_mount_request_rejects_invalid_or_host_owned_fields() {
     let cases = [
         (
             json!({
                 "namespace_path": "/proc/project",
-                "host_path": "/Users/morris/Developer/alan",
                 "access": "read_only",
-                "reason": "Read project docs"
-            }),
-            "namespace_path",
-        ),
-        (
-            json!({
-                "namespace_path": "/mnt",
-                "host_path": "/Users/morris/Developer/alan",
-                "access": "read_only",
-                "reason": "Read project docs"
+                "reason": "Read docs"
             }),
             "namespace_path",
         ),
         (
             json!({
                 "namespace_path": "/mnt/../project",
-                "host_path": "/Users/morris/Developer/alan",
                 "access": "read_only",
-                "reason": "Read project docs"
+                "reason": "Read docs"
             }),
             "namespace_path",
         ),
         (
             json!({
                 "namespace_path": "/mnt/llm",
-                "host_path": "/Users/morris/Developer/alan",
                 "access": "read_only",
-                "reason": "Read project docs"
+                "reason": "Read docs"
             }),
             "namespace_path",
         ),
         (
             json!({
-                "namespace_path": "/mnt/llm/connections",
-                "host_path": "/Users/morris/Developer/alan",
+                "namespace_path": "/mnt/host-mount",
                 "access": "read_only",
-                "reason": "Read project docs"
-            }),
-            "namespace_path",
-        ),
-        (
-            json!({
-                "namespace_path": "/mnt/mem",
-                "host_path": "/Users/morris/Developer/alan",
-                "access": "read_only",
-                "reason": "Read project docs"
-            }),
-            "namespace_path",
-        ),
-        (
-            json!({
-                "namespace_path": "/mnt/route/send",
-                "host_path": "/Users/morris/Developer/alan",
-                "access": "read_only",
-                "reason": "Read project docs"
+                "reason": "Read docs"
             }),
             "namespace_path",
         ),
         (
             json!({
                 "namespace_path": "/mnt/project",
-                "host_path": "relative/path",
-                "access": "read_only",
-                "reason": "Read project docs"
-            }),
-            "host_path",
-        ),
-        (
-            json!({
-                "namespace_path": "/mnt/project",
-                "host_path": "/",
-                "access": "read_only",
-                "reason": "Read project docs"
-            }),
-            "host_path",
-        ),
-        (
-            json!({
-                "namespace_path": "/mnt/project",
-                "host_path": "C:\\",
-                "access": "read_only",
-                "reason": "Read project docs"
-            }),
-            "host_path",
-        ),
-        (
-            json!({
-                "namespace_path": "/mnt/project",
-                "host_path": "\\\\server\\share\\",
-                "access": "read_only",
-                "reason": "Read project docs"
-            }),
-            "host_path",
-        ),
-        (
-            json!({
-                "namespace_path": "/mnt/project",
-                "host_path": "/Users/morris/./alan",
-                "access": "read_only",
-                "reason": "Read project docs"
-            }),
-            "host_path",
-        ),
-        (
-            json!({
-                "namespace_path": "/mnt/project",
-                "host_path": "/Users/morris//alan",
-                "access": "read_only",
-                "reason": "Read project docs"
-            }),
-            "host_path",
-        ),
-        (
-            json!({
-                "namespace_path": "/mnt/project",
-                "host_path": "/Users/morris/alan/",
-                "access": "read_only",
-                "reason": "Read project docs"
-            }),
-            "host_path",
-        ),
-        (
-            json!({
-                "namespace_path": "/mnt/project",
-                "host_path": "/Users/morris/Developer/alan",
                 "access": "admin",
-                "reason": "Read project docs"
+                "reason": "Read docs"
             }),
             "access",
         ),
         (
             json!({
                 "namespace_path": "/mnt/project",
-                "host_path": "/Users/morris/Developer/alan",
                 "access": "read_only",
                 "reason": "   "
             }),
             "reason",
         ),
+        (
+            json!({
+                "namespace_path": "/mnt/project",
+                "access": "read_only",
+                "reason": "Read docs",
+                "label": "   "
+            }),
+            "label",
+        ),
+        (
+            json!({
+                "namespace_path": "/mnt/project",
+                "host_path": "/Users/example/project",
+                "access": "read_only",
+                "reason": "Read docs"
+            }),
+            "unsupported fields",
+        ),
     ];
 
-    for (args, expected_error_field) in cases {
-        let error = parse_mount_request(&args).expect_err("expected invalid mount request");
-        assert!(
-            error.contains(expected_error_field),
-            "expected error for {expected_error_field}, got {error}"
-        );
+    for (arguments, expected) in cases {
+        let error = parse_mount_request(&arguments).expect_err("request must be rejected");
+        assert!(error.contains(expected), "expected {expected} in {error}");
     }
 }
+
+#[test]
+fn durable_mount_request_arguments_keep_only_valid_logical_values() {
+    let raw_host_path = "/Users/example/private-project";
+    let rejected = durable_mount_request_arguments(&json!({
+        "namespace_path": "/mnt/project",
+        "host_path": raw_host_path,
+        "access": "read_only",
+        "reason": "Read docs"
+    }));
+    assert_eq!(rejected, json!({"invalid_request": true}));
+    assert!(!rejected.to_string().contains(raw_host_path));
+
+    let accepted = durable_mount_request_arguments(&json!({
+        "namespace_path": "/mnt/project",
+        "access": "read_only",
+        "reason": "  Read docs  "
+    }));
+    assert_eq!(
+        accepted,
+        json!({
+            "namespace_path": "/mnt/project",
+            "access": "read_only",
+            "reason": "Read docs",
+            "label": null
+        })
+    );
+}
+
 #[tokio::test]
-async fn test_dispatch_virtual_tool_call_request_mount_escalates_even_when_allowed() {
+async fn policy_allow_commits_one_service_request_and_yields_authorization_wait() {
     let mut state = create_test_transition_state();
     state.runtime_config.policy_engine = crate::policy::PolicyEngine::allow_all();
-    let temp = TempDir::new().unwrap();
-    let host_path = std::fs::canonicalize(temp.path()).unwrap();
-    let host_path_text = host_path.display().to_string();
-
     let tool_call = NormalizedToolCall {
         id: "call_mount".to_string(),
         name: "request_mount".to_string(),
         arguments: json!({
             "namespace_path": "/mnt/project",
-            "host_path": host_path_text.clone(),
             "access": "read_write",
-            "reason": "Need to edit project files"
+            "reason": "Need to edit project files",
+            "label": "Project"
         }),
     };
-
-    let mut events = vec![];
+    let mut events = Vec::new();
     let mut emit = |event: Event| {
         events.push(event);
         async {}
     };
 
-    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
-    assert!(result.is_ok());
-    assert!(matches!(result.unwrap(), VirtualToolOutcome::PauseTurn));
+    let outcome = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit)
+        .await
+        .unwrap();
+    assert!(matches!(outcome, VirtualToolOutcome::PauseTurn));
 
     let pending = state
         .machine
-        .pending_confirmation()
-        .expect("mount request should pause for confirmation");
-    assert_eq!(
-        pending.checkpoint_type,
-        crate::approval::MOUNT_ESCALATION_CHECKPOINT_TYPE
-    );
-    assert_eq!(pending.checkpoint_id, "mount_escalation_call_mount");
-    assert_eq!(pending.details["tool_call_id"], "call_mount");
-    assert_eq!(
-        pending.details["mount_request"]["namespace_path"],
-        "/mnt/project"
-    );
-    assert_eq!(
-        pending.details["mount_request"]["host_path"],
-        host_path_text
-    );
-    assert_eq!(pending.details["mount_request"]["access"], "read_write");
-    assert_eq!(pending.details["policy"]["action"], "escalate");
-    assert_eq!(
-        pending.details["policy"]["reason"],
-        "host mount grants require approval"
-    );
+        .pending_host_mount("request-1")
+        .expect("Machine owns the opaque service wait");
+    assert_eq!(pending.tool_call_id, "call_mount");
+    assert_eq!(pending.namespace_path, "/mnt/project");
+    assert_eq!(pending.request_events_offset, 0);
+    assert!(state.machine.pending_confirmation().is_none());
 
+    let shell = Shell::new(state.environment.root_transport());
+    let request: serde_json::Value = serde_json::from_slice(
+        &shell
+            .cat("/mnt/host-mount/requests/request-1/request")
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(request, tool_call.arguments);
+    assert_eq!(
+        shell
+            .cat("/mnt/host-mount/requests/request-1/status")
+            .await
+            .unwrap(),
+        b"pending\n"
+    );
     assert!(events.iter().any(|event| matches!(
         event,
-        Event::ToolCallStarted { id, name, audit: None, .. }
-            if id == "call_mount" && name == "request_mount"
-    )));
-    assert!(events.iter().any(|event| matches!(
-        event,
-        Event::ToolCallCompleted { id, success: Some(true), audit: Some(audit), .. }
-            if id == "call_mount"
-                && audit.action == "escalate"
-                && audit.reason.as_deref() == Some("host mount grants require approval")
-    )));
-    assert!(events.iter().any(|event| matches!(
-        event,
-        Event::Yield { kind: alan_agent_protocol::YieldKind::Confirmation, payload, .. }
-            if payload["checkpoint_type"] == json!(crate::approval::MOUNT_ESCALATION_CHECKPOINT_TYPE)
-                && payload["details"]["mount_request"]["host_path"] == json!(host_path_text.clone())
-                && payload["default_option"] == json!("reject")
+        Event::Yield { request_id, kind: alan_agent_protocol::YieldKind::Custom(kind), payload }
+            if request_id == "request-1"
+                && kind == "authorization_wait"
+                && payload["details"]["request_reference"] == "request-1"
+                && !payload.to_string().contains("host_path")
     )));
 }
 
 #[tokio::test]
-async fn test_dispatch_virtual_tool_call_request_mount_does_not_probe_host_existence() {
+async fn raw_host_path_is_rejected_without_service_request_or_yield() {
     let mut state = create_test_transition_state();
-    state.runtime_config.policy_engine = crate::policy::PolicyEngine::allow_all();
-    let missing_host_path = TempDir::new()
-        .unwrap()
-        .path()
-        .join("missing-host-mount-root");
-    let missing_host_path_text = missing_host_path.display().to_string();
-
-    let tool_call = NormalizedToolCall {
-        id: "call_mount".to_string(),
-        name: "request_mount".to_string(),
-        arguments: json!({
-            "namespace_path": "/mnt/missing",
-            "host_path": missing_host_path_text.clone(),
-            "access": "read_only",
-            "reason": "Need to inspect files if available"
-        }),
-    };
-
-    let mut events = vec![];
-    let mut emit = |event: Event| {
-        events.push(event);
-        async {}
-    };
-
-    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
-    assert!(result.is_ok());
-    assert!(matches!(result.unwrap(), VirtualToolOutcome::PauseTurn));
-
-    let pending = state
-        .machine
-        .pending_confirmation()
-        .expect("syntactically valid mount request should pause for confirmation");
-    assert_eq!(
-        pending.details["mount_request"]["host_path"],
-        missing_host_path_text
-    );
-    assert!(events.iter().any(|event| matches!(
-        event,
-        Event::Yield { kind: alan_agent_protocol::YieldKind::Confirmation, payload, .. }
-            if payload["details"]["mount_request"]["host_path"] == json!(missing_host_path_text.clone())
-                && payload["default_option"] == json!("reject")
-    )));
-}
-
-#[tokio::test]
-async fn test_dispatch_virtual_tool_call_request_mount_denied_by_policy() {
-    let mut state = create_test_transition_state();
-    state.runtime_config.policy_engine = crate::policy::PolicyEngine::deny_all();
-    let temp = TempDir::new().unwrap();
-    let host_path = std::fs::canonicalize(temp.path()).unwrap();
-
     let tool_call = NormalizedToolCall {
         id: "call_mount".to_string(),
         name: "request_mount".to_string(),
         arguments: json!({
             "namespace_path": "/mnt/project",
-            "host_path": host_path.display().to_string(),
-            "access": "read_only",
-            "reason": "Need to inspect project files"
-        }),
-    };
-
-    let mut events = vec![];
-    let mut emit = |event: Event| {
-        events.push(event);
-        async {}
-    };
-
-    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
-    assert!(result.is_ok());
-    assert!(matches!(
-        result.unwrap(),
-        VirtualToolOutcome::Continue {
-            refresh_context: false
-        }
-    ));
-    assert!(state.machine.pending_confirmation().is_none());
-    assert!(!events.iter().any(|event| matches!(
-        event,
-        Event::Yield {
-            kind: alan_agent_protocol::YieldKind::Confirmation,
-            ..
-        }
-    )));
-    assert!(events.iter().any(|event| matches!(
-        event,
-        Event::ToolCallCompleted { success: Some(false), audit: Some(audit), .. }
-            if audit.action == "deny"
-    )));
-
-    let tool_result = tool_result_text_for_call(&state, "call_mount");
-    assert!(tool_result.contains("\"status\":\"blocked_by_policy\""));
-    assert!(tool_result.contains("/mnt/project"));
-}
-
-#[tokio::test]
-async fn test_dispatch_virtual_tool_call_request_mount_read_only_uses_read_policy() {
-    let mut state = create_test_transition_state();
-    let temp = TempDir::new().unwrap();
-    let host_dir = temp.path().join("ssh");
-    let host_path = host_dir.display().to_string();
-    std::fs::write(
-        temp.path().join("policy.yaml"),
-        format!(
-            r#"
-rules:
-  - id: deny-sensitive-read-mount
-    tool: request_mount
-    capability: read
-    match_path_prefix: "{}"
-    action: deny
-    reason: sensitive host reads are not allowed
-default_action: allow
-"#,
-            host_path
-        ),
-    )
-    .unwrap();
-    state.runtime_config.policy_engine =
-        crate::policy::PolicyEngine::load_or_default(Some(&temp.path().join("policy.yaml")));
-
-    let tool_call = NormalizedToolCall {
-        id: "call_mount".to_string(),
-        name: "request_mount".to_string(),
-        arguments: json!({
-            "namespace_path": "/mnt/ssh",
-            "host_path": host_path,
-            "access": "read_only",
-            "reason": "Need to inspect SSH configuration"
-        }),
-    };
-
-    let mut events = vec![];
-    let mut emit = |event: Event| {
-        events.push(event);
-        async {}
-    };
-
-    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
-    assert!(result.is_ok());
-    assert!(matches!(
-        result.unwrap(),
-        VirtualToolOutcome::Continue {
-            refresh_context: false
-        }
-    ));
-    assert!(state.machine.pending_confirmation().is_none());
-    assert!(events.iter().any(|event| matches!(
-        event,
-        Event::ToolCallCompleted { success: Some(false), audit: Some(audit), .. }
-            if audit.action == "deny"
-                && audit.capability == "read"
-                && audit.rule_id.as_deref() == Some("deny-sensitive-read-mount")
-    )));
-
-    let tool_result = tool_result_text_for_call(&state, "call_mount");
-    assert!(tool_result.contains("\"status\":\"blocked_by_policy\""));
-    assert!(tool_result.contains("sensitive host reads are not allowed"));
-}
-
-#[tokio::test]
-async fn test_dispatch_virtual_tool_call_request_mount_read_write_honors_read_denies() {
-    let mut state = create_test_transition_state();
-    let temp = TempDir::new().unwrap();
-    let host_dir = temp.path().join("ssh");
-    let host_path = host_dir.display().to_string();
-    std::fs::write(
-        temp.path().join("policy.yaml"),
-        format!(
-            r#"
-rules:
-  - id: deny-sensitive-read-mount
-    tool: request_mount
-    capability: read
-    match_path_prefix: "{}"
-    action: deny
-    reason: sensitive host reads are not allowed
-default_action: allow
-"#,
-            host_path
-        ),
-    )
-    .unwrap();
-    state.runtime_config.policy_engine =
-        crate::policy::PolicyEngine::load_or_default(Some(&temp.path().join("policy.yaml")));
-
-    let tool_call = NormalizedToolCall {
-        id: "call_mount".to_string(),
-        name: "request_mount".to_string(),
-        arguments: json!({
-            "namespace_path": "/mnt/ssh",
-            "host_path": host_path,
-            "access": "read_write",
-            "reason": "Need to update SSH configuration"
-        }),
-    };
-
-    let mut events = vec![];
-    let mut emit = |event: Event| {
-        events.push(event);
-        async {}
-    };
-
-    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
-    assert!(result.is_ok());
-    assert!(matches!(
-        result.unwrap(),
-        VirtualToolOutcome::Continue {
-            refresh_context: false
-        }
-    ));
-    assert!(state.machine.pending_confirmation().is_none());
-    assert!(events.iter().any(|event| matches!(
-        event,
-        Event::ToolCallCompleted { success: Some(false), audit: Some(audit), .. }
-            if audit.action == "deny"
-                && audit.capability == "read"
-                && audit.rule_id.as_deref() == Some("deny-sensitive-read-mount")
-    )));
-
-    let tool_result = tool_result_text_for_call(&state, "call_mount");
-    assert!(tool_result.contains("\"status\":\"blocked_by_policy\""));
-    assert!(tool_result.contains("sensitive host reads are not allowed"));
-}
-
-#[tokio::test]
-async fn test_dispatch_virtual_tool_call_request_mount_rejects_invalid_request() {
-    let mut state = create_test_transition_state();
-
-    let tool_call = NormalizedToolCall {
-        id: "call_mount".to_string(),
-        name: "request_mount".to_string(),
-        arguments: json!({
-            "namespace_path": "/proc/project",
-            "host_path": "relative/path",
+            "host_path": "/Users/example/project",
             "access": "read_only",
             "reason": "Need files"
         }),
     };
-
-    let mut events = vec![];
+    let mut events = Vec::new();
     let mut emit = |event: Event| {
         events.push(event);
         async {}
     };
 
-    let result = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
-    assert!(result.is_ok());
+    let outcome = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit)
+        .await
+        .unwrap();
     assert!(matches!(
-        result.unwrap(),
+        outcome,
         VirtualToolOutcome::Continue {
             refresh_context: true
         }
     ));
-    assert!(state.machine.pending_confirmation().is_none());
-    assert!(!events.iter().any(|event| matches!(
-        event,
-        Event::Yield {
-            kind: alan_agent_protocol::YieldKind::Confirmation,
-            ..
-        }
-    )));
-    assert!(events.iter().any(|event| matches!(
-        event,
-        Event::ToolCallCompleted {
-            success: Some(false),
-            audit: None,
-            ..
-        }
-    )));
+    assert!(!state.machine.has_pending_interaction());
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, Event::Yield { .. }))
+    );
+    let shell = Shell::new(state.environment.root_transport());
+    assert_eq!(
+        shell.ls("/mnt/host-mount/requests").await.unwrap(),
+        vec!["clone".to_string()]
+    );
+    let result = tool_result_text_for_call(&state, "call_mount");
+    assert!(!result.contains("/Users/example/project"));
+    assert!(!result.contains("host_path"));
+}
 
-    let tool_result = tool_result_text_for_call(&state, "call_mount");
-    assert!(tool_result.contains("\"status\":\"invalid_request\""));
-    assert!(tool_result.contains("namespace_path"));
+#[tokio::test]
+async fn policy_deny_does_not_create_service_request() {
+    let mut state = create_test_transition_state();
+    state.runtime_config.policy_engine = crate::policy::PolicyEngine::deny_all();
+    let tool_call = NormalizedToolCall {
+        id: "call_mount".to_string(),
+        name: "request_mount".to_string(),
+        arguments: json!({
+            "namespace_path": "/mnt/project",
+            "access": "read_only",
+            "reason": "Need files"
+        }),
+    };
+    let mut events = Vec::new();
+    let mut emit = |event: Event| {
+        events.push(event);
+        async {}
+    };
+
+    let outcome = dispatch_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit)
+        .await
+        .unwrap();
+    assert!(matches!(
+        outcome,
+        VirtualToolOutcome::Continue {
+            refresh_context: false
+        }
+    ));
+    assert!(!state.machine.has_pending_interaction());
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, Event::Yield { .. }))
+    );
+    let shell = Shell::new(state.environment.root_transport());
+    assert_eq!(
+        shell.ls("/mnt/host-mount/requests").await.unwrap(),
+        vec!["clone".to_string()]
+    );
 }

--- a/crates/agent-engine/src/runtime/submission_handlers.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers.rs
@@ -462,6 +462,15 @@ fn handle_host_mount_terminal(
 ) -> RuntimeOpAction {
     let status = terminal.status.as_str();
     let approved = status == "approved";
+    if approved {
+        let access = match pending.access.as_str() {
+            "read_write" => alan_kernel::Access::ReadWrite,
+            _ => alan_kernel::Access::ReadOnly,
+        };
+        runtime
+            .mount_control
+            .record_projected_host_mount(pending.namespace_path.clone(), access);
+    }
     let result = json!({
         "status": status,
         "approved": approved,

--- a/crates/agent-engine/src/runtime/submission_handlers.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers.rs
@@ -10,7 +10,7 @@ use crate::approval::{
 use crate::tape::ContentPart;
 
 use super::transition::{HostMountTerminalResult, NamespaceAgentFiles, TurnRunKind};
-use super::turn_support::cancel_current_task;
+use super::turn_support::{cancel_current_task, reset_turn_after_cancelling_host_mounts};
 use crate::agent_machine::{
     AgentMachine, HOST_MOUNT_REQUEST_TERMINAL_EVENT_TYPE, NormalizedToolCall,
     PendingHostMountRequest, PendingYield,
@@ -94,7 +94,13 @@ where
             .await;
         }
         Op::Interrupt => {
-            cancel_current_task(runtime.machine, &runtime.agent_files, emit).await?;
+            cancel_current_task(
+                runtime.machine,
+                &runtime.agent_files,
+                &runtime.host_mount_requests,
+                emit,
+            )
+            .await?;
         }
 
         // ====================================================================
@@ -111,7 +117,8 @@ where
             }
             merged_parts.extend(parts);
 
-            runtime.machine.reset_turn();
+            reset_turn_after_cancelling_host_mounts(runtime.machine, &runtime.host_mount_requests)
+                .await?;
             runtime.machine.set_active_turn_request_control_intent(
                 crate::RequestControlIntent::reasoning_effort(reasoning_effort),
             );
@@ -169,7 +176,11 @@ where
                         return Ok(RuntimeOpAction::NoTurn);
                     }
 
-                    runtime.machine.reset_turn();
+                    reset_turn_after_cancelling_host_mounts(
+                        runtime.machine,
+                        &runtime.host_mount_requests,
+                    )
+                    .await?;
                     return Ok(RuntimeOpAction::RunTurn {
                         turn_kind: TurnRunKind::NewTurn,
                         user_input: Some(parts),

--- a/crates/agent-engine/src/runtime/submission_handlers.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers.rs
@@ -10,7 +10,6 @@ use crate::approval::{
 use crate::tape::ContentPart;
 
 use super::transition::{HostMountTerminalResult, NamespaceAgentFiles, TurnRunKind};
-use super::turn_support::{cancel_current_task, reset_turn_after_cancelling_host_mounts};
 use crate::agent_machine::{
     AgentMachine, HOST_MOUNT_REQUEST_TERMINAL_EVENT_TYPE, NormalizedToolCall,
     PendingHostMountRequest, PendingYield,
@@ -94,13 +93,7 @@ where
             .await;
         }
         Op::Interrupt => {
-            cancel_current_task(
-                runtime.machine,
-                &runtime.agent_files,
-                &runtime.host_mount_requests,
-                emit,
-            )
-            .await?;
+            runtime.cancel_current_task(emit).await?;
         }
 
         // ====================================================================
@@ -117,8 +110,7 @@ where
             }
             merged_parts.extend(parts);
 
-            reset_turn_after_cancelling_host_mounts(runtime.machine, &runtime.host_mount_requests)
-                .await?;
+            runtime.reset_turn_after_cancelling_host_mounts().await?;
             runtime.machine.set_active_turn_request_control_intent(
                 crate::RequestControlIntent::reasoning_effort(reasoning_effort),
             );
@@ -176,11 +168,7 @@ where
                         return Ok(RuntimeOpAction::NoTurn);
                     }
 
-                    reset_turn_after_cancelling_host_mounts(
-                        runtime.machine,
-                        &runtime.host_mount_requests,
-                    )
-                    .await?;
+                    runtime.reset_turn_after_cancelling_host_mounts().await?;
                     return Ok(RuntimeOpAction::RunTurn {
                         turn_kind: TurnRunKind::NewTurn,
                         user_input: Some(parts),
@@ -233,6 +221,7 @@ where
                 };
                 let taken = runtime.machine.take_pending(&request_id);
                 debug_assert!(matches!(taken, Some(PendingYield::HostMount(_))));
+                runtime.preserve_approved_host_mount(&pending, &terminal)?;
                 return Ok(handle_host_mount_terminal(&mut runtime, pending, terminal));
             }
             let result = resume_content_to_value(&content);
@@ -473,17 +462,6 @@ fn handle_host_mount_terminal(
 ) -> RuntimeOpAction {
     let status = terminal.status.as_str();
     let approved = status == "approved";
-    if approved && let Some(grant_reference) = terminal.grant_reference.clone() {
-        let access = match pending.access.as_str() {
-            "read_write" => alan_kernel::Access::ReadWrite,
-            _ => alan_kernel::Access::ReadOnly,
-        };
-        runtime.record_projected_host_mount(
-            grant_reference,
-            pending.namespace_path.clone(),
-            access,
-        );
-    }
     let result = json!({
         "status": status,
         "approved": approved,

--- a/crates/agent-engine/src/runtime/submission_handlers.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers.rs
@@ -462,14 +462,16 @@ fn handle_host_mount_terminal(
 ) -> RuntimeOpAction {
     let status = terminal.status.as_str();
     let approved = status == "approved";
-    if approved {
+    if approved && let Some(grant_reference) = terminal.grant_reference.clone() {
         let access = match pending.access.as_str() {
             "read_write" => alan_kernel::Access::ReadWrite,
             _ => alan_kernel::Access::ReadOnly,
         };
-        runtime
-            .mount_control
-            .record_projected_host_mount(pending.namespace_path.clone(), access);
+        runtime.record_projected_host_mount(
+            grant_reference,
+            pending.namespace_path.clone(),
+            access,
+        );
     }
     let result = json!({
         "status": status,

--- a/crates/agent-engine/src/runtime/submission_handlers.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers.rs
@@ -4,18 +4,17 @@ use serde_json::json;
 
 use crate::ROLLBACK_NON_DURABLE_WARNING;
 use crate::approval::{
-    MOUNT_ESCALATION_CHECKPOINT_TYPE, RUNTIME_CONFIRMATION_CONTROL_SOURCE,
-    RUNTIME_CONFIRMATION_CONTROL_VERSION, is_effect_replay_confirmation, replays_tool_calls,
-    runtime_confirmation_control_kind,
+    RUNTIME_CONFIRMATION_CONTROL_SOURCE, RUNTIME_CONFIRMATION_CONTROL_VERSION,
+    is_effect_replay_confirmation, replays_tool_calls, runtime_confirmation_control_kind,
 };
 use crate::tape::ContentPart;
 
-use super::transition::{
-    ApprovedMountGrant, ApprovedMountGrantAccess, NamespaceAgentFiles, NamespaceMountApplication,
-    TurnRunKind,
-};
+use super::transition::{HostMountTerminalResult, NamespaceAgentFiles, TurnRunKind};
 use super::turn_support::cancel_current_task;
-use crate::agent_machine::{AgentMachine, NormalizedToolCall, PendingYield};
+use crate::agent_machine::{
+    AgentMachine, HOST_MOUNT_REQUEST_TERMINAL_EVENT_TYPE, NormalizedToolCall,
+    PendingHostMountRequest, PendingYield,
+};
 
 mod runtime_inputs;
 
@@ -206,6 +205,25 @@ where
             request_id,
             content,
         } => {
+            if let Some(pending) = runtime.machine.pending_host_mount(&request_id) {
+                let Some(terminal) = runtime
+                    .host_mount_requests
+                    .terminal_result(&request_id)
+                    .await?
+                else {
+                    emit(Event::Error {
+                        message: format!(
+                            "Host Mount request '{request_id}' is still pending; only Host Mount Service can settle it."
+                        ),
+                        recoverable: true,
+                    })
+                    .await;
+                    return Ok(RuntimeOpAction::NoTurn);
+                };
+                let taken = runtime.machine.take_pending(&request_id);
+                debug_assert!(matches!(taken, Some(PendingYield::HostMount(_))));
+                return Ok(handle_host_mount_terminal(&mut runtime, pending, terminal));
+            }
             let result = resume_content_to_value(&content);
             match runtime.machine.take_pending(&request_id) {
                 Some(PendingYield::Confirmation(pending)) => {
@@ -242,6 +260,9 @@ where
                         activate_task: false,
                     });
                 }
+                Some(PendingYield::HostMount(_)) => unreachable!(
+                    "Host Mount pending requests are resolved from service status above"
+                ),
                 None => {
                     emit(Event::Error {
                         message: format!(
@@ -298,12 +319,8 @@ fn first_resume_text(content: &[ContentPart]) -> Option<String> {
     })
 }
 
-fn default_confirmation_choice(pending: &crate::approval::PendingConfirmation) -> &'static str {
-    if pending.checkpoint_type == MOUNT_ESCALATION_CHECKPOINT_TYPE {
-        "reject"
-    } else {
-        "approve"
-    }
+fn default_confirmation_choice(_pending: &crate::approval::PendingConfirmation) -> &'static str {
+    "approve"
 }
 
 fn checkpoint_choice_for_rollout(choice_str: &str) -> &str {
@@ -366,12 +383,6 @@ async fn handle_confirmation_resolution(
 
     if let Some(modifications) = modifications {
         payload["modifications"] = serde_json::Value::String(modifications);
-    }
-
-    if pending.checkpoint_type == MOUNT_ESCALATION_CHECKPOINT_TYPE {
-        return Ok(handle_mount_escalation_resolution(
-            runtime, pending, choice_str,
-        ));
     }
 
     if let Some(control_kind) = runtime_confirmation_control_kind(&pending.checkpoint_type) {
@@ -444,213 +455,42 @@ async fn handle_confirmation_resolution(
     })
 }
 
-fn handle_mount_escalation_resolution(
+fn handle_host_mount_terminal(
     runtime: &mut SubmissionRuntime<'_>,
-    pending: crate::approval::PendingConfirmation,
-    choice_str: &str,
+    pending: PendingHostMountRequest,
+    terminal: HostMountTerminalResult,
 ) -> RuntimeOpAction {
-    let Some((tool_call_id, mount_request)) = validated_mount_escalation_request(&pending) else {
-        let result = json!({
-            "status": "invalid_mount_escalation_checkpoint",
-            "approved": false,
-            "live_applied": false,
-            "checkpoint_id": pending.checkpoint_id,
-            "checkpoint_type": pending.checkpoint_type,
-            "choice": choice_str,
-            "error": "Invalid mount escalation checkpoint.",
-        });
-        runtime
-            .machine
-            .add_tool_message(&pending.checkpoint_id, "request_mount", result);
-        return RuntimeOpAction::RunTurn {
-            turn_kind: TurnRunKind::ResumeTurn,
-            user_input: None,
-            activate_task: false,
-        };
-    };
-    let approved = choice_str == "approve";
-    let grant = parse_mount_grant_request(&mount_request);
-    let namespace_application = if approved {
-        grant
-            .as_ref()
-            .map(|grant| {
-                runtime
-                    .mount_control
-                    .apply_approved_grant(&grant.approved_mount_grant())
-            })
-            .unwrap_or_else(|| {
-                NamespaceMountApplication::unavailable("missing approved mount grant details")
-            })
-    } else {
-        NamespaceMountApplication {
-            namespace_applied: false,
-            namespace_error: None,
-        }
-    };
-    let native_grant = grant.as_ref().and_then(|grant| {
-        crate::HostMountGrant::new(
-            grant.namespace_path.clone(),
-            grant.host_path.clone(),
-            match grant.access {
-                ApprovedMountGrantAccess::ReadOnly => alan_kernel::Access::ReadOnly,
-                ApprovedMountGrantAccess::ReadWrite => alan_kernel::Access::ReadWrite,
-            },
-        )
-        .ok()
-    });
-    let namespace_applied = approved && namespace_application.namespace_applied;
-    let scratch_dir = runtime
-        .tool_execution
-        .execution_binding()
-        .map(|binding| binding.scratch_dir)
-        .or_else(|| runtime.runtime_scratch_dir.clone());
-    let tool_sandbox_projection_changed = namespace_applied
-        && native_grant.as_ref().is_some_and(|grant| {
-            runtime.mount_control.retain_host_mount(grant.clone());
-            scratch_dir
-                .clone()
-                .is_some_and(|scratch| runtime.mount_control.sync_tool_binding(scratch))
-        });
-    let tool_sandbox_applied = namespace_applied
-        && grant.as_ref().is_some_and(|grant| {
-            let binding = runtime.tool_execution.execution_binding();
-            binding.is_some_and(|binding| {
-                binding.host_mounts.iter().any(|mounted| {
-                    mounted.namespace_path == grant.namespace_path
-                        && normalize_mount_grant_host_path(&mounted.host_path)
-                            == normalize_mount_grant_host_path(&grant.host_path)
-                })
-            })
-        });
-    let status = if approved { "approved" } else { "rejected" };
+    let status = terminal.status.as_str();
+    let approved = status == "approved";
     let result = json!({
         "status": status,
         "approved": approved,
-        "live_applied": false,
-        "namespace_applied": namespace_application.namespace_applied,
-        "namespace_error": namespace_application.namespace_error,
-        "tool_sandbox_applied": tool_sandbox_applied,
-        "tool_sandbox_projection_changed": tool_sandbox_projection_changed,
-        "checkpoint_id": pending.checkpoint_id,
-        "checkpoint_type": pending.checkpoint_type,
-        "choice": choice_str,
-        "mount_request": mount_request,
+        "request_reference": pending.request_id,
+        "namespace_path": pending.namespace_path,
+        "access": pending.access,
+        "reason": pending.reason,
+        "label": pending.label,
+        "grant_reference": terminal.grant_reference,
+        "error": terminal.error,
     });
-
-    if approved {
-        runtime.machine.record_event(
-            "host_mount_grant",
-            host_mount_grant_event_payload(&pending.details, &result),
-        );
-    }
+    runtime.machine.record_event(
+        HOST_MOUNT_REQUEST_TERMINAL_EVENT_TYPE,
+        json!({
+            "request_id": pending.request_id,
+            "status": status,
+            "grant_reference": terminal.grant_reference,
+            "error": terminal.error,
+        }),
+    );
     runtime
         .machine
-        .add_tool_message(&tool_call_id, "request_mount", result);
+        .add_tool_message(&pending.tool_call_id, "request_mount", result);
 
     RuntimeOpAction::RunTurn {
         turn_kind: TurnRunKind::ResumeTurn,
         user_input: None,
         activate_task: false,
     }
-}
-
-fn validated_mount_escalation_request(
-    pending: &crate::approval::PendingConfirmation,
-) -> Option<(String, serde_json::Value)> {
-    if pending
-        .details
-        .get("kind")
-        .and_then(serde_json::Value::as_str)
-        != Some("mount_escalation")
-    {
-        return None;
-    }
-    if pending
-        .details
-        .get("tool_name")
-        .and_then(serde_json::Value::as_str)
-        != Some("request_mount")
-    {
-        return None;
-    }
-    let tool_call_id = pending
-        .details
-        .get("tool_call_id")
-        .and_then(serde_json::Value::as_str)
-        .map(str::trim)
-        .filter(|raw| !raw.is_empty())?
-        .to_string();
-    let mount_request = pending.details.get("mount_request")?;
-    let mount_request = super::mount_request_tool::parse_mount_request(mount_request)
-        .ok()?
-        .payload();
-    Some((tool_call_id, mount_request))
-}
-
-fn host_mount_grant_event_payload(
-    details: &serde_json::Value,
-    result: &serde_json::Value,
-) -> serde_json::Value {
-    let request = result
-        .get("mount_request")
-        .unwrap_or(&serde_json::Value::Null);
-    json!({
-        "namespace_path": request.get("namespace_path").and_then(serde_json::Value::as_str),
-        "host_path": request.get("host_path").and_then(serde_json::Value::as_str),
-        "access": request.get("access").and_then(serde_json::Value::as_str),
-        "reason": request.get("reason").and_then(serde_json::Value::as_str),
-        "checkpoint_id": result.get("checkpoint_id").and_then(serde_json::Value::as_str),
-        "approved": true,
-        "live_applied": false,
-        "namespace_applied": result.get("namespace_applied").and_then(serde_json::Value::as_bool),
-        "namespace_error": result.get("namespace_error").and_then(serde_json::Value::as_str),
-        "tool_sandbox_applied": result.get("tool_sandbox_applied").and_then(serde_json::Value::as_bool),
-        "tool_sandbox_projection_changed": result.get("tool_sandbox_projection_changed").and_then(serde_json::Value::as_bool),
-        "tool_call_id": details.get("tool_call_id").and_then(serde_json::Value::as_str),
-    })
-}
-
-struct MountGrantDetails {
-    namespace_path: String,
-    host_path: std::path::PathBuf,
-    access: ApprovedMountGrantAccess,
-    reason: String,
-}
-
-impl MountGrantDetails {
-    fn approved_mount_grant(&self) -> ApprovedMountGrant {
-        ApprovedMountGrant::new(
-            self.namespace_path.clone(),
-            self.host_path.clone(),
-            self.access,
-            self.reason.clone(),
-        )
-    }
-}
-
-fn parse_mount_grant_request(request: &serde_json::Value) -> Option<MountGrantDetails> {
-    let namespace_path = request.get("namespace_path")?.as_str()?.trim();
-    let host_path = request.get("host_path")?.as_str()?.trim();
-    let access = request.get("access")?.as_str()?.trim();
-    let reason = request.get("reason")?.as_str()?.trim();
-    if namespace_path.is_empty() || host_path.is_empty() || reason.is_empty() {
-        return None;
-    }
-    let access = match access {
-        "read_only" => ApprovedMountGrantAccess::ReadOnly,
-        "read_write" => ApprovedMountGrantAccess::ReadWrite,
-        _ => return None,
-    };
-    Some(MountGrantDetails {
-        namespace_path: namespace_path.to_string(),
-        host_path: std::path::PathBuf::from(host_path),
-        access,
-        reason: reason.to_string(),
-    })
-}
-
-fn normalize_mount_grant_host_path(path: &std::path::Path) -> std::path::PathBuf {
-    dunce::canonicalize(path).unwrap_or_else(|_| dunce::simplified(path).to_path_buf())
 }
 
 fn is_unknown_effect_confirmation(pending: &crate::approval::PendingConfirmation) -> bool {

--- a/crates/agent-engine/src/runtime/submission_handlers/runtime_inputs.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/runtime_inputs.rs
@@ -25,4 +25,14 @@ impl<'a> SubmissionRuntime<'a> {
             mount_control,
         }
     }
+
+    pub(super) fn record_projected_host_mount(
+        &mut self,
+        grant_reference: String,
+        namespace_path: String,
+        access: alan_kernel::Access,
+    ) {
+        self.mount_control
+            .record_projected_host_mount(grant_reference, namespace_path, access);
+    }
 }

--- a/crates/agent-engine/src/runtime/submission_handlers/runtime_inputs.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/runtime_inputs.rs
@@ -1,6 +1,6 @@
 use crate::{
     agent_machine::AgentMachine,
-    runtime::transition::{NamespaceAgentFiles, NamespaceHostMountRequests},
+    runtime::transition::{NamespaceAgentFiles, NamespaceHostMountRequests, NamespaceMountControl},
 };
 
 /// Explicit inputs for classifying and applying one non-compaction runtime operation.
@@ -8,6 +8,7 @@ pub(crate) struct SubmissionRuntime<'a> {
     pub(super) machine: &'a mut AgentMachine,
     pub(super) agent_files: NamespaceAgentFiles,
     pub(super) host_mount_requests: NamespaceHostMountRequests,
+    pub(super) mount_control: NamespaceMountControl<'a>,
 }
 
 impl<'a> SubmissionRuntime<'a> {
@@ -15,11 +16,13 @@ impl<'a> SubmissionRuntime<'a> {
         machine: &'a mut AgentMachine,
         agent_files: NamespaceAgentFiles,
         host_mount_requests: NamespaceHostMountRequests,
+        mount_control: NamespaceMountControl<'a>,
     ) -> Self {
         Self {
             machine,
             agent_files,
             host_mount_requests,
+            mount_control,
         }
     }
 }

--- a/crates/agent-engine/src/runtime/submission_handlers/runtime_inputs.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/runtime_inputs.rs
@@ -1,33 +1,25 @@
-use std::path::PathBuf;
-
 use crate::{
     agent_machine::AgentMachine,
-    runtime::transition::{NamespaceAgentFiles, NamespaceMountControl, NamespaceToolExecution},
+    runtime::transition::{NamespaceAgentFiles, NamespaceHostMountRequests},
 };
 
 /// Explicit inputs for classifying and applying one non-compaction runtime operation.
 pub(crate) struct SubmissionRuntime<'a> {
     pub(super) machine: &'a mut AgentMachine,
     pub(super) agent_files: NamespaceAgentFiles,
-    pub(super) mount_control: NamespaceMountControl<'a>,
-    pub(super) tool_execution: NamespaceToolExecution,
-    pub(super) runtime_scratch_dir: Option<PathBuf>,
+    pub(super) host_mount_requests: NamespaceHostMountRequests,
 }
 
 impl<'a> SubmissionRuntime<'a> {
     pub(crate) fn new(
         machine: &'a mut AgentMachine,
         agent_files: NamespaceAgentFiles,
-        mount_control: NamespaceMountControl<'a>,
-        tool_execution: NamespaceToolExecution,
-        runtime_scratch_dir: Option<PathBuf>,
+        host_mount_requests: NamespaceHostMountRequests,
     ) -> Self {
         Self {
             machine,
             agent_files,
-            mount_control,
-            tool_execution,
-            runtime_scratch_dir,
+            host_mount_requests,
         }
     }
 }

--- a/crates/agent-engine/src/runtime/submission_handlers/runtime_inputs.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/runtime_inputs.rs
@@ -1,7 +1,18 @@
 use crate::{
-    agent_machine::AgentMachine,
-    runtime::transition::{NamespaceAgentFiles, NamespaceHostMountRequests, NamespaceMountControl},
+    agent_machine::{AgentMachine, PendingHostMountRequest},
+    runtime::{
+        transition::{
+            HostMountTerminalResult, NamespaceAgentFiles, NamespaceHostMountRequests,
+            NamespaceMountControl,
+        },
+        turn_support::{
+            cancel_current_task, preserve_approved_host_mount,
+            reset_turn_after_cancelling_host_mounts,
+        },
+    },
 };
+use alan_agent_protocol::Event;
+use anyhow::Result;
 
 /// Explicit inputs for classifying and applying one non-compaction runtime operation.
 pub(crate) struct SubmissionRuntime<'a> {
@@ -26,13 +37,35 @@ impl<'a> SubmissionRuntime<'a> {
         }
     }
 
-    pub(super) fn record_projected_host_mount(
+    pub(super) async fn cancel_current_task<E, F>(&mut self, emit: &mut E) -> Result<()>
+    where
+        E: FnMut(Event) -> F,
+        F: std::future::Future<Output = ()>,
+    {
+        cancel_current_task(
+            self.machine,
+            &self.agent_files,
+            &self.host_mount_requests,
+            Some(&mut self.mount_control),
+            emit,
+        )
+        .await
+    }
+
+    pub(super) async fn reset_turn_after_cancelling_host_mounts(&mut self) -> Result<()> {
+        reset_turn_after_cancelling_host_mounts(
+            self.machine,
+            &self.host_mount_requests,
+            Some(&mut self.mount_control),
+        )
+        .await
+    }
+
+    pub(super) fn preserve_approved_host_mount(
         &mut self,
-        grant_reference: String,
-        namespace_path: String,
-        access: alan_kernel::Access,
-    ) {
-        self.mount_control
-            .record_projected_host_mount(grant_reference, namespace_path, access);
+        pending: &PendingHostMountRequest,
+        terminal: &HostMountTerminalResult,
+    ) -> Result<()> {
+        preserve_approved_host_mount(Some(&mut self.mount_control), pending, terminal)
     }
 }

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/confirmation_and_mount_support.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/confirmation_and_mount_support.inc.rs
@@ -1,74 +1,23 @@
-    use std::sync::{Arc, Mutex};
+    use std::sync::Arc;
 
     use super::*;
     use crate::{
         agent_machine::AgentMachine,
         config::Config,
         rollout::{RolloutItem, RolloutRecorder},
-        runtime::{MountGrantApplicator, NamespaceRuntimeEnvironment, RuntimeConfig},
+        runtime::{NamespaceRuntimeEnvironment, RuntimeConfig},
         tape::ContentPart,
         tools::ToolRegistry,
     };
+    use crate::runtime::test_host_mount::TestHostMountFs;
     use crate::runtime::transition::RuntimeLoopState;
     use alan_ap::InProcessTransport;
     use alan_kernel::{Access, MountFs, Namespace, ProcFs};
     use alan_shell::Shell;
     use tempfile::TempDir;
 
-    #[derive(Debug, Default)]
-    struct RecordingMountGrantApplicator {
-        grants: Mutex<Vec<ApprovedMountGrant>>,
-        fail_with: Option<&'static str>,
-    }
-
-    impl RecordingMountGrantApplicator {
-        fn failing(message: &'static str) -> Self {
-            Self {
-                grants: Mutex::new(Vec::new()),
-                fail_with: Some(message),
-            }
-        }
-
-        fn grants(&self) -> Vec<ApprovedMountGrant> {
-            self.grants.lock().unwrap().clone()
-        }
-    }
-
-    impl MountGrantApplicator for RecordingMountGrantApplicator {
-        fn apply_mount_grant(&self, grant: &ApprovedMountGrant) -> Result<Namespace> {
-            self.grants.lock().unwrap().push(grant.clone());
-            if let Some(message) = self.fail_with {
-                anyhow::bail!(message);
-            }
-            let access = match grant.access {
-                ApprovedMountGrantAccess::ReadOnly => Access::ReadOnly,
-                ApprovedMountGrantAccess::ReadWrite => Access::ReadWrite,
-            };
-            let mut namespace = Namespace::new();
-            namespace.mount(
-                &grant.namespace_path,
-                InProcessTransport::new(Arc::new(alan_ap::reference::MemFs::new())),
-                access,
-            );
-            Ok(namespace)
-        }
-    }
-
-    fn namespace_environment_for_test() -> NamespaceRuntimeEnvironment {
-        let mut namespace = Namespace::new();
-        namespace.mount(
-            "/agent/1",
-            InProcessTransport::new(Arc::new(alan_agentfs::AgentFs::new())),
-            Access::ReadWrite,
-        );
-        let root = InProcessTransport::new(Arc::new(MountFs::new(namespace)));
-        attach_test_process_context(NamespaceRuntimeEnvironment::new(
-            root, "/agent/1", "default",
-        ))
-    }
-
-    fn namespace_environment_with_mount_applicator_for_test(
-        applicator: Arc<dyn MountGrantApplicator>,
+    fn namespace_environment_for_test_with_host_mount(
+        host_mount: Arc<TestHostMountFs>,
     ) -> NamespaceRuntimeEnvironment {
         let mut namespace = Namespace::new();
         namespace.mount(
@@ -76,11 +25,18 @@
             InProcessTransport::new(Arc::new(alan_agentfs::AgentFs::new())),
             Access::ReadWrite,
         );
+        namespace.mount(
+            "/mnt/host-mount",
+            InProcessTransport::new(host_mount),
+            Access::ReadWrite,
+        );
         let root = InProcessTransport::new(Arc::new(MountFs::new(namespace)));
-        attach_test_process_context(
-            NamespaceRuntimeEnvironment::new(root, "/agent/1", "default")
-                .with_mount_grant_applicator(applicator),
-        )
+        attach_test_process_context(NamespaceRuntimeEnvironment::new(
+            root, "/agent/1", "default",
+        ))
+    }
+    fn namespace_environment_for_test() -> NamespaceRuntimeEnvironment {
+        namespace_environment_for_test_with_host_mount(TestHostMountFs::new())
     }
 
     fn attach_test_process_context(
@@ -99,6 +55,11 @@
         namespace.mount(
             "/agent/1",
             InProcessTransport::new(agentfs),
+            Access::ReadWrite,
+        );
+        namespace.mount(
+            "/mnt/host-mount",
+            InProcessTransport::new(TestHostMountFs::new()),
             Access::ReadWrite,
         );
         let root = InProcessTransport::new(Arc::new(MountFs::new(namespace)));
@@ -128,55 +89,12 @@
         }
     }
 
-    fn bind_test_source_mount(state: &mut RuntimeLoopState, source: &std::path::Path) {
-        let launch_context = crate::ProcessLaunchContext::new(
-            Namespace::new(),
-            alan_kernel::Credentials::user("test-agent"),
-            "/mnt/source",
-        )
-        .unwrap()
-        .with_host_mount(
-            crate::HostMountGrant::new("/mnt/source", source, alan_kernel::Access::ReadWrite)
-                .unwrap(),
-        );
-        state.environment = state
-            .environment
-            .clone()
-            .with_launch_context(launch_context.clone());
-        assert!(
-            state.tool_execution().set_execution_binding(
-                crate::tools::ToolExecutionBinding::from_launch_context(
-                    &launch_context,
-                    source.join("scratch"),
-                )
-                .unwrap(),
-            )
-        );
-    }
-
-    fn mount_escalation_pending_confirmation_with(
-        host_path: &str,
-        access: &str,
-        reason: &str,
-    ) -> crate::approval::PendingConfirmation {
-        crate::approval::PendingConfirmation {
-            checkpoint_id: "mount_escalation_call_mount".to_string(),
-            checkpoint_type: crate::approval::MOUNT_ESCALATION_CHECKPOINT_TYPE.to_string(),
-            summary: "Approve host mount?".to_string(),
-            details: json!({
-                "kind": "mount_escalation",
-                "tool_call_id": "call_mount",
-                "tool_name": "request_mount",
-                "mount_request": {
-                    "namespace_path": "/mnt/project",
-                    "host_path": host_path,
-                    "access": access,
-                    "reason": reason
-                },
-                "live_applied": false
-            }),
-            options: vec!["approve".to_string(), "reject".to_string()],
-        }
+    fn create_test_state_with_host_mount() -> (RuntimeLoopState, Arc<TestHostMountFs>) {
+        let host_mount = TestHostMountFs::new();
+        let mut state = create_test_state();
+        state.environment =
+            namespace_environment_for_test_with_host_mount(host_mount.clone());
+        (state, host_mount)
     }
 
     fn tool_result_text_for_call(state: &RuntimeLoopState, call_id: &str) -> String {
@@ -600,161 +518,4 @@
             .expect("expected persisted runtime confirmation checkpoint");
         assert_eq!(checkpoint.choice.as_deref(), Some("rejected"));
         assert!(checkpoint.knowledge_root.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_handle_mount_escalation_resume_approve_records_grant_and_tool_result() {
-        let temp = TempDir::new().unwrap();
-        let host_mount_root = TempDir::new().unwrap();
-        let approved_host = TempDir::new().unwrap();
-        let mut state = create_test_state();
-        state.machine =
-            AgentMachine::new_with_recorder_in_dir("mount-approve", "test-model", temp.path())
-                .await
-                .unwrap();
-        bind_test_source_mount(&mut state, host_mount_root.path());
-        state
-            .machine
-            .set_confirmation(mount_escalation_pending_confirmation_with(
-                approved_host.path().to_str().unwrap(),
-                "read_write",
-                "Need to edit project files",
-            ));
-        let cancel = CancellationToken::new();
-
-        let mut emit = |_event: Event| async {};
-        let op = Op::Resume {
-            request_id: "mount_escalation_call_mount".to_string(),
-            content: vec![ContentPart::structured(json!({"choice": "approve"}))],
-        };
-
-        let result = handle_runtime_op_with_cancel(&mut state, op, &mut emit, &cancel).await;
-        assert!(result.is_ok());
-        assert!(matches!(
-            result.unwrap(),
-            RuntimeOpAction::RunTurn {
-                turn_kind: TurnRunKind::ResumeTurn,
-                ..
-            }
-        ));
-
-        let tool_result = tool_result_json_for_call(&state, "call_mount");
-        assert_eq!(tool_result["status"], "approved");
-        assert_eq!(tool_result["tool_sandbox_applied"], false);
-        assert_eq!(tool_result["tool_sandbox_projection_changed"], false);
-        assert_eq!(tool_result["namespace_applied"], false);
-        assert_eq!(
-            tool_result["namespace_error"],
-            "live namespace mount applicator unavailable"
-        );
-        assert_eq!(tool_result["live_applied"], false);
-        assert_eq!(
-            tool_result["mount_request"]["namespace_path"],
-            "/mnt/project"
-        );
-        let roots = state.tool_execution().sandbox_writable_roots();
-        assert_eq!(
-            roots,
-            vec![dunce::canonicalize(host_mount_root.path()).unwrap()]
-        );
-
-        state.machine.flush().await;
-        let rollout_path = state.machine.rollout_path().unwrap().clone();
-        let items = RolloutRecorder::load_history(&rollout_path).await.unwrap();
-        let grant = items
-            .iter()
-            .find_map(|item| match item {
-                RolloutItem::Event(event) if event.event_type == "host_mount_grant" => Some(event),
-                _ => None,
-            })
-            .expect("expected approved mount grant event");
-        assert_eq!(grant.payload["namespace_path"], "/mnt/project");
-        assert_eq!(
-            grant.payload["host_path"],
-            approved_host.path().to_str().unwrap()
-        );
-        assert_eq!(grant.payload["access"], "read_write");
-        assert_eq!(grant.payload["reason"], "Need to edit project files");
-        assert_eq!(
-            grant.payload["checkpoint_id"],
-            "mount_escalation_call_mount"
-        );
-        assert_eq!(grant.payload["approved"], true);
-        assert_eq!(grant.payload["live_applied"], false);
-        assert_eq!(grant.payload["namespace_applied"], false);
-        assert_eq!(
-            grant.payload["namespace_error"],
-            "live namespace mount applicator unavailable"
-        );
-        assert_eq!(grant.payload["tool_sandbox_applied"], false);
-        assert_eq!(grant.payload["tool_sandbox_projection_changed"], false);
-        assert_eq!(grant.payload["tool_call_id"], "call_mount");
-    }
-
-    #[tokio::test]
-    async fn test_handle_mount_escalation_resume_applies_namespace_with_applicator() {
-        let host_mount_root = TempDir::new().unwrap();
-        let approved_host = TempDir::new().unwrap();
-        let applicator = Arc::new(RecordingMountGrantApplicator::default());
-        let mut state = create_test_state();
-        state.environment =
-            namespace_environment_with_mount_applicator_for_test(applicator.clone());
-        bind_test_source_mount(&mut state, host_mount_root.path());
-        state
-            .machine
-            .set_confirmation(mount_escalation_pending_confirmation_with(
-                approved_host.path().to_str().unwrap(),
-                "read_write",
-                "Need to edit project files",
-            ));
-        let cancel = CancellationToken::new();
-        let mut emit = |_event: Event| async {};
-
-        handle_runtime_op_with_cancel(
-            &mut state,
-            Op::Resume {
-                request_id: "mount_escalation_call_mount".to_string(),
-                content: vec![ContentPart::structured(json!({"choice": "approve"}))],
-            },
-            &mut emit,
-            &cancel,
-        )
-        .await
-        .unwrap();
-
-        let tool_result = tool_result_json_for_call(&state, "call_mount");
-        assert_eq!(tool_result["namespace_applied"], true);
-        assert_eq!(tool_result["namespace_error"], serde_json::Value::Null);
-        assert_eq!(tool_result["tool_sandbox_applied"], true);
-        assert_eq!(tool_result["tool_sandbox_projection_changed"], true);
-        assert_eq!(
-            state.tool_execution().sandbox_writable_roots(),
-            vec![
-                dunce::canonicalize(host_mount_root.path()).unwrap(),
-                dunce::canonicalize(approved_host.path()).unwrap()
-            ]
-        );
-        let grants = applicator.grants();
-        assert_eq!(grants.len(), 1);
-        assert_eq!(grants[0].namespace_path, "/mnt/project");
-        assert_eq!(grants[0].host_path, approved_host.path());
-        assert_eq!(grants[0].access, ApprovedMountGrantAccess::ReadWrite);
-        assert_eq!(grants[0].reason, "Need to edit project files");
-
-        let child_context = state
-            .child_launch()
-            .launch_context()
-            .expect("approved grant should persist in the Process Launch Context")
-            .child();
-        assert_eq!(
-            child_context.host_path("/mnt/project/file.txt"),
-            Some(approved_host.path().join("file.txt"))
-        );
-        assert!(
-            child_context
-                .namespace
-                .describe()
-                .iter()
-                .any(|(path, access)| path == "/mnt/project" && *access == Access::ReadWrite)
-        );
     }

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
@@ -93,6 +93,56 @@
     }
 
     #[tokio::test]
+    async fn new_turn_retains_host_mount_when_approval_wins_cancellation_race() {
+        let (mut state, host_mount, request_id) = pending_host_mount_state().await;
+        state.environment = state
+            .environment
+            .clone()
+            .with_launch_context(crate::ProcessLaunchContext::root());
+        host_mount
+            .settle(&request_id, "approved", Some("grant-race-winner"), None)
+            .await;
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+
+        let action = handle_runtime_op_with_cancel(
+            &mut state,
+            Op::Turn {
+                parts: vec![ContentPart::text("Start over")],
+                context: None,
+            },
+            &mut emit,
+            &cancel,
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            action,
+            RuntimeOpAction::RunTurn {
+                turn_kind: TurnRunKind::NewTurn,
+                ..
+            }
+        ));
+        assert!(state.machine.pending_host_mount(&request_id).is_none());
+        assert_eq!(host_mount.status(&request_id).await.as_deref(), Some("approved"));
+        let launch_context = state
+            .environment
+            .child_launch()
+            .launch_context()
+            .unwrap()
+            .clone();
+        assert_eq!(
+            launch_context.projected_host_mounts(),
+            vec![("/mnt/project".to_string(), alan_kernel::Access::ReadWrite)]
+        );
+        assert_eq!(
+            launch_context.projected_host_mount_references(),
+            vec!["grant-race-winner".to_string()]
+        );
+    }
+
+    #[tokio::test]
     async fn approved_service_request_resumes_with_opaque_grant_only() {
         let (mut state, host_mount, request_id) = pending_host_mount_state().await;
         state.environment = state

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
@@ -66,6 +66,10 @@
     #[tokio::test]
     async fn approved_service_request_resumes_with_opaque_grant_only() {
         let (mut state, host_mount, request_id) = pending_host_mount_state().await;
+        state.environment = state
+            .environment
+            .clone()
+            .with_launch_context(crate::ProcessLaunchContext::root());
         host_mount
             .settle(&request_id, "approved", Some("grant-opaque-1"), None)
             .await;
@@ -101,6 +105,15 @@
         assert!(!result.to_string().contains("host_path"));
         assert!(result.get("namespace_applied").is_none());
         assert!(result.get("tool_sandbox_applied").is_none());
+        assert_eq!(
+            state
+                .environment
+                .child_launch()
+                .launch_context()
+                .unwrap()
+                .projected_host_mounts(),
+            vec![("/mnt/project".to_string(), alan_kernel::Access::ReadWrite)]
+        );
     }
 
     #[tokio::test]

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
@@ -1,33 +1,46 @@
-
-    #[tokio::test]
-    async fn test_first_approved_mount_creates_process_tool_binding() {
-        let system_store = TempDir::new().unwrap();
-        let approved_host = TempDir::new().unwrap();
-        let applicator = Arc::new(RecordingMountGrantApplicator::default());
-        let mut state = create_test_state();
-        state.environment = namespace_environment_with_mount_applicator_for_test(applicator)
-            .with_launch_context(crate::ProcessLaunchContext::root());
-        state.runtime_config.store_bindings = Some(crate::AgentRuntimeStoreBindings {
-            rollouts: system_store.path().join("rollouts"),
-            checkpoints: system_store.path().join("checkpoints"),
-            cache: system_store.path().join("cache"),
-            tmp: system_store.path().join("tmp"),
-            metadata: system_store.path().join("metadata"),
+    async fn pending_host_mount_state(
+    ) -> (RuntimeLoopState, Arc<TestHostMountFs>, String) {
+        let (mut state, host_mount) = create_test_state_with_host_mount();
+        let request = json!({
+            "namespace_path": "/mnt/project",
+            "access": "read_write",
+            "reason": "Need project files",
+            "label": "Project"
         });
-        state
-            .machine
-            .set_confirmation(mount_escalation_pending_confirmation_with(
-                approved_host.path().to_str().unwrap(),
-                "read_write",
-                "Need project files",
-            ));
-        let cancel = CancellationToken::new();
-        let mut emit = |_event: Event| async {};
+        let request_id = state
+            .environment
+            .host_mount_requests()
+            .create(&serde_json::to_vec(&request).unwrap())
+            .await
+            .unwrap();
+        state.machine.set_host_mount_request(
+            crate::agent_machine::PendingHostMountRequest {
+                request_id: request_id.clone(),
+                tool_call_id: "call_mount".to_string(),
+                namespace_path: "/mnt/project".to_string(),
+                access: "read_write".to_string(),
+                reason: "Need project files".to_string(),
+                label: Some("Project".to_string()),
+                request_events_offset: 0,
+            },
+        );
+        (state, host_mount, request_id)
+    }
 
-        handle_runtime_op_with_cancel(
+    #[tokio::test]
+    async fn agent_resume_cannot_approve_pending_host_mount() {
+        let (mut state, _host_mount, request_id) = pending_host_mount_state().await;
+        let cancel = CancellationToken::new();
+        let mut events = Vec::new();
+        let mut emit = |event: Event| {
+            events.push(event);
+            async {}
+        };
+
+        let action = handle_runtime_op_with_cancel(
             &mut state,
             Op::Resume {
-                request_id: "mount_escalation_call_mount".to_string(),
+                request_id: request_id.clone(),
                 content: vec![ContentPart::structured(json!({"choice": "approve"}))],
             },
             &mut emit,
@@ -36,447 +49,96 @@
         .await
         .unwrap();
 
-        let binding = state
-            .tool_execution()
-            .execution_binding()
-            .expect("first approved Host Mount should create a Tool binding");
-        assert_eq!(
-            binding.cwd,
-            dunce::canonicalize(approved_host.path()).unwrap()
-        );
-        assert_eq!(binding.namespace_cwd, std::path::Path::new("/mnt/project"));
-        assert_eq!(
-            state
-                .child_launch()
-                .launch_context()
-                .expect("the Process Launch Context should remain available")
-                .cwd,
-            "/"
-        );
-        assert_eq!(binding.host_mounts.len(), 1);
-        assert_eq!(binding.host_mounts[0].namespace_path, "/mnt/project");
-        assert_eq!(
-            binding.host_mounts[0].resolve_host_path("/mnt/project/file.txt"),
-            Some(approved_host.path().join("file.txt"))
-        );
-        let sandbox = binding.sandbox_spec.as_ref().unwrap();
-        assert!(
-            !sandbox
-                .readable_roots
-                .iter()
-                .any(|root| root == &system_store.path().join("tmp"))
-        );
-        let execution = crate::tools::Sandbox::from_spec_with_backend(
-            sandbox.clone(),
-            crate::tools::SandboxBackendKind::HostMountPathGuard,
+        assert!(matches!(action, RuntimeOpAction::NoTurn));
+        assert!(state.machine.pending_host_mount(&request_id).is_some());
+        assert!(events.iter().any(|event| matches!(
+            event,
+            Event::Error { message, recoverable }
+                if *recoverable && message.contains("only Host Mount Service can settle")
+        )));
+        assert!(state
+            .machine
+            .messages()
+            .iter()
+            .all(|message| !matches!(message, crate::tape::Message::Tool { .. })));
+    }
+
+    #[tokio::test]
+    async fn approved_service_request_resumes_with_opaque_grant_only() {
+        let (mut state, host_mount, request_id) = pending_host_mount_state().await;
+        host_mount
+            .settle(&request_id, "approved", Some("grant-opaque-1"), None)
+            .await;
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+
+        let action = handle_runtime_op_with_cancel(
+            &mut state,
+            Op::Resume {
+                request_id: request_id.clone(),
+                content: vec![ContentPart::structured(json!({"choice": "reject"}))],
+            },
+            &mut emit,
+            &cancel,
         )
-        .exec("pwd", &binding.cwd)
         .await
         .unwrap();
-        assert_eq!(execution.exit_code, 0, "{execution:?}");
-        assert_eq!(
-            execution.stdout.trim(),
-            binding.cwd.to_string_lossy().as_ref()
-        );
+
+        assert!(matches!(
+            action,
+            RuntimeOpAction::RunTurn {
+                turn_kind: TurnRunKind::ResumeTurn,
+                ..
+            }
+        ));
+        assert!(state.machine.pending_host_mount(&request_id).is_none());
         let result = tool_result_json_for_call(&state, "call_mount");
-        assert_eq!(result["tool_sandbox_applied"], true);
-        assert_eq!(result["tool_sandbox_projection_changed"], true);
+        assert_eq!(result["status"], "approved");
+        assert_eq!(result["approved"], true);
+        assert_eq!(result["request_reference"], request_id);
+        assert_eq!(result["grant_reference"], "grant-opaque-1");
+        assert_eq!(result["namespace_path"], "/mnt/project");
+        assert!(!result.to_string().contains("host_path"));
+        assert!(result.get("namespace_applied").is_none());
+        assert!(result.get("tool_sandbox_applied").is_none());
     }
 
     #[tokio::test]
-    async fn test_handle_mount_escalation_resume_read_only_applies_namespace_only() {
-        let host_mount_root = TempDir::new().unwrap();
-        let approved_host = TempDir::new().unwrap();
-        let applicator = Arc::new(RecordingMountGrantApplicator::default());
-        let mut state = create_test_state();
-        state.environment =
-            namespace_environment_with_mount_applicator_for_test(applicator.clone());
-        bind_test_source_mount(&mut state, host_mount_root.path());
-        state
-            .machine
-            .set_confirmation(mount_escalation_pending_confirmation_with(
-                approved_host.path().to_str().unwrap(),
-                "read_only",
-                "Need to inspect project files",
-            ));
-        let cancel = CancellationToken::new();
-        let mut emit = |_event: Event| async {};
+    async fn every_non_approval_terminal_status_resumes_without_grant() {
+        for status in ["rejected", "cancelled", "failed"] {
+            let (mut state, host_mount, request_id) = pending_host_mount_state().await;
+            host_mount
+                .settle(&request_id, status, None, Some("Host authorization did not complete"))
+                .await;
+            let cancel = CancellationToken::new();
+            let mut emit = |_event: Event| async {};
 
-        handle_runtime_op_with_cancel(
-            &mut state,
-            Op::Resume {
-                request_id: "mount_escalation_call_mount".to_string(),
-                content: vec![ContentPart::structured(json!({"choice": "approve"}))],
-            },
-            &mut emit,
-            &cancel,
-        )
-        .await
-        .unwrap();
-
-        let tool_result = tool_result_json_for_call(&state, "call_mount");
-        assert_eq!(tool_result["namespace_applied"], true);
-        assert_eq!(tool_result["tool_sandbox_applied"], true);
-        assert_eq!(tool_result["tool_sandbox_projection_changed"], true);
-        assert_eq!(
-            state.tool_execution().sandbox_writable_roots(),
-            vec![dunce::canonicalize(host_mount_root.path()).unwrap()]
-        );
-        let grants = applicator.grants();
-        assert_eq!(grants.len(), 1);
-        assert_eq!(grants[0].access, ApprovedMountGrantAccess::ReadOnly);
-    }
-
-    #[tokio::test]
-    async fn test_handle_mount_escalation_resume_reports_namespace_apply_failure() {
-        let host_mount_root = TempDir::new().unwrap();
-        let approved_host = TempDir::new().unwrap();
-        let applicator = Arc::new(RecordingMountGrantApplicator::failing("mount failed"));
-        let mut state = create_test_state();
-        state.environment =
-            namespace_environment_with_mount_applicator_for_test(applicator.clone());
-        bind_test_source_mount(&mut state, host_mount_root.path());
-        state
-            .machine
-            .set_confirmation(mount_escalation_pending_confirmation_with(
-                approved_host.path().to_str().unwrap(),
-                "read_write",
-                "Need to edit project files",
-            ));
-        let cancel = CancellationToken::new();
-        let mut emit = |_event: Event| async {};
-
-        handle_runtime_op_with_cancel(
-            &mut state,
-            Op::Resume {
-                request_id: "mount_escalation_call_mount".to_string(),
-                content: vec![ContentPart::structured(json!({"choice": "approve"}))],
-            },
-            &mut emit,
-            &cancel,
-        )
-        .await
-        .unwrap();
-
-        let tool_result = tool_result_json_for_call(&state, "call_mount");
-        assert_eq!(tool_result["namespace_applied"], false);
-        assert_eq!(tool_result["namespace_error"], "mount failed");
-        assert_eq!(tool_result["tool_sandbox_applied"], false);
-        assert_eq!(tool_result["tool_sandbox_projection_changed"], false);
-        assert_eq!(
-            state.tool_execution().sandbox_writable_roots(),
-            vec![dunce::canonicalize(host_mount_root.path()).unwrap()]
-        );
-        let grants = applicator.grants();
-        assert_eq!(grants.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn test_handle_mount_escalation_resume_duplicate_read_write_grant_is_idempotent() {
-        let host_mount_root = TempDir::new().unwrap();
-        let approved_host = TempDir::new().unwrap();
-        let applicator = Arc::new(RecordingMountGrantApplicator::default());
-        let mut state = create_test_state();
-        state.environment = namespace_environment_with_mount_applicator_for_test(applicator);
-        bind_test_source_mount(&mut state, host_mount_root.path());
-        let cancel = CancellationToken::new();
-        let mut emit = |_event: Event| async {};
-
-        for _ in 0..2 {
-            state
-                .machine
-                .set_confirmation(mount_escalation_pending_confirmation_with(
-                    approved_host.path().to_str().unwrap(),
-                    "read_write",
-                    "Need to edit project files",
-                ));
-            handle_runtime_op_with_cancel(
+            let action = handle_runtime_op_with_cancel(
                 &mut state,
                 Op::Resume {
-                    request_id: "mount_escalation_call_mount".to_string(),
-                    content: vec![ContentPart::structured(json!({"choice": "approve"}))],
+                    request_id: request_id.clone(),
+                    content: Vec::new(),
                 },
                 &mut emit,
                 &cancel,
             )
             .await
             .unwrap();
+
+            assert!(matches!(
+                action,
+                RuntimeOpAction::RunTurn {
+                    turn_kind: TurnRunKind::ResumeTurn,
+                    ..
+                }
+            ));
+            let result = tool_result_json_for_call(&state, "call_mount");
+            assert_eq!(result["status"], status);
+            assert_eq!(result["approved"], false);
+            assert!(result["grant_reference"].is_null());
+            assert_eq!(result["error"], "Host authorization did not complete");
         }
-
-        let roots = state.tool_execution().sandbox_writable_roots();
-        assert_eq!(
-            roots,
-            vec![
-                dunce::canonicalize(host_mount_root.path()).unwrap(),
-                dunce::canonicalize(approved_host.path()).unwrap()
-            ]
-        );
-        let latest = tool_result_json_for_call(&state, "call_mount");
-        assert_eq!(latest["tool_sandbox_applied"], true);
-        assert_eq!(latest["tool_sandbox_projection_changed"], false);
     }
-
-    #[tokio::test]
-    async fn test_reapproved_namespace_path_replaces_persisted_host_grant() {
-        let host_mount_root = TempDir::new().unwrap();
-        let first_host = TempDir::new().unwrap();
-        let replacement_host = TempDir::new().unwrap();
-        let applicator = Arc::new(RecordingMountGrantApplicator::default());
-        let mut state = create_test_state();
-        state.environment = namespace_environment_with_mount_applicator_for_test(applicator);
-        bind_test_source_mount(&mut state, host_mount_root.path());
-        let cancel = CancellationToken::new();
-        let mut emit = |_event: Event| async {};
-
-        for host in [first_host.path(), replacement_host.path()] {
-            state
-                .machine
-                .set_confirmation(mount_escalation_pending_confirmation_with(
-                    host.to_str().unwrap(),
-                    "read_write",
-                    "Replace project mount",
-                ));
-            handle_runtime_op_with_cancel(
-                &mut state,
-                Op::Resume {
-                    request_id: "mount_escalation_call_mount".to_string(),
-                    content: vec![ContentPart::structured(json!({"choice": "approve"}))],
-                },
-                &mut emit,
-                &cancel,
-            )
-            .await
-            .unwrap();
-        }
-
-        let launch_context = state
-            .child_launch()
-            .launch_context()
-            .cloned()
-            .expect("approved grant should remain in the Process Launch Context");
-        assert_eq!(
-            launch_context.host_path("/mnt/project/file.txt"),
-            Some(replacement_host.path().join("file.txt"))
-        );
-        assert_eq!(
-            state.tool_execution().sandbox_writable_roots(),
-            vec![
-                dunce::canonicalize(host_mount_root.path()).unwrap(),
-                dunce::canonicalize(replacement_host.path()).unwrap()
-            ]
-        );
-        let latest = tool_result_json_for_call(&state, "call_mount");
-        assert_eq!(latest["tool_sandbox_applied"], true);
-        assert_eq!(latest["tool_sandbox_projection_changed"], true);
-    }
-
-    #[tokio::test]
-    async fn test_handle_mount_escalation_resume_read_only_grant_does_not_expand_tool_sandbox() {
-        let host_mount_root = TempDir::new().unwrap();
-        let approved_host = TempDir::new().unwrap();
-        let applicator = Arc::new(RecordingMountGrantApplicator::default());
-        let mut state = create_test_state();
-        state.environment = namespace_environment_with_mount_applicator_for_test(applicator);
-        bind_test_source_mount(&mut state, host_mount_root.path());
-        state
-            .machine
-            .set_confirmation(mount_escalation_pending_confirmation_with(
-                approved_host.path().to_str().unwrap(),
-                "read_only",
-                "Need to inspect project files",
-            ));
-        let cancel = CancellationToken::new();
-        let mut emit = |_event: Event| async {};
-
-        let result = handle_runtime_op_with_cancel(
-            &mut state,
-            Op::Resume {
-                request_id: "mount_escalation_call_mount".to_string(),
-                content: vec![ContentPart::structured(json!({"choice": "approve"}))],
-            },
-            &mut emit,
-            &cancel,
-        )
-        .await;
-        assert!(result.is_ok());
-
-        let tool_result = tool_result_json_for_call(&state, "call_mount");
-        assert_eq!(tool_result["status"], "approved");
-        assert_eq!(tool_result["tool_sandbox_applied"], true);
-        assert_eq!(tool_result["tool_sandbox_projection_changed"], true);
-        assert_eq!(
-            state.tool_execution().sandbox_writable_roots(),
-            vec![dunce::canonicalize(host_mount_root.path()).unwrap()]
-        );
-    }
-
-    #[tokio::test]
-    async fn test_handle_mount_escalation_resume_reject_returns_tool_result_without_grant() {
-        let temp = TempDir::new().unwrap();
-        let host_mount_root = TempDir::new().unwrap();
-        let approved_host = TempDir::new().unwrap();
-        let mut state = create_test_state();
-        state.machine =
-            AgentMachine::new_with_recorder_in_dir("mount-reject", "test-model", temp.path())
-                .await
-                .unwrap();
-        bind_test_source_mount(&mut state, host_mount_root.path());
-        state
-            .machine
-            .set_confirmation(mount_escalation_pending_confirmation_with(
-                approved_host.path().to_str().unwrap(),
-                "read_write",
-                "Need to edit project files",
-            ));
-        let cancel = CancellationToken::new();
-
-        let mut emit = |_event: Event| async {};
-        let op = Op::Resume {
-            request_id: "mount_escalation_call_mount".to_string(),
-            content: vec![ContentPart::structured(json!({"choice": "reject"}))],
-        };
-
-        let result = handle_runtime_op_with_cancel(&mut state, op, &mut emit, &cancel).await;
-        assert!(result.is_ok());
-        assert!(matches!(
-            result.unwrap(),
-            RuntimeOpAction::RunTurn {
-                turn_kind: TurnRunKind::ResumeTurn,
-                ..
-            }
-        ));
-
-        let tool_result = tool_result_json_for_call(&state, "call_mount");
-        assert_eq!(tool_result["status"], "rejected");
-        assert_eq!(tool_result["approved"], false);
-        assert_eq!(tool_result["tool_sandbox_applied"], false);
-        assert_eq!(tool_result["tool_sandbox_projection_changed"], false);
-        assert_eq!(tool_result["live_applied"], false);
-        assert_eq!(
-            state.tool_execution().sandbox_writable_roots(),
-            vec![dunce::canonicalize(host_mount_root.path()).unwrap()]
-        );
-
-        state.machine.flush().await;
-        let rollout_path = state.machine.rollout_path().unwrap().clone();
-        let items = RolloutRecorder::load_history(&rollout_path).await.unwrap();
-        assert!(!items.iter().any(|item| matches!(
-            item,
-            RolloutItem::Event(event) if event.event_type == "host_mount_grant"
-        )));
-    }
-
-    #[tokio::test]
-    async fn test_handle_mount_escalation_resume_missing_choice_defaults_to_reject() {
-        let temp = TempDir::new().unwrap();
-        let mut state = create_test_state();
-        state.machine = AgentMachine::new_with_recorder_in_dir(
-            "mount-default-reject",
-            "test-model",
-            temp.path(),
-        )
-        .await
-        .unwrap();
-        let host_path = std::fs::canonicalize(std::env::current_dir().unwrap()).unwrap();
-        let host_path = host_path.display().to_string();
-        state
-            .machine
-            .set_confirmation(mount_escalation_pending_confirmation_with(
-                &host_path,
-                "read_write",
-                "Need to edit project files",
-            ));
-        let cancel = CancellationToken::new();
-
-        let mut emit = |_event: Event| async {};
-        let op = Op::Resume {
-            request_id: "mount_escalation_call_mount".to_string(),
-            content: vec![ContentPart::structured(json!({}))],
-        };
-
-        let result = handle_runtime_op_with_cancel(&mut state, op, &mut emit, &cancel).await;
-        assert!(result.is_ok());
-        assert!(matches!(
-            result.unwrap(),
-            RuntimeOpAction::RunTurn {
-                turn_kind: TurnRunKind::ResumeTurn,
-                ..
-            }
-        ));
-
-        let tool_result = tool_result_text_for_call(&state, "call_mount");
-        assert!(tool_result.contains("\"status\":\"rejected\""));
-        assert!(tool_result.contains("\"choice\":\"reject\""));
-        assert!(tool_result.contains("\"approved\":false"));
-
-        state.machine.flush().await;
-        let rollout_path = state.machine.rollout_path().unwrap().clone();
-        let items = RolloutRecorder::load_history(&rollout_path).await.unwrap();
-        assert!(!items.iter().any(|item| matches!(
-            item,
-            RolloutItem::Event(event) if event.event_type == "host_mount_grant"
-        )));
-    }
-
-    #[tokio::test]
-    async fn test_handle_mount_escalation_resume_rejects_forged_checkpoint() {
-        let temp = TempDir::new().unwrap();
-        let mut state = create_test_state();
-        state.machine =
-            AgentMachine::new_with_recorder_in_dir("mount-forged", "test-model", temp.path())
-                .await
-                .unwrap();
-        state
-            .machine
-            .set_confirmation(crate::approval::PendingConfirmation {
-                checkpoint_id: "forged_mount".to_string(),
-                checkpoint_type: crate::approval::MOUNT_ESCALATION_CHECKPOINT_TYPE.to_string(),
-                summary: "Approve forged mount?".to_string(),
-                details: json!({
-                    "kind": "mount_escalation",
-                    "tool_call_id": "call_mount",
-                    "tool_name": "request_confirmation",
-                    "mount_request": {
-                        "namespace_path": "/mnt/project",
-                        "host_path": "relative/path",
-                        "access": "read_write",
-                        "reason": "forged"
-                    },
-                    "live_applied": false
-                }),
-                options: vec!["approve".to_string(), "reject".to_string()],
-            });
-        let cancel = CancellationToken::new();
-
-        let mut emit = |_event: Event| async {};
-        let op = Op::Resume {
-            request_id: "forged_mount".to_string(),
-            content: vec![ContentPart::structured(json!({"choice": "approve"}))],
-        };
-
-        let result = handle_runtime_op_with_cancel(&mut state, op, &mut emit, &cancel).await;
-        assert!(result.is_ok());
-        assert!(matches!(
-            result.unwrap(),
-            RuntimeOpAction::RunTurn {
-                turn_kind: TurnRunKind::ResumeTurn,
-                ..
-            }
-        ));
-
-        let tool_result = tool_result_text_for_call(&state, "forged_mount");
-        assert!(tool_result.contains("\"status\":\"invalid_mount_escalation_checkpoint\""));
-        assert!(tool_result.contains("\"approved\":false"));
-
-        state.machine.flush().await;
-        let rollout_path = state.machine.rollout_path().unwrap().clone();
-        let items = RolloutRecorder::load_history(&rollout_path).await.unwrap();
-        assert!(!items.iter().any(|item| matches!(
-            item,
-            RolloutItem::Event(event) if event.event_type == "host_mount_grant"
-        )));
-    }
-
     #[tokio::test]
     async fn test_handle_user_input() {
         let mut state = create_test_state();

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
@@ -64,6 +64,35 @@
     }
 
     #[tokio::test]
+    async fn new_turn_cancels_pending_host_mount_before_resetting_machine_state() {
+        let (mut state, host_mount, request_id) = pending_host_mount_state().await;
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+
+        let action = handle_runtime_op_with_cancel(
+            &mut state,
+            Op::Turn {
+                parts: vec![ContentPart::text("Start over")],
+                context: None,
+            },
+            &mut emit,
+            &cancel,
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            action,
+            RuntimeOpAction::RunTurn {
+                turn_kind: TurnRunKind::NewTurn,
+                ..
+            }
+        ));
+        assert!(state.machine.pending_host_mount(&request_id).is_none());
+        assert_eq!(host_mount.status(&request_id).await.as_deref(), Some("cancelled"));
+    }
+
+    #[tokio::test]
     async fn approved_service_request_resumes_with_opaque_grant_only() {
         let (mut state, host_mount, request_id) = pending_host_mount_state().await;
         state.environment = state

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
@@ -114,6 +114,15 @@
                 .projected_host_mounts(),
             vec![("/mnt/project".to_string(), alan_kernel::Access::ReadWrite)]
         );
+        assert_eq!(
+            state
+                .environment
+                .child_launch()
+                .launch_context()
+                .unwrap()
+                .projected_host_mount_references(),
+            vec!["grant-opaque-1".to_string()]
+        );
     }
 
     #[tokio::test]

--- a/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
+++ b/crates/agent-engine/src/runtime/submission_handlers/tests/mount_and_user_input_contract.inc.rs
@@ -143,6 +143,60 @@
     }
 
     #[tokio::test]
+    async fn new_turn_waits_for_in_flight_host_mount_decision_before_reset() {
+        let (mut state, host_mount, request_id) = pending_host_mount_state().await;
+        state.environment = state
+            .environment
+            .clone()
+            .with_launch_context(crate::ProcessLaunchContext::root());
+        host_mount.begin_decision(&request_id).await;
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+
+        let reset = handle_runtime_op_with_cancel(
+            &mut state,
+            Op::Turn {
+                parts: vec![ContentPart::text("Start over")],
+                context: None,
+            },
+            &mut emit,
+            &cancel,
+        );
+        let settle = async {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            host_mount
+                .settle(&request_id, "approved", Some("grant-in-flight"), None)
+                .await;
+        };
+        let (action, ()) = tokio::join!(reset, settle);
+        let action = action.unwrap();
+
+        assert!(matches!(
+            action,
+            RuntimeOpAction::RunTurn {
+                turn_kind: TurnRunKind::NewTurn,
+                ..
+            }
+        ));
+        assert!(state.machine.pending_host_mount(&request_id).is_none());
+        assert_eq!(host_mount.status(&request_id).await.as_deref(), Some("approved"));
+        let launch_context = state
+            .environment
+            .child_launch()
+            .launch_context()
+            .unwrap()
+            .clone();
+        assert_eq!(
+            launch_context.projected_host_mounts(),
+            vec![("/mnt/project".to_string(), alan_kernel::Access::ReadWrite)]
+        );
+        assert_eq!(
+            launch_context.projected_host_mount_references(),
+            vec!["grant-in-flight".to_string()]
+        );
+    }
+
+    #[tokio::test]
     async fn approved_service_request_resumes_with_opaque_grant_only() {
         let (mut state, host_mount, request_id) = pending_host_mount_state().await;
         state.environment = state

--- a/crates/agent-engine/src/runtime/test_host_mount.rs
+++ b/crates/agent-engine/src/runtime/test_host_mount.rs
@@ -1,0 +1,296 @@
+use std::collections::{BTreeMap, HashMap};
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use alan_ap::{ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat};
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+#[derive(Clone, Debug)]
+struct RequestRecord {
+    document: serde_json::Value,
+    status: String,
+    grant: String,
+    error: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Node {
+    Root,
+    Requests,
+    Clone,
+    Request(String),
+    Field(String, &'static str),
+}
+
+struct FidState {
+    node: Node,
+    mode: Option<OpenMode>,
+    clone_id: Option<String>,
+    write_buf: Vec<u8>,
+    wrote: bool,
+}
+
+impl FidState {
+    fn at(node: Node) -> Self {
+        Self {
+            node,
+            mode: None,
+            clone_id: None,
+            write_buf: Vec::new(),
+            wrote: false,
+        }
+    }
+}
+
+#[derive(Default)]
+struct State {
+    next_id: u64,
+    requests: BTreeMap<String, RequestRecord>,
+    fids: HashMap<Fid, FidState>,
+}
+
+/// Test-only aP implementation of the logical request/status seam.
+pub(crate) struct TestHostMountFs {
+    state: Mutex<State>,
+}
+
+impl TestHostMountFs {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(State::default()),
+        })
+    }
+
+    pub(crate) async fn settle(
+        &self,
+        request_id: &str,
+        status: &str,
+        grant: Option<&str>,
+        error: Option<&str>,
+    ) {
+        let mut state = self.state.lock().await;
+        let request = state
+            .requests
+            .get_mut(request_id)
+            .expect("test Host Mount request exists");
+        assert_eq!(request.status, "pending", "terminal status is immutable");
+        request.status = status.to_string();
+        request.grant = grant.unwrap_or_default().to_string();
+        request.error = error.unwrap_or_default().to_string();
+    }
+
+    fn qid(node: &Node) -> Qid {
+        let (kind, key) = match node {
+            Node::Root => (FileKind::Dir, "/".to_string()),
+            Node::Requests => (FileKind::Dir, "requests".to_string()),
+            Node::Clone => (FileKind::Clone, "requests/clone".to_string()),
+            Node::Request(id) => (FileKind::Dir, format!("requests/{id}")),
+            Node::Field(id, field) => (FileKind::File, format!("requests/{id}/{field}")),
+        };
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        key.hash(&mut hasher);
+        Qid {
+            kind,
+            version: 0,
+            path: hasher.finish(),
+        }
+    }
+
+    fn bytes(state: &State, node: &Node) -> Result<Vec<u8>, ErrorCode> {
+        match node {
+            Node::Root => Ok(b"requests".to_vec()),
+            Node::Requests => {
+                let mut names = vec!["clone".to_string()];
+                names.extend(state.requests.keys().cloned());
+                Ok(names.join("\n").into_bytes())
+            }
+            Node::Request(_) => Ok(b"request\nstatus\ngrant\nerror".to_vec()),
+            Node::Field(id, field) => {
+                let request = state.requests.get(id).ok_or(ErrorCode::NotFound)?;
+                let bytes = match *field {
+                    "request" => serde_json::to_vec(&request.document).unwrap(),
+                    "status" => format!("{}\n", request.status).into_bytes(),
+                    "grant" => request.grant.as_bytes().to_vec(),
+                    "error" => request.error.as_bytes().to_vec(),
+                    _ => return Err(ErrorCode::NotFound),
+                };
+                Ok(bytes)
+            }
+            Node::Clone => Ok(Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl FileServer for TestHostMountFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        if newfid == Fid::ROOT {
+            return Err(ErrorCode::BadRequest);
+        }
+        let mut state = self.state.lock().await;
+        if state.fids.contains_key(&newfid) {
+            return Err(ErrorCode::BadRequest);
+        }
+        let mut node = if fid == Fid::ROOT {
+            Node::Root
+        } else {
+            state
+                .fids
+                .get(&fid)
+                .map(|fid| fid.node.clone())
+                .ok_or(ErrorCode::NotFound)?
+        };
+        for name in names {
+            node = match (&node, name.as_str()) {
+                (Node::Root, "requests") => Node::Requests,
+                (Node::Requests, "clone") => Node::Clone,
+                (Node::Requests, id) if state.requests.contains_key(id) => {
+                    Node::Request(id.to_string())
+                }
+                (Node::Request(id), field)
+                    if matches!(field, "request" | "status" | "grant" | "error") =>
+                {
+                    Node::Field(
+                        id.clone(),
+                        match field {
+                            "request" => "request",
+                            "status" => "status",
+                            "grant" => "grant",
+                            _ => "error",
+                        },
+                    )
+                }
+                (Node::Root | Node::Requests | Node::Request(_), _) => {
+                    return Err(ErrorCode::NotFound);
+                }
+                _ => return Err(ErrorCode::NotDirectory),
+            };
+        }
+        let qid = Self::qid(&node);
+        state.fids.insert(newfid, FidState::at(node));
+        Ok(qid)
+    }
+
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
+        if fid == Fid::ROOT {
+            return (mode == OpenMode::Read)
+                .then(|| Self::qid(&Node::Root))
+                .ok_or(ErrorCode::NoAccess);
+        }
+        let mut state = self.state.lock().await;
+        let is_clone = matches!(state.fids.get(&fid).map(|fid| &fid.node), Some(Node::Clone));
+        if (is_clone && mode != OpenMode::ReadWrite) || (!is_clone && mode != OpenMode::Read) {
+            return Err(ErrorCode::NoAccess);
+        }
+        let clone_id = if is_clone {
+            state.next_id += 1;
+            Some(format!("request-{}", state.next_id))
+        } else {
+            None
+        };
+        let fid_state = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
+        if fid_state.mode.is_some() {
+            return Err(ErrorCode::BadRequest);
+        }
+        fid_state.mode = Some(mode);
+        fid_state.clone_id = clone_id;
+        Ok(Self::qid(&fid_state.node))
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let state = self.state.lock().await;
+        let (node, clone_id, mode) = if fid == Fid::ROOT {
+            (Node::Root, None, Some(OpenMode::Read))
+        } else {
+            let fid = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+            (fid.node.clone(), fid.clone_id.clone(), fid.mode)
+        };
+        if !matches!(mode, Some(OpenMode::Read | OpenMode::ReadWrite)) {
+            return Err(ErrorCode::NoAccess);
+        }
+        let bytes = clone_id
+            .map(String::into_bytes)
+            .unwrap_or(Self::bytes(&state, &node)?);
+        Ok(slice(bytes, offset, count))
+    }
+
+    async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        let mut state = self.state.lock().await;
+        let fid = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
+        if !matches!(fid.node, Node::Clone) || fid.mode != Some(OpenMode::ReadWrite) {
+            return Err(ErrorCode::NoAccess);
+        }
+        let start = offset as usize;
+        let end = start.checked_add(data.len()).ok_or(ErrorCode::BadRequest)?;
+        if end > 64 * 1024 {
+            return Err(ErrorCode::BadRequest);
+        }
+        fid.write_buf.resize(fid.write_buf.len().max(end), 0);
+        fid.write_buf[start..end].copy_from_slice(data);
+        fid.wrote = true;
+        Ok(data.len() as u32)
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        let state = self.state.lock().await;
+        let node = if fid == Fid::ROOT {
+            Node::Root
+        } else {
+            state
+                .fids
+                .get(&fid)
+                .map(|fid| fid.node.clone())
+                .ok_or(ErrorCode::NotFound)?
+        };
+        Ok(Stat {
+            name: String::new(),
+            qid: Self::qid(&node),
+            length: Self::bytes(&state, &node)?.len() as u64,
+            executable: false,
+            writable: matches!(node, Node::Clone),
+        })
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(());
+        }
+        let mut state = self.state.lock().await;
+        let fid = state.fids.remove(&fid).ok_or(ErrorCode::NotFound)?;
+        if matches!(fid.node, Node::Clone) && fid.wrote {
+            let document =
+                serde_json::from_slice(&fid.write_buf).map_err(|_| ErrorCode::BadRequest)?;
+            state.requests.insert(
+                fid.clone_id.ok_or(ErrorCode::BadRequest)?,
+                RequestRecord {
+                    document,
+                    status: "pending".to_string(),
+                    grant: String::new(),
+                    error: String::new(),
+                },
+            );
+        }
+        Ok(())
+    }
+}
+
+fn slice(bytes: Vec<u8>, offset: Offset, count: u32) -> Vec<u8> {
+    let start = (offset as usize).min(bytes.len());
+    let end = bytes.len().min(start.saturating_add(count as usize));
+    bytes[start..end].to_vec()
+}

--- a/crates/agent-engine/src/runtime/test_host_mount.rs
+++ b/crates/agent-engine/src/runtime/test_host_mount.rs
@@ -12,6 +12,7 @@ struct RequestRecord {
     status: String,
     grant: String,
     error: String,
+    decision_in_progress: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -78,6 +79,21 @@ impl TestHostMountFs {
         request.status = status.to_string();
         request.grant = grant.unwrap_or_default().to_string();
         request.error = error.unwrap_or_default().to_string();
+        request.decision_in_progress = false;
+    }
+
+    pub(crate) async fn begin_decision(&self, request_id: &str) {
+        let mut state = self.state.lock().await;
+        let request = state
+            .requests
+            .get_mut(request_id)
+            .expect("test Host Mount request exists");
+        assert_eq!(
+            request.status, "pending",
+            "only pending requests can be claimed"
+        );
+        assert!(!request.decision_in_progress, "request is already claimed");
+        request.decision_in_progress = true;
     }
 
     pub(crate) async fn status(&self, request_id: &str) -> Option<String> {
@@ -308,6 +324,7 @@ impl FileServer for TestHostMountFs {
                             status: "pending".to_string(),
                             grant: String::new(),
                             error: String::new(),
+                            decision_in_progress: false,
                         },
                     );
                 }
@@ -322,7 +339,7 @@ impl FileServer for TestHostMountFs {
                         .requests
                         .get_mut(&request_id)
                         .ok_or(ErrorCode::NotFound)?;
-                    if request.status != "pending" {
+                    if request.status != "pending" || request.decision_in_progress {
                         return Err(ErrorCode::BadRequest);
                     }
                     request.status = "cancelled".to_string();

--- a/crates/agent-engine/src/runtime/test_host_mount.rs
+++ b/crates/agent-engine/src/runtime/test_host_mount.rs
@@ -80,6 +80,15 @@ impl TestHostMountFs {
         request.error = error.unwrap_or_default().to_string();
     }
 
+    pub(crate) async fn status(&self, request_id: &str) -> Option<String> {
+        self.state
+            .lock()
+            .await
+            .requests
+            .get(request_id)
+            .map(|request| request.status.clone())
+    }
+
     fn qid(node: &Node) -> Qid {
         let (kind, key) = match node {
             Node::Root => (FileKind::Dir, "/".to_string()),
@@ -180,7 +189,14 @@ impl FileServer for TestHostMountFs {
         }
         let mut state = self.state.lock().await;
         let is_clone = matches!(state.fids.get(&fid).map(|fid| &fid.node), Some(Node::Clone));
-        if (is_clone && mode != OpenMode::ReadWrite) || (!is_clone && mode != OpenMode::Read) {
+        let is_status = matches!(
+            state.fids.get(&fid).map(|fid| &fid.node),
+            Some(Node::Field(_, "status"))
+        );
+        let valid_mode = (is_clone && mode == OpenMode::ReadWrite)
+            || (is_status && matches!(mode, OpenMode::Read | OpenMode::Write))
+            || (!is_clone && !is_status && mode == OpenMode::Read);
+        if !valid_mode {
             return Err(ErrorCode::NoAccess);
         }
         let clone_id = if is_clone {
@@ -218,12 +234,20 @@ impl FileServer for TestHostMountFs {
     async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
         let mut state = self.state.lock().await;
         let fid = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
-        if !matches!(fid.node, Node::Clone) || fid.mode != Some(OpenMode::ReadWrite) {
+        let valid_write = (matches!(fid.node, Node::Clone)
+            && fid.mode == Some(OpenMode::ReadWrite))
+            || (matches!(fid.node, Node::Field(_, "status")) && fid.mode == Some(OpenMode::Write));
+        if !valid_write {
             return Err(ErrorCode::NoAccess);
         }
         let start = offset as usize;
         let end = start.checked_add(data.len()).ok_or(ErrorCode::BadRequest)?;
-        if end > 64 * 1024 {
+        let max_bytes = if matches!(fid.node, Node::Clone) {
+            64 * 1024
+        } else {
+            64
+        };
+        if end > max_bytes {
             return Err(ErrorCode::BadRequest);
         }
         fid.write_buf.resize(fid.write_buf.len().max(end), 0);
@@ -248,7 +272,7 @@ impl FileServer for TestHostMountFs {
             qid: Self::qid(&node),
             length: Self::bytes(&state, &node)?.len() as u64,
             executable: false,
-            writable: matches!(node, Node::Clone),
+            writable: matches!(node, Node::Clone | Node::Field(_, "status")),
         })
     }
 
@@ -272,18 +296,40 @@ impl FileServer for TestHostMountFs {
         }
         let mut state = self.state.lock().await;
         let fid = state.fids.remove(&fid).ok_or(ErrorCode::NotFound)?;
-        if matches!(fid.node, Node::Clone) && fid.wrote {
-            let document =
-                serde_json::from_slice(&fid.write_buf).map_err(|_| ErrorCode::BadRequest)?;
-            state.requests.insert(
-                fid.clone_id.ok_or(ErrorCode::BadRequest)?,
-                RequestRecord {
-                    document,
-                    status: "pending".to_string(),
-                    grant: String::new(),
-                    error: String::new(),
-                },
-            );
+        if fid.wrote {
+            match fid.node {
+                Node::Clone => {
+                    let document = serde_json::from_slice(&fid.write_buf)
+                        .map_err(|_| ErrorCode::BadRequest)?;
+                    state.requests.insert(
+                        fid.clone_id.ok_or(ErrorCode::BadRequest)?,
+                        RequestRecord {
+                            document,
+                            status: "pending".to_string(),
+                            grant: String::new(),
+                            error: String::new(),
+                        },
+                    );
+                }
+                Node::Field(request_id, "status") => {
+                    let command = std::str::from_utf8(&fid.write_buf)
+                        .map_err(|_| ErrorCode::BadRequest)?
+                        .trim();
+                    if command != "cancelled" {
+                        return Err(ErrorCode::BadRequest);
+                    }
+                    let request = state
+                        .requests
+                        .get_mut(&request_id)
+                        .ok_or(ErrorCode::NotFound)?;
+                    if request.status != "pending" {
+                        return Err(ErrorCode::BadRequest);
+                    }
+                    request.status = "cancelled".to_string();
+                    request.error = "cancelled by requesting Process".to_string();
+                }
+                _ => return Err(ErrorCode::Unsupported),
+            }
         }
         Ok(())
     }

--- a/crates/agent-engine/src/runtime/tool_execution.rs
+++ b/crates/agent-engine/src/runtime/tool_execution.rs
@@ -219,7 +219,14 @@ where
     )
     .await;
     if cancel.is_cancelled()
-        && check_turn_cancelled(runtime.machine, &runtime.agent_files, emit, cancel).await?
+        && check_turn_cancelled(
+            runtime.machine,
+            &runtime.agent_files,
+            &runtime.host_mount_requests,
+            emit,
+            cancel,
+        )
+        .await?
     {
         return Ok(ToolExecutionOutcome::EndTurn);
     }

--- a/crates/agent-engine/src/runtime/tool_execution/runtime_inputs.rs
+++ b/crates/agent-engine/src/runtime/tool_execution/runtime_inputs.rs
@@ -1,12 +1,15 @@
 use crate::{
     agent_machine::AgentMachine,
-    runtime::transition::{NamespaceAgentFiles, NamespaceToolExecution},
+    runtime::transition::{
+        NamespaceAgentFiles, NamespaceHostMountRequests, NamespaceToolExecution,
+    },
 };
 
 /// Explicit inputs for one policy-approved Tool Process execution transition.
 pub(crate) struct ToolExecutionRuntime<'a> {
     pub(super) machine: &'a mut AgentMachine,
     pub(super) agent_files: NamespaceAgentFiles,
+    pub(super) host_mount_requests: NamespaceHostMountRequests,
     pub(super) tool_execution: NamespaceToolExecution,
     pub(super) process_path: String,
 }
@@ -15,12 +18,14 @@ impl<'a> ToolExecutionRuntime<'a> {
     pub(crate) fn new(
         machine: &'a mut AgentMachine,
         agent_files: NamespaceAgentFiles,
+        host_mount_requests: NamespaceHostMountRequests,
         tool_execution: NamespaceToolExecution,
         process_path: String,
     ) -> Self {
         Self {
             machine,
             agent_files,
+            host_mount_requests,
             tool_execution,
             process_path,
         }

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -663,7 +663,8 @@ fn submission_runtime(state: &mut RuntimeLoopState) -> SubmissionRuntime<'_> {
     } = state;
     let agent_files = environment.agent_files();
     let host_mount_requests = environment.host_mount_requests();
-    SubmissionRuntime::new(machine, agent_files, host_mount_requests)
+    let mount_control = environment.mount_control();
+    SubmissionRuntime::new(machine, agent_files, host_mount_requests, mount_control)
 }
 
 pub(super) async fn handle_runtime_op<E, F>(

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -20,8 +20,8 @@ pub use namespace_environment::{
     NamespaceTurnOutput, NamespaceTurnRuntime, NamespaceTurnRuntimeConfig,
 };
 pub(crate) use namespace_environment::{
-    NamespaceAgentFiles, NamespaceChildLaunch, NamespaceGeneration, NamespaceProcessFiles,
-    NamespaceToolExecution,
+    HostMountTerminalResult, NamespaceAgentFiles, NamespaceChildLaunch, NamespaceGeneration,
+    NamespaceHostMountRequests, NamespaceProcessFiles, NamespaceToolExecution,
 };
 
 use std::collections::VecDeque;
@@ -217,12 +217,14 @@ pub(super) fn mount_request_runtime(
     state: &mut RuntimeLoopState,
 ) -> super::mount_request_tool::MountRequestRuntime<'_> {
     let agent_files = state.agent_files();
+    let host_mount_requests = state.environment.host_mount_requests();
     let tool_execution = state.tool_execution();
     super::mount_request_tool::MountRequestRuntime::new(
         &mut state.machine,
         &state.runtime_config.policy_engine,
         &state.runtime_config.governance,
         agent_files,
+        host_mount_requests,
         tool_execution,
     )
 }
@@ -657,23 +659,11 @@ fn submission_runtime(state: &mut RuntimeLoopState) -> SubmissionRuntime<'_> {
     let RuntimeLoopState {
         machine,
         environment,
-        runtime_config,
         ..
     } = state;
     let agent_files = environment.agent_files();
-    let tool_execution = environment.tool_execution();
-    let runtime_scratch_dir = runtime_config
-        .store_bindings
-        .as_ref()
-        .map(|stores| stores.tmp.clone());
-    let mount_control = environment.mount_control();
-    SubmissionRuntime::new(
-        machine,
-        agent_files,
-        mount_control,
-        tool_execution,
-        runtime_scratch_dir,
-    )
+    let host_mount_requests = environment.host_mount_requests();
+    SubmissionRuntime::new(machine, agent_files, host_mount_requests)
 }
 
 pub(super) async fn handle_runtime_op<E, F>(

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -20,8 +20,8 @@ pub use namespace_environment::{
     NamespaceTurnOutput, NamespaceTurnRuntime, NamespaceTurnRuntimeConfig,
 };
 pub(crate) use namespace_environment::{
-    HostMountTerminalResult, NamespaceAgentFiles, NamespaceChildLaunch, NamespaceGeneration,
-    NamespaceHostMountRequests, NamespaceProcessFiles, NamespaceToolExecution,
+    HostMountTerminalResult, HostMountTerminalStatus, NamespaceAgentFiles, NamespaceChildLaunch,
+    NamespaceGeneration, NamespaceHostMountRequests, NamespaceProcessFiles, NamespaceToolExecution,
 };
 
 use std::collections::VecDeque;

--- a/crates/agent-engine/src/runtime/transition.rs
+++ b/crates/agent-engine/src/runtime/transition.rs
@@ -175,6 +175,7 @@ pub(super) fn delegated_skill_runtime(
     state: &mut RuntimeLoopState,
 ) -> super::delegated_skill_tool::DelegatedSkillRuntime<'_> {
     let agent_files = state.agent_files();
+    let host_mount_requests = state.environment.host_mount_requests();
     let child_run_registry = state.child_run_registry().clone();
     let child_launch = state.child_launch();
     let base_agent_config = child_launch_base_agent_config(state);
@@ -191,6 +192,7 @@ pub(super) fn delegated_skill_runtime(
         &mut state.machine,
         &mut state.prompt_cache,
         agent_files,
+        host_mount_requests,
         child_runtime_inputs,
     )
 }
@@ -249,9 +251,16 @@ where
     F: std::future::Future<Output = ()>,
 {
     let agent_files = state.agent_files();
+    let host_mount_requests = state.environment.host_mount_requests();
     if cancel.is_cancelled()
-        && super::turn_support::check_turn_cancelled(&mut state.machine, &agent_files, emit, cancel)
-            .await?
+        && super::turn_support::check_turn_cancelled(
+            &mut state.machine,
+            &agent_files,
+            &host_mount_requests,
+            emit,
+            cancel,
+        )
+        .await?
     {
         return Ok(super::virtual_tool::VirtualToolOutcome::EndTurn);
     }
@@ -345,11 +354,13 @@ pub(super) fn tool_execution_runtime(
     state: &mut RuntimeLoopState,
 ) -> super::tool_execution::ToolExecutionRuntime<'_> {
     let agent_files = state.agent_files();
+    let host_mount_requests = state.environment.host_mount_requests();
     let tool_execution = state.tool_execution();
     let process_path = state.process_path();
     super::tool_execution::ToolExecutionRuntime::new(
         &mut state.machine,
         agent_files,
+        host_mount_requests,
         tool_execution,
         process_path,
     )

--- a/crates/agent-engine/src/runtime/transition/accepted_submission.rs
+++ b/crates/agent-engine/src/runtime/transition/accepted_submission.rs
@@ -81,10 +81,17 @@ where
 
     loop {
         let next_submission = if state.machine.has_pending_interaction() {
+            let RuntimeLoopState {
+                machine,
+                environment,
+                ..
+            } = state;
+            let mut mount_control = environment.mount_control();
             next_pending_interaction_submission(
-                &mut state.machine,
+                machine,
                 &agent_files,
                 &host_mount_requests,
+                &mut mount_control,
                 broker,
                 emit,
                 cancel,

--- a/crates/agent-engine/src/runtime/transition/accepted_submission.rs
+++ b/crates/agent-engine/src/runtime/transition/accepted_submission.rs
@@ -69,6 +69,7 @@ where
     broker.clear().await;
     let _ = state.machine.clear_buffered_inband_submissions();
     let agent_files = state.agent_files();
+    let host_mount_requests = state.environment.host_mount_requests();
     handle_submission_with_cancel_and_steering(
         state,
         initial_submission,
@@ -83,6 +84,7 @@ where
             next_pending_interaction_submission(
                 &mut state.machine,
                 &agent_files,
+                &host_mount_requests,
                 broker,
                 emit,
                 cancel,

--- a/crates/agent-engine/src/runtime/transition/namespace_environment.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment.rs
@@ -278,7 +278,7 @@ pub(crate) struct NamespaceHostMountRequests {
     root: InProcessTransport,
 }
 
-pub(crate) use host_mount_requests::HostMountTerminalResult;
+pub(crate) use host_mount_requests::{HostMountTerminalResult, HostMountTerminalStatus};
 
 /// Narrow handle for child Agent Process launch capabilities.
 #[derive(Clone)]

--- a/crates/agent-engine/src/runtime/transition/namespace_environment.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment.rs
@@ -9,6 +9,7 @@ mod agent_files;
 mod child_launch;
 mod client;
 mod generation;
+mod host_mount_requests;
 mod mount_control;
 mod process_files;
 mod tool_execution;
@@ -133,7 +134,7 @@ pub struct NamespaceToolActionOutput {
     pub exit_code: i32,
 }
 
-/// Access mode for an approved host mount grant.
+/// Access mode for a transitional, pre-authorized Host-backed launch declaration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApprovedMountGrantAccess {
     ReadOnly,
@@ -149,7 +150,10 @@ impl ApprovedMountGrantAccess {
     }
 }
 
-/// A host mount grant that has already passed the approval boundary.
+/// Transitional Host backing used only while pre-authorized launch mounts move to handles.
+///
+/// The file-native `request_mount` path never constructs or observes this type. Host Mount Service
+/// owns that path's requests and status; the next ownership slice removes this launch-only record.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApprovedMountGrant {
     pub namespace_path: String,
@@ -174,13 +178,10 @@ impl ApprovedMountGrant {
     }
 }
 
-/// Host-provided hook for applying approved mount grants to a live namespace.
+/// Transitional Host hook for applying pre-authorized launch declarations.
 ///
-/// The engine owns the approval flow, but the host composition root owns
-/// host-backed file-server construction. Implementations must keep hostfs
-/// dependencies out of `alan-agent-engine`. A successful call returns the full
-/// post-application namespace snapshot so later child launches inherit the same
-/// view without exposing Host file-server construction to the engine.
+/// Host Mount Service owns runtime request approval and live projection. This hook remains only for
+/// launch-time Agent Definition backing until the handle/projection slice replaces it.
 pub trait MountGrantApplicator: std::fmt::Debug + Send + Sync {
     fn apply_mount_grant(&self, grant: &ApprovedMountGrant) -> Result<alan_kernel::Namespace>;
 }
@@ -268,6 +269,14 @@ pub(crate) struct NamespaceProcessFiles {
     agent_path: String,
 }
 
+/// Narrow aP handle for logical Host Mount Service requests and status.
+#[derive(Clone)]
+pub(crate) struct NamespaceHostMountRequests {
+    root: InProcessTransport,
+}
+
+pub(crate) use host_mount_requests::HostMountTerminalResult;
+
 /// Narrow handle for child Agent Process launch capabilities.
 #[derive(Clone)]
 pub(crate) struct NamespaceChildLaunch {
@@ -280,7 +289,6 @@ pub(crate) struct NamespaceChildLaunch {
 pub struct NamespaceMountControl<'a> {
     launch_context: &'a mut Option<crate::ProcessLaunchContext>,
     mount_grant_applicator: Option<Arc<dyn MountGrantApplicator>>,
-    tool_process_context: Option<NamespaceToolProcessContext>,
 }
 
 /// Narrow handle for Tool package discovery, policy capability, and execution.
@@ -360,6 +368,12 @@ impl NamespaceRuntimeEnvironment {
         }
     }
 
+    pub(crate) fn host_mount_requests(&self) -> NamespaceHostMountRequests {
+        NamespaceHostMountRequests {
+            root: self.root.clone(),
+        }
+    }
+
     pub(crate) fn child_launch(&self) -> NamespaceChildLaunch {
         NamespaceChildLaunch {
             llm_connection: self.llm_connection.clone(),
@@ -373,7 +387,6 @@ impl NamespaceRuntimeEnvironment {
         NamespaceMountControl {
             launch_context: &mut self.launch_context,
             mount_grant_applicator: self.mount_grant_applicator.clone(),
-            tool_process_context: self.tool_process_context.clone(),
         }
     }
 

--- a/crates/agent-engine/src/runtime/transition/namespace_environment.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment.rs
@@ -188,12 +188,15 @@ pub trait MountGrantApplicator: std::fmt::Debug + Send + Sync {
 
 /// Host-provided factory that can build a mount grant applicator once the engine
 /// has created the live namespace handle for a runtime.
+///
+/// Inherited mount references are opaque metadata. The Host implementation must also verify that
+/// the spawning Process currently holds each referenced projection before delegating it.
 pub trait MountGrantApplicatorFactory: std::fmt::Debug + Send + Sync {
     fn create(
         &self,
         pid: alan_kernel::Pid,
         live_namespace: alan_kernel::LiveNamespace,
-        inherited_mount_paths: &[String],
+        inherited_mount_references: &[String],
     ) -> Arc<dyn MountGrantApplicator>;
 
     fn tool_execution_authority(&self) -> Option<Arc<dyn crate::tools::ToolExecutionAuthority>> {

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/host_mount_requests.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/host_mount_requests.rs
@@ -106,6 +106,19 @@ impl NamespaceHostMountRequests {
             other => bail!("unknown Host Mount request status `{other}`"),
         }
     }
+
+    pub(crate) async fn cancel(&self, request_id: &str) -> Result<()> {
+        validate_request_id(request_id)?;
+        let status_path = format!("/mnt/host-mount/requests/{request_id}/status");
+        let client = NamespaceClient::new(self.root.clone());
+        if let Err(cancel_error) = client.write_document(&status_path, b"cancelled\n").await {
+            if self.terminal_result(request_id).await?.is_some() {
+                return Ok(());
+            }
+            return Err(cancel_error).context("cancel pending Host Mount Service request");
+        }
+        Ok(())
+    }
 }
 
 async fn read_optional_text(client: &NamespaceClient, path: &str) -> Result<Option<String>> {

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/host_mount_requests.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/host_mount_requests.rs
@@ -1,0 +1,128 @@
+use anyhow::{Context, Result, bail};
+
+use super::{NamespaceHostMountRequests, client::NamespaceClient};
+
+const HOST_MOUNT_REQUEST_CLONE: &str = "/mnt/host-mount/requests/clone";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HostMountTerminalStatus {
+    Approved,
+    Rejected,
+    Cancelled,
+    Failed,
+}
+
+impl HostMountTerminalStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Approved => "approved",
+            Self::Rejected => "rejected",
+            Self::Cancelled => "cancelled",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct HostMountTerminalResult {
+    pub(crate) status: HostMountTerminalStatus,
+    pub(crate) grant_reference: Option<String>,
+    pub(crate) error: Option<String>,
+}
+
+impl NamespaceHostMountRequests {
+    pub(crate) async fn create(&self, document: &[u8]) -> Result<String> {
+        let request_id = NamespaceClient::new(self.root.clone())
+            .clone_with_document(HOST_MOUNT_REQUEST_CLONE, document)
+            .await
+            .context("commit logical Host Mount request")?;
+        validate_request_id(&request_id)
+            .context("Host Mount Service returned an invalid request reference")?;
+        Ok(request_id)
+    }
+
+    pub(crate) async fn terminal_result(
+        &self,
+        request_id: &str,
+    ) -> Result<Option<HostMountTerminalResult>> {
+        validate_request_id(request_id)?;
+        let client = NamespaceClient::new(self.root.clone());
+        let status_path = format!("/mnt/host-mount/requests/{request_id}/status");
+        let Some(status) = client.try_read_file(&status_path).await? else {
+            return Ok(Some(HostMountTerminalResult {
+                status: HostMountTerminalStatus::Failed,
+                grant_reference: None,
+                error: Some("Host Mount request is no longer available".to_string()),
+            }));
+        };
+        let status = String::from_utf8(status).context("Host Mount request status is not utf8")?;
+        match status.trim() {
+            "pending" => Ok(None),
+            "approved" => {
+                let grant = read_optional_text(
+                    &client,
+                    &format!("/mnt/host-mount/requests/{request_id}/grant"),
+                )
+                .await?;
+                if grant.is_none() {
+                    return Ok(Some(HostMountTerminalResult {
+                        status: HostMountTerminalStatus::Failed,
+                        grant_reference: None,
+                        error: Some(
+                            "Host Mount Service approved the request without a grant reference"
+                                .to_string(),
+                        ),
+                    }));
+                }
+                Ok(Some(HostMountTerminalResult {
+                    status: HostMountTerminalStatus::Approved,
+                    grant_reference: grant,
+                    error: None,
+                }))
+            }
+            "rejected" | "cancelled" | "failed" => {
+                let terminal_status = match status.trim() {
+                    "rejected" => HostMountTerminalStatus::Rejected,
+                    "cancelled" => HostMountTerminalStatus::Cancelled,
+                    _ => HostMountTerminalStatus::Failed,
+                };
+                let error = read_optional_text(
+                    &client,
+                    &format!("/mnt/host-mount/requests/{request_id}/error"),
+                )
+                .await?
+                .or_else(|| {
+                    Some(format!(
+                        "Host Mount request was {}",
+                        terminal_status.as_str()
+                    ))
+                });
+                Ok(Some(HostMountTerminalResult {
+                    status: terminal_status,
+                    grant_reference: None,
+                    error,
+                }))
+            }
+            other => bail!("unknown Host Mount request status `{other}`"),
+        }
+    }
+}
+
+async fn read_optional_text(client: &NamespaceClient, path: &str) -> Result<Option<String>> {
+    let Some(bytes) = client.try_read_file(path).await? else {
+        return Ok(None);
+    };
+    let value = String::from_utf8(bytes).with_context(|| format!("{path} is not utf8"))?;
+    Ok((!value.trim().is_empty()).then(|| value.trim().to_string()))
+}
+
+fn validate_request_id(request_id: &str) -> Result<()> {
+    if request_id.is_empty()
+        || request_id.contains('/')
+        || matches!(request_id, "." | "..")
+        || request_id.chars().any(char::is_whitespace)
+    {
+        bail!("invalid Host Mount request reference");
+    }
+    Ok(())
+}

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/host_mount_requests.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/host_mount_requests.rs
@@ -107,17 +107,19 @@ impl NamespaceHostMountRequests {
         }
     }
 
-    pub(crate) async fn cancel(&self, request_id: &str) -> Result<()> {
+    pub(crate) async fn cancel(&self, request_id: &str) -> Result<HostMountTerminalResult> {
         validate_request_id(request_id)?;
         let status_path = format!("/mnt/host-mount/requests/{request_id}/status");
         let client = NamespaceClient::new(self.root.clone());
         if let Err(cancel_error) = client.write_document(&status_path, b"cancelled\n").await {
-            if self.terminal_result(request_id).await?.is_some() {
-                return Ok(());
+            if let Some(terminal) = self.terminal_result(request_id).await? {
+                return Ok(terminal);
             }
             return Err(cancel_error).context("cancel pending Host Mount Service request");
         }
-        Ok(())
+        self.terminal_result(request_id)
+            .await?
+            .context("cancelled Host Mount Service request did not reach terminal status")
     }
 }
 

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/host_mount_requests.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/host_mount_requests.rs
@@ -1,8 +1,11 @@
 use anyhow::{Context, Result, bail};
+use std::time::Duration;
 
 use super::{NamespaceHostMountRequests, client::NamespaceClient};
 
 const HOST_MOUNT_REQUEST_CLONE: &str = "/mnt/host-mount/requests/clone";
+const HOST_MOUNT_TERMINAL_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const HOST_MOUNT_DECISION_SETTLE_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum HostMountTerminalStatus {
@@ -115,7 +118,21 @@ impl NamespaceHostMountRequests {
             if let Some(terminal) = self.terminal_result(request_id).await? {
                 return Ok(terminal);
             }
-            return Err(cancel_error).context("cancel pending Host Mount Service request");
+            let terminal = tokio::time::timeout(HOST_MOUNT_DECISION_SETTLE_TIMEOUT, async {
+                loop {
+                    if let Some(terminal) = self.terminal_result(request_id).await? {
+                        return Ok::<_, anyhow::Error>(terminal);
+                    }
+                    tokio::time::sleep(HOST_MOUNT_TERMINAL_POLL_INTERVAL).await;
+                }
+            })
+            .await;
+            return match terminal {
+                Ok(result) => result,
+                Err(_) => Err(cancel_error).context(
+                    "Host Mount Service request stayed pending after cancellation was rejected",
+                ),
+            };
         }
         self.terminal_result(request_id)
             .await?

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/mount_control.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/mount_control.rs
@@ -1,7 +1,5 @@
 //! Approved Namespace mount mutation and dependent Tool binding projection.
 
-use std::path::PathBuf;
-
 use super::{ApprovedMountGrant, NamespaceMountApplication, NamespaceMountControl};
 
 impl NamespaceMountControl<'_> {
@@ -24,44 +22,5 @@ impl NamespaceMountControl<'_> {
             }
             Err(error) => NamespaceMountApplication::failed(error),
         }
-    }
-
-    pub(crate) fn retain_host_mount(&mut self, grant: crate::HostMountGrant) -> bool {
-        let Some(context) = self.launch_context.as_mut() else {
-            return false;
-        };
-        if let Some(index) = context
-            .host_mounts
-            .iter()
-            .position(|existing| existing.namespace_path == grant.namespace_path)
-        {
-            let changed = context.host_mounts[index] != grant;
-            context.host_mounts[index] = grant;
-            return changed;
-        }
-        context.host_mounts.push(grant);
-        true
-    }
-
-    pub(crate) fn sync_tool_binding(&self, scratch_dir: PathBuf) -> bool {
-        let Some(launch_context) = self.launch_context.as_ref() else {
-            return false;
-        };
-        let Ok(binding) =
-            crate::tools::ToolExecutionBinding::from_launch_context(launch_context, scratch_dir)
-        else {
-            return false;
-        };
-        let Some(process_context) = self.tool_process_context.as_ref() else {
-            return false;
-        };
-        let changed = process_context
-            .tool_runner
-            .process_binding(process_context.pid)
-            != Some(binding.clone());
-        process_context
-            .tool_runner
-            .register_process_binding(process_context.pid, binding);
-        changed
     }
 }

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/mount_control.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/mount_control.rs
@@ -6,11 +6,12 @@ impl NamespaceMountControl<'_> {
     /// Retain logical projection metadata after Host Mount Service commits the live mount.
     pub fn record_projected_host_mount(
         &mut self,
+        grant_reference: String,
         namespace_path: String,
         access: alan_kernel::Access,
     ) {
         if let Some(context) = self.launch_context.as_mut() {
-            context.record_projected_host_mount(namespace_path, access);
+            context.record_projected_host_mount(grant_reference, namespace_path, access);
         }
     }
 

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/mount_control.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/mount_control.rs
@@ -3,6 +3,17 @@
 use super::{ApprovedMountGrant, NamespaceMountApplication, NamespaceMountControl};
 
 impl NamespaceMountControl<'_> {
+    /// Retain logical projection metadata after Host Mount Service commits the live mount.
+    pub fn record_projected_host_mount(
+        &mut self,
+        namespace_path: String,
+        access: alan_kernel::Access,
+    ) {
+        if let Some(context) = self.launch_context.as_mut() {
+            context.record_projected_host_mount(namespace_path, access);
+        }
+    }
+
     /// Apply an approved grant to the live Namespace and retain its new snapshot.
     pub fn apply_approved_grant(
         &mut self,

--- a/crates/agent-engine/src/runtime/transition/namespace_environment/tool_execution.rs
+++ b/crates/agent-engine/src/runtime/transition/namespace_environment/tool_execution.rs
@@ -50,27 +50,6 @@ impl NamespaceToolExecution {
             .unwrap_or(alan_agent_protocol::ToolCapability::Unknown)
     }
 
-    #[cfg(test)]
-    pub(crate) fn set_execution_binding(
-        &self,
-        binding: crate::tools::ToolExecutionBinding,
-    ) -> bool {
-        self.tool_process_context.as_ref().is_some_and(|context| {
-            context
-                .tool_runner
-                .register_process_binding(context.pid, binding);
-            true
-        })
-    }
-
-    #[cfg(test)]
-    pub(crate) fn sandbox_writable_roots(&self) -> Vec<std::path::PathBuf> {
-        self.execution_binding()
-            .and_then(|binding| binding.sandbox_spec)
-            .map(|spec| spec.writable_roots)
-            .unwrap_or_default()
-    }
-
     /// Discover model-callable Tools from complete packages visible in this namespace.
     pub(crate) async fn discover_packages(&self) -> Result<Vec<ToolPackageManifest>> {
         let client = self.client();

--- a/crates/agent-engine/src/runtime/transition/tests/core_behaviors.rs
+++ b/crates/agent-engine/src/runtime/transition/tests/core_behaviors.rs
@@ -170,7 +170,14 @@ async fn test_cancel_current_task() {
     };
 
     let agent_files = state.agent_files();
-    let result = cancel_current_task(&mut state.machine, &agent_files, &mut emit).await;
+    let host_mount_requests = state.environment.host_mount_requests();
+    let result = cancel_current_task(
+        &mut state.machine,
+        &agent_files,
+        &host_mount_requests,
+        &mut emit,
+    )
+    .await;
 
     assert!(result.is_ok());
     assert!(state.machine.pending_confirmation().is_none());

--- a/crates/agent-engine/src/runtime/transition/tests/core_behaviors.rs
+++ b/crates/agent-engine/src/runtime/transition/tests/core_behaviors.rs
@@ -175,6 +175,7 @@ async fn test_cancel_current_task() {
         &mut state.machine,
         &agent_files,
         &host_mount_requests,
+        None,
         &mut emit,
     )
     .await;

--- a/crates/agent-engine/src/runtime/transition/turn_execution.rs
+++ b/crates/agent-engine/src/runtime/transition/turn_execution.rs
@@ -183,6 +183,7 @@ where
     }
 
     let agent_files = state.agent_files();
+    let host_mount_requests = state.environment.host_mount_requests();
     if matches!(turn_kind, TurnRunKind::NewTurn) && user_input.is_none() {
         let input = agent_files
             .read_next_input()
@@ -232,7 +233,15 @@ where
             warn!("Context compaction timeout - continuing without compaction");
         }
     }
-    if check_turn_cancelled(&mut state.machine, &agent_files, emit, cancel).await? {
+    if check_turn_cancelled(
+        &mut state.machine,
+        &agent_files,
+        &host_mount_requests,
+        emit,
+        cancel,
+    )
+    .await?
+    {
         return Ok(TurnExecutionOutcome::Finished);
     }
 
@@ -317,7 +326,15 @@ where
     let mut response_guardrails = ResponseGuardrails::default();
     let mut pending_guardrail_instruction: Option<String> = None;
     loop {
-        if check_turn_cancelled(&mut state.machine, &agent_files, emit, cancel).await? {
+        if check_turn_cancelled(
+            &mut state.machine,
+            &agent_files,
+            &host_mount_requests,
+            emit,
+            cancel,
+        )
+        .await?
+        {
             return Ok(TurnExecutionOutcome::Finished);
         }
         let provider = generation.provider();
@@ -396,7 +413,14 @@ where
             Ok(response) => response,
             Err(error) => {
                 if cancel.is_cancelled()
-                    && check_turn_cancelled(&mut state.machine, &agent_files, emit, cancel).await?
+                    && check_turn_cancelled(
+                        &mut state.machine,
+                        &agent_files,
+                        &host_mount_requests,
+                        emit,
+                        cancel,
+                    )
+                    .await?
                 {
                     return Ok(TurnExecutionOutcome::Finished);
                 }
@@ -467,7 +491,15 @@ where
                     ),
                 )
                 .await?;
-                if check_turn_cancelled(&mut state.machine, &agent_files, emit, cancel).await? {
+                if check_turn_cancelled(
+                    &mut state.machine,
+                    &agent_files,
+                    &host_mount_requests,
+                    emit,
+                    cancel,
+                )
+                .await?
+                {
                     return Ok(TurnExecutionOutcome::Finished);
                 }
                 continue;
@@ -575,7 +607,15 @@ where
                         ),
                     )
                     .await?;
-                    if check_turn_cancelled(&mut state.machine, &agent_files, emit, cancel).await? {
+                    if check_turn_cancelled(
+                        &mut state.machine,
+                        &agent_files,
+                        &host_mount_requests,
+                        emit,
+                        cancel,
+                    )
+                    .await?
+                    {
                         return Ok(TurnExecutionOutcome::Finished);
                     }
                 }

--- a/crates/agent-engine/src/runtime/transition/turn_execution.rs
+++ b/crates/agent-engine/src/runtime/transition/turn_execution.rs
@@ -508,7 +508,13 @@ where
                 .map(|tc| crate::tape::ToolRequest {
                     id: tc.id.clone(),
                     name: tc.name.clone(),
-                    arguments: tc.arguments.clone(),
+                    arguments: if tc.name == "request_mount" {
+                        crate::runtime::mount_request_tool::durable_mount_request_arguments(
+                            &tc.arguments,
+                        )
+                    } else {
+                        tc.arguments.clone()
+                    },
                 })
                 .collect();
             state

--- a/crates/agent-engine/src/runtime/transition/turn_execution/tests.rs
+++ b/crates/agent-engine/src/runtime/transition/turn_execution/tests.rs
@@ -943,6 +943,7 @@ use support::*;
 
 mod namespace_generation;
 
+mod host_mount_evidence;
 mod turn_execution;
 
 mod confirmation;

--- a/crates/agent-engine/src/runtime/transition/turn_execution/tests/host_mount_evidence.rs
+++ b/crates/agent-engine/src/runtime/transition/turn_execution/tests/host_mount_evidence.rs
@@ -1,0 +1,78 @@
+use super::*;
+
+#[tokio::test]
+async fn invalid_mount_host_location_never_enters_machine_tape() {
+    let raw_host_path = "/Users/example/private-project";
+    let generate_calls = Arc::new(AtomicUsize::new(0));
+    let provider = SequenceMockProvider::new(
+        vec![
+            GenerationResponse {
+                content: String::new(),
+                thinking: None,
+                thinking_signature: None,
+                redacted_thinking: Vec::new(),
+                tool_calls: vec![ToolCall {
+                    id: Some("call-invalid-mount".to_string()),
+                    name: "request_mount".to_string(),
+                    arguments: json!({
+                        "namespace_path": "/mnt/project",
+                        "host_path": raw_host_path,
+                        "access": "read_only",
+                        "reason": "Read project files"
+                    }),
+                }],
+                usage: None,
+                finish_reason: None,
+                warnings: Vec::new(),
+                provider_response_id: None,
+                provider_response_status: None,
+            },
+            GenerationResponse {
+                content: "The invalid request was rejected.".to_string(),
+                thinking: None,
+                thinking_signature: None,
+                redacted_thinking: Vec::new(),
+                tool_calls: Vec::new(),
+                usage: None,
+                finish_reason: None,
+                warnings: Vec::new(),
+                provider_response_id: None,
+                provider_response_status: None,
+            },
+        ],
+        Arc::clone(&generate_calls),
+    );
+    let mut state = create_test_state_with_provider(provider);
+    let cancel = CancellationToken::new();
+    let mut emit = |_event: Event| async {};
+
+    let outcome = run_turn_with_cancel(
+        &mut state,
+        TurnRunKind::NewTurn,
+        Some(vec![ContentPart::text("Mount my project")]),
+        &mut emit,
+        &cancel,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome, TurnExecutionOutcome::Finished);
+    assert_eq!(generate_calls.load(Ordering::SeqCst), 2);
+    let machine_tape = serde_json::to_string(state.machine.messages()).unwrap();
+    assert!(!machine_tape.contains(raw_host_path));
+    assert!(!machine_tape.contains("host_path"));
+    let persisted_request = state
+        .machine
+        .messages()
+        .iter()
+        .find_map(|message| match message {
+            Message::Assistant { tool_requests, .. } => tool_requests.first(),
+            _ => None,
+        })
+        .expect("assistant Tool request is retained without Host-owned values");
+    assert_eq!(
+        persisted_request.arguments,
+        json!({"invalid_request": true})
+    );
+}

--- a/crates/agent-engine/src/runtime/turn_input.rs
+++ b/crates/agent-engine/src/runtime/turn_input.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use tokio::sync::{Mutex, Notify};
 use tokio_util::sync::CancellationToken;
 
-use super::transition::NamespaceAgentFiles;
+use super::transition::{NamespaceAgentFiles, NamespaceHostMountRequests};
 use super::turn_support::cancel_current_task;
 use crate::agent_machine::AgentMachine;
 
@@ -105,6 +105,7 @@ fn is_brokered_input(op: &Op) -> bool {
 pub(super) async fn next_pending_interaction_submission<E, F>(
     machine: &mut AgentMachine,
     agent_files: &NamespaceAgentFiles,
+    host_mount_requests: &NamespaceHostMountRequests,
     broker: &TurnInputBroker,
     emit: &mut E,
     cancel: &CancellationToken,
@@ -114,7 +115,9 @@ where
     F: std::future::Future<Output = ()>,
 {
     loop {
-        if let Some(submission) = namespace_pending_resume_submission(machine, agent_files).await? {
+        if let Some(submission) =
+            namespace_pending_resume_submission(machine, agent_files, host_mount_requests).await?
+        {
             return Ok(Some(submission));
         }
 
@@ -158,8 +161,25 @@ where
 pub(super) async fn namespace_pending_resume_submission(
     machine: &AgentMachine,
     agent_files: &NamespaceAgentFiles,
+    host_mount_requests: &NamespaceHostMountRequests,
 ) -> Result<Option<Submission>> {
     for request_id in machine.pending_request_ids() {
+        if machine.pending_host_mount(&request_id).is_some() {
+            if host_mount_requests
+                .terminal_result(&request_id)
+                .await?
+                .is_some()
+            {
+                return Ok(Some(Submission {
+                    id: format!("host-mount:{request_id}"),
+                    op: Op::Resume {
+                        request_id,
+                        content: Vec::new(),
+                    },
+                }));
+            }
+            continue;
+        }
         if let Some(submission) = agent_files
             .resume_submission_from_answered_request(&request_id)
             .await?
@@ -398,6 +418,7 @@ mod tests {
             super::super::transition::NamespaceRuntimeEnvironment::new(root, "/agent/1", "default");
 
         let agent_files = environment.agent_files();
+        let host_mount_requests = environment.host_mount_requests();
         let request_id = agent_files
             .write_request(super::super::transition::NamespaceRequestRecord::new(
                 "structured_input",
@@ -425,6 +446,7 @@ mod tests {
         let waiter = next_pending_interaction_submission(
             &mut machine,
             &agent_files,
+            &host_mount_requests,
             &broker,
             &mut emit,
             &cancel,
@@ -466,5 +488,84 @@ mod tests {
             other => panic!("expected Op::Resume from namespace response, got {other:?}"),
         }
         assert!(events.is_empty());
+    }
+
+    #[tokio::test]
+    async fn host_mount_service_terminal_status_unblocks_recovered_logical_wait() {
+        let agentfs = Arc::new(AgentFs::new());
+        let host_mount = crate::runtime::test_host_mount::TestHostMountFs::new();
+        let mut ns = Namespace::new();
+        ns.mount(
+            "/agent/1",
+            InProcessTransport::new(agentfs),
+            Access::ReadWrite,
+        );
+        ns.mount(
+            "/mnt/host-mount",
+            InProcessTransport::new(host_mount.clone()),
+            Access::ReadWrite,
+        );
+        let root = InProcessTransport::new(Arc::new(MountFs::new(ns)));
+        let environment =
+            super::super::transition::NamespaceRuntimeEnvironment::new(root, "/agent/1", "default");
+        let agent_files = environment.agent_files();
+        let host_mount_requests = environment.host_mount_requests();
+        let request_document = serde_json::json!({
+            "namespace_path": "/mnt/project",
+            "access": "read_only",
+            "reason": "Read project files"
+        });
+        let request_id = host_mount_requests
+            .create(&serde_json::to_vec(&request_document).unwrap())
+            .await
+            .unwrap();
+        let mut machine = AgentMachine::new();
+        machine.set_host_mount_request(crate::agent_machine::PendingHostMountRequest {
+            request_id: request_id.clone(),
+            tool_call_id: "call-mount".to_string(),
+            namespace_path: "/mnt/project".to_string(),
+            access: "read_only".to_string(),
+            reason: "Read project files".to_string(),
+            label: None,
+            request_events_offset: 0,
+        });
+        assert!(agent_files.request_ids().await.unwrap().is_empty());
+
+        let broker = TurnInputBroker::default();
+        let cancel = CancellationToken::new();
+        let mut emit = |_event| async {};
+        let waiter = next_pending_interaction_submission(
+            &mut machine,
+            &agent_files,
+            &host_mount_requests,
+            &broker,
+            &mut emit,
+            &cancel,
+        );
+        let settler = async {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            host_mount
+                .settle(&request_id, "approved", Some("grant-opaque"), None)
+                .await;
+        };
+        let (submission, _) = tokio::time::timeout(Duration::from_secs(1), async {
+            tokio::join!(waiter, settler)
+        })
+        .await
+        .expect("Host Mount terminal status should unblock pending wait");
+        let submission = submission
+            .unwrap()
+            .expect("service status becomes a submission");
+        assert_eq!(submission.id, format!("host-mount:{request_id}"));
+        match submission.op {
+            Op::Resume {
+                request_id: resumed_id,
+                content,
+            } => {
+                assert_eq!(resumed_id, request_id);
+                assert!(content.is_empty());
+            }
+            other => panic!("expected Host Mount Op::Resume, got {other:?}"),
+        }
     }
 }

--- a/crates/agent-engine/src/runtime/turn_input.rs
+++ b/crates/agent-engine/src/runtime/turn_input.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use tokio::sync::{Mutex, Notify};
 use tokio_util::sync::CancellationToken;
 
-use super::transition::{NamespaceAgentFiles, NamespaceHostMountRequests};
+use super::transition::{NamespaceAgentFiles, NamespaceHostMountRequests, NamespaceMountControl};
 use super::turn_support::cancel_current_task;
 use crate::agent_machine::AgentMachine;
 
@@ -106,6 +106,7 @@ pub(super) async fn next_pending_interaction_submission<E, F>(
     machine: &mut AgentMachine,
     agent_files: &NamespaceAgentFiles,
     host_mount_requests: &NamespaceHostMountRequests,
+    mount_control: &mut NamespaceMountControl<'_>,
     broker: &TurnInputBroker,
     emit: &mut E,
     cancel: &CancellationToken,
@@ -128,7 +129,14 @@ where
                         // Report and clear buffered in-turn submissions before cancel_current_task
                         // resets Machine turn state, otherwise the drop count under-reports.
                         emit_dropped_in_turn_submissions(emit, machine, broker).await;
-                        cancel_current_task(machine, agent_files, host_mount_requests, emit).await?;
+                        cancel_current_task(
+                            machine,
+                            agent_files,
+                            host_mount_requests,
+                            Some(mount_control),
+                            emit,
+                        )
+                        .await?;
                         return Ok(None);
                     }
                     emit_dropped_in_turn_submissions(emit, machine, broker).await;
@@ -414,7 +422,7 @@ mod tests {
         );
         let root = InProcessTransport::new(Arc::new(MountFs::new(ns)));
         let shell = Shell::new(root.clone());
-        let environment =
+        let mut environment =
             super::super::transition::NamespaceRuntimeEnvironment::new(root, "/agent/1", "default");
 
         let agent_files = environment.agent_files();
@@ -443,10 +451,12 @@ mod tests {
         };
 
         let response_path = format!("/agent/1/requests/{request_id}/response");
+        let mut mount_control = environment.mount_control();
         let waiter = next_pending_interaction_submission(
             &mut machine,
             &agent_files,
             &host_mount_requests,
+            &mut mount_control,
             &broker,
             &mut emit,
             &cancel,
@@ -506,7 +516,7 @@ mod tests {
             Access::ReadWrite,
         );
         let root = InProcessTransport::new(Arc::new(MountFs::new(ns)));
-        let environment =
+        let mut environment =
             super::super::transition::NamespaceRuntimeEnvironment::new(root, "/agent/1", "default");
         let agent_files = environment.agent_files();
         let host_mount_requests = environment.host_mount_requests();
@@ -534,10 +544,12 @@ mod tests {
         let broker = TurnInputBroker::default();
         let cancel = CancellationToken::new();
         let mut emit = |_event| async {};
+        let mut mount_control = environment.mount_control();
         let waiter = next_pending_interaction_submission(
             &mut machine,
             &agent_files,
             &host_mount_requests,
+            &mut mount_control,
             &broker,
             &mut emit,
             &cancel,

--- a/crates/agent-engine/src/runtime/turn_input.rs
+++ b/crates/agent-engine/src/runtime/turn_input.rs
@@ -128,7 +128,7 @@ where
                         // Report and clear buffered in-turn submissions before cancel_current_task
                         // resets Machine turn state, otherwise the drop count under-reports.
                         emit_dropped_in_turn_submissions(emit, machine, broker).await;
-                        cancel_current_task(machine, agent_files, emit).await?;
+                        cancel_current_task(machine, agent_files, host_mount_requests, emit).await?;
                         return Ok(None);
                     }
                     emit_dropped_in_turn_submissions(emit, machine, broker).await;

--- a/crates/agent-engine/src/runtime/turn_support.rs
+++ b/crates/agent-engine/src/runtime/turn_support.rs
@@ -1,23 +1,55 @@
 use alan_agent_protocol::Event;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 use uuid::Uuid;
 
-use super::transition::{NamespaceAgentFiles, NamespaceHostMountRequests};
-use crate::agent_machine::{AgentMachine, NormalizedToolCall};
+use super::transition::{
+    HostMountTerminalResult, HostMountTerminalStatus, NamespaceAgentFiles,
+    NamespaceHostMountRequests, NamespaceMountControl,
+};
+use crate::agent_machine::{AgentMachine, NormalizedToolCall, PendingHostMountRequest};
+
+pub(super) fn preserve_approved_host_mount(
+    mount_control: Option<&mut NamespaceMountControl<'_>>,
+    pending: &PendingHostMountRequest,
+    terminal: &HostMountTerminalResult,
+) -> Result<()> {
+    if terminal.status != HostMountTerminalStatus::Approved {
+        return Ok(());
+    }
+    let grant_reference = terminal
+        .grant_reference
+        .clone()
+        .context("approved Host Mount request has no grant reference")?;
+    let mount_control = mount_control.context(
+        "approved Host Mount request cannot be cleared without retaining its projection",
+    )?;
+    let access = match pending.access.as_str() {
+        "read_write" => alan_kernel::Access::ReadWrite,
+        _ => alan_kernel::Access::ReadOnly,
+    };
+    mount_control.record_projected_host_mount(
+        grant_reference,
+        pending.namespace_path.clone(),
+        access,
+    );
+    Ok(())
+}
 
 pub(super) async fn reset_turn_after_cancelling_host_mounts(
     machine: &mut AgentMachine,
     host_mount_requests: &NamespaceHostMountRequests,
+    mut mount_control: Option<&mut NamespaceMountControl<'_>>,
 ) -> Result<()> {
     let pending_host_mounts = machine
         .pending_request_ids()
         .into_iter()
-        .filter(|request_id| machine.pending_host_mount(request_id).is_some())
+        .filter_map(|request_id| machine.pending_host_mount(&request_id))
         .collect::<Vec<_>>();
-    for request_id in pending_host_mounts {
-        host_mount_requests.cancel(&request_id).await?;
+    for pending in pending_host_mounts {
+        let terminal = host_mount_requests.cancel(&pending.request_id).await?;
+        preserve_approved_host_mount(mount_control.as_deref_mut(), &pending, &terminal)?;
     }
     machine.reset_turn();
     Ok(())
@@ -27,6 +59,7 @@ pub(super) async fn cancel_current_task<E, F>(
     machine: &mut AgentMachine,
     agent_files: &NamespaceAgentFiles,
     host_mount_requests: &NamespaceHostMountRequests,
+    mount_control: Option<&mut NamespaceMountControl<'_>>,
     emit: &mut E,
 ) -> Result<()>
 where
@@ -36,7 +69,7 @@ where
     warn!("Cancelling current task");
     // Clear turn-scoped pending state, but preserve machine history so the user can
     // continue the same conversation after an interrupt/cancel.
-    reset_turn_after_cancelling_host_mounts(machine, host_mount_requests).await?;
+    reset_turn_after_cancelling_host_mounts(machine, host_mount_requests, mount_control).await?;
     machine.clear_plan_snapshot();
     machine.clear_active_task();
     super::ui_surfaces::turn_completed(agent_files, true).await?;
@@ -212,6 +245,6 @@ where
         .await;
         return Ok(false);
     }
-    cancel_current_task(machine, agent_files, host_mount_requests, emit).await?;
+    cancel_current_task(machine, agent_files, host_mount_requests, None, emit).await?;
     Ok(true)
 }

--- a/crates/agent-engine/src/runtime/turn_support.rs
+++ b/crates/agent-engine/src/runtime/turn_support.rs
@@ -4,12 +4,29 @@ use tokio_util::sync::CancellationToken;
 use tracing::warn;
 use uuid::Uuid;
 
-use super::transition::NamespaceAgentFiles;
+use super::transition::{NamespaceAgentFiles, NamespaceHostMountRequests};
 use crate::agent_machine::{AgentMachine, NormalizedToolCall};
+
+pub(super) async fn reset_turn_after_cancelling_host_mounts(
+    machine: &mut AgentMachine,
+    host_mount_requests: &NamespaceHostMountRequests,
+) -> Result<()> {
+    let pending_host_mounts = machine
+        .pending_request_ids()
+        .into_iter()
+        .filter(|request_id| machine.pending_host_mount(request_id).is_some())
+        .collect::<Vec<_>>();
+    for request_id in pending_host_mounts {
+        host_mount_requests.cancel(&request_id).await?;
+    }
+    machine.reset_turn();
+    Ok(())
+}
 
 pub(super) async fn cancel_current_task<E, F>(
     machine: &mut AgentMachine,
     agent_files: &NamespaceAgentFiles,
+    host_mount_requests: &NamespaceHostMountRequests,
     emit: &mut E,
 ) -> Result<()>
 where
@@ -19,7 +36,7 @@ where
     warn!("Cancelling current task");
     // Clear turn-scoped pending state, but preserve machine history so the user can
     // continue the same conversation after an interrupt/cancel.
-    machine.reset_turn();
+    reset_turn_after_cancelling_host_mounts(machine, host_mount_requests).await?;
     machine.clear_plan_snapshot();
     machine.clear_active_task();
     super::ui_surfaces::turn_completed(agent_files, true).await?;
@@ -176,6 +193,7 @@ where
 pub(super) async fn check_turn_cancelled<E, F>(
     machine: &mut AgentMachine,
     agent_files: &NamespaceAgentFiles,
+    host_mount_requests: &NamespaceHostMountRequests,
     emit: &mut E,
     cancel: &CancellationToken,
 ) -> Result<bool>
@@ -194,6 +212,6 @@ where
         .await;
         return Ok(false);
     }
-    cancel_current_task(machine, agent_files, emit).await?;
+    cancel_current_task(machine, agent_files, host_mount_requests, emit).await?;
     Ok(true)
 }

--- a/crates/agent-engine/src/runtime/virtual_tools_tests.rs
+++ b/crates/agent-engine/src/runtime/virtual_tools_tests.rs
@@ -20,7 +20,9 @@ use crate::{
             parse_confirmation_request, parse_plan_status, parse_plan_update,
             parse_structured_user_input_request,
         },
-        mount_request_tool::{MountRequestAccess, parse_mount_request},
+        mount_request_tool::{
+            MountRequestAccess, durable_mount_request_arguments, parse_mount_request,
+        },
         transition::NamespaceActionRecord,
         virtual_tool::VirtualToolOutcome,
     },
@@ -51,6 +53,11 @@ fn namespace_environment_for_virtual_tool_test(
     namespace.mount(
         "/agent/1",
         InProcessTransport::new(agentfs),
+        Access::ReadWrite,
+    );
+    namespace.mount(
+        "/mnt/host-mount",
+        InProcessTransport::new(crate::runtime::test_host_mount::TestHostMountFs::new()),
         Access::ReadWrite,
     );
     let root = InProcessTransport::new(Arc::new(MountFs::new(namespace)));

--- a/crates/agent-engine/src/tools/context.rs
+++ b/crates/agent-engine/src/tools/context.rs
@@ -134,12 +134,16 @@ impl ToolExecutionBinding {
         }
 
         let namespace_cwd = self.namespace_cwd.to_string_lossy();
-        let current = self.host_mounts.iter().find(|grant| {
-            namespace_cwd == grant.namespace_path
-                || namespace_cwd
-                    .strip_prefix(&grant.namespace_path)
-                    .is_some_and(|suffix| suffix.starts_with('/'))
-        });
+        let current = self
+            .host_mounts
+            .iter()
+            .filter(|grant| {
+                namespace_cwd == grant.namespace_path
+                    || namespace_cwd
+                        .strip_prefix(&grant.namespace_path)
+                        .is_some_and(|suffix| suffix.starts_with('/'))
+            })
+            .max_by_key(|grant| grant.namespace_path.len());
         let selected = current
             .or_else(|| {
                 self.host_mounts
@@ -503,5 +507,39 @@ mod tests {
         let execution = sandbox.exec("pwd", &ctx.cwd).await.unwrap();
         assert_eq!(execution.exit_code, 0, "{execution:?}");
         assert_eq!(ctx.project_text(execution.stdout.trim()), "/mnt/project");
+    }
+
+    #[test]
+    fn binding_uses_longest_namespace_prefix_for_overlapping_mounts() {
+        let project = tempfile::tempdir().unwrap();
+        let docs = tempfile::tempdir().unwrap();
+        let mut binding = ToolExecutionBinding::awaiting_host_projection(
+            PathBuf::from("/mnt/project/docs/guides"),
+            PathBuf::from("/tmp/scratch"),
+        );
+
+        binding
+            .apply_host_mount(
+                crate::HostMountGrant::new(
+                    "/mnt/project",
+                    project.path(),
+                    alan_kernel::Access::ReadWrite,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        binding
+            .apply_host_mount(
+                crate::HostMountGrant::new(
+                    "/mnt/project/docs",
+                    docs.path(),
+                    alan_kernel::Access::ReadOnly,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+
+        assert_eq!(binding.namespace_cwd, Path::new("/mnt/project/docs/guides"));
+        assert_eq!(binding.cwd, docs.path().join("guides"));
     }
 }

--- a/crates/agent-engine/src/tools/context.rs
+++ b/crates/agent-engine/src/tools/context.rs
@@ -46,6 +46,17 @@ impl ToolExecutionBinding {
         }
     }
 
+    /// Create a binding whose native Host projection will be supplied by the Host adapter.
+    pub fn awaiting_host_projection(namespace_cwd: PathBuf, scratch_dir: PathBuf) -> Self {
+        Self {
+            cwd: scratch_dir.clone(),
+            namespace_cwd,
+            host_mounts: Vec::new(),
+            scratch_dir,
+            sandbox_spec: None,
+        }
+    }
+
     /// Create a native adapter binding from the same Process Launch Context
     /// that owns namespace reachability and sandbox authority.
     pub fn from_launch_context(

--- a/crates/agent-engine/src/tools/mod.rs
+++ b/crates/agent-engine/src/tools/mod.rs
@@ -20,7 +20,6 @@ pub use reified_namespace::{
     ReifiedNamespaceRunError, ReifiedNamespaceRunner, ReifiedScratchTmpMount,
     default_execution_substrate,
 };
-pub(crate) use sandbox::protected_path_component;
 pub use sandbox::{ExecResult, NetworkPosture, Sandbox, SandboxSpec};
 pub use sandbox_backend::{
     LinuxReificationCapability, LinuxReificationCapabilityReport, LinuxReificationStatus,

--- a/crates/agent-engine/tests/dependency_boundary.rs
+++ b/crates/agent-engine/tests/dependency_boundary.rs
@@ -810,7 +810,6 @@ fn mount_changes_use_only_the_narrow_namespace_mount_control() {
     for required_field in [
         "launch_context: &'a mut Option<crate::ProcessLaunchContext>",
         "mount_grant_applicator: Option<Arc<dyn MountGrantApplicator>>",
-        "tool_process_context: Option<NamespaceToolProcessContext>",
     ] {
         assert!(
             mount_control.contains(required_field),
@@ -821,6 +820,7 @@ fn mount_changes_use_only_the_narrow_namespace_mount_control() {
         "root: InProcessTransport",
         "agent_path",
         "llm_connection",
+        "tool_process_context",
         "child_run_registry",
         "child_process_assembler",
     ] {

--- a/crates/agent-engine/tests/dependency_boundary/submission_runtime.rs
+++ b/crates/agent-engine/tests/dependency_boundary/submission_runtime.rs
@@ -19,7 +19,9 @@ fn submission_handling_uses_only_explicit_runtime_inputs() {
     assert!(transition.contains("async fn handle_runtime_op"));
     assert!(transition.contains("Op::CompactWithOptions"));
     assert!(handlers.contains("handle_non_compaction_runtime_op"));
-    assert!(handlers.contains("runtime.mount_control"));
+    assert!(runtime.contains("host_mount_requests: NamespaceHostMountRequests"));
+    assert!(handlers.contains(".host_mount_requests"));
+    assert!(!handlers.contains("runtime.mount_control"));
     assert!(!handlers.contains("state.mount_control()"));
     assert!(!handlers.contains("state.environment"));
 }

--- a/crates/alan/src/main.rs
+++ b/crates/alan/src/main.rs
@@ -77,7 +77,7 @@ enum HostAction {
 
 #[derive(Subcommand)]
 enum HostMountAction {
-    /// List pending requests and Alan OS-visible grants
+    /// List logical requests and Alan OS-visible grants
     List,
     /// Approve a pending request with a native Host directory
     Approve {
@@ -387,14 +387,7 @@ async fn main() -> Result<()> {
                 match action {
                     HostMountAction::List => {
                         let shell = alan_shell::Shell::new(attached.root);
-                        println!(
-                            "requests: {}",
-                            String::from_utf8(shell.cat("/mnt/host-mount/request").await?)?
-                        );
-                        println!(
-                            "grants: {}",
-                            String::from_utf8(shell.cat("/mnt/host-mount/grants").await?)?
-                        );
+                        print_host_mount_state(&shell).await?;
                     }
                     HostMountAction::Approve {
                         request_id,
@@ -705,6 +698,40 @@ fn print_host_status(status: &alan_os_host::HostStatus, json: bool) -> Result<()
         println!("boot: {}", status.boot_id);
         println!("host pid: {}", status.pid);
         println!("attachment: {}", status.socket.display());
+    }
+    Ok(())
+}
+
+async fn print_host_mount_state(shell: &alan_shell::Shell) -> Result<()> {
+    let request_ids = shell
+        .ls("/mnt/host-mount/requests")
+        .await?
+        .into_iter()
+        .filter(|entry| !matches!(entry.as_str(), "clone" | "events"))
+        .collect::<Vec<_>>();
+    println!("requests:");
+    if request_ids.is_empty() {
+        println!("  (none)");
+    }
+    for request_id in request_ids {
+        let base = format!("/mnt/host-mount/requests/{request_id}");
+        let status = String::from_utf8(shell.cat(&format!("{base}/status")).await?)?;
+        let request = String::from_utf8(shell.cat(&format!("{base}/request")).await?)?;
+        println!("  {request_id} [{}] {request}", status.trim());
+    }
+
+    let grant_ids = shell.ls("/mnt/host-mount/grants").await?;
+    println!("grants:");
+    if grant_ids.is_empty() {
+        println!("  (none)");
+    }
+    for grant_id in grant_ids {
+        let record = String::from_utf8(
+            shell
+                .cat(&format!("/mnt/host-mount/grants/{grant_id}/record"))
+                .await?,
+        )?;
+        println!("  {grant_id} {record}");
     }
     Ok(())
 }

--- a/crates/os-host/src/host_mounts.rs
+++ b/crates/os-host/src/host_mounts.rs
@@ -39,8 +39,22 @@ impl HostMountExport for NativeHostMountExport {
         self.tree.clone()
     }
 
-    fn apply_tool_authority(&self, binding: &mut ToolExecutionBinding) -> Result<()> {
-        binding.apply_host_mount(self.grant.clone())
+    fn apply_tool_authority(
+        &self,
+        effective_access: HostMountAccess,
+        binding: &mut ToolExecutionBinding,
+    ) -> Result<()> {
+        let effective_access = match effective_access {
+            HostMountAccess::ReadOnly => Access::ReadOnly,
+            HostMountAccess::ReadWrite => Access::ReadWrite,
+        };
+        anyhow::ensure!(
+            self.grant.access == Access::ReadWrite || effective_access == Access::ReadOnly,
+            "Host Mount Tool authority cannot amplify export access"
+        );
+        let mut grant = self.grant.clone();
+        grant.access = effective_access;
+        binding.apply_host_mount(grant)
     }
 }
 
@@ -423,6 +437,43 @@ mod tests {
             SandboxSpec::default_sensitive_read_denylist()
         );
         assert_eq!(spec.network, NetworkPosture::Deny);
+    }
+
+    #[test]
+    fn writable_export_can_be_narrowed_for_tool_authority() {
+        let host = tempfile::tempdir().unwrap();
+        let export =
+            native_export("/mnt/project", host.path(), HostMountAccess::ReadWrite).unwrap();
+        let mut binding = ToolExecutionBinding::awaiting_host_projection(
+            PathBuf::from("/mnt/project"),
+            host.path().join("scratch"),
+        );
+
+        export
+            .apply_tool_authority(HostMountAccess::ReadOnly, &mut binding)
+            .unwrap();
+
+        assert_eq!(binding.host_mounts.len(), 1);
+        assert_eq!(binding.host_mounts[0].access, Access::ReadOnly);
+        assert!(binding.sandbox_spec.unwrap().writable_roots.is_empty());
+    }
+
+    #[test]
+    fn read_only_export_rejects_writable_tool_authority() {
+        let host = tempfile::tempdir().unwrap();
+        let export = native_export("/mnt/project", host.path(), HostMountAccess::ReadOnly).unwrap();
+        let mut binding = ToolExecutionBinding::awaiting_host_projection(
+            PathBuf::from("/mnt/project"),
+            host.path().join("scratch"),
+        );
+
+        let error = export
+            .apply_tool_authority(HostMountAccess::ReadWrite, &mut binding)
+            .unwrap_err();
+
+        assert!(error.to_string().contains("cannot amplify"));
+        assert!(binding.host_mounts.is_empty());
+        assert!(binding.sandbox_spec.is_none());
     }
 
     async fn assert_file_bytes(

--- a/crates/os-host/src/host_mounts.rs
+++ b/crates/os-host/src/host_mounts.rs
@@ -68,7 +68,17 @@ pub fn approve_host_mount(
     let request = service
         .pending_request(request_id)
         .with_context(|| format!("unknown Host Mount request `{request_id}`"))?;
-    let export = native_export(&request.namespace_path, host_path, request.access)?;
+    let export = match native_export(&request.namespace_path, host_path, request.access) {
+        Ok(export) => export,
+        Err(error) => {
+            let _ = service.fail_request(
+                request_id,
+                "Host adapter could not authorize or export the selected directory",
+                "host-adapter",
+            );
+            return Err(error);
+        }
+    };
     service.approve_export(request_id, export, provenance, actor)
 }
 

--- a/crates/os-host/src/local.rs
+++ b/crates/os-host/src/local.rs
@@ -34,6 +34,9 @@ enum LocalRequest {
         request_id: String,
         host_path: PathBuf,
     },
+    CancelHostMount {
+        request_id: String,
+    },
     RevokeHostMount {
         grant_id: String,
     },
@@ -271,6 +274,22 @@ impl AlanOsHost {
                                 )
                                 .await
                             }
+                            LocalRequest::CancelHostMount { request_id } => {
+                                let result = host_mount.cancel_request(
+                                    &request_id,
+                                    "cancelled by native user",
+                                    "local-user",
+                                );
+                                write_local_response(
+                                    &mut write,
+                                    LocalResponse {
+                                        boot_id,
+                                        grant: None,
+                                        error: result.err().map(|error| error.to_string()),
+                                    },
+                                )
+                                .await
+                            }
                             LocalRequest::RevokeHostMount { grant_id } => {
                                 let result = host_mount.revoke(&grant_id, "local-user");
                                 write_local_response(
@@ -399,6 +418,14 @@ impl HostCommandPlane {
         .await?
         .grant
         .context("Host Mount approval returned no grant")
+    }
+
+    pub async fn cancel_host_mount(&self, request_id: impl Into<String>) -> Result<()> {
+        self.call(LocalRequest::CancelHostMount {
+            request_id: request_id.into(),
+        })
+        .await?;
+        Ok(())
     }
 
     pub async fn revoke_host_mount(&self, grant_id: impl Into<String>) -> Result<()> {

--- a/crates/os-host/tests/lifecycle.rs
+++ b/crates/os-host/tests/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::os::unix::fs::{FileTypeExt, PermissionsExt, symlink};
 use std::time::Duration;
 
-use alan_agent_engine::{AgentProcessConfig, LlmClient, ToolRegistry};
+use alan_agent_engine::{AgentProcessConfig, LlmClient, ToolCall, ToolRegistry};
 use alan_llm::{GenerationResponse, MockLlmProvider};
 use alan_os_host::{
     AlanOsHost, HostBootConfig, HostCommandPlane, HostEndpointPaths, HostStorePaths,
@@ -39,6 +39,43 @@ fn config_for(channel_id: &str) -> HostBootConfig {
         ),
         ToolRegistry::new(),
     )
+}
+
+fn mount_request_config() -> HostBootConfig {
+    let mut request = response("");
+    request.tool_calls = vec![ToolCall {
+        id: Some("call-mount".to_string()),
+        name: "request_mount".to_string(),
+        arguments: serde_json::json!({
+            "label": "Documents",
+            "namespace_path": "/mnt/docs",
+            "access": "read_only",
+            "reason": "test"
+        }),
+    }];
+    HostBootConfig::ephemeral(
+        "test",
+        AgentProcessConfig::default(),
+        LlmClient::new(MockLlmProvider::new().with_responses(vec![request, response("done")])),
+        ToolRegistry::new(),
+    )
+}
+
+async fn wait_for_host_mount_request(shell: &alan_shell::Shell) -> String {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let requests = shell.ls("/mnt/host-mount/requests").await.unwrap();
+            if let Some(request_id) = requests
+                .into_iter()
+                .find(|entry| !matches!(entry.as_str(), "clone" | "events"))
+            {
+                return request_id;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("Agent request_mount should publish a logical service request")
 }
 
 async fn wait_for_turn_idle(events: &mut alan_shell::Tail, phase: &str) {
@@ -320,7 +357,9 @@ async fn native_host_mount_approval_keeps_host_path_out_of_namespace_records() {
     let runtime = tempfile::tempdir().unwrap();
     let host_dir = tempfile::tempdir().unwrap();
     let paths = HostEndpointPaths::from_runtime_dir(runtime.path(), "test").unwrap();
-    let host = AlanOsHost::boot(config(), paths.clone()).await.unwrap();
+    let host = AlanOsHost::boot(mount_request_config(), paths.clone())
+        .await
+        .unwrap();
     let shutdown = CancellationToken::new();
     let shutdown_request = shutdown.clone();
     let server =
@@ -337,29 +376,61 @@ async fn native_host_mount_approval_keeps_host_path_out_of_namespace_records() {
     .trim()
     .parse::<u64>()
     .unwrap();
+    let mut activity = shell.tail("/agent/root/machine/ui/events").await.unwrap();
     shell
-        .write(
-            "/mnt/host-mount/request",
-            &serde_json::to_vec(&serde_json::json!({
-                "id": "docs",
-                "label": "Documents",
-                "namespace_path": "/mnt/docs",
-                "access": "read_only",
-                "reason": "test",
-                "requesting_pid": root_pid,
-            }))
-            .unwrap(),
-        )
+        .write("/agent/root/io/input", b"request documents")
         .await
         .unwrap();
+    let request_id = wait_for_host_mount_request(&shell).await;
+    assert_eq!(
+        shell
+            .cat(&format!("/mnt/host-mount/requests/{request_id}/status"))
+            .await
+            .unwrap(),
+        b"pending\n"
+    );
 
     HostCommandPlane::new(paths)
-        .approve_host_mount("docs", host_dir.path().to_path_buf())
+        .approve_host_mount(request_id.clone(), host_dir.path().to_path_buf())
         .await
         .unwrap();
-    let grants = String::from_utf8(shell.cat("/mnt/host-mount/grants").await.unwrap()).unwrap();
-    assert!(grants.contains("\"namespace_path\":\"/mnt/docs\""));
-    assert!(!grants.contains(&host_dir.path().display().to_string()));
+    wait_for_turn_idle(&mut activity, "Host Mount approval").await;
+    activity.close().await.unwrap();
+    assert_eq!(
+        shell
+            .cat(&format!("/mnt/host-mount/requests/{request_id}/status"))
+            .await
+            .unwrap(),
+        b"approved\n"
+    );
+    let grant_record = String::from_utf8(
+        shell
+            .cat(&format!("/mnt/host-mount/grants/{request_id}/record"))
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert!(grant_record.contains("\"namespace_path\":\"/mnt/docs\""));
+    assert!(!grant_record.contains(&host_dir.path().display().to_string()));
+    let request_events =
+        String::from_utf8(shell.cat("/mnt/host-mount/requests/events").await.unwrap()).unwrap();
+    assert!(!request_events.contains(&host_dir.path().display().to_string()));
+    let process_namespace = String::from_utf8(
+        shell
+            .cat(&format!("/proc/{root_pid}/namespace"))
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert!(process_namespace.lines().any(|line| line == "/mnt/docs ro"));
+    for retired in ["request", "projection", "approval", "status"] {
+        assert!(
+            shell
+                .stat(&format!("/mnt/host-mount/{retired}"))
+                .await
+                .is_err()
+        );
+    }
 
     shutdown.cancel();
     server.await.unwrap().unwrap();

--- a/crates/os-host/tests/lifecycle.rs
+++ b/crates/os-host/tests/lifecycle.rs
@@ -1,7 +1,15 @@
 use std::os::unix::fs::{FileTypeExt, PermissionsExt, symlink};
+use std::path::Path;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use std::time::Duration;
 
-use alan_agent_engine::{AgentProcessConfig, LlmClient, ToolCall, ToolRegistry};
+use alan_agent_engine::{
+    AgentProcessConfig, AgentRuntimeStoreBindings, LlmClient, ToolCall, ToolRegistry,
+    tools::{Tool, ToolContext, ToolResult},
+};
 use alan_llm::{GenerationResponse, MockLlmProvider};
 use alan_os_host::{
     AlanOsHost, HostBootConfig, HostCommandPlane, HostEndpointPaths, HostStorePaths,
@@ -41,7 +49,43 @@ fn config_for(channel_id: &str) -> HostBootConfig {
     )
 }
 
-fn mount_request_config() -> HostBootConfig {
+struct MountProbeTool {
+    completed: Arc<AtomicBool>,
+}
+
+impl Tool for MountProbeTool {
+    fn name(&self) -> &str {
+        "mount_probe"
+    }
+
+    fn description(&self) -> &str {
+        "Read a test file through an approved Alan OS Host Mount"
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        })
+    }
+
+    fn execute(&self, arguments: serde_json::Value, context: &ToolContext) -> ToolResult {
+        let path = arguments["path"].as_str().unwrap().to_string();
+        let resolved = context.resolve_path(&path);
+        let completed = self.completed.clone();
+        Box::pin(async move {
+            let contents = std::fs::read_to_string(resolved?)?;
+            completed.store(true, Ordering::Release);
+            Ok(serde_json::json!({ "contents": contents }))
+        })
+    }
+}
+
+fn mount_request_config(store_root: &Path, completed: Arc<AtomicBool>) -> HostBootConfig {
     let mut request = response("");
     request.tool_calls = vec![ToolCall {
         id: Some("call-mount".to_string()),
@@ -53,11 +97,43 @@ fn mount_request_config() -> HostBootConfig {
             "reason": "test"
         }),
     }];
+    let mut probe = response("");
+    probe.tool_calls = vec![ToolCall {
+        id: Some("call-probe".to_string()),
+        name: "mount_probe".to_string(),
+        arguments: serde_json::json!({ "path": "/mnt/docs/probe.txt" }),
+    }];
+    let stores = AgentRuntimeStoreBindings {
+        rollouts: store_root.join("rollouts"),
+        checkpoints: store_root.join("checkpoints"),
+        cache: store_root.join("cache"),
+        tmp: store_root.join("tmp"),
+        metadata: store_root.join("metadata"),
+    };
+    for path in [
+        &stores.rollouts,
+        &stores.checkpoints,
+        &stores.cache,
+        &stores.tmp,
+        &stores.metadata,
+    ] {
+        std::fs::create_dir_all(path).unwrap();
+    }
+    let process = AgentProcessConfig {
+        store_bindings: Some(stores),
+        ..AgentProcessConfig::default()
+    };
+    let mut tools = ToolRegistry::new();
+    tools.register(MountProbeTool { completed });
     HostBootConfig::ephemeral(
         "test",
-        AgentProcessConfig::default(),
-        LlmClient::new(MockLlmProvider::new().with_responses(vec![request, response("done")])),
-        ToolRegistry::new(),
+        process,
+        LlmClient::new(MockLlmProvider::new().with_responses(vec![
+            request,
+            probe,
+            response("done"),
+        ])),
+        tools,
     )
 }
 
@@ -352,14 +428,22 @@ async fn shell_client_exit_detaches_without_stopping_host_or_root_agent() {
 }
 
 #[tokio::test]
-async fn native_host_mount_approval_keeps_host_path_out_of_namespace_records() {
+async fn native_host_mount_approval_hides_host_path_and_enables_first_tool() {
     let _host_guard = TEST_HOST_LOCK.lock().await;
     let runtime = tempfile::tempdir().unwrap();
     let host_dir = tempfile::tempdir().unwrap();
+    std::fs::write(host_dir.path().join("probe.txt"), "visible through grant").unwrap();
+    let probe_completed = Arc::new(AtomicBool::new(false));
     let paths = HostEndpointPaths::from_runtime_dir(runtime.path(), "test").unwrap();
-    let host = AlanOsHost::boot(mount_request_config(), paths.clone())
-        .await
-        .unwrap();
+    let host = AlanOsHost::boot(
+        mount_request_config(
+            &runtime.path().join("system-store"),
+            probe_completed.clone(),
+        ),
+        paths.clone(),
+    )
+    .await
+    .unwrap();
     let shutdown = CancellationToken::new();
     let shutdown_request = shutdown.clone();
     let server =
@@ -394,6 +478,13 @@ async fn native_host_mount_approval_keeps_host_path_out_of_namespace_records() {
         .approve_host_mount(request_id.clone(), host_dir.path().to_path_buf())
         .await
         .unwrap();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !probe_completed.load(Ordering::Acquire) {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("the first approved logical Host Mount should establish Tool execution authority");
     wait_for_turn_idle(&mut activity, "Host Mount approval").await;
     activity.close().await.unwrap();
     assert_eq!(

--- a/crates/os-host/tests/lifecycle.rs
+++ b/crates/os-host/tests/lifecycle.rs
@@ -428,6 +428,56 @@ async fn shell_client_exit_detaches_without_stopping_host_or_root_agent() {
 }
 
 #[tokio::test]
+async fn native_host_mount_cancellation_settles_waiting_agent() {
+    let _host_guard = TEST_HOST_LOCK.lock().await;
+    let runtime = tempfile::tempdir().unwrap();
+    let probe_completed = Arc::new(AtomicBool::new(false));
+    let paths = HostEndpointPaths::from_runtime_dir(runtime.path(), "test").unwrap();
+    let host = AlanOsHost::boot(
+        mount_request_config(
+            &runtime.path().join("system-store"),
+            probe_completed.clone(),
+        ),
+        paths.clone(),
+    )
+    .await
+    .unwrap();
+    let shutdown = CancellationToken::new();
+    let shutdown_request = shutdown.clone();
+    let server =
+        tokio::spawn(async move { host.serve_until(shutdown_request.cancelled_owned()).await });
+    let attachment = LocalAttachment::new(paths.clone()).connect().await.unwrap();
+    let shell = alan_shell::Shell::new(attachment.root);
+    let mut activity = shell.tail("/agent/root/machine/ui/events").await.unwrap();
+    shell
+        .write("/agent/root/io/input", b"request documents")
+        .await
+        .unwrap();
+    let request_id = wait_for_host_mount_request(&shell).await;
+
+    HostCommandPlane::new(paths)
+        .cancel_host_mount(request_id.clone())
+        .await
+        .unwrap();
+
+    wait_for_turn_idle(&mut activity, "Host Mount cancellation").await;
+    activity.close().await.unwrap();
+    assert!(!probe_completed.load(Ordering::Acquire));
+    let request_base = format!("/mnt/host-mount/requests/{request_id}");
+    assert_eq!(
+        shell.cat(&format!("{request_base}/status")).await.unwrap(),
+        b"cancelled\n"
+    );
+    assert_eq!(
+        shell.cat(&format!("{request_base}/error")).await.unwrap(),
+        b"cancelled by native user\n"
+    );
+
+    shutdown.cancel();
+    server.await.unwrap().unwrap();
+}
+
+#[tokio::test]
 async fn native_host_mount_approval_hides_host_path_and_enables_first_tool() {
     let _host_guard = TEST_HOST_LOCK.lock().await;
     let runtime = tempfile::tempdir().unwrap();

--- a/crates/service-manager/src/agent_runtime.rs
+++ b/crates/service-manager/src/agent_runtime.rs
@@ -17,7 +17,7 @@ use alan_agent_engine::{
         MountGrantApplicatorFactory,
     },
     spawn_with_namespace_environment,
-    tools::ToolProcessRunner,
+    tools::{ToolExecutionAuthority, ToolProcessRunner},
 };
 use alan_ap::{Fid, FileServer, InProcessTransport, OpenMode};
 use alan_kernel::{
@@ -225,7 +225,7 @@ impl AgentRuntimeService {
             let root = InProcessTransport::new(Arc::new(
                 alan_kernel::MountFs::from_live_namespace(namespace.clone()),
             ));
-            let launch_context = launch_context.rebound(namespace.snapshot(), credentials);
+            let launch_context = launch_context.rebound_live(namespace.clone(), credentials);
             let mount_applicator =
                 self.mount_applicator(pid, namespace.clone(), &launch_context, &tool_runner);
             let environment = alan_agent_engine::runtime::NamespaceRuntimeEnvironment::new(
@@ -300,11 +300,7 @@ impl AgentRuntimeService {
         tool_runner: &ToolProcessRunner,
     ) -> Arc<dyn MountGrantApplicator> {
         let factory = HostMountApplicatorFactory::new(self.host_mount.clone());
-        let inherited_mount_paths = launch_context
-            .host_mounts
-            .iter()
-            .map(|grant| grant.namespace_path.clone())
-            .collect::<Vec<_>>();
+        let inherited_mount_paths = launch_context.host_mount_namespace_paths();
         let applicator = factory.create(pid, namespace, &inherited_mount_paths);
         if let Some(authority) = factory.tool_execution_authority() {
             tool_runner.register_process_authority(pid, authority);
@@ -330,7 +326,7 @@ impl AgentRuntimeService {
         request: ChildAgentProcessAssemblyRequest,
     ) -> Result<AssembledChildAgentProcess> {
         let ChildAgentProcessAssemblyRequest {
-            plan,
+            mut plan,
             scratch_dir,
             executable,
         } = request;
@@ -369,6 +365,19 @@ impl AgentRuntimeService {
             pid: child_pid,
         });
 
+        let child_credentials = Credentials::user("child-agent");
+        let live_namespace =
+            LiveNamespace::new(child_namespace(&plan, agent_root_tree.clone(), &handles));
+        let mount_applicator = self.mount_applicator(
+            child_pid,
+            live_namespace.clone(),
+            &plan.launch_context,
+            &self.tool_runner,
+        );
+        plan.launch_context = plan
+            .launch_context
+            .rebound_live(live_namespace.clone(), child_credentials.clone());
+
         let launch = async {
             let exec = child_exec_spec(&plan, &pid, executable);
             let exec_bytes = serde_json::to_vec(&exec).context("serialize child exec spec")?;
@@ -388,14 +397,22 @@ impl AgentRuntimeService {
                     .select(child_pid.0, &plan.llm_connection_name)?;
             }
 
-            if !plan.launch_context.host_mounts.is_empty() {
+            if plan.launch_context.has_host_mounts() {
                 let scratch = scratch_dir.context(
                     "child Agent Process with Host Mounts requires Agent Runtime Service store bindings",
                 )?;
-                let binding = alan_agent_engine::tools::ToolExecutionBinding::from_launch_context(
-                    &plan.launch_context,
-                    scratch,
-                )?;
+                let binding = if plan.launch_context.host_mounts.is_empty() {
+                    alan_agent_engine::tools::ToolExecutionBinding::awaiting_host_projection(
+                        Path::new(&plan.launch_context.cwd).to_path_buf(),
+                        scratch,
+                    )
+                } else {
+                    alan_agent_engine::tools::ToolExecutionBinding::from_launch_context(
+                        &plan.launch_context,
+                        scratch,
+                    )?
+                };
+                let binding = self.host_mount.reconcile(child_pid, binding)?;
                 self.tool_runner
                     .register_process_binding(child_pid, binding);
             }
@@ -404,29 +421,18 @@ impl AgentRuntimeService {
                 .procfs
                 .clone()
                 .with_runner(Arc::new(self.tool_runner.clone()));
-            let live_namespace = LiveNamespace::new(child_namespace(
-                &plan,
-                agent_root_tree,
-                &handles,
-            ));
             runtime_procfs
                 .bind_live_namespace(child_pid, live_namespace.clone())
                 .await;
             let child_procfs = runtime_procfs.for_live_spawner(
                 Some(child_pid),
                 live_namespace.clone(),
-                Credentials::user("child-agent"),
+                child_credentials,
             );
             live_namespace.mount(
                 "/proc",
                 InProcessTransport::new(Arc::new(child_procfs)),
                 Access::ReadWrite,
-            );
-            let mount_applicator = self.mount_applicator(
-                child_pid,
-                live_namespace.clone(),
-                &plan.launch_context,
-                &self.tool_runner,
             );
             live_namespace.replace_mount(
                 "/mnt/host-mount",
@@ -436,7 +442,7 @@ impl AgentRuntimeService {
                 Access::ReadWrite,
             );
             let root = InProcessTransport::new(Arc::new(
-                alan_kernel::MountFs::from_live_namespace(live_namespace),
+                alan_kernel::MountFs::from_live_namespace(live_namespace.clone()),
             ));
             let mut environment =
                 alan_agent_engine::runtime::NamespaceRuntimeEnvironment::new(
@@ -596,6 +602,12 @@ fn child_namespace_manifest(
     mounts.extend(plan.launch_context.host_mounts.iter().map(|grant| {
         ExecNamespaceMount::new(grant.namespace_path.clone(), exec_access(grant.access))
     }));
+    mounts.extend(
+        plan.launch_context
+            .projected_host_mounts()
+            .into_iter()
+            .map(|(path, access)| ExecNamespaceMount::new(path, exec_access(access))),
+    );
     mounts.extend(
         plan.launch_context
             .package_references

--- a/crates/service-manager/src/agent_runtime.rs
+++ b/crates/service-manager/src/agent_runtime.rs
@@ -188,6 +188,11 @@ impl AgentRuntimeService {
                 Access::ReadWrite,
             );
             self.host_mount.register_process(pid, namespace.clone());
+            namespace.replace_mount(
+                "/mnt/host-mount",
+                InProcessTransport::new(self.host_mount.file_server_for_process(pid.0)),
+                Access::ReadWrite,
+            );
             if self.connection.has_profile(&template.llm_connection) {
                 self.connection.select(pid.0, &template.llm_connection)?;
             }
@@ -417,15 +422,22 @@ impl AgentRuntimeService {
                 InProcessTransport::new(Arc::new(child_procfs)),
                 Access::ReadWrite,
             );
-            let root = InProcessTransport::new(Arc::new(
-                alan_kernel::MountFs::from_live_namespace(live_namespace.clone()),
-            ));
             let mount_applicator = self.mount_applicator(
                 child_pid,
-                live_namespace,
+                live_namespace.clone(),
                 &plan.launch_context,
                 &self.tool_runner,
             );
+            live_namespace.replace_mount(
+                "/mnt/host-mount",
+                InProcessTransport::new(
+                    self.host_mount.file_server_for_process(child_pid.0),
+                ),
+                Access::ReadWrite,
+            );
+            let root = InProcessTransport::new(Arc::new(
+                alan_kernel::MountFs::from_live_namespace(live_namespace),
+            ));
             let mut environment =
                 alan_agent_engine::runtime::NamespaceRuntimeEnvironment::new(
                     root,

--- a/crates/service-manager/src/agent_runtime.rs
+++ b/crates/service-manager/src/agent_runtime.rs
@@ -22,7 +22,7 @@ use alan_agent_engine::{
 use alan_ap::{Fid, FileServer, InProcessTransport, OpenMode};
 use alan_kernel::{
     Access, Credentials, ExecNamespaceAccess, ExecNamespaceManifest, ExecNamespaceMount, ExecSpec,
-    LiveNamespace, Pid,
+    LiveNamespace, Namespace, Pid,
 };
 use alan_llm::ProviderCapabilities;
 use anyhow::{Context, Result, ensure};
@@ -227,7 +227,7 @@ impl AgentRuntimeService {
             ));
             let launch_context = launch_context.rebound_live(namespace.clone(), credentials);
             let mount_applicator =
-                self.mount_applicator(pid, namespace.clone(), &launch_context, &tool_runner);
+                self.mount_applicator(pid, namespace.clone(), &launch_context, &tool_runner, None);
             self.register_tool_execution_binding(
                 pid,
                 &launch_context,
@@ -307,10 +307,16 @@ impl AgentRuntimeService {
         namespace: LiveNamespace,
         launch_context: &alan_agent_engine::ProcessLaunchContext,
         tool_runner: &ToolProcessRunner,
+        inherited_from: Option<Pid>,
     ) -> Arc<dyn MountGrantApplicator> {
-        let factory = HostMountApplicatorFactory::new(self.host_mount.clone());
-        let inherited_mount_paths = launch_context.host_mount_namespace_paths();
-        let applicator = factory.create(pid, namespace, &inherited_mount_paths);
+        let factory = inherited_from.map_or_else(
+            || HostMountApplicatorFactory::new(self.host_mount.clone()),
+            |parent_pid| {
+                HostMountApplicatorFactory::inheriting_from(self.host_mount.clone(), parent_pid)
+            },
+        );
+        let inherited_mount_references = launch_context.projected_host_mount_references();
+        let applicator = factory.create(pid, namespace, &inherited_mount_references);
         if let Some(authority) = factory.tool_execution_authority() {
             tool_runner.register_process_authority(pid, authority);
         }
@@ -420,6 +426,7 @@ impl AgentRuntimeService {
             live_namespace.clone(),
             &plan.launch_context,
             &self.tool_runner,
+            Some(parent_pid),
         );
         plan.launch_context = plan
             .launch_context
@@ -610,6 +617,7 @@ fn child_namespace_manifest(
     plan: &ChildAgentProcessAssemblyPlan,
     _pid: &str,
 ) -> ExecNamespaceManifest {
+    let namespace = plan.launch_context.namespace_snapshot();
     let mut mounts = vec![
         ExecNamespaceMount::new(plan.agent_mount.clone(), ExecNamespaceAccess::ReadWrite),
         ExecNamespaceMount::new(plan.llm_mount.clone(), ExecNamespaceAccess::ReadWrite),
@@ -628,19 +636,16 @@ fn child_namespace_manifest(
     mounts.extend(plan.launch_context.host_mounts.iter().map(|grant| {
         ExecNamespaceMount::new(grant.namespace_path.clone(), exec_access(grant.access))
     }));
-    mounts.extend(
-        plan.launch_context
-            .projected_host_mounts()
-            .into_iter()
-            .map(|(path, access)| ExecNamespaceMount::new(path, exec_access(access))),
-    );
+    mounts.extend(live_projected_host_mounts(
+        &namespace,
+        plan.launch_context.projected_host_mounts(),
+    ));
     mounts.extend(
         plan.launch_context
             .package_references
             .iter()
             .filter_map(|reference| {
-                plan.launch_context
-                    .namespace
+                namespace
                     .resolve(&reference.namespace_path)
                     .ok()
                     .map(|resolved| {
@@ -665,16 +670,9 @@ fn child_namespace_manifest(
                     })
             })
             .filter_map(|descriptor| {
-                plan.launch_context
-                    .namespace
-                    .resolve(&descriptor.path)
-                    .ok()
-                    .map(|resolved| {
-                        ExecNamespaceMount::new(
-                            descriptor.path.clone(),
-                            exec_access(resolved.access),
-                        )
-                    })
+                namespace.resolve(&descriptor.path).ok().map(|resolved| {
+                    ExecNamespaceMount::new(descriptor.path.clone(), exec_access(resolved.access))
+                })
             }),
     );
     mounts.sort_by(|left, right| {
@@ -684,6 +682,21 @@ fn child_namespace_manifest(
     });
     mounts.dedup();
     ExecNamespaceManifest { mounts }
+}
+
+fn live_projected_host_mounts(
+    namespace: &Namespace,
+    projected: Vec<(String, Access)>,
+) -> Vec<ExecNamespaceMount> {
+    projected
+        .into_iter()
+        .filter_map(|(path, _)| {
+            namespace
+                .union_at(&path)
+                .last()
+                .map(|mount| ExecNamespaceMount::new(path, exec_access(mount.access)))
+        })
+        .collect()
 }
 
 fn exec_access(access: Access) -> ExecNamespaceAccess {
@@ -816,6 +829,37 @@ fn next_child_fid() -> Fid {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn child_manifest_omits_projected_mounts_missing_from_the_live_namespace() {
+        let mut namespace = Namespace::new();
+        namespace.mount(
+            "/",
+            InProcessTransport::new(Arc::new(alan_ap::reference::MemFs::new())),
+            Access::ReadWrite,
+        );
+        namespace.mount(
+            "/mnt/live",
+            InProcessTransport::new(Arc::new(alan_ap::reference::MemFs::new())),
+            Access::ReadOnly,
+        );
+
+        let mounts = live_projected_host_mounts(
+            &namespace,
+            vec![
+                ("/mnt/live".to_string(), Access::ReadOnly),
+                ("/mnt/revoked".to_string(), Access::ReadWrite),
+            ],
+        );
+
+        assert_eq!(
+            mounts,
+            vec![ExecNamespaceMount::new(
+                "/mnt/live",
+                ExecNamespaceAccess::ReadOnly,
+            )]
+        );
+    }
 
     #[tokio::test]
     async fn service_assembles_and_releases_child_agent_process() {

--- a/crates/service-manager/src/agent_runtime.rs
+++ b/crates/service-manager/src/agent_runtime.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::BTreeSet,
-    path::Path,
+    path::{Path, PathBuf},
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
@@ -228,6 +228,15 @@ impl AgentRuntimeService {
             let launch_context = launch_context.rebound_live(namespace.clone(), credentials);
             let mount_applicator =
                 self.mount_applicator(pid, namespace.clone(), &launch_context, &tool_runner);
+            self.register_tool_execution_binding(
+                pid,
+                &launch_context,
+                template
+                    .process
+                    .store_bindings
+                    .as_ref()
+                    .map(|stores| stores.tmp.clone()),
+            )?;
             let environment = alan_agent_engine::runtime::NamespaceRuntimeEnvironment::new(
                 root.clone(),
                 format!("/agent/{}", pid.0),
@@ -306,6 +315,44 @@ impl AgentRuntimeService {
             tool_runner.register_process_authority(pid, authority);
         }
         applicator
+    }
+
+    /// Seed one Process with an explicit Tool binding.
+    ///
+    /// Host Mount Service reconciles this binding immediately before each Tool Process starts.
+    /// Keeping an authority-free seed for a mount-free Process means the first logical Host Mount
+    /// can supply native authority without recreating a binding in the Agent Execution Engine.
+    fn register_tool_execution_binding(
+        &self,
+        pid: Pid,
+        launch_context: &alan_agent_engine::ProcessLaunchContext,
+        scratch_dir: Option<PathBuf>,
+    ) -> Result<()> {
+        let Some(scratch_dir) = scratch_dir else {
+            ensure!(
+                !launch_context.has_host_mounts(),
+                "Agent Process with Host Mounts requires Agent Runtime Service store bindings",
+            );
+            return Ok(());
+        };
+        let binding = if launch_context.host_mounts.is_empty() {
+            alan_agent_engine::tools::ToolExecutionBinding::awaiting_host_projection(
+                Path::new(&launch_context.cwd).to_path_buf(),
+                scratch_dir,
+            )
+        } else {
+            alan_agent_engine::tools::ToolExecutionBinding::from_launch_context(
+                launch_context,
+                scratch_dir,
+            )?
+        };
+        let binding = if launch_context.has_host_mounts() {
+            self.host_mount.reconcile(pid, binding)?
+        } else {
+            binding
+        };
+        self.tool_runner.register_process_binding(pid, binding);
+        Ok(())
     }
 }
 
@@ -397,25 +444,7 @@ impl AgentRuntimeService {
                     .select(child_pid.0, &plan.llm_connection_name)?;
             }
 
-            if plan.launch_context.has_host_mounts() {
-                let scratch = scratch_dir.context(
-                    "child Agent Process with Host Mounts requires Agent Runtime Service store bindings",
-                )?;
-                let binding = if plan.launch_context.host_mounts.is_empty() {
-                    alan_agent_engine::tools::ToolExecutionBinding::awaiting_host_projection(
-                        Path::new(&plan.launch_context.cwd).to_path_buf(),
-                        scratch,
-                    )
-                } else {
-                    alan_agent_engine::tools::ToolExecutionBinding::from_launch_context(
-                        &plan.launch_context,
-                        scratch,
-                    )?
-                };
-                let binding = self.host_mount.reconcile(child_pid, binding)?;
-                self.tool_runner
-                    .register_process_binding(child_pid, binding);
-            }
+            self.register_tool_execution_binding(child_pid, &plan.launch_context, scratch_dir)?;
 
             let runtime_procfs = self
                 .procfs
@@ -436,24 +465,21 @@ impl AgentRuntimeService {
             );
             live_namespace.replace_mount(
                 "/mnt/host-mount",
-                InProcessTransport::new(
-                    self.host_mount.file_server_for_process(child_pid.0),
-                ),
+                InProcessTransport::new(self.host_mount.file_server_for_process(child_pid.0)),
                 Access::ReadWrite,
             );
             let root = InProcessTransport::new(Arc::new(
                 alan_kernel::MountFs::from_live_namespace(live_namespace.clone()),
             ));
-            let mut environment =
-                alan_agent_engine::runtime::NamespaceRuntimeEnvironment::new(
-                    root,
-                    format!("/agent/{pid}"),
-                    plan.llm_connection_name()?,
-                )
-                .with_launch_context(plan.launch_context.clone())
-                .with_tool_process_context(child_pid, self.tool_runner.clone())
-                .with_mount_grant_applicator(mount_applicator)
-                .with_child_process_assembler(self.child_process_assembler(child_pid));
+            let mut environment = alan_agent_engine::runtime::NamespaceRuntimeEnvironment::new(
+                root,
+                format!("/agent/{pid}"),
+                plan.llm_connection_name()?,
+            )
+            .with_launch_context(plan.launch_context.clone())
+            .with_tool_process_context(child_pid, self.tool_runner.clone())
+            .with_mount_grant_applicator(mount_applicator)
+            .with_child_process_assembler(self.child_process_assembler(child_pid));
             apply_agent_definition_grant(&mut environment, &plan)?;
             let observation_environment =
                 child_observation_environment(&self.procfs, &self.agent_root, &pid, &plan).await?;

--- a/crates/service-manager/src/host_mount.rs
+++ b/crates/service-manager/src/host_mount.rs
@@ -732,6 +732,7 @@ impl ToolExecutionAuthority for HostMountService {
         pid: Pid,
         mut binding: ToolExecutionBinding,
     ) -> Result<ToolExecutionBinding> {
+        let carried_host_mount_authority = !binding.host_mounts.is_empty();
         let state = self.state.lock().unwrap();
         let managed_paths = state
             .grants
@@ -762,8 +763,10 @@ impl ToolExecutionAuthority for HostMountService {
         for export in exports {
             export.apply_tool_authority(&mut binding)?;
         }
+        // An empty seed is a valid zero-authority binding for mount-free Tools. Fail closed only
+        // when reconciliation removed Host Mount authority that the cached binding carried.
         ensure!(
-            !binding.host_mounts.is_empty(),
+            !carried_host_mount_authority || !binding.host_mounts.is_empty(),
             "Tool Process has no active Host Mount"
         );
         Ok(binding)

--- a/crates/service-manager/src/host_mount.rs
+++ b/crates/service-manager/src/host_mount.rs
@@ -1,5 +1,8 @@
 use std::collections::BTreeMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicU32, Ordering},
+};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use alan_agent_engine::runtime::{
@@ -11,15 +14,18 @@ use alan_kernel::{Access, LiveNamespace, Namespace, Pid};
 use anyhow::{Context, Result, ensure};
 use serde::{Deserialize, Serialize};
 
-use crate::flat_fs::{FlatFileService, FlatServiceFs};
+mod file_server;
 
-const FILES: &[(&str, bool)] = &[
-    ("request", true),
-    ("grants", false),
-    ("status", false),
-    ("audit", false),
-    ("projection", true),
-    ("revoke", true),
+use file_server::{HostMountEventStreams, HostMountFs};
+
+const RESERVED_MOUNT_NAMESPACE_ROOTS: &[&str] = &[
+    "connections",
+    "host-mount",
+    "llm",
+    "mem",
+    "package",
+    "route",
+    "service-manager",
 ];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -47,10 +53,11 @@ pub trait HostMountExport: std::fmt::Debug + Send + Sync {
     fn apply_tool_authority(&self, binding: &mut ToolExecutionBinding) -> Result<()>;
 }
 
-/// Platform boundary used by runtime-approved mount requests.
+/// Transitional platform boundary for pre-authorized launch declarations.
 ///
-/// Only the Host implementation may inspect the raw path carried by the legacy
-/// engine approval object while that engine surface is being replaced.
+/// Logical runtime requests use [`HostMountExport`] directly after native authorization. Only the
+/// Host implementation may inspect the raw path carried by the launch-only engine record while
+/// that record is replaced with a service-issued handle.
 pub trait HostMountExportAdapter: std::fmt::Debug + Send + Sync {
     fn export_approved(&self, grant: &ApprovedMountGrant) -> Result<Arc<dyn HostMountExport>>;
 }
@@ -73,6 +80,42 @@ pub struct HostMountRequest {
     pub access: HostMountAccess,
     pub reason: String,
     pub requesting_pid: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HostMountRequestDocument {
+    namespace_path: String,
+    access: HostMountAccess,
+    reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    label: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HostMountStatus {
+    Pending,
+    Approved,
+    Rejected,
+    Cancelled,
+    Failed,
+}
+
+impl HostMountStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Approved => "approved",
+            Self::Rejected => "rejected",
+            Self::Cancelled => "cancelled",
+            Self::Failed => "failed",
+        }
+    }
+
+    fn is_terminal(self) -> bool {
+        !matches!(self, Self::Pending)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -106,9 +149,25 @@ struct Grant {
     projections: Vec<Projection>,
 }
 
+struct RequestState {
+    request: HostMountRequest,
+    status: HostMountStatus,
+    decision_in_progress: bool,
+    grant: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(Clone)]
+pub(super) struct HostMountRequestSnapshot {
+    pub(super) request: HostMountRequest,
+    pub(super) status: HostMountStatus,
+    pub(super) grant: Option<String>,
+    pub(super) error: Option<String>,
+}
+
 #[derive(Default)]
 struct State {
-    requests: BTreeMap<String, HostMountRequest>,
+    requests: BTreeMap<String, RequestState>,
     grants: BTreeMap<String, Grant>,
     processes: BTreeMap<Pid, LiveNamespace>,
     audit: Vec<AuditRecord>,
@@ -119,6 +178,9 @@ struct State {
 pub struct HostMountService {
     adapter: Arc<dyn HostMountExportAdapter>,
     state: Mutex<State>,
+    generation: AtomicU32,
+    request_events: HostMountEventStreams,
+    events: HostMountEventStreams,
 }
 
 impl std::fmt::Debug for HostMountService {
@@ -132,6 +194,9 @@ impl HostMountService {
         Arc::new(Self {
             adapter,
             state: Mutex::new(State::default()),
+            generation: AtomicU32::new(0),
+            request_events: HostMountEventStreams::new(),
+            events: HostMountEventStreams::new(),
         })
     }
 
@@ -140,7 +205,12 @@ impl HostMountService {
     }
 
     pub fn file_server(self: &Arc<Self>) -> Arc<dyn FileServer> {
-        Arc::new(FlatServiceFs::new(self.clone()))
+        Arc::new(HostMountFs::new(self.clone(), None))
+    }
+
+    /// Return the Process-scoped request view mounted into one Agent Process.
+    pub fn file_server_for_process(self: &Arc<Self>, pid: u64) -> Arc<dyn FileServer> {
+        Arc::new(HostMountFs::new(self.clone(), Some(pid)))
     }
 
     pub fn register_process(&self, pid: Pid, namespace: LiveNamespace) {
@@ -195,7 +265,15 @@ impl HostMountService {
     }
 
     pub fn pending_request(&self, request_id: &str) -> Option<HostMountRequest> {
-        self.state.lock().unwrap().requests.get(request_id).cloned()
+        self.state
+            .lock()
+            .unwrap()
+            .requests
+            .get(request_id)
+            .filter(|request| {
+                request.status == HostMountStatus::Pending && !request.decision_in_progress
+            })
+            .map(|request| request.request.clone())
     }
 
     pub fn approve_export(
@@ -205,11 +283,8 @@ impl HostMountService {
         provenance: impl Into<String>,
         actor: impl Into<String>,
     ) -> Result<HostMountGrantRecord> {
-        let mut state = self.state.lock().unwrap();
-        let request = state
-            .requests
-            .remove(request_id)
-            .with_context(|| format!("unknown Host Mount request `{request_id}`"))?;
+        let actor = actor.into();
+        let request = self.claim_pending_request(request_id)?;
         let record = HostMountGrantRecord {
             id: request.id.clone(),
             label: request.label.clone(),
@@ -218,6 +293,7 @@ impl HostMountService {
             provenance: provenance.into(),
             active: true,
         };
+        let mut state = self.state.lock().unwrap();
         state.grants.insert(
             record.id.clone(),
             Grant {
@@ -227,22 +303,132 @@ impl HostMountService {
                 projections: Vec::new(),
             },
         );
-        audit(&mut state, "approve", &record.id, actor.into(), Vec::new());
         drop(state);
         if let Err(error) = self.project(&record.id, request.requesting_pid) {
             let mut state = self.state.lock().unwrap();
             state.grants.remove(&record.id);
-            state.requests.insert(request.id.clone(), request);
+            if let Some(request) = state.requests.get_mut(&record.id) {
+                request.status = HostMountStatus::Failed;
+                request.error = Some("Host Mount namespace projection failed".to_string());
+            }
             audit(
                 &mut state,
-                "approval_rollback",
+                "approval_failed",
                 &record.id,
                 "service-manager".to_string(),
                 Vec::new(),
             );
+            drop(state);
+            self.bump_generation();
+            self.append_request_event(
+                &record.id,
+                HostMountStatus::Failed,
+                None,
+                Some("Host Mount namespace projection failed"),
+            );
             return Err(error);
         }
+        let mut state = self.state.lock().unwrap();
+        let request_state = state
+            .requests
+            .get_mut(&record.id)
+            .expect("approved request remains retained");
+        request_state.status = HostMountStatus::Approved;
+        request_state.grant = Some(record.id.clone());
+        audit(&mut state, "approve", &record.id, actor, Vec::new());
+        drop(state);
+        self.bump_generation();
+        self.append_request_event(
+            &record.id,
+            HostMountStatus::Approved,
+            Some(&record.id),
+            None,
+        );
         Ok(record)
+    }
+
+    fn claim_pending_request(&self, request_id: &str) -> Result<HostMountRequest> {
+        let mut state = self.state.lock().unwrap();
+        let request = state
+            .requests
+            .get_mut(request_id)
+            .with_context(|| format!("unknown Host Mount request `{request_id}`"))?;
+        ensure!(
+            request.status == HostMountStatus::Pending && !request.decision_in_progress,
+            "Host Mount request `{request_id}` is already settled or being settled"
+        );
+        request.decision_in_progress = true;
+        Ok(request.request.clone())
+    }
+
+    pub fn reject_request(
+        &self,
+        request_id: &str,
+        reason: impl Into<String>,
+        actor: impl Into<String>,
+    ) -> Result<()> {
+        self.set_terminal_request(
+            request_id,
+            HostMountStatus::Rejected,
+            reason.into(),
+            actor.into(),
+        )
+    }
+
+    pub fn cancel_request(
+        &self,
+        request_id: &str,
+        reason: impl Into<String>,
+        actor: impl Into<String>,
+    ) -> Result<()> {
+        self.set_terminal_request(
+            request_id,
+            HostMountStatus::Cancelled,
+            reason.into(),
+            actor.into(),
+        )
+    }
+
+    pub fn fail_request(
+        &self,
+        request_id: &str,
+        reason: impl Into<String>,
+        actor: impl Into<String>,
+    ) -> Result<()> {
+        self.set_terminal_request(
+            request_id,
+            HostMountStatus::Failed,
+            reason.into(),
+            actor.into(),
+        )
+    }
+
+    fn set_terminal_request(
+        &self,
+        request_id: &str,
+        status: HostMountStatus,
+        reason: String,
+        actor: String,
+    ) -> Result<()> {
+        ensure!(status.is_terminal(), "terminal request status is required");
+        let reason = concise_terminal_reason(&reason);
+        let mut state = self.state.lock().unwrap();
+        let request = state
+            .requests
+            .get_mut(request_id)
+            .with_context(|| format!("unknown Host Mount request `{request_id}`"))?;
+        ensure!(
+            request.status == HostMountStatus::Pending && !request.decision_in_progress,
+            "Host Mount request `{request_id}` is already settled or being settled"
+        );
+        request.decision_in_progress = true;
+        request.status = status;
+        request.error = Some(reason.clone());
+        audit(&mut state, status.as_str(), request_id, actor, Vec::new());
+        drop(state);
+        self.bump_generation();
+        self.append_request_event(request_id, status, None, Some(&reason));
+        Ok(())
     }
 
     pub fn project(&self, grant_id: &str, pid: u64) -> Result<()> {
@@ -301,7 +487,22 @@ impl HostMountService {
                 projection.pid.0
             })
             .collect::<Vec<_>>();
-        audit(&mut state, "revoke", grant_id, actor.into(), affected);
+        audit(
+            &mut state,
+            "revoke",
+            grant_id,
+            actor.into(),
+            affected.clone(),
+        );
+        drop(state);
+        self.bump_generation();
+        self.append_service_event(
+            serde_json::json!({
+                "type": "grant_revoked",
+                "grant_id": grant_id,
+            }),
+            &affected,
+        );
         Ok(())
     }
 
@@ -330,7 +531,16 @@ impl HostMountService {
             request.id
         );
         let id = request.id.clone();
-        state.requests.insert(id.clone(), request);
+        state.requests.insert(
+            id.clone(),
+            RequestState {
+                request,
+                status: HostMountStatus::Pending,
+                decision_in_progress: false,
+                grant: None,
+                error: None,
+            },
+        );
         audit(
             &mut state,
             "request",
@@ -338,7 +548,181 @@ impl HostMountService {
             "process".to_string(),
             Vec::new(),
         );
+        drop(state);
+        self.bump_generation();
+        self.append_request_event(&id, HostMountStatus::Pending, None, None);
         Ok(id)
+    }
+
+    pub(super) fn allocate_request_id(&self) -> String {
+        let mut state = self.state.lock().unwrap();
+        state.next_id += 1;
+        format!("request-{}", state.next_id)
+    }
+
+    pub(super) fn commit_request(
+        &self,
+        requesting_pid: u64,
+        request_id: String,
+        bytes: &[u8],
+    ) -> Result<(), ErrorCode> {
+        let document: HostMountRequestDocument =
+            serde_json::from_slice(bytes).map_err(|_| ErrorCode::BadRequest)?;
+        let label = match document.label {
+            Some(label) => {
+                let label = label.trim();
+                if label.is_empty() {
+                    return Err(ErrorCode::BadRequest);
+                }
+                label.to_string()
+            }
+            None => default_label(&document.namespace_path),
+        };
+        let request = HostMountRequest {
+            id: request_id,
+            label,
+            namespace_path: document.namespace_path,
+            access: document.access,
+            reason: document.reason.trim().to_string(),
+            requesting_pid,
+        };
+        self.enqueue(request).map_err(|_| ErrorCode::BadRequest)?;
+        Ok(())
+    }
+
+    pub(super) fn generation(&self) -> u32 {
+        self.generation.load(Ordering::Acquire)
+    }
+
+    #[cfg(test)]
+    pub(super) fn has_request(&self, id: &str) -> bool {
+        self.state.lock().unwrap().requests.contains_key(id)
+    }
+
+    pub(super) fn request_is_visible_to(&self, id: &str, pid: Option<u64>) -> bool {
+        self.state
+            .lock()
+            .unwrap()
+            .requests
+            .get(id)
+            .is_some_and(|request| pid.is_none_or(|pid| request.request.requesting_pid == pid))
+    }
+
+    pub(super) fn request_ids_visible_to(&self, pid: Option<u64>) -> Vec<String> {
+        self.state
+            .lock()
+            .unwrap()
+            .requests
+            .iter()
+            .filter(|(_, request)| pid.is_none_or(|pid| request.request.requesting_pid == pid))
+            .map(|(id, _)| id.clone())
+            .collect()
+    }
+
+    pub(super) fn request_snapshot(&self, id: &str) -> Option<HostMountRequestSnapshot> {
+        self.state
+            .lock()
+            .unwrap()
+            .requests
+            .get(id)
+            .map(|request| HostMountRequestSnapshot {
+                request: request.request.clone(),
+                status: request.status,
+                grant: request.grant.clone(),
+                error: request.error.clone(),
+            })
+    }
+
+    pub(super) fn grant_is_visible_to(&self, id: &str, pid: Option<u64>) -> bool {
+        self.state
+            .lock()
+            .unwrap()
+            .grants
+            .get(id)
+            .is_some_and(|grant| {
+                pid.is_none_or(|pid| {
+                    grant.owner.0 == pid
+                        || grant
+                            .projections
+                            .iter()
+                            .any(|projection| projection.pid.0 == pid)
+                })
+            })
+    }
+
+    pub(super) fn grant_ids_visible_to(&self, pid: Option<u64>) -> Vec<String> {
+        self.state
+            .lock()
+            .unwrap()
+            .grants
+            .iter()
+            .filter(|(_, grant)| {
+                pid.is_none_or(|pid| {
+                    grant.owner.0 == pid
+                        || grant
+                            .projections
+                            .iter()
+                            .any(|projection| projection.pid.0 == pid)
+                })
+            })
+            .map(|(id, _)| id.clone())
+            .collect()
+    }
+
+    pub(super) fn grant_record(&self, id: &str) -> Option<HostMountGrantRecord> {
+        self.state
+            .lock()
+            .unwrap()
+            .grants
+            .get(id)
+            .map(|grant| grant.public.clone())
+    }
+
+    fn request_events(&self, pid: Option<u64>) -> file_server::HostMountEventStream {
+        self.request_events.stream(pid)
+    }
+
+    fn events(&self, pid: Option<u64>) -> file_server::HostMountEventStream {
+        self.events.stream(pid)
+    }
+
+    fn bump_generation(&self) {
+        self.generation.fetch_add(1, Ordering::AcqRel);
+    }
+
+    fn append_request_event(
+        &self,
+        request_id: &str,
+        status: HostMountStatus,
+        grant: Option<&str>,
+        error: Option<&str>,
+    ) {
+        let event = serde_json::json!({
+            "type": "request_status",
+            "request_id": request_id,
+            "status": status,
+            "grant": grant,
+            "error": error,
+        });
+        let mut bytes = serde_json::to_vec(&event).expect("Host Mount event serializes");
+        bytes.push(b'\n');
+        let requesting_pid = self
+            .state
+            .lock()
+            .unwrap()
+            .requests
+            .get(request_id)
+            .expect("Host Mount request remains retained")
+            .request
+            .requesting_pid;
+        self.request_events.append_for(requesting_pid, &bytes);
+        self.events.append_for(requesting_pid, &bytes);
+    }
+
+    fn append_service_event(&self, event: serde_json::Value, affected_processes: &[u64]) {
+        let mut bytes = serde_json::to_vec(&event).expect("Host Mount event serializes");
+        bytes.push(b'\n');
+        self.events.append_for_many(affected_processes, &bytes);
     }
 }
 
@@ -383,73 +767,6 @@ impl ToolExecutionAuthority for HostMountService {
             "Tool Process has no active Host Mount"
         );
         Ok(binding)
-    }
-}
-
-#[async_trait::async_trait]
-impl FlatFileService for HostMountService {
-    fn files(&self) -> &'static [(&'static str, bool)] {
-        FILES
-    }
-
-    fn read(&self, name: &str) -> Result<Vec<u8>, ErrorCode> {
-        let state = self.state.lock().unwrap();
-        let rendered = match name {
-            "request" => serde_json::to_string(&state.requests.values().collect::<Vec<_>>()),
-            "grants" => serde_json::to_string(
-                &state
-                    .grants
-                    .values()
-                    .map(|grant| &grant.public)
-                    .collect::<Vec<_>>(),
-            ),
-            "status" => Ok(format!(
-                "requests={} grants={} active={}\n",
-                state.requests.len(),
-                state.grants.len(),
-                state
-                    .grants
-                    .values()
-                    .filter(|grant| grant.public.active)
-                    .count()
-            )),
-            "audit" => serde_json::to_string(&state.audit),
-            "projection" => Ok("write {\"grant_id\":\"...\",\"pid\":1}\n".to_string()),
-            "revoke" => Ok("write a grant id\n".to_string()),
-            _ => return Err(ErrorCode::NotFound),
-        }
-        .map_err(|_| ErrorCode::Io)?;
-        Ok(rendered.into_bytes())
-    }
-
-    async fn commit(&self, name: &str, bytes: &[u8]) -> Result<(), ErrorCode> {
-        match name {
-            "request" => {
-                let request = serde_json::from_slice(bytes).map_err(|_| ErrorCode::BadRequest)?;
-                self.enqueue(request).map_err(|_| ErrorCode::BadRequest)?;
-                Ok(())
-            }
-            "projection" => {
-                #[derive(Deserialize)]
-                #[serde(deny_unknown_fields)]
-                struct Command {
-                    grant_id: String,
-                    pid: u64,
-                }
-                let command: Command =
-                    serde_json::from_slice(bytes).map_err(|_| ErrorCode::BadRequest)?;
-                self.project(&command.grant_id, command.pid)
-                    .map_err(|_| ErrorCode::BadRequest)
-            }
-            "revoke" => {
-                let id = std::str::from_utf8(bytes)
-                    .map_err(|_| ErrorCode::BadRequest)?
-                    .trim();
-                self.revoke(id, "file-control")
-                    .map_err(|_| ErrorCode::BadRequest)
-            }
-            _ => Err(ErrorCode::NoAccess),
-        }
     }
 }
 
@@ -522,20 +839,60 @@ fn validate_request(request: &HostMountRequest, allow_agent_definition: bool) ->
         !request.label.trim().is_empty(),
         "Host Mount label is empty"
     );
-    ensure!(
-        (request.namespace_path.starts_with("/mnt/")
-            || (allow_agent_definition && request.namespace_path == "/agent-definition"))
-            && !request
-                .namespace_path
-                .split('/')
-                .any(|component| matches!(component, "." | "..")),
-        "Host Mount namespace path must be below /mnt"
-    );
+    validate_mount_namespace_path(&request.namespace_path, allow_agent_definition)?;
     ensure!(
         request.requesting_pid > 0,
         "requesting PID must be positive"
     );
+    ensure!(
+        !request.reason.trim().is_empty(),
+        "Host Mount reason is empty"
+    );
     Ok(())
+}
+
+fn validate_mount_namespace_path(path: &str, allow_agent_definition: bool) -> Result<()> {
+    if allow_agent_definition && path == "/agent-definition" {
+        return Ok(());
+    }
+    ensure!(
+        path == path.trim(),
+        "Host Mount namespace path is not normalized"
+    );
+    let suffix = path
+        .strip_prefix("/mnt/")
+        .context("Host Mount namespace path must be below /mnt")?;
+    let components = suffix.split('/').collect::<Vec<_>>();
+    ensure!(
+        !components.is_empty()
+            && components
+                .iter()
+                .all(|component| !component.is_empty() && !matches!(*component, "." | "..")),
+        "Host Mount namespace path is not normalized"
+    );
+    ensure!(
+        !RESERVED_MOUNT_NAMESPACE_ROOTS.contains(&components[0]),
+        "Host Mount namespace path targets a reserved mount root"
+    );
+    Ok(())
+}
+
+fn default_label(namespace_path: &str) -> String {
+    namespace_path
+        .rsplit('/')
+        .find(|component| !component.is_empty())
+        .unwrap_or("Host Mount")
+        .to_string()
+}
+
+fn concise_terminal_reason(reason: &str) -> String {
+    let trimmed = reason.trim();
+    let concise = if trimmed.is_empty() {
+        "Host Mount request was not approved"
+    } else {
+        trimmed
+    };
+    concise.chars().take(512).collect()
 }
 
 fn audit(
@@ -558,315 +915,5 @@ fn audit(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::path::PathBuf;
-
-    use alan_agent_engine::{HostMountGrant, tools::ToolExecutionBinding};
-
-    struct TestExport {
-        tree: InProcessTransport,
-        grant: HostMountGrant,
-    }
-
-    impl std::fmt::Debug for TestExport {
-        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            formatter.write_str("TestExport")
-        }
-    }
-
-    impl HostMountExport for TestExport {
-        fn file_tree(&self) -> InProcessTransport {
-            self.tree.clone()
-        }
-
-        fn apply_tool_authority(&self, binding: &mut ToolExecutionBinding) -> Result<()> {
-            binding.apply_host_mount(self.grant.clone())
-        }
-    }
-
-    #[derive(Debug, Default)]
-    struct TestAdapter;
-
-    impl HostMountExportAdapter for TestAdapter {
-        fn export_approved(&self, grant: &ApprovedMountGrant) -> Result<Arc<dyn HostMountExport>> {
-            Ok(test_export(
-                &grant.namespace_path,
-                grant.host_path.clone(),
-                match grant.access {
-                    ApprovedMountGrantAccess::ReadOnly => HostMountAccess::ReadOnly,
-                    ApprovedMountGrantAccess::ReadWrite => HostMountAccess::ReadWrite,
-                },
-            ))
-        }
-    }
-
-    fn service() -> Arc<HostMountService> {
-        HostMountService::new(Arc::new(TestAdapter))
-    }
-
-    fn test_export(
-        namespace_path: &str,
-        host_path: PathBuf,
-        access: HostMountAccess,
-    ) -> Arc<dyn HostMountExport> {
-        Arc::new(TestExport {
-            tree: InProcessTransport::new(Arc::new(alan_ap::reference::MemFs::new())),
-            grant: HostMountGrant::new(namespace_path, host_path, access.kernel()).unwrap(),
-        })
-    }
-
-    #[test]
-    fn grants_project_explicitly_hide_paths_and_revoke() {
-        let host = tempfile::tempdir().unwrap();
-        std::fs::write(host.path().join("note"), "hello").unwrap();
-        let service = service();
-        let namespace = LiveNamespace::new(Namespace::new());
-        service.register_process(Pid(7), namespace.clone());
-        let id = service
-            .enqueue(HostMountRequest {
-                id: "grant-a".to_string(),
-                label: "project".to_string(),
-                namespace_path: "/mnt/project".to_string(),
-                access: HostMountAccess::ReadWrite,
-                reason: "work".to_string(),
-                requesting_pid: 7,
-            })
-            .unwrap();
-        let export = test_export(
-            "/mnt/project",
-            host.path().to_path_buf(),
-            HostMountAccess::ReadWrite,
-        );
-        let record = service
-            .approve_export(&id, export.clone(), "user", "tester")
-            .unwrap();
-        assert_eq!(record.namespace_path, "/mnt/project");
-        assert!(
-            !serde_json::to_string(&record)
-                .unwrap()
-                .contains(host.path().to_str().unwrap())
-        );
-        assert!(
-            namespace
-                .describe()
-                .iter()
-                .any(|(path, _)| path == "/mnt/project")
-        );
-        let mut cached =
-            ToolExecutionBinding::new(host.path().to_path_buf(), host.path().join("scratch"));
-        export.apply_tool_authority(&mut cached).unwrap();
-        let reconciled = service.reconcile(Pid(7), cached.clone()).unwrap();
-        assert_eq!(reconciled.host_mounts.len(), 1);
-        assert_eq!(reconciled.sandbox_spec.unwrap().writable_roots.len(), 1);
-
-        service.revoke(&id, "tester").unwrap();
-        assert!(
-            !namespace
-                .describe()
-                .iter()
-                .any(|(path, _)| path == "/mnt/project")
-        );
-        assert!(service.reconcile(Pid(7), cached).is_err());
-    }
-
-    #[test]
-    fn knowing_grant_id_does_not_project_to_another_process() {
-        let host = tempfile::tempdir().unwrap();
-        let service = service();
-        let parent = LiveNamespace::new(Namespace::new());
-        let child = LiveNamespace::new(Namespace::new());
-        service.register_process(Pid(1), parent.clone());
-        service.register_process(Pid(2), child.clone());
-        let id = service
-            .enqueue(HostMountRequest {
-                id: "grant-parent".to_string(),
-                label: "parent".to_string(),
-                namespace_path: "/mnt/data".to_string(),
-                access: HostMountAccess::ReadOnly,
-                reason: "read".to_string(),
-                requesting_pid: 1,
-            })
-            .unwrap();
-        service
-            .approve_export(
-                &id,
-                test_export(
-                    "/mnt/data",
-                    host.path().to_path_buf(),
-                    HostMountAccess::ReadOnly,
-                ),
-                "user",
-                "tester",
-            )
-            .unwrap();
-        assert!(
-            parent
-                .describe()
-                .iter()
-                .any(|(path, _)| path == "/mnt/data")
-        );
-        assert!(!child.describe().iter().any(|(path, _)| path == "/mnt/data"));
-        assert!(service.project(&id, 2).is_err());
-    }
-
-    #[test]
-    fn failed_initial_projection_restores_the_request_and_removes_the_grant() {
-        let host = tempfile::tempdir().unwrap();
-        let service = service();
-        let namespace = LiveNamespace::new(Namespace::new());
-        service.register_process(Pid(7), namespace.clone());
-        let id = service
-            .enqueue(HostMountRequest {
-                id: "grant-retry".to_string(),
-                label: "retry".to_string(),
-                namespace_path: "/mnt/retry".to_string(),
-                access: HostMountAccess::ReadOnly,
-                reason: "retry after Process exit".to_string(),
-                requesting_pid: 7,
-            })
-            .unwrap();
-        let export = test_export(
-            "/mnt/retry",
-            host.path().to_path_buf(),
-            HostMountAccess::ReadOnly,
-        );
-
-        service.unregister_process(Pid(7));
-        assert!(
-            service
-                .approve_export(&id, export.clone(), "user", "tester")
-                .is_err()
-        );
-        assert!(service.pending_request(&id).is_some());
-        assert!(!service.state.lock().unwrap().grants.contains_key(&id));
-
-        service.register_process(Pid(7), namespace.clone());
-        service
-            .approve_export(&id, export, "user", "tester")
-            .unwrap();
-        assert!(service.pending_request(&id).is_none());
-        assert!(
-            namespace
-                .describe()
-                .iter()
-                .any(|(path, _)| path == "/mnt/retry")
-        );
-    }
-
-    #[test]
-    fn approved_agent_definition_uses_the_internal_projection_path_only() {
-        let host = tempfile::tempdir().unwrap();
-        let service = service();
-        let namespace = LiveNamespace::new(Namespace::new());
-        service.register_process(Pid(3), namespace.clone());
-        assert!(
-            service
-                .enqueue(HostMountRequest {
-                    id: "public-definition".to_string(),
-                    label: "definition".to_string(),
-                    namespace_path: "/agent-definition".to_string(),
-                    access: HostMountAccess::ReadOnly,
-                    reason: "public request".to_string(),
-                    requesting_pid: 3,
-                })
-                .is_err()
-        );
-
-        let factory = HostMountApplicatorFactory::new(service);
-        let applicator = factory.create(Pid(3), namespace.clone(), &[]);
-        applicator
-            .apply_mount_grant(&ApprovedMountGrant::new(
-                "/agent-definition",
-                host.path().to_path_buf(),
-                ApprovedMountGrantAccess::ReadOnly,
-                "Agent Definition launch reference",
-            ))
-            .unwrap();
-        assert!(
-            namespace
-                .describe()
-                .iter()
-                .any(|(path, access)| path == "/agent-definition" && *access == Access::ReadOnly)
-        );
-    }
-
-    #[test]
-    fn explicitly_passed_child_projection_is_revoked_with_its_parent() {
-        let host = tempfile::tempdir().unwrap();
-        let service = service();
-        let parent = LiveNamespace::new(Namespace::new());
-        service.register_process(Pid(1), parent.clone());
-        let id = service
-            .enqueue(HostMountRequest {
-                id: "grant-parent".to_string(),
-                label: "parent".to_string(),
-                namespace_path: "/mnt/data".to_string(),
-                access: HostMountAccess::ReadWrite,
-                reason: "write".to_string(),
-                requesting_pid: 1,
-            })
-            .unwrap();
-        let export = test_export(
-            "/mnt/data",
-            host.path().to_path_buf(),
-            HostMountAccess::ReadWrite,
-        );
-        service
-            .approve_export(&id, export.clone(), "user", "tester")
-            .unwrap();
-
-        let child = LiveNamespace::new(parent.snapshot());
-        let factory = HostMountApplicatorFactory::new(service.clone());
-        factory.create(Pid(2), child.clone(), &["/mnt/data".to_string()]);
-        let mut cached =
-            ToolExecutionBinding::new(host.path().to_path_buf(), host.path().join("scratch"));
-        export.apply_tool_authority(&mut cached).unwrap();
-        assert!(service.reconcile(Pid(2), cached.clone()).is_ok());
-
-        service.revoke(&id, "tester").unwrap();
-        assert!(parent.snapshot().resolve("/mnt/data").is_err());
-        assert!(child.snapshot().resolve("/mnt/data").is_err());
-        assert!(service.reconcile(Pid(2), cached).is_err());
-    }
-
-    #[tokio::test]
-    async fn projection_enforces_read_only_and_read_write_access() {
-        for (pid, access, writable) in [
-            (Pid(10), HostMountAccess::ReadOnly, false),
-            (Pid(11), HostMountAccess::ReadWrite, true),
-        ] {
-            let service = service();
-            let namespace = LiveNamespace::new(Namespace::new());
-            service.register_process(pid, namespace.clone());
-            let id = service
-                .enqueue(HostMountRequest {
-                    id: format!("grant-{}", pid.0),
-                    label: "data".to_string(),
-                    namespace_path: "/mnt/data".to_string(),
-                    access,
-                    reason: "test".to_string(),
-                    requesting_pid: pid.0,
-                })
-                .unwrap();
-            service
-                .approve_export(
-                    &id,
-                    test_export("/mnt/data", PathBuf::from("/tmp/data"), access),
-                    "test",
-                    "tester",
-                )
-                .unwrap();
-            let shell = alan_shell::Shell::new(InProcessTransport::new(Arc::new(
-                alan_kernel::MountFs::from_live_namespace(namespace),
-            )));
-            assert_eq!(shell.cat("/mnt/data/greeting").await.unwrap(), b"hi");
-            let write = shell.write("/mnt/data/submit", b"{}").await;
-            if writable {
-                assert_eq!(write, Ok(()));
-            } else {
-                assert_eq!(write, Err(ErrorCode::NoAccess));
-            }
-        }
-    }
-}
+#[path = "host_mount/tests.rs"]
+mod tests;

--- a/crates/service-manager/src/host_mount.rs
+++ b/crates/service-manager/src/host_mount.rs
@@ -480,6 +480,21 @@ impl HostMountService {
                 grant.export.clone(),
             )
         };
+        ensure!(
+            !state.grants.iter().any(|(id, existing)| {
+                id != grant_id
+                    && existing.public.active
+                    && existing
+                        .projections
+                        .iter()
+                        .any(|projection| projection.pid == pid)
+                    && namespace_paths_strictly_overlap(
+                        &namespace_path,
+                        &existing.public.namespace_path,
+                    )
+            }),
+            "Host Mount namespace path overlaps an active Process projection"
+        );
         for (id, grant) in &mut state.grants {
             if id != grant_id && grant.public.namespace_path == namespace_path {
                 grant.projections.retain(|projection| projection.pid != pid);
@@ -934,6 +949,12 @@ fn validate_mount_namespace_path(path: &str, allow_agent_definition: bool) -> Re
         "Host Mount namespace path targets a reserved mount root"
     );
     Ok(())
+}
+
+fn namespace_paths_strictly_overlap(left: &str, right: &str) -> bool {
+    left != right
+        && (std::path::Path::new(left).starts_with(right)
+            || std::path::Path::new(right).starts_with(left))
 }
 
 fn default_label(namespace_path: &str) -> String {

--- a/crates/service-manager/src/host_mount.rs
+++ b/crates/service-manager/src/host_mount.rs
@@ -789,6 +789,7 @@ impl ToolExecutionAuthority for HostMountService {
         mut binding: ToolExecutionBinding,
     ) -> Result<ToolExecutionBinding> {
         let carried_host_mount_authority = !binding.host_mounts.is_empty();
+        let requested_namespace_cwd = binding.namespace_cwd.clone();
         let state = self.state.lock().unwrap();
         let managed_paths = state
             .grants
@@ -819,10 +820,10 @@ impl ToolExecutionAuthority for HostMountService {
 
         binding.remove_host_mount_paths(&managed_paths)?;
         for (export, effective_access) in exports {
+            binding.namespace_cwd = requested_namespace_cwd.clone();
             export.apply_tool_authority(effective_access, &mut binding)?;
         }
-        // An empty seed is a valid zero-authority binding for mount-free Tools. Fail closed only
-        // when reconciliation removed Host Mount authority that the cached binding carried.
+        // Fail closed only if reconciliation removed cached Host Mount authority.
         ensure!(
             !carried_host_mount_authority || !binding.host_mounts.is_empty(),
             "Tool Process has no active Host Mount"

--- a/crates/service-manager/src/host_mount.rs
+++ b/crates/service-manager/src/host_mount.rs
@@ -50,7 +50,12 @@ impl HostMountAccess {
 /// native Tool authority, but it never receives or stores the raw Host path.
 pub trait HostMountExport: std::fmt::Debug + Send + Sync {
     fn file_tree(&self) -> InProcessTransport;
-    fn apply_tool_authority(&self, binding: &mut ToolExecutionBinding) -> Result<()>;
+    /// Add native Tool authority at the Process projection's effective access.
+    fn apply_tool_authority(
+        &self,
+        effective_access: HostMountAccess,
+        binding: &mut ToolExecutionBinding,
+    ) -> Result<()>;
 }
 
 /// Transitional platform boundary for pre-authorized launch declarations.
@@ -140,6 +145,7 @@ struct AuditRecord {
 struct Projection {
     pid: Pid,
     namespace: LiveNamespace,
+    access: HostMountAccess,
 }
 
 struct Grant {
@@ -252,9 +258,14 @@ impl HostMountService {
                     .iter()
                     .any(|projection| projection.pid == pid)
             {
+                let access = match visible_access.expect("validated exact mount access") {
+                    Access::ReadOnly => HostMountAccess::ReadOnly,
+                    Access::ReadWrite => grant.public.access,
+                };
                 grant.projections.push(Projection {
                     pid,
                     namespace: namespace.clone(),
+                    access,
                 });
                 inherited.push(id.clone());
             }
@@ -486,7 +497,11 @@ impl HostMountService {
         {
             return Ok(());
         }
-        grant.projections.push(Projection { pid, namespace });
+        grant.projections.push(Projection {
+            pid,
+            namespace,
+            access,
+        });
         audit(
             &mut state,
             "project",
@@ -774,20 +789,22 @@ impl ToolExecutionAuthority for HostMountService {
         let exports = state
             .grants
             .values()
-            .filter(|grant| {
-                grant.public.active
-                    && grant
-                        .projections
-                        .iter()
-                        .any(|projection| projection.pid == pid)
+            .filter_map(|grant| {
+                if !grant.public.active {
+                    return None;
+                }
+                grant
+                    .projections
+                    .iter()
+                    .find(|projection| projection.pid == pid)
+                    .map(|projection| (grant.export.clone(), projection.access))
             })
-            .map(|grant| grant.export.clone())
             .collect::<Vec<_>>();
         drop(state);
 
         binding.remove_host_mount_paths(&managed_paths)?;
-        for export in exports {
-            export.apply_tool_authority(&mut binding)?;
+        for (export, effective_access) in exports {
+            export.apply_tool_authority(effective_access, &mut binding)?;
         }
         // An empty seed is a valid zero-authority binding for mount-free Tools. Fail closed only
         // when reconciliation removed Host Mount authority that the cached binding carried.

--- a/crates/service-manager/src/host_mount.rs
+++ b/crates/service-manager/src/host_mount.rs
@@ -217,22 +217,36 @@ impl HostMountService {
         self.state.lock().unwrap().processes.insert(pid, namespace);
     }
 
-    fn register_process_with_inherited_mounts(
+    fn register_process_with_inherited_grants(
         &self,
         pid: Pid,
         namespace: LiveNamespace,
-        inherited_mount_paths: &[String],
+        inherited_from: Option<Pid>,
+        inherited_grant_references: &[String],
     ) {
         let visible = namespace.snapshot();
         let mut state = self.state.lock().unwrap();
         state.processes.insert(pid, namespace.clone());
+        let Some(inherited_from) = inherited_from else {
+            return;
+        };
         let mut inherited = Vec::new();
-        for (id, grant) in &mut state.grants {
+        for id in inherited_grant_references {
+            let Some(grant) = state.grants.get_mut(id) else {
+                continue;
+            };
+            let visible_access = visible
+                .union_at(&grant.public.namespace_path)
+                .last()
+                .map(|mount| mount.access);
             if grant.public.active
-                && inherited_mount_paths
+                && grant
+                    .projections
                     .iter()
-                    .any(|path| path == &grant.public.namespace_path)
-                && visible.resolve(&grant.public.namespace_path).is_ok()
+                    .any(|projection| projection.pid == inherited_from)
+                && visible_access.is_some_and(|access| {
+                    grant.public.access.kernel() == Access::ReadWrite || access == Access::ReadOnly
+                })
                 && !grant
                     .projections
                     .iter()
@@ -439,15 +453,32 @@ impl HostMountService {
             .get(&pid)
             .cloned()
             .with_context(|| format!("unknown Process {pid:?}"))?;
+        let (namespace_path, access, export) = {
+            let grant = state
+                .grants
+                .get(grant_id)
+                .with_context(|| format!("unknown Host Mount grant `{grant_id}`"))?;
+            ensure!(grant.public.active, "Host Mount grant is revoked");
+            ensure!(
+                grant.owner == pid,
+                "Host Mount grant belongs to another Process"
+            );
+            (
+                grant.public.namespace_path.clone(),
+                grant.public.access,
+                grant.export.clone(),
+            )
+        };
+        for (id, grant) in &mut state.grants {
+            if id != grant_id && grant.public.namespace_path == namespace_path {
+                grant.projections.retain(|projection| projection.pid != pid);
+            }
+        }
+        namespace.replace_mount(&namespace_path, export.file_tree(), access.kernel());
         let grant = state
             .grants
             .get_mut(grant_id)
-            .with_context(|| format!("unknown Host Mount grant `{grant_id}`"))?;
-        ensure!(grant.public.active, "Host Mount grant is revoked");
-        ensure!(
-            grant.owner == pid,
-            "Host Mount grant belongs to another Process"
-        );
+            .expect("validated Host Mount grant remains retained");
         if grant
             .projections
             .iter()
@@ -455,11 +486,6 @@ impl HostMountService {
         {
             return Ok(());
         }
-        namespace.replace_mount(
-            &grant.public.namespace_path,
-            grant.export.file_tree(),
-            grant.public.access.kernel(),
-        );
         grant.projections.push(Projection { pid, namespace });
         audit(
             &mut state,
@@ -776,11 +802,23 @@ impl ToolExecutionAuthority for HostMountService {
 #[derive(Debug)]
 pub struct HostMountApplicatorFactory {
     service: Arc<HostMountService>,
+    inherited_from: Option<Pid>,
 }
 
 impl HostMountApplicatorFactory {
     pub fn new(service: Arc<HostMountService>) -> Self {
-        Self { service }
+        Self {
+            service,
+            inherited_from: None,
+        }
+    }
+
+    /// Create a factory that may delegate grants currently projected to `parent_pid`.
+    pub fn inheriting_from(service: Arc<HostMountService>, parent_pid: Pid) -> Self {
+        Self {
+            service,
+            inherited_from: Some(parent_pid),
+        }
     }
 }
 
@@ -789,12 +827,13 @@ impl MountGrantApplicatorFactory for HostMountApplicatorFactory {
         &self,
         pid: Pid,
         live_namespace: LiveNamespace,
-        inherited_mount_paths: &[String],
+        inherited_mount_references: &[String],
     ) -> Arc<dyn MountGrantApplicator> {
-        self.service.register_process_with_inherited_mounts(
+        self.service.register_process_with_inherited_grants(
             pid,
             live_namespace.clone(),
-            inherited_mount_paths,
+            self.inherited_from,
+            inherited_mount_references,
         );
         Arc::new(HostMountApplicator {
             service: self.service.clone(),

--- a/crates/service-manager/src/host_mount/file_server.rs
+++ b/crates/service-manager/src/host_mount/file_server.rs
@@ -9,6 +9,7 @@ use tokio::sync::watch;
 use super::HostMountService;
 
 const MAX_REQUEST_BYTES: usize = 64 * 1024;
+const MAX_STATUS_COMMAND_BYTES: usize = 64;
 
 #[derive(Clone)]
 pub(super) struct HostMountEventStream {
@@ -304,6 +305,13 @@ impl FileServer for HostMountFs {
                 }
                 state.clone_id = Some(self.service.allocate_request_id());
             }
+            Node::RequestField(_, RequestField::Status) => {
+                let readable = mode == OpenMode::Read;
+                let cancellable = mode == OpenMode::Write && self.requesting_pid.is_some();
+                if !readable && !cancellable {
+                    return Err(ErrorCode::NoAccess);
+                }
+            }
             _ if mode != OpenMode::Read => return Err(ErrorCode::NoAccess),
             _ => {}
         }
@@ -346,12 +354,14 @@ impl FileServer for HostMountFs {
         if !matches!(state.mode, Some(OpenMode::Write | OpenMode::ReadWrite)) {
             return Err(ErrorCode::NoAccess);
         }
-        if !matches!(state.node, Node::RequestsClone) {
-            return Err(ErrorCode::Unsupported);
-        }
         let start = usize::try_from(offset).map_err(|_| ErrorCode::BadRequest)?;
         let end = start.checked_add(data.len()).ok_or(ErrorCode::BadRequest)?;
-        if end > MAX_REQUEST_BYTES {
+        let max_bytes = match &state.node {
+            Node::RequestsClone => MAX_REQUEST_BYTES,
+            Node::RequestField(_, RequestField::Status) => MAX_STATUS_COMMAND_BYTES,
+            _ => return Err(ErrorCode::Unsupported),
+        };
+        if end > max_bytes {
             return Err(ErrorCode::BadRequest);
         }
         if state.write_buf.len() < end {
@@ -374,7 +384,11 @@ impl FileServer for HostMountFs {
             qid: qid(&node, self.service.generation()),
             length,
             executable: false,
-            writable: matches!(node, Node::RequestsClone) && self.requesting_pid.is_some(),
+            writable: self.requesting_pid.is_some()
+                && matches!(
+                    node,
+                    Node::RequestsClone | Node::RequestField(_, RequestField::Status)
+                ),
         })
     }
 
@@ -402,11 +416,32 @@ impl FileServer for HostMountFs {
             .await
             .remove(&fid)
             .ok_or(ErrorCode::NotFound)?;
-        if matches!(state.node, Node::RequestsClone) && state.wrote {
-            let pid = self.requesting_pid.ok_or(ErrorCode::NoAccess)?;
-            let request_id = state.clone_id.ok_or(ErrorCode::BadRequest)?;
-            self.service
-                .commit_request(pid, request_id, &state.write_buf)?;
+        if state.wrote {
+            match state.node {
+                Node::RequestsClone => {
+                    let pid = self.requesting_pid.ok_or(ErrorCode::NoAccess)?;
+                    let request_id = state.clone_id.ok_or(ErrorCode::BadRequest)?;
+                    self.service
+                        .commit_request(pid, request_id, &state.write_buf)?;
+                }
+                Node::RequestField(request_id, RequestField::Status) => {
+                    let pid = self.requesting_pid.ok_or(ErrorCode::NoAccess)?;
+                    let command = std::str::from_utf8(&state.write_buf)
+                        .map_err(|_| ErrorCode::BadRequest)?
+                        .trim();
+                    if command != "cancelled" {
+                        return Err(ErrorCode::BadRequest);
+                    }
+                    self.service
+                        .cancel_request(
+                            &request_id,
+                            "cancelled by requesting Process",
+                            format!("process:{pid}"),
+                        )
+                        .map_err(|_| ErrorCode::BadRequest)?;
+                }
+                _ => return Err(ErrorCode::Unsupported),
+            }
         }
         Ok(())
     }
@@ -486,6 +521,119 @@ mod tests {
             )
             .await,
             Err(ErrorCode::NoAccess)
+        );
+    }
+
+    #[tokio::test]
+    async fn requesting_process_can_cancel_but_not_settle_status_otherwise() {
+        let service = HostMountService::unavailable();
+        let request_id = service
+            .enqueue(crate::host_mount::HostMountRequest {
+                id: "request-cancel".to_string(),
+                label: "Project".to_string(),
+                namespace_path: "/mnt/project".to_string(),
+                access: crate::host_mount::HostMountAccess::ReadOnly,
+                reason: "Read project files".to_string(),
+                requesting_pid: 7,
+            })
+            .unwrap();
+
+        let global = InProcessTransport::new(service.file_server());
+        call(
+            &global,
+            Request::Walk {
+                fid: Fid::ROOT,
+                newfid: Fid(1),
+                names: vec!["requests".into(), request_id.clone(), "status".into()],
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            call(
+                &global,
+                Request::Open {
+                    fid: Fid(1),
+                    mode: OpenMode::Write,
+                },
+            )
+            .await,
+            Err(ErrorCode::NoAccess)
+        );
+
+        let owner = InProcessTransport::new(service.file_server_for_process(7));
+        call(
+            &owner,
+            Request::Walk {
+                fid: Fid::ROOT,
+                newfid: Fid(2),
+                names: vec!["requests".into(), request_id.clone(), "status".into()],
+            },
+        )
+        .await
+        .unwrap();
+        call(
+            &owner,
+            Request::Open {
+                fid: Fid(2),
+                mode: OpenMode::Write,
+            },
+        )
+        .await
+        .unwrap();
+        call(
+            &owner,
+            Request::Write {
+                fid: Fid(2),
+                offset: 0,
+                data: b"approved\n".to_vec(),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            call(&owner, Request::Clunk { fid: Fid(2) }).await,
+            Err(ErrorCode::BadRequest),
+            "requesters may never approve their own Host Mount"
+        );
+        assert_eq!(
+            service.request_snapshot(&request_id).unwrap().status,
+            crate::host_mount::HostMountStatus::Pending
+        );
+
+        call(
+            &owner,
+            Request::Walk {
+                fid: Fid::ROOT,
+                newfid: Fid(3),
+                names: vec!["requests".into(), request_id.clone(), "status".into()],
+            },
+        )
+        .await
+        .unwrap();
+        call(
+            &owner,
+            Request::Open {
+                fid: Fid(3),
+                mode: OpenMode::Write,
+            },
+        )
+        .await
+        .unwrap();
+        call(
+            &owner,
+            Request::Write {
+                fid: Fid(3),
+                offset: 0,
+                data: b"cancelled\n".to_vec(),
+            },
+        )
+        .await
+        .unwrap();
+        call(&owner, Request::Clunk { fid: Fid(3) }).await.unwrap();
+        assert_eq!(
+            service.request_snapshot(&request_id).unwrap().status,
+            crate::host_mount::HostMountStatus::Cancelled
         );
     }
 

--- a/crates/service-manager/src/host_mount/file_server.rs
+++ b/crates/service-manager/src/host_mount/file_server.rs
@@ -1,0 +1,803 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex};
+
+use alan_ap::{ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat};
+use async_trait::async_trait;
+use tokio::sync::watch;
+
+use super::HostMountService;
+
+const MAX_REQUEST_BYTES: usize = 64 * 1024;
+
+#[derive(Clone)]
+pub(super) struct HostMountEventStream {
+    inner: Arc<EventStreamInner>,
+}
+
+pub(super) struct HostMountEventStreams {
+    all: HostMountEventStream,
+    by_process: Mutex<BTreeMap<u64, HostMountEventStream>>,
+}
+
+impl HostMountEventStreams {
+    pub(super) fn new() -> Self {
+        Self {
+            all: HostMountEventStream::new(),
+            by_process: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    pub(super) fn stream(&self, pid: Option<u64>) -> HostMountEventStream {
+        let Some(pid) = pid else {
+            return self.all.clone();
+        };
+        self.by_process
+            .lock()
+            .unwrap()
+            .entry(pid)
+            .or_insert_with(HostMountEventStream::new)
+            .clone()
+    }
+
+    pub(super) fn append_for(&self, pid: u64, bytes: &[u8]) {
+        self.all.append(bytes);
+        self.stream(Some(pid)).append(bytes);
+    }
+
+    pub(super) fn append_for_many(&self, pids: &[u64], bytes: &[u8]) {
+        self.all.append(bytes);
+        for pid in pids.iter().copied().collect::<BTreeSet<_>>() {
+            self.stream(Some(pid)).append(bytes);
+        }
+    }
+}
+
+struct EventStreamInner {
+    bytes: Mutex<Vec<u8>>,
+    length: watch::Sender<u64>,
+}
+
+impl HostMountEventStream {
+    pub(super) fn new() -> Self {
+        let (length, _) = watch::channel(0);
+        Self {
+            inner: Arc::new(EventStreamInner {
+                bytes: Mutex::new(Vec::new()),
+                length,
+            }),
+        }
+    }
+
+    pub(super) fn append(&self, bytes: &[u8]) {
+        let length = {
+            let mut retained = self.inner.bytes.lock().unwrap();
+            retained.extend_from_slice(bytes);
+            retained.len() as u64
+        };
+        let _ = self.inner.length.send(length);
+    }
+
+    pub(super) fn len(&self) -> u64 {
+        self.inner.bytes.lock().unwrap().len() as u64
+    }
+
+    pub(super) async fn read(&self, offset: Offset, count: u32) -> Vec<u8> {
+        if count == 0 {
+            return Vec::new();
+        }
+        let mut changes = self.inner.length.subscribe();
+        loop {
+            {
+                let retained = self.inner.bytes.lock().unwrap();
+                let start = offset as usize;
+                if start < retained.len() {
+                    let end = retained.len().min(start.saturating_add(count as usize));
+                    return retained[start..end].to_vec();
+                }
+            }
+            if changes.changed().await.is_err() {
+                return Vec::new();
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Node {
+    Root,
+    Requests,
+    RequestsClone,
+    RequestsEvents,
+    Request(String),
+    RequestField(String, RequestField),
+    Grants,
+    Grant(String),
+    GrantRecord(String),
+    Events,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RequestField {
+    Request,
+    Status,
+    Grant,
+    Error,
+}
+
+struct FidState {
+    node: Node,
+    mode: Option<OpenMode>,
+    clone_id: Option<String>,
+    write_buf: Vec<u8>,
+    wrote: bool,
+}
+
+impl FidState {
+    fn at(node: Node) -> Self {
+        Self {
+            node,
+            mode: None,
+            clone_id: None,
+            write_buf: Vec::new(),
+            wrote: false,
+        }
+    }
+}
+
+/// Per-mount aP view over the shared Host Mount Service state.
+///
+/// A Process-scoped view binds request creation to the caller PID. The global
+/// `/srv/host-mount` view remains readable for Host-side inspection but cannot
+/// allocate requests because aP fids intentionally carry no ambient caller ID.
+pub(super) struct HostMountFs {
+    service: Arc<HostMountService>,
+    requesting_pid: Option<u64>,
+    fids: tokio::sync::Mutex<HashMap<Fid, FidState>>,
+}
+
+impl HostMountFs {
+    pub(super) fn new(service: Arc<HostMountService>, requesting_pid: Option<u64>) -> Self {
+        Self {
+            service,
+            requesting_pid,
+            fids: tokio::sync::Mutex::new(HashMap::new()),
+        }
+    }
+
+    async fn node_of(&self, fid: Fid) -> Result<Node, ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(Node::Root);
+        }
+        self.fids
+            .lock()
+            .await
+            .get(&fid)
+            .map(|state| state.node.clone())
+            .ok_or(ErrorCode::NotFound)
+    }
+
+    fn child(&self, parent: &Node, name: &str) -> Result<Node, ErrorCode> {
+        match parent {
+            Node::Root => match name {
+                "requests" => Ok(Node::Requests),
+                "grants" => Ok(Node::Grants),
+                "events" => Ok(Node::Events),
+                _ => Err(ErrorCode::NotFound),
+            },
+            Node::Requests => match name {
+                "clone" => Ok(Node::RequestsClone),
+                "events" => Ok(Node::RequestsEvents),
+                id if self.service.request_is_visible_to(id, self.requesting_pid) => {
+                    Ok(Node::Request(id.to_string()))
+                }
+                _ => Err(ErrorCode::NotFound),
+            },
+            Node::Request(id) => match name {
+                "request" => Ok(Node::RequestField(id.clone(), RequestField::Request)),
+                "status" => Ok(Node::RequestField(id.clone(), RequestField::Status)),
+                "grant" => Ok(Node::RequestField(id.clone(), RequestField::Grant)),
+                "error" => Ok(Node::RequestField(id.clone(), RequestField::Error)),
+                _ => Err(ErrorCode::NotFound),
+            },
+            Node::Grants if self.service.grant_is_visible_to(name, self.requesting_pid) => {
+                Ok(Node::Grant(name.to_string()))
+            }
+            Node::Grant(id) if name == "record" => Ok(Node::GrantRecord(id.clone())),
+            Node::RequestsClone
+            | Node::RequestsEvents
+            | Node::RequestField(..)
+            | Node::GrantRecord(_)
+            | Node::Events
+            | Node::Grants
+            | Node::Grant(_) => Err(ErrorCode::NotDirectory),
+        }
+    }
+
+    fn computed_bytes(&self, node: &Node) -> Result<Vec<u8>, ErrorCode> {
+        let bytes = match node {
+            Node::Root => b"requests\ngrants\nevents".to_vec(),
+            Node::Requests => {
+                let mut names = vec!["clone".to_string(), "events".to_string()];
+                names.extend(self.service.request_ids_visible_to(self.requesting_pid));
+                names.join("\n").into_bytes()
+            }
+            Node::Request(_id) => b"request\nstatus\ngrant\nerror".to_vec(),
+            Node::RequestField(id, field) => {
+                let request = self
+                    .service
+                    .request_snapshot(id)
+                    .ok_or(ErrorCode::NotFound)?;
+                match field {
+                    RequestField::Request => {
+                        serde_json::to_vec(&request.request).map_err(|_| ErrorCode::Io)?
+                    }
+                    RequestField::Status => format!("{}\n", request.status.as_str()).into_bytes(),
+                    RequestField::Grant => request
+                        .grant
+                        .map(|grant| format!("{grant}\n").into_bytes())
+                        .unwrap_or_default(),
+                    RequestField::Error => request
+                        .error
+                        .map(|error| format!("{error}\n").into_bytes())
+                        .unwrap_or_default(),
+                }
+            }
+            Node::Grants => self
+                .service
+                .grant_ids_visible_to(self.requesting_pid)
+                .join("\n")
+                .into_bytes(),
+            Node::Grant(_) => b"record".to_vec(),
+            Node::GrantRecord(id) => {
+                serde_json::to_vec(&self.service.grant_record(id).ok_or(ErrorCode::NotFound)?)
+                    .map_err(|_| ErrorCode::Io)?
+            }
+            Node::RequestsClone | Node::RequestsEvents | Node::Events => Vec::new(),
+        };
+        Ok(bytes)
+    }
+}
+
+#[async_trait]
+impl FileServer for HostMountFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        if newfid == Fid::ROOT {
+            return Err(ErrorCode::BadRequest);
+        }
+        let mut fids = self.fids.lock().await;
+        if fids.contains_key(&newfid) {
+            return Err(ErrorCode::BadRequest);
+        }
+        let mut node = if fid == Fid::ROOT {
+            Node::Root
+        } else {
+            fids.get(&fid)
+                .map(|state| state.node.clone())
+                .ok_or(ErrorCode::NotFound)?
+        };
+        for name in names {
+            node = self.child(&node, name)?;
+        }
+        let qid = qid(&node, self.service.generation());
+        fids.insert(newfid, FidState::at(node));
+        Ok(qid)
+    }
+
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
+        if fid == Fid::ROOT {
+            return if mode == OpenMode::Read {
+                Ok(qid(&Node::Root, self.service.generation()))
+            } else {
+                Err(ErrorCode::NoAccess)
+            };
+        }
+        let mut fids = self.fids.lock().await;
+        let state = fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
+        if state.mode.is_some() {
+            return Err(ErrorCode::BadRequest);
+        }
+        match &state.node {
+            Node::RequestsClone => {
+                if mode != OpenMode::ReadWrite || self.requesting_pid.is_none() {
+                    return Err(ErrorCode::NoAccess);
+                }
+                state.clone_id = Some(self.service.allocate_request_id());
+            }
+            _ if mode != OpenMode::Read => return Err(ErrorCode::NoAccess),
+            _ => {}
+        }
+        state.mode = Some(mode);
+        Ok(qid(&state.node, self.service.generation()))
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let (node, clone_id, mode) = if fid == Fid::ROOT {
+            (Node::Root, None, Some(OpenMode::Read))
+        } else {
+            let fids = self.fids.lock().await;
+            let state = fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+            (state.node.clone(), state.clone_id.clone(), state.mode)
+        };
+        if !matches!(mode, Some(OpenMode::Read | OpenMode::ReadWrite)) {
+            return Err(ErrorCode::NoAccess);
+        }
+        if let Some(id) = clone_id {
+            return Ok(slice(id.into_bytes(), offset, count));
+        }
+        match node {
+            Node::RequestsEvents => Ok(self
+                .service
+                .request_events(self.requesting_pid)
+                .read(offset, count)
+                .await),
+            Node::Events => Ok(self
+                .service
+                .events(self.requesting_pid)
+                .read(offset, count)
+                .await),
+            other => Ok(slice(self.computed_bytes(&other)?, offset, count)),
+        }
+    }
+
+    async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        let mut fids = self.fids.lock().await;
+        let state = fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
+        if !matches!(state.mode, Some(OpenMode::Write | OpenMode::ReadWrite)) {
+            return Err(ErrorCode::NoAccess);
+        }
+        if !matches!(state.node, Node::RequestsClone) {
+            return Err(ErrorCode::Unsupported);
+        }
+        let start = usize::try_from(offset).map_err(|_| ErrorCode::BadRequest)?;
+        let end = start.checked_add(data.len()).ok_or(ErrorCode::BadRequest)?;
+        if end > MAX_REQUEST_BYTES {
+            return Err(ErrorCode::BadRequest);
+        }
+        if state.write_buf.len() < end {
+            state.write_buf.resize(end, 0);
+        }
+        state.write_buf[start..end].copy_from_slice(data);
+        state.wrote = true;
+        Ok(data.len() as u32)
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        let node = self.node_of(fid).await?;
+        let length = match &node {
+            Node::RequestsEvents => self.service.request_events(self.requesting_pid).len(),
+            Node::Events => self.service.events(self.requesting_pid).len(),
+            _ => self.computed_bytes(&node)?.len() as u64,
+        };
+        Ok(Stat {
+            name: String::new(),
+            qid: qid(&node, self.service.generation()),
+            length,
+            executable: false,
+            writable: matches!(node, Node::RequestsClone) && self.requesting_pid.is_some(),
+        })
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(());
+        }
+        let state = self
+            .fids
+            .lock()
+            .await
+            .remove(&fid)
+            .ok_or(ErrorCode::NotFound)?;
+        if matches!(state.node, Node::RequestsClone) && state.wrote {
+            let pid = self.requesting_pid.ok_or(ErrorCode::NoAccess)?;
+            let request_id = state.clone_id.ok_or(ErrorCode::BadRequest)?;
+            self.service
+                .commit_request(pid, request_id, &state.write_buf)?;
+        }
+        Ok(())
+    }
+}
+
+fn qid(node: &Node, generation: u32) -> Qid {
+    let (kind, stable_key, mutable) = match node {
+        Node::Root => (FileKind::Dir, "/".to_string(), true),
+        Node::Requests => (FileKind::Dir, "requests".to_string(), true),
+        Node::RequestsClone => (FileKind::Clone, "requests/clone".to_string(), false),
+        Node::RequestsEvents => (FileKind::Stream, "requests/events".to_string(), false),
+        Node::Request(id) => (FileKind::Dir, format!("requests/{id}"), false),
+        Node::RequestField(id, field) => (
+            FileKind::File,
+            format!("requests/{id}/{}", request_field_name(*field)),
+            true,
+        ),
+        Node::Grants => (FileKind::Dir, "grants".to_string(), true),
+        Node::Grant(id) => (FileKind::Dir, format!("grants/{id}"), false),
+        Node::GrantRecord(id) => (FileKind::File, format!("grants/{id}/record"), true),
+        Node::Events => (FileKind::Stream, "events".to_string(), false),
+    };
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    stable_key.hash(&mut hasher);
+    Qid {
+        kind,
+        version: if mutable { generation } else { 0 },
+        path: hasher.finish(),
+    }
+}
+
+fn request_field_name(field: RequestField) -> &'static str {
+    match field {
+        RequestField::Request => "request",
+        RequestField::Status => "status",
+        RequestField::Grant => "grant",
+        RequestField::Error => "error",
+    }
+}
+
+fn slice(bytes: Vec<u8>, offset: Offset, count: u32) -> Vec<u8> {
+    let start = (offset as usize).min(bytes.len());
+    let end = bytes.len().min(start.saturating_add(count as usize));
+    bytes[start..end].to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alan_ap::{InProcessTransport, Request, Response};
+
+    async fn call(transport: &InProcessTransport, request: Request) -> Result<Response, ErrorCode> {
+        transport.call(request).await
+    }
+
+    #[tokio::test]
+    async fn global_view_cannot_allocate_process_requests() {
+        let service = HostMountService::unavailable();
+        let transport = InProcessTransport::new(service.file_server());
+        call(
+            &transport,
+            Request::Walk {
+                fid: Fid::ROOT,
+                newfid: Fid(1),
+                names: vec!["requests".into(), "clone".into()],
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            call(
+                &transport,
+                Request::Open {
+                    fid: Fid(1),
+                    mode: OpenMode::ReadWrite,
+                },
+            )
+            .await,
+            Err(ErrorCode::NoAccess)
+        );
+    }
+
+    #[tokio::test]
+    async fn clone_commit_rejects_host_path_without_publishing_request() {
+        let service = HostMountService::unavailable();
+        let transport = InProcessTransport::new(service.file_server_for_process(7));
+        call(
+            &transport,
+            Request::Walk {
+                fid: Fid::ROOT,
+                newfid: Fid(1),
+                names: vec!["requests".into(), "clone".into()],
+            },
+        )
+        .await
+        .unwrap();
+        call(
+            &transport,
+            Request::Open {
+                fid: Fid(1),
+                mode: OpenMode::ReadWrite,
+            },
+        )
+        .await
+        .unwrap();
+        let request_id = match call(
+            &transport,
+            Request::Read {
+                fid: Fid(1),
+                offset: 0,
+                count: 128,
+            },
+        )
+        .await
+        .unwrap()
+        {
+            Response::Read { data } => String::from_utf8(data).unwrap(),
+            other => panic!("unexpected response: {other:?}"),
+        };
+        let document = br#"{"namespace_path":"/mnt/project","host_path":"/tmp/project","access":"read_only","reason":"read"}"#;
+        call(
+            &transport,
+            Request::Write {
+                fid: Fid(1),
+                offset: 0,
+                data: document.to_vec(),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            call(&transport, Request::Clunk { fid: Fid(1) }).await,
+            Err(ErrorCode::BadRequest)
+        );
+        assert!(!service.has_request(&request_id));
+    }
+
+    #[tokio::test]
+    async fn clone_commit_rejects_non_normal_and_reserved_namespace_paths() {
+        for (index, namespace_path) in [
+            "/mnt/project/../private",
+            "/mnt/project//private",
+            "/mnt/project/",
+            "/mnt/host-mount",
+            "/mnt/package/private",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let service = HostMountService::unavailable();
+            let transport = InProcessTransport::new(service.file_server_for_process(7));
+            let fid = Fid(index as u64 + 1);
+            call(
+                &transport,
+                Request::Walk {
+                    fid: Fid::ROOT,
+                    newfid: fid,
+                    names: vec!["requests".into(), "clone".into()],
+                },
+            )
+            .await
+            .unwrap();
+            call(
+                &transport,
+                Request::Open {
+                    fid,
+                    mode: OpenMode::ReadWrite,
+                },
+            )
+            .await
+            .unwrap();
+            let document = serde_json::to_vec(&serde_json::json!({
+                "namespace_path": namespace_path,
+                "access": "read_only",
+                "reason": "read"
+            }))
+            .unwrap();
+            call(
+                &transport,
+                Request::Write {
+                    fid,
+                    offset: 0,
+                    data: document,
+                },
+            )
+            .await
+            .unwrap();
+            assert_eq!(
+                call(&transport, Request::Clunk { fid }).await,
+                Err(ErrorCode::BadRequest),
+                "{namespace_path} must be rejected"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn process_view_hides_other_process_requests_and_events() {
+        let service = HostMountService::unavailable();
+        let owner = InProcessTransport::new(service.file_server_for_process(7));
+        call(
+            &owner,
+            Request::Walk {
+                fid: Fid::ROOT,
+                newfid: Fid(1),
+                names: vec!["requests".into(), "clone".into()],
+            },
+        )
+        .await
+        .unwrap();
+        call(
+            &owner,
+            Request::Open {
+                fid: Fid(1),
+                mode: OpenMode::ReadWrite,
+            },
+        )
+        .await
+        .unwrap();
+        let request_id = match call(
+            &owner,
+            Request::Read {
+                fid: Fid(1),
+                offset: 0,
+                count: 128,
+            },
+        )
+        .await
+        .unwrap()
+        {
+            Response::Read { data } => String::from_utf8(data).unwrap(),
+            other => panic!("unexpected response: {other:?}"),
+        };
+        call(
+            &owner,
+            Request::Write {
+                fid: Fid(1),
+                offset: 0,
+                data: br#"{"namespace_path":"/mnt/project","access":"read_only","reason":"read"}"#
+                    .to_vec(),
+            },
+        )
+        .await
+        .unwrap();
+        call(&owner, Request::Clunk { fid: Fid(1) }).await.unwrap();
+
+        let other = InProcessTransport::new(service.file_server_for_process(8));
+        let shell = alan_shell::Shell::new(other);
+        assert_eq!(
+            shell.ls("/requests").await.unwrap(),
+            vec!["clone", "events"]
+        );
+        assert!(
+            shell
+                .stat(&format!("/requests/{request_id}"))
+                .await
+                .is_err()
+        );
+        assert!(shell.cat("/requests/events").await.unwrap().is_empty());
+        assert!(shell.cat("/events").await.unwrap().is_empty());
+
+        let global = alan_shell::Shell::new(InProcessTransport::new(service.file_server()));
+        assert!(global.ls("/requests").await.unwrap().contains(&request_id));
+        assert!(
+            String::from_utf8(global.cat("/requests/events").await.unwrap())
+                .unwrap()
+                .contains(&request_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn clone_commit_publishes_one_logical_request_with_immutable_terminal_status() {
+        let service = HostMountService::unavailable();
+        let transport = InProcessTransport::new(service.file_server_for_process(7));
+        call(
+            &transport,
+            Request::Walk {
+                fid: Fid::ROOT,
+                newfid: Fid(1),
+                names: vec!["requests".into(), "clone".into()],
+            },
+        )
+        .await
+        .unwrap();
+        call(
+            &transport,
+            Request::Open {
+                fid: Fid(1),
+                mode: OpenMode::ReadWrite,
+            },
+        )
+        .await
+        .unwrap();
+        let request_id = match call(
+            &transport,
+            Request::Read {
+                fid: Fid(1),
+                offset: 0,
+                count: 128,
+            },
+        )
+        .await
+        .unwrap()
+        {
+            Response::Read { data } => String::from_utf8(data).unwrap(),
+            other => panic!("unexpected response: {other:?}"),
+        };
+        let document = br#"{"namespace_path":"/mnt/project","access":"read_only","reason":"Read project files","label":"Project"}"#;
+        call(
+            &transport,
+            Request::Write {
+                fid: Fid(1),
+                offset: 0,
+                data: document.to_vec(),
+            },
+        )
+        .await
+        .unwrap();
+        call(&transport, Request::Clunk { fid: Fid(1) })
+            .await
+            .unwrap();
+
+        let shell = alan_shell::Shell::new(transport);
+        assert_eq!(
+            shell.ls("/").await.unwrap(),
+            vec!["requests", "grants", "events"]
+        );
+        for retired in ["request", "projection", "approval", "status"] {
+            assert!(shell.stat(&format!("/{retired}")).await.is_err());
+        }
+        assert_eq!(
+            shell.ls("/requests").await.unwrap(),
+            vec!["clone", "events", request_id.as_str()]
+        );
+        let request: serde_json::Value = serde_json::from_slice(
+            &shell
+                .cat(&format!("/requests/{request_id}/request"))
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(request["namespace_path"], "/mnt/project");
+        assert_eq!(request["requesting_pid"], 7);
+        assert!(!request.to_string().contains("host_path"));
+        assert_eq!(
+            shell
+                .cat(&format!("/requests/{request_id}/status"))
+                .await
+                .unwrap(),
+            b"pending\n"
+        );
+        assert!(
+            String::from_utf8(shell.cat("/requests/events").await.unwrap())
+                .unwrap()
+                .contains(&format!(r#""request_id":"{request_id}""#))
+        );
+
+        service
+            .reject_request(&request_id, "User declined", "test-host")
+            .unwrap();
+        assert_eq!(
+            shell
+                .cat(&format!("/requests/{request_id}/status"))
+                .await
+                .unwrap(),
+            b"rejected\n"
+        );
+        assert_eq!(
+            shell
+                .cat(&format!("/requests/{request_id}/error"))
+                .await
+                .unwrap(),
+            b"User declined\n"
+        );
+        assert!(
+            service
+                .cancel_request(&request_id, "changed mind", "test-host")
+                .is_err(),
+            "terminal request status must be immutable"
+        );
+    }
+
+    #[test]
+    fn all_terminal_statuses_are_terminal() {
+        for status in [
+            crate::host_mount::HostMountStatus::Approved,
+            crate::host_mount::HostMountStatus::Rejected,
+            crate::host_mount::HostMountStatus::Cancelled,
+            crate::host_mount::HostMountStatus::Failed,
+        ] {
+            assert!(status.is_terminal());
+        }
+        assert!(!crate::host_mount::HostMountStatus::Pending.is_terminal());
+    }
+}

--- a/crates/service-manager/src/host_mount/tests.rs
+++ b/crates/service-manager/src/host_mount/tests.rs
@@ -283,10 +283,14 @@ fn explicitly_passed_child_projection_is_revoked_with_its_parent() {
     let child = LiveNamespace::new(parent.snapshot());
     let factory = HostMountApplicatorFactory::new(service.clone());
     factory.create(Pid(2), child.clone(), &["/mnt/data".to_string()]);
-    let mut cached =
-        ToolExecutionBinding::new(host.path().to_path_buf(), host.path().join("scratch"));
-    export.apply_tool_authority(&mut cached).unwrap();
-    assert!(service.reconcile(Pid(2), cached.clone()).is_ok());
+    let cached = ToolExecutionBinding::awaiting_host_projection(
+        PathBuf::from("/mnt/data"),
+        host.path().join("scratch"),
+    );
+    let reconciled = service.reconcile(Pid(2), cached.clone()).unwrap();
+    assert_eq!(reconciled.namespace_cwd, PathBuf::from("/mnt/data"));
+    assert_eq!(reconciled.cwd, host.path());
+    assert_eq!(reconciled.host_mounts.len(), 1);
 
     service.revoke(&id, "tester").unwrap();
     assert!(parent.snapshot().resolve("/mnt/data").is_err());

--- a/crates/service-manager/src/host_mount/tests.rs
+++ b/crates/service-manager/src/host_mount/tests.rs
@@ -110,6 +110,23 @@ fn grants_project_explicitly_hide_paths_and_revoke() {
 }
 
 #[test]
+fn mount_free_tool_binding_reconciles_without_acquiring_authority() {
+    let service = service();
+    let namespace = LiveNamespace::new(Namespace::new());
+    service.register_process(Pid(7), namespace);
+    let binding = ToolExecutionBinding::awaiting_host_projection(
+        PathBuf::from("/"),
+        PathBuf::from("/tmp/alan-scratch"),
+    );
+
+    let reconciled = service.reconcile(Pid(7), binding.clone()).unwrap();
+
+    assert_eq!(reconciled, binding);
+    assert!(reconciled.host_mounts.is_empty());
+    assert!(reconciled.sandbox_spec.is_none());
+}
+
+#[test]
 fn knowing_grant_id_does_not_project_to_another_process() {
     let host = tempfile::tempdir().unwrap();
     let service = service();
@@ -295,7 +312,9 @@ fn explicitly_passed_child_projection_is_revoked_with_its_parent() {
     service.revoke(&id, "tester").unwrap();
     assert!(parent.snapshot().resolve("/mnt/data").is_err());
     assert!(child.snapshot().resolve("/mnt/data").is_err());
-    assert!(service.reconcile(Pid(2), cached).is_err());
+    let revoked = service.reconcile(Pid(2), cached).unwrap();
+    assert!(revoked.host_mounts.is_empty());
+    assert!(revoked.sandbox_spec.is_none());
 }
 
 #[tokio::test]

--- a/crates/service-manager/src/host_mount/tests.rs
+++ b/crates/service-manager/src/host_mount/tests.rs
@@ -490,6 +490,57 @@ fn inherited_read_only_projection_does_not_recover_write_authority() {
     );
 }
 
+#[test]
+fn overlapping_projections_reconcile_tool_cwd_by_longest_namespace_prefix() {
+    let project = tempfile::tempdir().unwrap();
+    let docs = tempfile::tempdir().unwrap();
+    let service = service();
+    service.register_process(Pid(1), LiveNamespace::new(Namespace::new()));
+
+    for (id, namespace_path, host_path, access) in [
+        (
+            "grant-project",
+            "/mnt/project",
+            project.path(),
+            HostMountAccess::ReadWrite,
+        ),
+        (
+            "grant-docs",
+            "/mnt/project/docs",
+            docs.path(),
+            HostMountAccess::ReadOnly,
+        ),
+    ] {
+        service
+            .enqueue(HostMountRequest {
+                id: id.to_string(),
+                label: id.to_string(),
+                namespace_path: namespace_path.to_string(),
+                access,
+                reason: "test overlapping namespace mounts".to_string(),
+                requesting_pid: 1,
+            })
+            .unwrap();
+        service
+            .approve_export(
+                id,
+                test_export(namespace_path, host_path.to_path_buf(), access),
+                "user",
+                "tester",
+            )
+            .unwrap();
+    }
+
+    let binding = ToolExecutionBinding::awaiting_host_projection(
+        PathBuf::from("/mnt/project/docs/guides"),
+        project.path().join("scratch"),
+    );
+    let reconciled = service.reconcile(Pid(1), binding).unwrap();
+
+    assert_eq!(reconciled.host_mounts.len(), 2);
+    assert_eq!(reconciled.cwd, docs.path().join("guides"));
+}
+
 #[tokio::test]
 async fn projection_enforces_read_only_and_read_write_access() {
     for (pid, access, writable) in [

--- a/crates/service-manager/src/host_mount/tests.rs
+++ b/crates/service-manager/src/host_mount/tests.rs
@@ -1,0 +1,335 @@
+use super::*;
+use std::path::PathBuf;
+
+use alan_agent_engine::{HostMountGrant, tools::ToolExecutionBinding};
+
+struct TestExport {
+    tree: InProcessTransport,
+    grant: HostMountGrant,
+}
+
+impl std::fmt::Debug for TestExport {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("TestExport")
+    }
+}
+
+impl HostMountExport for TestExport {
+    fn file_tree(&self) -> InProcessTransport {
+        self.tree.clone()
+    }
+
+    fn apply_tool_authority(&self, binding: &mut ToolExecutionBinding) -> Result<()> {
+        binding.apply_host_mount(self.grant.clone())
+    }
+}
+
+#[derive(Debug, Default)]
+struct TestAdapter;
+
+impl HostMountExportAdapter for TestAdapter {
+    fn export_approved(&self, grant: &ApprovedMountGrant) -> Result<Arc<dyn HostMountExport>> {
+        Ok(test_export(
+            &grant.namespace_path,
+            grant.host_path.clone(),
+            match grant.access {
+                ApprovedMountGrantAccess::ReadOnly => HostMountAccess::ReadOnly,
+                ApprovedMountGrantAccess::ReadWrite => HostMountAccess::ReadWrite,
+            },
+        ))
+    }
+}
+
+fn service() -> Arc<HostMountService> {
+    HostMountService::new(Arc::new(TestAdapter))
+}
+
+fn test_export(
+    namespace_path: &str,
+    host_path: PathBuf,
+    access: HostMountAccess,
+) -> Arc<dyn HostMountExport> {
+    Arc::new(TestExport {
+        tree: InProcessTransport::new(Arc::new(alan_ap::reference::MemFs::new())),
+        grant: HostMountGrant::new(namespace_path, host_path, access.kernel()).unwrap(),
+    })
+}
+
+#[test]
+fn grants_project_explicitly_hide_paths_and_revoke() {
+    let host = tempfile::tempdir().unwrap();
+    std::fs::write(host.path().join("note"), "hello").unwrap();
+    let service = service();
+    let namespace = LiveNamespace::new(Namespace::new());
+    service.register_process(Pid(7), namespace.clone());
+    let id = service
+        .enqueue(HostMountRequest {
+            id: "grant-a".to_string(),
+            label: "project".to_string(),
+            namespace_path: "/mnt/project".to_string(),
+            access: HostMountAccess::ReadWrite,
+            reason: "work".to_string(),
+            requesting_pid: 7,
+        })
+        .unwrap();
+    let export = test_export(
+        "/mnt/project",
+        host.path().to_path_buf(),
+        HostMountAccess::ReadWrite,
+    );
+    let record = service
+        .approve_export(&id, export.clone(), "user", "tester")
+        .unwrap();
+    assert_eq!(record.namespace_path, "/mnt/project");
+    assert!(
+        !serde_json::to_string(&record)
+            .unwrap()
+            .contains(host.path().to_str().unwrap())
+    );
+    assert!(
+        namespace
+            .describe()
+            .iter()
+            .any(|(path, _)| path == "/mnt/project")
+    );
+    let mut cached =
+        ToolExecutionBinding::new(host.path().to_path_buf(), host.path().join("scratch"));
+    export.apply_tool_authority(&mut cached).unwrap();
+    let reconciled = service.reconcile(Pid(7), cached.clone()).unwrap();
+    assert_eq!(reconciled.host_mounts.len(), 1);
+    assert_eq!(reconciled.sandbox_spec.unwrap().writable_roots.len(), 1);
+
+    service.revoke(&id, "tester").unwrap();
+    assert!(
+        !namespace
+            .describe()
+            .iter()
+            .any(|(path, _)| path == "/mnt/project")
+    );
+    assert!(service.reconcile(Pid(7), cached).is_err());
+}
+
+#[test]
+fn knowing_grant_id_does_not_project_to_another_process() {
+    let host = tempfile::tempdir().unwrap();
+    let service = service();
+    let parent = LiveNamespace::new(Namespace::new());
+    let child = LiveNamespace::new(Namespace::new());
+    service.register_process(Pid(1), parent.clone());
+    service.register_process(Pid(2), child.clone());
+    let id = service
+        .enqueue(HostMountRequest {
+            id: "grant-parent".to_string(),
+            label: "parent".to_string(),
+            namespace_path: "/mnt/data".to_string(),
+            access: HostMountAccess::ReadOnly,
+            reason: "read".to_string(),
+            requesting_pid: 1,
+        })
+        .unwrap();
+    service
+        .approve_export(
+            &id,
+            test_export(
+                "/mnt/data",
+                host.path().to_path_buf(),
+                HostMountAccess::ReadOnly,
+            ),
+            "user",
+            "tester",
+        )
+        .unwrap();
+    assert!(
+        parent
+            .describe()
+            .iter()
+            .any(|(path, _)| path == "/mnt/data")
+    );
+    assert!(!child.describe().iter().any(|(path, _)| path == "/mnt/data"));
+    assert!(service.project(&id, 2).is_err());
+}
+
+#[test]
+fn failed_initial_projection_is_terminal_and_removes_the_grant() {
+    let host = tempfile::tempdir().unwrap();
+    let service = service();
+    let namespace = LiveNamespace::new(Namespace::new());
+    service.register_process(Pid(7), namespace.clone());
+    let id = service
+        .enqueue(HostMountRequest {
+            id: "grant-retry".to_string(),
+            label: "retry".to_string(),
+            namespace_path: "/mnt/retry".to_string(),
+            access: HostMountAccess::ReadOnly,
+            reason: "retry after Process exit".to_string(),
+            requesting_pid: 7,
+        })
+        .unwrap();
+    let export = test_export(
+        "/mnt/retry",
+        host.path().to_path_buf(),
+        HostMountAccess::ReadOnly,
+    );
+
+    service.unregister_process(Pid(7));
+    assert!(
+        service
+            .approve_export(&id, export.clone(), "user", "tester")
+            .is_err()
+    );
+    assert!(service.pending_request(&id).is_none());
+    assert!(!service.state.lock().unwrap().grants.contains_key(&id));
+    let failed = service.request_snapshot(&id).unwrap();
+    assert_eq!(failed.status, HostMountStatus::Failed);
+    assert_eq!(
+        failed.error.as_deref(),
+        Some("Host Mount namespace projection failed")
+    );
+
+    service.register_process(Pid(7), namespace.clone());
+    assert!(
+        service
+            .approve_export(&id, export, "user", "tester")
+            .is_err()
+    );
+    assert!(namespace.snapshot().resolve("/mnt/retry").is_err());
+}
+
+#[test]
+fn claimed_approval_cannot_be_overtaken_by_another_terminal_decision() {
+    let service = service();
+    let id = service
+        .enqueue(HostMountRequest {
+            id: "grant-race".to_string(),
+            label: "race".to_string(),
+            namespace_path: "/mnt/race".to_string(),
+            access: HostMountAccess::ReadOnly,
+            reason: "verify immutable settlement".to_string(),
+            requesting_pid: 7,
+        })
+        .unwrap();
+    assert_eq!(service.claim_pending_request(&id).unwrap().id, id);
+    assert!(
+        service
+            .reject_request(&id, "late rejection", "second-decider")
+            .is_err()
+    );
+    assert!(service.claim_pending_request(&id).is_err());
+    assert!(service.pending_request(&id).is_none());
+}
+
+#[test]
+fn approved_agent_definition_uses_the_internal_projection_path_only() {
+    let host = tempfile::tempdir().unwrap();
+    let service = service();
+    let namespace = LiveNamespace::new(Namespace::new());
+    service.register_process(Pid(3), namespace.clone());
+    assert!(
+        service
+            .enqueue(HostMountRequest {
+                id: "public-definition".to_string(),
+                label: "definition".to_string(),
+                namespace_path: "/agent-definition".to_string(),
+                access: HostMountAccess::ReadOnly,
+                reason: "public request".to_string(),
+                requesting_pid: 3,
+            })
+            .is_err()
+    );
+
+    let factory = HostMountApplicatorFactory::new(service);
+    let applicator = factory.create(Pid(3), namespace.clone(), &[]);
+    applicator
+        .apply_mount_grant(&ApprovedMountGrant::new(
+            "/agent-definition",
+            host.path().to_path_buf(),
+            ApprovedMountGrantAccess::ReadOnly,
+            "Agent Definition launch reference",
+        ))
+        .unwrap();
+    assert!(
+        namespace
+            .describe()
+            .iter()
+            .any(|(path, access)| path == "/agent-definition" && *access == Access::ReadOnly)
+    );
+}
+
+#[test]
+fn explicitly_passed_child_projection_is_revoked_with_its_parent() {
+    let host = tempfile::tempdir().unwrap();
+    let service = service();
+    let parent = LiveNamespace::new(Namespace::new());
+    service.register_process(Pid(1), parent.clone());
+    let id = service
+        .enqueue(HostMountRequest {
+            id: "grant-parent".to_string(),
+            label: "parent".to_string(),
+            namespace_path: "/mnt/data".to_string(),
+            access: HostMountAccess::ReadWrite,
+            reason: "write".to_string(),
+            requesting_pid: 1,
+        })
+        .unwrap();
+    let export = test_export(
+        "/mnt/data",
+        host.path().to_path_buf(),
+        HostMountAccess::ReadWrite,
+    );
+    service
+        .approve_export(&id, export.clone(), "user", "tester")
+        .unwrap();
+
+    let child = LiveNamespace::new(parent.snapshot());
+    let factory = HostMountApplicatorFactory::new(service.clone());
+    factory.create(Pid(2), child.clone(), &["/mnt/data".to_string()]);
+    let mut cached =
+        ToolExecutionBinding::new(host.path().to_path_buf(), host.path().join("scratch"));
+    export.apply_tool_authority(&mut cached).unwrap();
+    assert!(service.reconcile(Pid(2), cached.clone()).is_ok());
+
+    service.revoke(&id, "tester").unwrap();
+    assert!(parent.snapshot().resolve("/mnt/data").is_err());
+    assert!(child.snapshot().resolve("/mnt/data").is_err());
+    assert!(service.reconcile(Pid(2), cached).is_err());
+}
+
+#[tokio::test]
+async fn projection_enforces_read_only_and_read_write_access() {
+    for (pid, access, writable) in [
+        (Pid(10), HostMountAccess::ReadOnly, false),
+        (Pid(11), HostMountAccess::ReadWrite, true),
+    ] {
+        let service = service();
+        let namespace = LiveNamespace::new(Namespace::new());
+        service.register_process(pid, namespace.clone());
+        let id = service
+            .enqueue(HostMountRequest {
+                id: format!("grant-{}", pid.0),
+                label: "data".to_string(),
+                namespace_path: "/mnt/data".to_string(),
+                access,
+                reason: "test".to_string(),
+                requesting_pid: pid.0,
+            })
+            .unwrap();
+        service
+            .approve_export(
+                &id,
+                test_export("/mnt/data", PathBuf::from("/tmp/data"), access),
+                "test",
+                "tester",
+            )
+            .unwrap();
+        let shell = alan_shell::Shell::new(InProcessTransport::new(Arc::new(
+            alan_kernel::MountFs::from_live_namespace(namespace),
+        )));
+        assert_eq!(shell.cat("/mnt/data/greeting").await.unwrap(), b"hi");
+        let write = shell.write("/mnt/data/submit", b"{}").await;
+        if writable {
+            assert_eq!(write, Ok(()));
+        } else {
+            assert_eq!(write, Err(ErrorCode::NoAccess));
+        }
+    }
+}

--- a/crates/service-manager/src/host_mount/tests.rs
+++ b/crates/service-manager/src/host_mount/tests.rs
@@ -491,54 +491,81 @@ fn inherited_read_only_projection_does_not_recover_write_authority() {
 }
 
 #[test]
-fn overlapping_projections_reconcile_tool_cwd_by_longest_namespace_prefix() {
-    let project = tempfile::tempdir().unwrap();
-    let docs = tempfile::tempdir().unwrap();
-    let service = service();
-    service.register_process(Pid(1), LiveNamespace::new(Namespace::new()));
-
-    for (id, namespace_path, host_path, access) in [
+fn process_projection_rejects_strictly_overlapping_namespace_paths() {
+    for (case, first_path, first_access, second_path, second_access) in [
         (
-            "grant-project",
+            "parent-first",
             "/mnt/project",
-            project.path(),
             HostMountAccess::ReadWrite,
-        ),
-        (
-            "grant-docs",
             "/mnt/project/docs",
-            docs.path(),
             HostMountAccess::ReadOnly,
         ),
+        (
+            "child-first",
+            "/mnt/project/docs",
+            HostMountAccess::ReadOnly,
+            "/mnt/project",
+            HostMountAccess::ReadWrite,
+        ),
     ] {
+        let first_host = tempfile::tempdir().unwrap();
+        let second_host = tempfile::tempdir().unwrap();
+        let service = service();
+        service.register_process(Pid(1), LiveNamespace::new(Namespace::new()));
+        let first_id = format!("grant-first-{case}");
         service
             .enqueue(HostMountRequest {
-                id: id.to_string(),
-                label: id.to_string(),
-                namespace_path: namespace_path.to_string(),
-                access,
+                id: first_id.clone(),
+                label: first_id.clone(),
+                namespace_path: first_path.to_string(),
+                access: first_access,
                 reason: "test overlapping namespace mounts".to_string(),
                 requesting_pid: 1,
             })
             .unwrap();
         service
             .approve_export(
-                id,
-                test_export(namespace_path, host_path.to_path_buf(), access),
+                &first_id,
+                test_export(first_path, first_host.path().to_path_buf(), first_access),
                 "user",
                 "tester",
             )
             .unwrap();
+        let second_id = format!("grant-second-{case}");
+        service
+            .enqueue(HostMountRequest {
+                id: second_id.clone(),
+                label: second_id.clone(),
+                namespace_path: second_path.to_string(),
+                access: second_access,
+                reason: "test overlapping namespace mounts".to_string(),
+                requesting_pid: 1,
+            })
+            .unwrap();
+
+        let error = service
+            .approve_export(
+                &second_id,
+                test_export(second_path, second_host.path().to_path_buf(), second_access),
+                "user",
+                "tester",
+            )
+            .unwrap_err();
+
+        assert!(error.to_string().contains("overlaps"));
+        assert_eq!(
+            service.request_snapshot(&second_id).unwrap().status,
+            HostMountStatus::Failed
+        );
+        assert!(service.grant_record(&second_id).is_none());
+        let binding = ToolExecutionBinding::awaiting_host_projection(
+            PathBuf::from(format!("{first_path}/guides")),
+            first_host.path().join("scratch"),
+        );
+        let reconciled = service.reconcile(Pid(1), binding).unwrap();
+        assert_eq!(reconciled.host_mounts.len(), 1);
+        assert_eq!(reconciled.cwd, first_host.path().join("guides"));
     }
-
-    let binding = ToolExecutionBinding::awaiting_host_projection(
-        PathBuf::from("/mnt/project/docs/guides"),
-        project.path().join("scratch"),
-    );
-    let reconciled = service.reconcile(Pid(1), binding).unwrap();
-
-    assert_eq!(reconciled.host_mounts.len(), 2);
-    assert_eq!(reconciled.cwd, docs.path().join("guides"));
 }
 
 #[tokio::test]

--- a/crates/service-manager/src/host_mount/tests.rs
+++ b/crates/service-manager/src/host_mount/tests.rs
@@ -110,6 +110,58 @@ fn grants_project_explicitly_hide_paths_and_revoke() {
 }
 
 #[test]
+fn replacing_a_process_mount_path_retires_the_old_projection_identity() {
+    let old_host = tempfile::tempdir().unwrap();
+    let latest_host = tempfile::tempdir().unwrap();
+    let service = service();
+    let namespace = LiveNamespace::new(Namespace::new());
+    service.register_process(Pid(7), namespace.clone());
+
+    for (id, host) in [
+        ("grant-old", old_host.path()),
+        ("grant-latest", latest_host.path()),
+    ] {
+        service
+            .enqueue(HostMountRequest {
+                id: id.to_string(),
+                label: id.to_string(),
+                namespace_path: "/mnt/project".to_string(),
+                access: HostMountAccess::ReadOnly,
+                reason: "replace exact mount".to_string(),
+                requesting_pid: 7,
+            })
+            .unwrap();
+        service
+            .approve_export(
+                id,
+                test_export(
+                    "/mnt/project",
+                    host.to_path_buf(),
+                    HostMountAccess::ReadOnly,
+                ),
+                "user",
+                "tester",
+            )
+            .unwrap();
+    }
+
+    let binding = ToolExecutionBinding::awaiting_host_projection(
+        PathBuf::from("/mnt/project"),
+        latest_host.path().join("scratch"),
+    );
+    let reconciled = service.reconcile(Pid(7), binding.clone()).unwrap();
+    assert_eq!(reconciled.cwd, latest_host.path());
+
+    service.revoke("grant-old", "tester").unwrap();
+
+    assert!(namespace.snapshot().resolve("/mnt/project").is_ok());
+    assert_eq!(
+        service.reconcile(Pid(7), binding).unwrap().cwd,
+        latest_host.path()
+    );
+}
+
+#[test]
 fn mount_free_tool_binding_reconciles_without_acquiring_authority() {
     let service = service();
     let namespace = LiveNamespace::new(Namespace::new());
@@ -298,8 +350,8 @@ fn explicitly_passed_child_projection_is_revoked_with_its_parent() {
         .unwrap();
 
     let child = LiveNamespace::new(parent.snapshot());
-    let factory = HostMountApplicatorFactory::new(service.clone());
-    factory.create(Pid(2), child.clone(), &["/mnt/data".to_string()]);
+    let factory = HostMountApplicatorFactory::inheriting_from(service.clone(), Pid(1));
+    factory.create(Pid(2), child.clone(), std::slice::from_ref(&id));
     let cached = ToolExecutionBinding::awaiting_host_projection(
         PathBuf::from("/mnt/data"),
         host.path().join("scratch"),
@@ -315,6 +367,62 @@ fn explicitly_passed_child_projection_is_revoked_with_its_parent() {
     let revoked = service.reconcile(Pid(2), cached).unwrap();
     assert!(revoked.host_mounts.is_empty());
     assert!(revoked.sandbox_spec.is_none());
+}
+
+#[test]
+fn child_inheritance_uses_the_exact_grant_held_by_its_parent() {
+    let first_host = tempfile::tempdir().unwrap();
+    let other_host = tempfile::tempdir().unwrap();
+    let service = service();
+    let first_parent = LiveNamespace::new(Namespace::new());
+    let other_parent = LiveNamespace::new(Namespace::new());
+    service.register_process(Pid(1), first_parent.clone());
+    service.register_process(Pid(2), other_parent);
+
+    for (id, pid, host) in [
+        ("grant-a", Pid(1), first_host.path()),
+        ("grant-z", Pid(2), other_host.path()),
+    ] {
+        service
+            .enqueue(HostMountRequest {
+                id: id.to_string(),
+                label: id.to_string(),
+                namespace_path: "/mnt/project".to_string(),
+                access: HostMountAccess::ReadOnly,
+                reason: "test exact inheritance".to_string(),
+                requesting_pid: pid.0,
+            })
+            .unwrap();
+        service
+            .approve_export(
+                id,
+                test_export(
+                    "/mnt/project",
+                    host.to_path_buf(),
+                    HostMountAccess::ReadOnly,
+                ),
+                "user",
+                "tester",
+            )
+            .unwrap();
+    }
+
+    let child = LiveNamespace::new(first_parent.snapshot());
+    HostMountApplicatorFactory::inheriting_from(service.clone(), Pid(1)).create(
+        Pid(3),
+        child,
+        &["grant-a".to_string()],
+    );
+    let binding = ToolExecutionBinding::awaiting_host_projection(
+        PathBuf::from("/mnt/project"),
+        first_host.path().join("scratch"),
+    );
+
+    let reconciled = service.reconcile(Pid(3), binding).unwrap();
+
+    assert_eq!(reconciled.host_mounts.len(), 1);
+    assert_eq!(reconciled.cwd, first_host.path());
+    assert_ne!(reconciled.cwd, other_host.path());
 }
 
 #[tokio::test]

--- a/crates/service-manager/src/host_mount/tests.rs
+++ b/crates/service-manager/src/host_mount/tests.rs
@@ -187,6 +187,54 @@ fn mount_free_tool_binding_reconciles_without_acquiring_authority() {
 }
 
 #[test]
+fn reconcile_preserves_cwd_until_all_projected_mounts_are_applied() {
+    let first_host = tempfile::tempdir().unwrap();
+    let cwd_host = tempfile::tempdir().unwrap();
+    std::fs::create_dir(cwd_host.path().join("work")).unwrap();
+    let service = service();
+    service.register_process(Pid(7), LiveNamespace::new(Namespace::new()));
+
+    for (id, namespace_path, host) in [
+        ("grant-a", "/mnt/a", first_host.path()),
+        ("grant-z", "/mnt/z", cwd_host.path()),
+    ] {
+        service
+            .enqueue(HostMountRequest {
+                id: id.to_string(),
+                label: id.to_string(),
+                namespace_path: namespace_path.to_string(),
+                access: HostMountAccess::ReadWrite,
+                reason: "test multi-mount cwd reconciliation".to_string(),
+                requesting_pid: 7,
+            })
+            .unwrap();
+        service
+            .approve_export(
+                id,
+                test_export(
+                    namespace_path,
+                    host.to_path_buf(),
+                    HostMountAccess::ReadWrite,
+                ),
+                "user",
+                "tester",
+            )
+            .unwrap();
+    }
+
+    let binding = ToolExecutionBinding::awaiting_host_projection(
+        PathBuf::from("/mnt/z/work"),
+        cwd_host.path().join("scratch"),
+    );
+
+    let reconciled = service.reconcile(Pid(7), binding).unwrap();
+
+    assert_eq!(reconciled.host_mounts.len(), 2);
+    assert_eq!(reconciled.namespace_cwd, PathBuf::from("/mnt/z/work"));
+    assert_eq!(reconciled.cwd, cwd_host.path().join("work"));
+}
+
+#[test]
 fn knowing_grant_id_does_not_project_to_another_process() {
     let host = tempfile::tempdir().unwrap();
     let service = service();

--- a/crates/service-manager/src/host_mount/tests.rs
+++ b/crates/service-manager/src/host_mount/tests.rs
@@ -19,8 +19,14 @@ impl HostMountExport for TestExport {
         self.tree.clone()
     }
 
-    fn apply_tool_authority(&self, binding: &mut ToolExecutionBinding) -> Result<()> {
-        binding.apply_host_mount(self.grant.clone())
+    fn apply_tool_authority(
+        &self,
+        effective_access: HostMountAccess,
+        binding: &mut ToolExecutionBinding,
+    ) -> Result<()> {
+        let mut grant = self.grant.clone();
+        grant.access = effective_access.kernel();
+        binding.apply_host_mount(grant)
     }
 }
 
@@ -94,7 +100,9 @@ fn grants_project_explicitly_hide_paths_and_revoke() {
     );
     let mut cached =
         ToolExecutionBinding::new(host.path().to_path_buf(), host.path().join("scratch"));
-    export.apply_tool_authority(&mut cached).unwrap();
+    export
+        .apply_tool_authority(HostMountAccess::ReadWrite, &mut cached)
+        .unwrap();
     let reconciled = service.reconcile(Pid(7), cached.clone()).unwrap();
     assert_eq!(reconciled.host_mounts.len(), 1);
     assert_eq!(reconciled.sandbox_spec.unwrap().writable_roots.len(), 1);
@@ -423,6 +431,63 @@ fn child_inheritance_uses_the_exact_grant_held_by_its_parent() {
     assert_eq!(reconciled.host_mounts.len(), 1);
     assert_eq!(reconciled.cwd, first_host.path());
     assert_ne!(reconciled.cwd, other_host.path());
+}
+
+#[test]
+fn inherited_read_only_projection_does_not_recover_write_authority() {
+    let host = tempfile::tempdir().unwrap();
+    let service = service();
+    let parent = LiveNamespace::new(Namespace::new());
+    service.register_process(Pid(1), parent.clone());
+    let id = service
+        .enqueue(HostMountRequest {
+            id: "grant-writable-parent".to_string(),
+            label: "project".to_string(),
+            namespace_path: "/mnt/project".to_string(),
+            access: HostMountAccess::ReadWrite,
+            reason: "test narrowed delegation".to_string(),
+            requesting_pid: 1,
+        })
+        .unwrap();
+    service
+        .approve_export(
+            &id,
+            test_export(
+                "/mnt/project",
+                host.path().to_path_buf(),
+                HostMountAccess::ReadWrite,
+            ),
+            "user",
+            "tester",
+        )
+        .unwrap();
+
+    let child_namespace = parent
+        .snapshot()
+        .project_mounts([("/mnt/project", "/mnt/project", Access::ReadOnly)])
+        .unwrap();
+    let child = LiveNamespace::new(child_namespace);
+    HostMountApplicatorFactory::inheriting_from(service.clone(), Pid(1)).create(
+        Pid(2),
+        child,
+        std::slice::from_ref(&id),
+    );
+    let binding = ToolExecutionBinding::awaiting_host_projection(
+        PathBuf::from("/mnt/project"),
+        host.path().join("scratch"),
+    );
+
+    let reconciled = service.reconcile(Pid(2), binding).unwrap();
+
+    assert_eq!(reconciled.host_mounts.len(), 1);
+    assert_eq!(reconciled.host_mounts[0].access, Access::ReadOnly);
+    assert!(
+        reconciled
+            .sandbox_spec
+            .expect("read-only Host Mount still has a sandbox spec")
+            .writable_roots
+            .is_empty()
+    );
 }
 
 #[tokio::test]

--- a/crates/service-manager/src/lib.rs
+++ b/crates/service-manager/src/lib.rs
@@ -33,7 +33,8 @@ pub use control_fs::{
 };
 pub use host_mount::{
     HostMountAccess, HostMountApplicatorFactory, HostMountExport, HostMountExportAdapter,
-    HostMountGrantRecord, HostMountRequest, HostMountService, UnavailableHostMountExportAdapter,
+    HostMountGrantRecord, HostMountRequest, HostMountService, HostMountStatus,
+    UnavailableHostMountExportAdapter,
 };
 pub use local_entry::LocalEntryService;
 pub use package::{

--- a/crates/service-manager/src/runtime/tests.rs
+++ b/crates/service-manager/src/runtime/tests.rs
@@ -476,11 +476,27 @@ async fn root_agent_is_replaced_without_pid_continuity() {
             .unwrap()
             .contains("channel=test")
     );
-    assert!(
-        String::from_utf8(shell.cat("/mnt/host-mount/status").await.unwrap())
-            .unwrap()
-            .contains("active=0")
+    assert_eq!(
+        shell.ls("/mnt/host-mount").await.unwrap(),
+        vec![
+            "requests".to_string(),
+            "grants".to_string(),
+            "events".to_string(),
+        ]
     );
+    assert_eq!(
+        shell.ls("/mnt/host-mount/requests").await.unwrap(),
+        vec!["clone".to_string(), "events".to_string()]
+    );
+    for retired in ["request", "projection", "approval", "status"] {
+        assert!(
+            shell
+                .stat(&format!("/mnt/host-mount/{retired}"))
+                .await
+                .is_err(),
+            "retired flat Host Mount surface {retired} must be absent"
+        );
+    }
     assert!(
         shell
             .ls("/mnt/llm/connections")

--- a/openspec/changes/complete-agent-runtime-file-native-seam/.openspec.yaml
+++ b/openspec/changes/complete-agent-runtime-file-native-seam/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-19

--- a/openspec/changes/complete-agent-runtime-file-native-seam/design.md
+++ b/openspec/changes/complete-agent-runtime-file-native-seam/design.md
@@ -1,0 +1,223 @@
+## Context
+
+ADR-0008, ADR-0009, ADR-0021, ADR-0024, ADR-0025, ADR-0034, ADR-0035, and
+ADR-0050 already establish the target: Agent Runtime Service starts Agent
+Processes, Process creation is `/proc/clone`, authority is descriptor-passed,
+and Host Mount Service owns Host file grants. The current runtime still carries
+three transitional inversions:
+
+- `alan-agent-engine` depends normally on `alan-kernel` and owns
+  Kernel-shaped launch and Tool Process context.
+- child Agent creation enters Agent Runtime Service through engine-owned
+  assembly and lifecycle callbacks instead of `/bin/alan-agent`.
+- `request_mount` accepts a raw Host path and propagates it through Agent
+  Machine, AgentFS, Tool results, rollout evidence, namespace applicators, and
+  Tool sandbox roots.
+
+This change starts after `deepen-agent-machine-transition-module` so engine
+transition ownership is stable before system composition is removed from it.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make Agent Runtime Service the concrete Agent Executable implementation.
+- Make Host Mount Service the sole request, grant, projection, revocation,
+  status, and audit authority.
+- Keep raw Host OS paths exclusively inside Host adapters.
+- Pass Host Mount authority through real file-server handles, mounted trees, or
+  descriptors rather than records or IDs.
+- Remove Kernel-shaped engine collaborators and the normal engine-to-Kernel
+  dependency.
+- Delete every displaced compatibility path in the same focused slice that
+  moves its owner.
+
+**Non-Goals:**
+
+- Redesign Kernel Process semantics, `/proc/clone`, aP, the Standard Namespace,
+  or AgentFS generally.
+- Introduce a second Agent Process type or a separate child-agent spawn API.
+- Preserve legacy `host_path`, flat Host Mount request files, aggregate Host
+  Mount inheritance, or callback-based child assembly.
+- Refactor unrelated `SpawnHandle` variants, provider adapters, Tool behavior,
+  or Alan for macOS attachment design.
+- Claim hard multi-process isolation beyond the enforcement state recorded by
+  ADR-0024.
+
+## Confirmed Live Seam Inventory
+
+The implementation baseline after `deepen-agent-machine-transition-module` contains these complete
+replacement seams:
+
+- raw Host backing and launch identity: `HostMountGrant` and `ProcessLaunchContext` in
+  `crates/agent-engine/src/process_launch.rs`;
+- runtime projection callbacks: `ApprovedMountGrant`, `MountGrantApplicator`, and
+  `MountGrantApplicatorFactory` in the engine namespace environment, with the Service Manager
+  implementation in `host_mount.rs`;
+- aggregate inheritance: `SpawnHandle::HostMounts` plus child launch-context and delegated-Skill
+  inference in the engine runtime;
+- child assembly and cleanup callbacks: `ChildAgentProcessAssembler` and `AgentProcessLifecycle`
+  in the engine, implemented by Agent Runtime Service;
+- Kernel-shaped Tool and child launch state across engine runtime, Tool execution, and sandbox
+  modules, backed by the normal `alan-kernel` dependency in `crates/agent-engine/Cargo.toml`.
+
+The pre-replacement characterization rail covers logical request Yield/resume and recovery, live
+read-only/read-write namespace projection, Tool sandbox reconciliation, explicit child projection,
+grant-ID non-authority, revocation, and Process lifecycle cleanup. Each implementation slice keeps
+the unaffected characterization tests while replacing and deleting its listed seam.
+
+## Decisions
+
+### Decision: Host Mount requests contain intent, never Host location
+
+`request_mount` accepts a normalized `/mnt/<name>` path, access, non-empty
+reason, and optional human label. It creates a Host Mount Service request and
+Yields while that request is pending. The Host adapter presents the native
+chooser or authorization surface, selects the Host directory, and returns a
+hostfs export to Host Mount Service. Agent Execution Engine, AgentFS, Tool
+results, rollout/checkpoint evidence, and Alan OS-visible audit records never
+receive the raw Host OS path.
+
+Agent policy may reject a request before native authorization, but it cannot
+approve one. AgentFS may expose the opaque request reference and waiting state
+needed by Agent Machine; writing an AgentFS decision cannot bypass Host Mount
+Service or the Host adapter.
+
+Alternative considered: keep `host_path` but redact it from selected evidence.
+Rejected because the engine would still own Host location and every missed
+projection would remain a disclosure and authority leak.
+
+### Decision: Host Mount Service exposes one clone-based request protocol
+
+The service is mounted at `/mnt/host-mount` with this minimal tree:
+
+```text
+/mnt/host-mount/
+├── requests/
+│   ├── clone
+│   ├── events
+│   └── <id>/
+│       ├── request
+│       ├── status
+│       ├── grant
+│       └── error
+├── grants/
+│   └── <id>/...
+└── events
+```
+
+Opening `requests/clone` allocates a fid-private request; writing the logical
+request document and clunking commits it. Status is one of `pending`,
+`approved`, `rejected`, `cancelled`, or `failed`. `grant` is populated only for
+approval, `error` only for terminal failure/rejection detail, and the event
+streams support offset-based waiting. The request reference is stable enough to
+resume after a Yield or runtime restart.
+
+The old flat `request`, `projection`, and approval files are removed. There is
+no dual protocol or adapter translating old requests to new ones.
+
+Alternative considered: add the request tree beside the flat protocol.
+Rejected because two writable approval surfaces would create two authorities.
+
+### Decision: A grant ID is metadata; a handle is authority
+
+Host Mount Service retains the native backing and issues an opaque mountable
+file-server handle. A Process gains access only when that handle or its mounted
+tree is explicitly delegated into its namespace. Alan OS-visible grant records
+may carry the grant ID, label, access, provenance, and namespace path, but the
+ID cannot resolve ambient authority.
+
+The engine-owned raw `HostMountGrant` backing and aggregate
+`SpawnHandle::HostMounts` are deleted. Child launch explicitly lists selected
+grant handles and target namespace paths; the default is none. The spawner must
+already possess each delegated handle and cannot amplify access. A cwd below a
+Host Mount does not imply inheritance.
+
+Alternative considered: pass grant IDs and look them up globally in the child.
+Rejected because a globally resolvable ID bypasses the Process namespace
+capability boundary.
+
+### Decision: Tool sandbox authority derives from the same grant
+
+When Alan OS starts a native Tool Process, the Host adapter maps the explicitly
+delegated Host Mount handles to native sandbox rights. Read-write grants may add
+native write authority; read-only grants do not. Agent Execution Engine sees
+only the Alan OS namespace and spawn intent and never stores or updates raw
+native writable roots.
+
+Alternative considered: keep an engine-owned list of native paths synchronized
+with namespace mounts. Rejected because it is a second authority ledger with a
+different lifetime.
+
+### Decision: Agent Runtime Service implements `/bin/alan-agent`
+
+A child Agent Process is an ordinary `/proc/clone` execution of
+`/bin/alan-agent`. The parent supplies the `SpawnSpec`, namespace capabilities,
+descriptors, and optional explicit Host Mount handles. Agent Runtime Service
+implements the Agent Executable by binding AgentFS, selecting the mounted
+connection, starting Agent Machine, and cleaning up runtime state when the
+Process exits.
+
+`/proc/<pid>` remains lifecycle truth. `/agent/<pid>` and the parent's AgentFS
+children projection provide the agent view; no `/agent/.../children/clone`
+spawn protocol is introduced.
+
+Alternative considered: retain `ChildAgentProcessAssembler` behind a narrower
+trait. Rejected because the callback itself keeps Process assembly owned by the
+engine.
+
+### Decision: The engine stops depending on Kernel-shaped runtime types
+
+`ProcessLaunchContext`, Tool Process native sandbox construction, child
+assembly callbacks, lifecycle callbacks, and live Host Mount applicators leave
+`alan-agent-engine`. The engine uses aP and agent-protocol file/spawn records for
+runtime effects. Its normal `alan-kernel` dependency is removed and the
+repository dependency ledger is tightened in the same PR; a dev-dependency is
+allowed only for public contract tests.
+
+Alternative considered: move existing types to a neutral crate without
+changing their contents. Rejected because that would preserve raw Host backing
+and lifecycle inversion under a new package name.
+
+## Risks / Trade-offs
+
+- [Native approval resumes the wrong request] → Bind every decision to the
+  service request fid/reference and make terminal states immutable.
+- [Opaque handles accidentally become global IDs] → Require delegation from a
+  handle the spawner can already open; test that ID-only and unpassed grants
+  confer no access.
+- [Namespace and native sandbox authority diverge] → Derive both projections
+  from the same service-owned grant and revoke them through the same owner.
+- [Restart loses a pending Yield] → Persist the opaque request reference in
+  Agent Machine evidence and resume by reading service status/events.
+- [Breaking protocol leaves hidden callers] → Remove legacy fields and symbols,
+  update all fixtures atomically, and add absence checks for retired surfaces.
+- [Large cross-crate rewrite is hard to review] → Use focused stacked PRs that
+  each move one complete owner and delete its old path before merge.
+
+## Migration Plan
+
+1. Merge and archive `deepen-agent-machine-transition-module`.
+2. Replace `request_mount` end to end with the logical Host Mount Service
+   request tree; update AgentFS/evidence and delete `host_path` plus the flat
+   approval protocol in the same slice.
+3. Replace raw Host Mount launch backing, live applicators, aggregate inheritance,
+   and engine sandbox roots with explicit service-issued handles; tighten
+   capability and revocation tests.
+4. Route child Agent launch through `/proc/clone` and `/bin/alan-agent`; move
+   AgentFS/Machine lifecycle ownership into Agent Runtime Service and delete the
+   assembler/lifecycle callback path.
+5. Remove remaining Kernel-shaped engine DTOs and the normal `alan-kernel`
+   dependency; tighten the architecture dependency ledger and retired-symbol
+   checks.
+6. Run focused runtime/service tests, `just check`, `just test`, strict OpenSpec
+   validation, and the dependency gate. Merge each PR only after CI and Codex
+   Review remain clean on the current HEAD through a follow-up review window.
+
+The repository is in early development, so migration is an atomic contract
+replacement rather than a compatibility period. Rollback is by reverting the
+complete focused PR; no old protocol remains active alongside the new one.
+
+## Open Questions
+
+None.

--- a/openspec/changes/complete-agent-runtime-file-native-seam/proposal.md
+++ b/openspec/changes/complete-agent-runtime-file-native-seam/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+The accepted file-native architecture is not yet complete: Agent Execution
+Engine still receives Kernel-shaped launch and lifecycle collaborators, while
+Host Mount requests and Tool sandbox projection still carry raw Host OS paths
+through Agent Machine and evidence. These transitional seams put Alan OS and
+Host adapter authority in the transition engine.
+
+## What Changes
+
+- **BREAKING** Remove `host_path` from the `request_mount` request, AgentFS
+  projection, Tool result, rollout, and audit contracts. Requests carry only the
+  Alan OS `/mnt` path, access, reason, and optional label.
+- Make Host Mount Service the sole request, native approval, grant, projection,
+  revocation, status, and audit authority through a clone-via-open service tree;
+  the Host adapter alone sees and authorizes the raw Host OS path.
+- Replace raw Host Mount backing and aggregate `HostMounts` inheritance with
+  explicit opaque grant handles or mounted file-tree descriptors. Grant IDs are
+  metadata, never authority, and child Processes receive no Host Mount by
+  default.
+- Launch child Agent Processes as ordinary `/proc/clone` executions of
+  `/bin/alan-agent`; Agent Runtime Service implements the Agent Executable and
+  owns AgentFS binding, namespace assembly, connection selection, Machine
+  startup, and lifecycle cleanup.
+- Delete engine-owned launch context, child assembly/lifecycle callbacks, live
+  mount applicators, and Kernel-shaped DTOs after their responsibilities move.
+- Remove the normal `alan-agent-engine` dependency on `alan-kernel`; a
+  development-only dependency for public contract tests remains allowed.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `agent-namespace-runtime`: Complete the Agent Runtime Service/Agent Executable
+  assembly boundary and remove Kernel-shaped engine collaborators.
+- `host-mount-service`: Define the logical request tree, native approval
+  authority, opaque grant handles, and terminal request states.
+- `process-launch-context`: Replace engine-owned raw Host Mount backing and
+  aggregate inheritance with explicit namespace mounts and descriptors.
+- `agent-mount-escalation`: Remove raw Host paths and engine-local approval from
+  the Agent-visible mount request contract and evidence.
+- `live-mount-grant-namespace-projection`: Move live projection from an engine
+  applicator callback to Host Mount Service handle projection.
+- `mount-grant-tool-sandbox-projection`: Derive native Tool sandbox authority
+  from Host Mount Service grants inside Host adapters rather than engine-owned
+  raw writable roots.
+
+## Impact
+
+This change follows `deepen-agent-machine-transition-module` and affects Agent
+Runtime Service, Service Manager composition, Agent Execution Engine, Host Mount
+Service, Host adapters, Tool Process launch, AgentFS request projection, rollout
+records, and the affected aP file contracts. The old request and flat service
+surfaces are removed rather than retained as compatibility paths; callers and
+fixtures must migrate atomically in focused stacked PRs.

--- a/openspec/changes/complete-agent-runtime-file-native-seam/specs/agent-mount-escalation/spec.md
+++ b/openspec/changes/complete-agent-runtime-file-native-seam/specs/agent-mount-escalation/spec.md
@@ -1,0 +1,74 @@
+## MODIFIED Requirements
+
+### Requirement: Agent-requested host mounts require approval
+Agent Processes SHALL request Host Mounts through the runtime-provided
+`request_mount` control operation. The operation SHALL validate a normalized
+absolute `/mnt/<name>` namespace path, supported access, non-empty reason, and
+optional label, then commit that logical request to Host Mount Service. It MUST
+NOT accept or derive a raw Host OS path. A valid request SHALL pause the turn
+with an authorization-wait Yield while service status is `pending` and SHALL
+NOT grant access before Host-adapter authorization.
+
+#### Scenario: Valid logical mount request pauses for approval
+- **WHEN** an Agent Process calls `request_mount` with a valid namespace path,
+  supported access, non-empty reason, and optional label
+- **THEN** the runtime commits one Host Mount Service request and emits a Yield
+  containing its opaque request reference
+- **AND** the turn pauses without changing the Process namespace
+
+#### Scenario: Invalid mount request is rejected before approval
+- **WHEN** an Agent Process calls `request_mount` with a reserved or non-normal
+  namespace path, unsupported access, blank reason, or a raw Host path field
+- **THEN** the runtime completes the control call with an invalid-request result
+- **AND** no Host Mount Service request, Yield, or grant is created
+
+### Requirement: Mount authorization cannot be auto-allowed
+Every valid mount request SHALL cross Host Mount Service and a Host-adapter
+native authorization boundary. Agent policy evaluation MAY deny the request,
+but an allow decision MUST only permit creation of the pending service request
+and MUST NOT create or approve a grant. AgentFS and Agent Machine decision files
+MUST NOT bypass native authorization.
+
+#### Scenario: Policy allow creates only a pending request
+- **WHEN** policy evaluation allows a valid `request_mount` call
+- **THEN** the runtime creates a pending Host Mount Service request and Yields
+- **AND** only the Host adapter and Host Mount Service can produce approval
+
+#### Scenario: Policy deny blocks a mount request
+- **WHEN** policy evaluation denies a valid `request_mount` call
+- **THEN** the runtime returns a blocked-by-policy result
+- **AND** no service request or grant is created
+
+#### Scenario: Agent writes an approval decision
+- **WHEN** an Agent Process writes an approval value to its own AgentFS request
+- **THEN** Host Mount Service status remains unchanged
+- **AND** no namespace or native sandbox authority is granted
+
+### Requirement: Approved mount requests produce auditable grants
+When Host Mount Service reaches a terminal request status, Agent Machine SHALL
+resume from the opaque request reference and return a structured
+`request_mount` result containing request identity, logical namespace path,
+access, status, and approved grant reference or concise error. Agent-visible
+results, AgentFS, Machine state, rollout/checkpoint evidence, and Alan OS audit
+records MUST NOT contain the raw Host OS path. Projection and revocation truth
+SHALL remain in Host Mount Service rather than an engine-owned audit event.
+
+#### Scenario: Approved request resumes execution
+- **WHEN** Host Mount Service reports `approved` and exposes the service-owned
+  grant
+- **THEN** Agent Machine resumes the control call with an approved result and
+  opaque grant reference
+- **AND** future namespace and Tool Process access derive from the mounted grant
+  handle
+- **AND** neither result nor durable evidence contains a Host path
+
+#### Scenario: Rejected request resumes execution
+- **WHEN** Host Mount Service reports `rejected`
+- **THEN** Agent Machine returns a rejected result with the logical request
+  identity and concise reason
+- **AND** no grant or namespace access is created
+
+#### Scenario: Failed or cancelled request resumes execution
+- **WHEN** Host Mount Service reports `failed` or `cancelled`
+- **THEN** Agent Machine returns the matching terminal result without claiming
+  namespace or Tool sandbox projection

--- a/openspec/changes/complete-agent-runtime-file-native-seam/specs/agent-namespace-runtime/spec.md
+++ b/openspec/changes/complete-agent-runtime-file-native-seam/specs/agent-namespace-runtime/spec.md
@@ -1,0 +1,42 @@
+## MODIFIED Requirements
+
+### Requirement: Agent Runtime Service owns Agent Process assembly
+Agent Runtime Service SHALL implement the Agent Executable bound at
+`/bin/alan-agent` and SHALL own Process clone inputs, namespace mount assembly,
+AgentFS lifecycle wiring, mounted connection selection, Agent Machine startup,
+and runtime cleanup. Agent Execution Engine SHALL receive the assembled
+namespace and transition-owned file handles and MUST NOT construct Kernel,
+AgentFS, LLMFS, RouteFS, Host Mount, Tool Process native sandbox, or child
+Process namespace infrastructure. It MUST NOT receive an engine-owned Process
+launch context, child assembler, lifecycle callback, or live mount applicator.
+
+#### Scenario: Agent Process starts
+- **WHEN** a Process executes `/bin/alan-agent` through `/proc/clone`
+- **THEN** Agent Runtime Service binds AgentFS, resolves the mounted connection,
+  starts Agent Machine, and wires cleanup before transitions begin
+- **AND** Agent Execution Engine receives only the namespace and files needed to
+  execute transitions
+
+#### Scenario: Child Agent Process starts
+- **WHEN** an Agent Process requests a child with an explicitly delegated,
+  possibly narrower capability set
+- **THEN** the parent writes an exec spec for `/bin/alan-agent` through
+  `/proc/clone`
+- **AND** Agent Runtime Service assembles the child AgentFS and runtime from that
+  Process namespace
+- **AND** Agent Execution Engine does not call a child assembly or lifecycle
+  callback
+
+#### Scenario: Agent Process exits
+- **WHEN** `/proc/<pid>` reaches a terminal exit state
+- **THEN** Agent Runtime Service cleans up its Agent Machine and AgentFS runtime
+  backing
+- **AND** `/proc/<pid>` remains the lifecycle source of truth
+
+#### Scenario: Dependency validation runs
+- **WHEN** repository validation inspects `alan-agent-engine` normal dependencies
+- **THEN** `alan-kernel` and displaced system-composition dependencies are absent
+- **AND** a development-only dependency used by a public contract test is not
+  treated as production ownership
+- **AND** the repository dependency gate rejects reintroduction of a removed
+  normal edge

--- a/openspec/changes/complete-agent-runtime-file-native-seam/specs/host-mount-service/spec.md
+++ b/openspec/changes/complete-agent-runtime-file-native-seam/specs/host-mount-service/spec.md
@@ -105,9 +105,11 @@ request before clearing the corresponding Agent Machine wait.
 - **AND** approval-like status writes from the requesting Process are rejected
 
 #### Scenario: Approval wins the race with runtime abandonment
-- **WHEN** Host Mount Service reaches `approved` before the requesting runtime's
-  cancellation write commits
-- **THEN** Agent Runtime observes the immutable approved result and retains its
-  opaque grant reference and logical projection before clearing the Machine wait
+- **WHEN** Host Mount Service has claimed an approval decision before the
+  requesting runtime's cancellation write commits
+- **THEN** Agent Runtime waits for the service to publish an immutable terminal
+  result instead of treating the still-pending decision as cancellation failure
+- **AND** an approved result retains its opaque grant reference and logical
+  projection before clearing the Machine wait
 - **AND** later child launch isolation cannot mistake the live mount for ambient
   authority

--- a/openspec/changes/complete-agent-runtime-file-native-seam/specs/host-mount-service/spec.md
+++ b/openspec/changes/complete-agent-runtime-file-native-seam/specs/host-mount-service/spec.md
@@ -76,7 +76,10 @@ A committed Host Mount request SHALL move from `pending` to exactly one of
 immutable, `grant` SHALL identify an approved service grant, `error` SHALL carry
 concise terminal failure or rejection detail, and clients SHALL be able to
 resume waiting by request reference and event offset after a Yield or runtime
-restart.
+restart. The requesting Process MAY cancel only its own pending request through
+the Process-scoped request tree; it MUST NOT write an approval or any other
+terminal decision. Agent Runtime SHALL settle or cancel a pending service
+request before clearing the corresponding Agent Machine wait.
 
 #### Scenario: Pending request is approved
 - **WHEN** the Host adapter authorizes a directory and Host Mount Service creates
@@ -91,3 +94,12 @@ restart.
 - **THEN** it rereads status or continues the request event stream
 - **AND** it does not recreate the request or depend on an in-memory approval
   callback
+
+#### Scenario: Runtime abandons a pending mount Yield
+- **WHEN** a new turn or cancellation clears an Agent Machine wait for a pending
+  Host Mount request
+- **THEN** Agent Runtime first asks Host Mount Service to mark that request
+  `cancelled` through the requesting Process's scoped status file
+- **AND** the Machine wait is not cleared while the service request can still be
+  approved
+- **AND** approval-like status writes from the requesting Process are rejected

--- a/openspec/changes/complete-agent-runtime-file-native-seam/specs/host-mount-service/spec.md
+++ b/openspec/changes/complete-agent-runtime-file-native-seam/specs/host-mount-service/spec.md
@@ -103,3 +103,11 @@ request before clearing the corresponding Agent Machine wait.
 - **AND** the Machine wait is not cleared while the service request can still be
   approved
 - **AND** approval-like status writes from the requesting Process are rejected
+
+#### Scenario: Approval wins the race with runtime abandonment
+- **WHEN** Host Mount Service reaches `approved` before the requesting runtime's
+  cancellation write commits
+- **THEN** Agent Runtime observes the immutable approved result and retains its
+  opaque grant reference and logical projection before clearing the Machine wait
+- **AND** later child launch isolation cannot mistake the live mount for ambient
+  authority

--- a/openspec/changes/complete-agent-runtime-file-native-seam/specs/host-mount-service/spec.md
+++ b/openspec/changes/complete-agent-runtime-file-native-seam/specs/host-mount-service/spec.md
@@ -1,0 +1,93 @@
+## MODIFIED Requirements
+
+### Requirement: Host Mount Service is the grant authority
+Host Mount Service SHALL own logical request records, native authorization
+coordination, user decisions, hostfs exports, grants, namespace projection,
+revocation, audit, and status. The Host adapter SHALL be the only component that
+selects or observes the raw Host OS path. Alan OS-visible records SHALL expose
+request and grant identity, label, access, provenance, status, and `/mnt` path
+but MUST NOT expose the raw Host OS path.
+
+#### Scenario: User approves a writable directory
+- **WHEN** a Host adapter authorizes a native directory and returns a writable
+  hostfs export for a pending logical request
+- **THEN** Host Mount Service records the grant and mounts its handle into the
+  requesting Process live namespace at the approved Alan OS path
+- **AND** no Alan OS-visible request, result, Machine, or audit record contains
+  the native directory path
+
+#### Scenario: AgentFS receives an approval write
+- **WHEN** an Agent Process or renderer writes an approve-like value to an
+  AgentFS request or Machine control file
+- **THEN** no Host Mount grant is created unless Host Mount Service receives a
+  Host-adapter authorization
+- **AND** AgentFS cannot act as a second grant authority
+
+### Requirement: Grant authority is capability-passed
+Knowing a grant ID SHALL confer no access. A Process SHALL gain access only when
+the service-issued file-server handle or mount is explicitly projected into its
+namespace, and native sandbox rights SHALL derive from that same grant. Host
+Mount Service MUST reject delegation that the spawner cannot authorize from its
+own namespace and access rights.
+
+#### Scenario: Child does not receive parent grant
+- **WHEN** a parent launches a child without explicitly passing a Host Mount
+  handle and target namespace path
+- **THEN** the child cannot use the grant ID, infer the Host backing, or discover
+  the grant through its cwd
+
+#### Scenario: Child receives selected grant
+- **WHEN** a parent explicitly delegates a Host Mount handle it already holds
+  with equal or narrower access
+- **THEN** the child may reach the mounted tree at the specified Alan OS path
+- **AND** no other parent Host Mount is inherited
+
+## ADDED Requirements
+
+### Requirement: Host Mount requests use a clone-based logical file protocol
+Host Mount Service SHALL expose logical requests through
+`/mnt/host-mount/requests/clone` using clone-via-open and commit-on-clunk. A
+committed request SHALL contain a normalized `/mnt/<name>` namespace path,
+access, non-empty reason, and optional label, and MUST NOT contain a raw Host OS
+path. The service SHALL expose each committed request at
+`requests/<id>/{request,status,grant,error}`, request updates at
+`requests/events`, grant trees at `grants/<id>`, and service updates at
+`events`.
+
+#### Scenario: Agent commits a valid request
+- **WHEN** an Agent Process opens `requests/clone`, writes a valid logical
+  request document, and clunks the fid
+- **THEN** Host Mount Service publishes one `pending` request with a stable ID
+- **AND** no grant or namespace access exists before native authorization
+
+#### Scenario: Agent commits an invalid request
+- **WHEN** the request document has a reserved or non-normal namespace path,
+  unsupported access, blank reason, or a Host path field
+- **THEN** clunk fails without publishing a request or grant
+
+#### Scenario: Legacy flat protocol is inspected
+- **WHEN** a client walks the Host Mount Service tree
+- **THEN** no flat writable approval, projection, or legacy `request` surface is
+  present beside the clone-based protocol
+
+### Requirement: Host Mount request status is terminal and resumable
+A committed Host Mount request SHALL move from `pending` to exactly one of
+`approved`, `rejected`, `cancelled`, or `failed`. Terminal status SHALL be
+immutable, `grant` SHALL identify an approved service grant, `error` SHALL carry
+concise terminal failure or rejection detail, and clients SHALL be able to
+resume waiting by request reference and event offset after a Yield or runtime
+restart.
+
+#### Scenario: Pending request is approved
+- **WHEN** the Host adapter authorizes a directory and Host Mount Service creates
+  its export and projection
+- **THEN** the request becomes `approved` and its `grant` file references the
+  service-owned grant
+- **AND** later decision attempts cannot replace that terminal result
+
+#### Scenario: Runtime resumes a pending mount Yield
+- **WHEN** Agent Machine restarts with the request reference and last event
+  offset recorded in durable evidence
+- **THEN** it rereads status or continues the request event stream
+- **AND** it does not recreate the request or depend on an in-memory approval
+  callback

--- a/openspec/changes/complete-agent-runtime-file-native-seam/specs/host-mount-service/spec.md
+++ b/openspec/changes/complete-agent-runtime-file-native-seam/specs/host-mount-service/spec.md
@@ -16,6 +16,13 @@ but MUST NOT expose the raw Host OS path.
 - **AND** no Alan OS-visible request, result, Machine, or audit record contains
   the native directory path
 
+#### Scenario: User dismisses native directory authorization
+- **WHEN** a Host adapter presents a pending request and the user dismisses the
+  native directory authorization panel
+- **THEN** the adapter asks Host Mount Service to publish a terminal `cancelled`
+  result through the same-user Host command plane
+- **AND** Agent Runtime resumes the waiting Agent Process without a grant
+
 #### Scenario: AgentFS receives an approval write
 - **WHEN** an Agent Process or renderer writes an approve-like value to an
   AgentFS request or Machine control file

--- a/openspec/changes/complete-agent-runtime-file-native-seam/specs/live-mount-grant-namespace-projection/spec.md
+++ b/openspec/changes/complete-agent-runtime-file-native-seam/specs/live-mount-grant-namespace-projection/spec.md
@@ -1,0 +1,90 @@
+## MODIFIED Requirements
+
+### Requirement: Approved mount grants update the live Agent Process namespace
+Host Mount Service SHALL project an approved grant's mountable file-server
+handle into the requesting Process live namespace at the requested absolute
+`/mnt/<name>` path. Future aP walks SHALL resolve through that handle. The same
+live namespace SHALL remain the source of truth for file walks,
+`/proc/<pid>/namespace`, and snapshots used for later Process spawn.
+
+#### Scenario: Approved read-write grant is mounted into the namespace
+- **WHEN** Host Mount Service approves a logical `/mnt/project` request with
+  `access = read_write`
+- **THEN** future aP walks and mutations under `/mnt/project` use the approved
+  grant handle and access rights
+- **AND** the request status reports the successful projection
+
+#### Scenario: Approved read-only grant is mounted into the namespace
+- **WHEN** Host Mount Service approves a logical `/mnt/docs` request with
+  `access = read_only`
+- **THEN** future aP walks and reads under `/mnt/docs` use the approved grant
+  handle
+- **AND** aP mutations are rejected and native writable authority is not added
+
+#### Scenario: Proc namespace views and child spawns observe live grants
+- **WHEN** an approved grant changes the requesting Process live namespace
+- **THEN** future `/proc/<pid>/namespace` reads include the mount
+- **AND** a later child receives it only when the spawner explicitly delegates
+  that grant handle in the child's namespace
+- **AND** Host Mount Service does not report success while Process namespace
+  state remains stale
+
+#### Scenario: Live namespace mutation invalidates namespace metadata
+- **WHEN** Host Mount Service mutates the live namespace
+- **THEN** the live namespace generation and affected synthetic qids or versions
+  change
+- **AND** cache-by-qid clients can detect that namespace metadata must be reread
+
+### Requirement: Namespace projection preserves host/kernel/engine layering
+The Host adapter SHALL construct the host-backed file-server export from the raw
+Host OS path and return that opaque export to Host Mount Service. Host Mount
+Service SHALL project only the service-issued handle, namespace path, and access
+into the Process namespace. `alan-agent-engine` MUST NOT construct `HostDirFs`,
+depend on `alan_hostfs`, receive the raw path, or invoke a live mount applicator;
+Alan Kernel MUST NOT store Host path provenance.
+
+#### Scenario: Host composition owns HostDirFs construction
+- **WHEN** a pending request receives native authorization
+- **THEN** the Host adapter constructs the host-backed export and Host Mount
+  Service projects its handle
+- **AND** Agent Execution Engine observes only service request status through aP
+- **AND** Alan Kernel records only the mounted file server and access mode
+
+#### Scenario: Host export construction fails
+- **WHEN** the Host adapter cannot construct or authorize the requested export
+- **THEN** Host Mount Service records `failed` with a concise error
+- **AND** no namespace mount or approved grant is reported
+
+### Requirement: Namespace projection is idempotent by namespace path
+Host Mount Service SHALL replace the exact requested namespace mount path for
+future walks instead of accumulating duplicate mounts. Rejected, cancelled, or
+failed requests SHALL NOT change the live namespace.
+
+#### Scenario: Repeated approved grant replaces the same namespace path
+- **WHEN** the same Process receives a later approved grant for an existing
+  exact namespace path
+- **THEN** future walks resolve through one latest mounted grant handle
+- **AND** namespace descriptions do not accumulate duplicate exact-path entries
+
+#### Scenario: Non-approved request leaves the namespace unchanged
+- **WHEN** a request reaches `rejected`, `cancelled`, or `failed`
+- **THEN** its requested namespace path is not mounted
+
+### Requirement: Namespace application outcome is audited independently
+Host Mount Service request status and audit records SHALL report grant approval
+and namespace projection without relying on an engine-owned grant event. Native
+Tool sandbox derivation MAY have a separate outcome, but both projections SHALL
+refer to the same service-owned grant and MUST NOT expose its raw Host backing.
+
+#### Scenario: Namespace apply failure is reported without false approval
+- **WHEN** native authorization succeeds but live namespace projection fails
+- **THEN** Host Mount Service records the projection failure and does not expose
+  an usable approved grant to the requesting Process
+- **AND** the Agent-visible result contains only the logical request and concise
+  error
+
+#### Scenario: Read-only grant has no writable Tool projection
+- **WHEN** an approved read-only grant is mounted into the Process namespace
+- **THEN** Host Mount Service reports the namespace projection
+- **AND** the Host adapter does not derive native write authority for Tool
+  Processes

--- a/openspec/changes/complete-agent-runtime-file-native-seam/specs/mount-grant-tool-sandbox-projection/spec.md
+++ b/openspec/changes/complete-agent-runtime-file-native-seam/specs/mount-grant-tool-sandbox-projection/spec.md
@@ -1,0 +1,55 @@
+## MODIFIED Requirements
+
+### Requirement: Approved read-write mount grants update the runtime tool sandbox
+The Host adapter SHALL derive native writable authority from the same
+service-owned grant when Alan OS starts a native Tool Process with an explicitly
+delegated read-write Host Mount. Agent Execution Engine
+MUST NOT store the raw Host backing, add native paths to an engine-owned sandbox
+list, or apply sandbox authority from a grant ID alone.
+
+#### Scenario: Approved read-write grant is passed to a Tool Process
+- **WHEN** a Tool Process launch explicitly includes a read-write Host Mount
+  handle mounted at `/mnt/project`
+- **THEN** the Host adapter adds the grant's native backing to the OS sandbox
+  with writable access
+- **AND** Tool code continues to address the tree through the Alan OS namespace
+
+#### Scenario: Duplicate grant delegation is idempotent
+- **WHEN** the same read-write grant handle is included more than once in one
+  Tool Process launch
+- **THEN** the Host adapter emits one effective native sandbox authorization
+
+### Requirement: Non-writable mount grants do not expand writable roots
+The Host adapter SHALL NOT derive native writable authority from a read-only
+Host Mount grant. The approved grant MAY remain readable through its mounted
+file-server handle according to the Tool Process namespace and Host sandbox
+policy.
+
+#### Scenario: Approved read-only grant is passed to a Tool Process
+- **WHEN** a Tool Process launch explicitly includes a read-only Host Mount
+  handle
+- **THEN** the Host adapter does not add its native backing as a writable root
+- **AND** no engine-owned sandbox state is mutated
+
+### Requirement: Tool sandbox path checks honor all writable roots
+Host adapter containment checks and OS sandbox profile generation SHALL include
+the native backing of every explicitly delegated read-write Host Mount grant
+and SHALL reject paths outside the Tool Process's delegated writable authority.
+Those native roots SHALL remain Host-adapter implementation data and MUST NOT be
+serialized into Agent Machine, AgentFS, rollout/checkpoint, or Tool result
+records.
+
+#### Scenario: Tool can access an approved writable grant
+- **WHEN** the Tool Process has an explicitly delegated read-write Host Mount
+  and executes below its Alan OS mount
+- **THEN** Host containment checks and the OS sandbox permit the corresponding
+  native access
+- **AND** a path outside every delegated writable grant remains rejected
+
+#### Scenario: Bash uses an approved writable grant as cwd
+- **WHEN** bash starts with cwd below an explicitly delegated read-write Host
+  Mount
+- **THEN** the Host adapter resolves the grant internally and permits the native
+  cwd
+- **AND** bash launch records do not expose the raw Host path to Agent Execution
+  Engine

--- a/openspec/changes/complete-agent-runtime-file-native-seam/specs/mount-grant-tool-sandbox-projection/spec.md
+++ b/openspec/changes/complete-agent-runtime-file-native-seam/specs/mount-grant-tool-sandbox-projection/spec.md
@@ -53,3 +53,11 @@ records.
   cwd
 - **AND** bash launch records do not expose the raw Host path to Agent Execution
   Engine
+
+#### Scenario: Tool cwd is below overlapping delegated mounts
+- **WHEN** a Tool Process cwd is below both a parent Host Mount and a more
+  specific nested Host Mount
+- **THEN** native cwd projection uses the longest matching Alan OS namespace
+  prefix, consistent with Kernel path resolution
+- **AND** the parent grant cannot replace or amplify the nested grant's backing
+  or access

--- a/openspec/changes/complete-agent-runtime-file-native-seam/specs/mount-grant-tool-sandbox-projection/spec.md
+++ b/openspec/changes/complete-agent-runtime-file-native-seam/specs/mount-grant-tool-sandbox-projection/spec.md
@@ -54,10 +54,9 @@ records.
 - **AND** bash launch records do not expose the raw Host path to Agent Execution
   Engine
 
-#### Scenario: Tool cwd is below overlapping delegated mounts
-- **WHEN** a Tool Process cwd is below both a parent Host Mount and a more
-  specific nested Host Mount
-- **THEN** native cwd projection uses the longest matching Alan OS namespace
-  prefix, consistent with Kernel path resolution
-- **AND** the parent grant cannot replace or amplify the nested grant's backing
-  or access
+#### Scenario: Process requests overlapping Host Mount projections
+- **WHEN** a Process already holds an active Host Mount projection and another
+  grant would mount at a strict parent or child namespace path
+- **THEN** Host Mount Service rejects the overlapping projection before native
+  Tool sandbox authority is constructed
+- **AND** the existing projection remains unchanged

--- a/openspec/changes/complete-agent-runtime-file-native-seam/specs/mount-grant-tool-sandbox-projection/spec.md
+++ b/openspec/changes/complete-agent-runtime-file-native-seam/specs/mount-grant-tool-sandbox-projection/spec.md
@@ -54,6 +54,13 @@ records.
 - **AND** bash launch records do not expose the raw Host path to Agent Execution
   Engine
 
+#### Scenario: Bash preserves cwd across multiple delegated mounts
+- **WHEN** a Tool Process cwd is below one of multiple explicitly delegated Host
+  Mounts
+- **THEN** Host authority reconciliation resolves the cwd through that covering
+  mount independent of grant iteration order
+- **AND** every other delegated mount remains available with its effective access
+
 #### Scenario: Process requests overlapping Host Mount projections
 - **WHEN** a Process already holds an active Host Mount projection and another
   grant would mount at a strict parent or child namespace path

--- a/openspec/changes/complete-agent-runtime-file-native-seam/specs/process-launch-context/spec.md
+++ b/openspec/changes/complete-agent-runtime-file-native-seam/specs/process-launch-context/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: Process launch has no workspace identity
+Alan OS SHALL create every Process from its parent namespace snapshot, explicit
+mounts and descriptors, credentials, and normalized initial namespace cwd. It
+MUST NOT assign a workspace ID or Host root identity, carry raw Host Mount
+backing records, or use a grant ID as launch authority.
+
+#### Scenario: Agent starts with a Host Mount
+- **WHEN** a Shell Process spawns an Agent Executable with a Host Mount handle
+  explicitly projected at `/mnt/source` and cwd set to `/mnt/source`
+- **THEN** the child receives that namespace mount without a workspace field or
+  raw Host OS path
+- **AND** native sandbox authority is derived from the same delegated grant by
+  the Host adapter
+
+#### Scenario: Child launch requests a non-normal namespace cwd
+- **WHEN** a child launch requests a cwd containing `.` or `..` path components
+- **THEN** the Process launch is rejected before storing the cwd
+- **AND** Tool Process binding cannot fall back to a different Host Mount
+
+### Requirement: Child context follows namespace inheritance
+A child Process SHALL start from the namespace capabilities its spawner can
+delegate and SHALL gain additional authority only through explicitly passed
+mounts or descriptors. A Process launch MUST NOT contain an aggregate
+all-Host-Mounts handle, and Host Mount inheritance SHALL default to none unless
+each selected grant handle and target namespace path is listed explicitly.
+
+#### Scenario: Child lacks an unpassed mount
+- **WHEN** a parent launches a child without listing a parent Host Mount
+- **THEN** the child cannot reach that Host Mount by grant ID, Host-path
+  inference, cwd inference, or ambient discovery
+
+#### Scenario: Child requests amplified access
+- **WHEN** a parent attempts to pass a Host Mount handle or access mode it cannot
+  itself delegate
+- **THEN** Process creation rejects the launch
+- **AND** the child never receives the amplified mount

--- a/openspec/changes/complete-agent-runtime-file-native-seam/tasks.md
+++ b/openspec/changes/complete-agent-runtime-file-native-seam/tasks.md
@@ -1,0 +1,81 @@
+## 1. Confirm The Prerequisite And Live Seams
+
+- [x] 1.1 Start from main after `deepen-agent-machine-transition-module` is
+  merged, synced, and archived.
+- [x] 1.2 Map every live `host_path`, raw `HostMountGrant`, aggregate
+  `SpawnHandle::HostMounts`, mount applicator, Process launch context, child
+  assembler/lifecycle callback, and normal engine-to-Kernel dependency use.
+- [x] 1.3 Add focused characterization tests for mount request Yield/resume,
+  live namespace projection, Tool sandbox authority, child Agent launch, and
+  lifecycle cleanup before replacing the seams.
+
+## 2. Replace The Host Mount Request Contract
+
+- [x] 2.1 Implement the clone-via-open Host Mount Service request tree,
+  commit-on-clunk validation, terminal status files, grant/error files, and
+  offset-based event streams.
+- [x] 2.2 Change `request_mount` to accept only namespace path, access, reason,
+  and optional label; persist the opaque request reference across Yield/restart.
+- [x] 2.3 Move native directory choice and authorization exclusively into the
+  Host adapter and make Host Mount Service the only approval/status authority.
+- [x] 2.4 Remove `host_path` from Agent Machine, AgentFS, Tool results,
+  rollout/checkpoint records, audit records, protocol DTOs, fixtures, and tests.
+- [x] 2.5 Delete the flat Host Mount request/projection/approval surfaces and add
+  absence checks so no compatibility protocol or AgentFS approval bypass
+  remains.
+
+## 3. Replace Host Backing With Handles
+
+- [ ] 3.1 Make Host Mount Service retain native backing and issue the opaque
+  mountable handle used for namespace projection and revocation.
+- [ ] 3.2 Replace engine-owned raw Host Mount launch records with explicit
+  mounts/descriptors and prove a grant ID alone confers no access.
+- [ ] 3.3 Delete aggregate Host Mount inheritance; require each child launch to
+  list selected grant handles and target namespace paths, defaulting to none
+  without cwd-based inheritance.
+- [ ] 3.4 Move live namespace projection to Host Mount Service and delete engine
+  namespace applicator traits, implementations, and callbacks.
+- [ ] 3.5 Derive native Tool Process sandbox rights from the same delegated grant
+  inside Host adapters and delete engine-owned native writable-root mutation.
+- [ ] 3.6 Verify read-only/read-write behavior, non-amplification, idempotent
+  projection, revocation, restart resume, and absence of Host paths in evidence.
+
+## 4. Make Agent Runtime Service The Agent Executable
+
+- [ ] 4.1 Route root and child Agent Process launch through `/proc/clone` with
+  `/bin/alan-agent`, explicit `SpawnSpec`, namespace capabilities, and
+  descriptors.
+- [ ] 4.2 Make Agent Runtime Service bind AgentFS, select the mounted connection,
+  start Agent Machine, and clean up runtime backing from `/proc` lifecycle.
+- [ ] 4.3 Preserve parent/child observation through `/proc/<pid>`,
+  `/agent/<pid>`, and the existing AgentFS child projection without adding a
+  second child-spawn protocol.
+- [ ] 4.4 Delete `ChildAgentProcessAssembler`, `AgentProcessLifecycle`,
+  engine-owned `ProcessLaunchContext`, Kernel-shaped Tool Process DTOs, and all
+  displaced assembly callbacks.
+- [ ] 4.5 Remove the normal `alan-agent-engine` dependency on `alan-kernel` and
+  tighten the dependency ledger and retired-symbol checks in the same PR.
+
+## 5. Verify And Deliver The Stack
+
+- [ ] 5.1 Run focused Agent Execution Engine, AgentFS, Kernel, Service Manager,
+  Host Mount, Tool, and sandbox contract tests plus `just check`, `just test`,
+  and strict OpenSpec validation.
+- [ ] 5.2 Deliver the logical-request, handle/projection, and Agent Executable
+  ownership slices as stacked PRs; every PR must delete its displaced path and
+  leave no scaffolding-only or dual-protocol state.
+- [ ] 5.3 For every PR, resolve all actionable Codex Review comments, rerun CI on
+  the current HEAD, wait through a follow-up review window, and merge only when
+  no unresolved or new issue remains.
+- [ ] 5.4 Verify the final dependency graph has no normal engine-to-Kernel edge,
+  retired symbols and `host_path` contracts are absent, and ID-only or unpassed
+  Host Mounts confer no authority.
+
+## 6. Sync And Archive
+
+- [ ] 6.1 After every implementation PR is merged, sync all six delta specs into
+  their canonical capabilities and run strict OpenSpec validation.
+- [ ] 6.2 Confirm canonical specs and merged code expose only the logical request
+  protocol, service-issued grant handles, and `/bin/alan-agent` launch path.
+- [ ] 6.3 Archive the change only after implementation, review, verification,
+  and canonical spec sync are complete.


### PR DESCRIPTION
## Summary

- add the complete-agent-runtime-file-native-seam OpenSpec change and live seam inventory
- replace request_mount with logical intent plus a clone-via-open Host Mount Service request tree
- make Host Mount Service and the Host adapter the only approval and status authority
- persist opaque pending request references across Agent Machine yield and recovery
- remove the flat request, projection, approval, and status protocol plus AgentFS approval handling
- keep native Host paths out of Agent Machine, Tool results, rollout evidence, and Alan OS-visible records
- scope request, grant, and event views to the owning Process

## Stack

This is implementation slice 1 of 3. It completes OpenSpec tasks 1.1 through 2.5. The next slices replace Host backing with service-issued handles, then make Agent Runtime Service the Agent Executable.

## Verification

- just check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test -p alan-agent-engine -p alan-service-manager -p alan-os-host
- cargo test -p alan-os-host --test lifecycle native_host_mount_approval_keeps_host_path_out_of_namespace_records
- openspec validate complete-agent-runtime-file-native-seam --strict