### PR TITLE
docs(openspec): define alan interaction model

### DIFF
--- a/openspec/changes/define-alan-interaction-model/design.md
+++ b/openspec/changes/define-alan-interaction-model/design.md
@@ -99,6 +99,14 @@ wanted, not the first screen. The TUI remains the terminal-native host and
 naturally centers the shell; the interaction model still governs its agent
 surfaces.
 
+Reconciliation with shell-first contracts: ADR-0039 governs the system-level
+entry of the `alan` CLI and Local Entry — the Shell Process still starts
+there, unchanged. What changes is only the renderer-presented default, so
+this change carries a MODIFIED delta to `macos-shell-workspace-persistence`:
+the default manifest's selected Tab becomes the workspace home surface and a
+default terminal Tab is no longer required. This is a deliberate presentation
+change, not a contradiction of the boot order.
+
 ### D6: The vocabulary rule
 
 Default UI copy names user objects: agent, conversation, work, result,

--- a/openspec/changes/define-alan-interaction-model/design.md
+++ b/openspec/changes/define-alan-interaction-model/design.md
@@ -51,9 +51,8 @@ is backed by a real file, so peeling back is always possible and always safe.
 - **Intent layer**: the user states what they want; an agent works. Objects:
   intent text, agents, results.
 - **Work layer**: agent file surfaces rendered as native affordances —
-  `machine/tape` as conversation, `machine/plan` as a plan card, pending
-  actions as approval sheets, `/proc/<pid>/ctl` as a Stop button (Pause, when
-  it exists, writes the agent-owned `machine/ctl` surface instead),
+  `machine/tape` as conversation, `machine/ui/plan` as a plan card, pending
+  actions as approval sheets, `/proc/<pid>/ctl` as a Stop button,
   rollouts as evidence views. User gestures become file writes and `ctl`
   commands.
 - **Files layer**: the raw namespace as an explicit mode ("view as files",

--- a/openspec/changes/define-alan-interaction-model/design.md
+++ b/openspec/changes/define-alan-interaction-model/design.md
@@ -1,0 +1,130 @@
+## Context
+
+Alan OS converges on a Plan 9 model: a volatile kernel, one system-level
+instance per channel (ADR-0044), local hosts attaching over aP Unix sockets
+(ADR-0045), renderers persisting only Process References and offsets
+(ADR-0046/0047), and Host Mount Service as the sole grant authority
+(ADR-0050). These decisions already make every user-visible surface a live
+view of files. What is missing is the product contract above them: who the
+user is, what objects they manipulate, and which OS concepts may reach the
+default UI.
+
+The audience decision for this contract is: **advanced personal users** —
+people who want leverage from agents and will inspect, script, and customize
+when given the layer, but who do not think in mounts and namespaces and should
+never have to. The interaction-mode decision is: conversation is one mode
+among three; the primary posture is **agents as background servants whose
+results the user reviews**, extended by **event-driven behavior** where agents
+act on triggers and report outcomes.
+
+## Goals
+
+- One interaction model that every renderer host (macOS, TUI, future Alan
+  Apps) implements, so users learn it once.
+- The file-native architecture remains fully reachable and scriptable — the
+  model adds layers over the truth, never a parallel truth.
+- OS vocabulary is quarantined: default UI copy passes a "user object" test.
+- Mounting, approvals, and stopping work reuse the grant and `/proc/<pid>/ctl`
+  mechanisms the system already provides; UX introduces no new authority.
+
+## Non-Goals
+
+- Runtime event/trigger machinery (schedulers, watchers, rule storage): this
+  change defines only how event-driven behavior appears to the user.
+- Visual design tokens and material treatment: owned by
+  `macos-shell-ui-ux-conformance`.
+- Onboarding flows, empty states, and first-run copy: a later change.
+- TUI-specific keybindings and macOS-specific layout details.
+
+## Decisions
+
+### D1: The file system is the API, not the UI
+
+The namespace is how agents, apps, and hosts share truth — like iOS's file
+system, it is infrastructure, not a user concept. Unlike iOS, the file layer
+is never locked: it is the inspect-and-program layer (D2, Files). The
+differentiating bet versus black-box agent products is that every UI element
+is backed by a real file, so peeling back is always possible and always safe.
+
+### D2: Three disclosure layers over one truth
+
+- **Intent layer**: the user states what they want; an agent works. Objects:
+  intent text, agents, results.
+- **Work layer**: agent file surfaces rendered as native affordances —
+  `machine/tape` as conversation, `machine/plan` as a plan card, pending
+  actions as approval sheets, `/proc/<pid>/ctl` as Stop/Pause buttons,
+  rollouts as evidence views. User gestures become file writes and `ctl`
+  commands.
+- **Files layer**: the raw namespace as an explicit mode ("view as files",
+  an inspector, the shell tab). This is where mounts, paths, and `/proc`
+  vocabulary legitimately live, and where programmability starts.
+
+Layers are views, not tiers of capability: anything doable in the Work layer
+is a file operation visible in the Files layer, and vice versa. This follows
+ADR-0046 — renderers hold references and offsets, never copied state — so
+there is nothing to synchronize.
+
+### D3: Three interaction modes, conversation is not the entry assumption
+
+- **Conversation**: direct dialogue with an agent. One mode, not the default
+  posture.
+- **Background servant**: the user dispatches work; agents run detached
+  (closing a view detaches per ADR-0047); the user primarily reviews finished
+  work — results, diffs, evidence — in an inbox-style surface rather than
+  watching execution.
+- **Event-driven**: standing rules (triggers, schedules, watched folders,
+  service notices) cause agents to act; proactive reports arrive in the same
+  review surface. The user manages the rule set and the outcome stream, not
+  processes.
+
+All three modes share one review surface for outcomes and one approval
+mechanism for consequential actions, so the user has a single place to trust.
+
+### D4: Permission is the UX of mounting
+
+Host file access is expressed as grants per ADR-0050. In the UX: dragging a
+folder to an agent, picking it in a system dialog, or approving an agent's
+access request all create a grant; mount and bind are side effects the user
+never names. A single Permissions surface lists active grants by label and
+scope; revoking unmounts. Raw host paths never appear — only grant labels —
+which matches what Alan OS is allowed to see.
+
+### D5: Workspace-first entry, shell as a tab type
+
+The macOS app opens into a workspace: active agents, recent work, installed
+services (`/srv` rendered as services/apps, each opening its own file-backed
+UI). Alan Shell remains an ordinary Process and the system entry per
+ADR-0039/0048/0049, but in the UX it is one tab type the user opens when
+wanted, not the first screen. The TUI remains the terminal-native host and
+naturally centers the shell; the interaction model still governs its agent
+surfaces.
+
+### D6: The vocabulary rule
+
+Default UI copy names user objects: agent, conversation, work, result,
+folder, permission, service, rule. It must not name OS objects: mount,
+namespace, fid, descriptor, `/proc`, tape, rollout (as a word — the concept
+renders as "evidence" or "history"). OS vocabulary is allowed only in the
+Files layer, power-user surfaces, debugging views, and documentation. This
+rule is reviewable per screen and belongs in UI conformance checks.
+
+## Risks / Trade-offs
+
+- **Three layers is more design surface than one chat window.** Mitigation:
+  the layers are one truth with three renderings; the Work layer ships first
+  and the Files layer starts as an inspector, not a full file manager.
+- **Event-driven UX without runtime machinery risks spec drift.** Mitigation:
+  this change pins only the user-visible contract (rules surface, shared
+  review inbox, approvals); the runtime change that implements triggers must
+  conform to it.
+- **Vocabulary rule can feel constraining to developer-users.** Accepted:
+  advanced personal users are the audience; the Files layer preserves full
+  fidelity for anyone who wants it.
+
+## Open Questions
+
+- Exact name of the unified review surface (Inbox / Results / Activity) —
+  copy-level, resolved in the macOS implementation change.
+- Whether the TUI adopts the Intent layer entry or stays shell-first — the
+  model permits host-specific entry emphasis as long as the three layers and
+  modes exist.

--- a/openspec/changes/define-alan-interaction-model/design.md
+++ b/openspec/changes/define-alan-interaction-model/design.md
@@ -75,7 +75,10 @@ there is nothing to synchronize.
 - **Event-driven**: standing rules (triggers, schedules, watched folders,
   service notices) cause agents to act; proactive reports arrive in the same
   review surface. The user manages the rule set and the outcome stream, not
-  processes.
+  processes. This mode is recorded as the designated direction, not a current
+  obligation: no runtime or service contract owns rule storage or triggers
+  yet, so renderer conformance only requires keeping the review surface
+  unified until that owning contract lands.
 
 All three modes share one review surface for outcomes and one approval
 mechanism for consequential actions, so the user has a single place to trust.

--- a/openspec/changes/define-alan-interaction-model/design.md
+++ b/openspec/changes/define-alan-interaction-model/design.md
@@ -52,7 +52,8 @@ is backed by a real file, so peeling back is always possible and always safe.
   intent text, agents, results.
 - **Work layer**: agent file surfaces rendered as native affordances —
   `machine/tape` as conversation, `machine/plan` as a plan card, pending
-  actions as approval sheets, `/proc/<pid>/ctl` as Stop/Pause buttons,
+  actions as approval sheets, `/proc/<pid>/ctl` as a Stop button (Pause, when
+  it exists, writes the agent-owned `machine/ctl` surface instead),
   rollouts as evidence views. User gestures become file writes and `ctl`
   commands.
 - **Files layer**: the raw namespace as an explicit mode ("view as files",

--- a/openspec/changes/define-alan-interaction-model/design.md
+++ b/openspec/changes/define-alan-interaction-model/design.md
@@ -105,8 +105,12 @@ entry of the `alan` CLI and Local Entry — the Shell Process still starts
 there, unchanged. What changes is only the renderer-presented default, so
 this change carries a MODIFIED delta to `macos-shell-workspace-persistence`:
 the default manifest's selected Tab becomes the workspace home surface and a
-default terminal Tab is no longer required. This is a deliberate presentation
-change, not a contradiction of the boot order.
+default terminal Tab is no longer required. Because shell core owns default
+manifest semantics and content kinds, a matching
+`shell-workspace-core-contract` delta defines a platform-neutral workspace
+home content kind so no platform-private defaulting algorithm is
+reintroduced. This is a deliberate presentation change, not a contradiction
+of the boot order.
 
 ### D6: The vocabulary rule
 

--- a/openspec/changes/define-alan-interaction-model/proposal.md
+++ b/openspec/changes/define-alan-interaction-model/proposal.md
@@ -62,6 +62,11 @@ their own answer, and OS vocabulary will leak into the default UI.
   selected Tab becomes the workspace home surface; a default terminal Tab is
   no longer required, aligning the macOS default presentation with
   workspace-first entry.
+- `shell-workspace-core-contract`: Shell core owns a platform-neutral
+  workspace home content kind and selects it in default manifest creation
+  instead of hard-coding a terminal Tab, so the macOS persistence delta has a
+  portable owner and no platform-private defaulting algorithm is
+  reintroduced.
 
 ## Impact
 

--- a/openspec/changes/define-alan-interaction-model/proposal.md
+++ b/openspec/changes/define-alan-interaction-model/proposal.md
@@ -58,6 +58,10 @@ their own answer, and OS vocabulary will leak into the default UI.
 - `alan-renderer-host-contract`: Renderer hosts SHALL render agent and service
   file surfaces as domain-native affordances, provide the three disclosure
   layers, and keep OS vocabulary out of the default UI.
+- `macos-shell-workspace-persistence`: The default workspace manifest's
+  selected Tab becomes the workspace home surface; a default terminal Tab is
+  no longer required, aligning the macOS default presentation with
+  workspace-first entry.
 
 ## Impact
 

--- a/openspec/changes/define-alan-interaction-model/proposal.md
+++ b/openspec/changes/define-alan-interaction-model/proposal.md
@@ -28,11 +28,12 @@ their own answer, and OS vocabulary will leak into the default UI.
   and **Files** (the raw namespace as an explicit inspect/program layer for
   power users). All layers are live views of the same files per ADR-0046;
   no layer owns copied state.
-- Establish three first-class interaction modes: **conversation** (one mode,
-  not the entry assumption), **background servant** (agents run detached;
-  the user primarily reviews completed work and evidence), and
-  **event-driven** (agents act on events and proactively report; the user
-  manages rules and an inbox of outcomes).
+- Establish the interaction modes: **conversation** and **background
+  servant** (agents run detached; the user primarily reviews completed work
+  and evidence) are first-class obligations; **event-driven** (agents act on
+  events and proactively report) is recorded as the designated third mode,
+  binding on renderer hosts only once a runtime or service contract owns rule
+  storage and triggers.
 - Make permission the UX of mounting: giving an agent access to a host folder
   is a grant flow (drag in, file picker, or approval sheet) through Host Mount
   Service per ADR-0050; mount/bind are side effects, and revocation lives in a

--- a/openspec/changes/define-alan-interaction-model/proposal.md
+++ b/openspec/changes/define-alan-interaction-model/proposal.md
@@ -1,0 +1,74 @@
+## Why
+
+Alan's target architecture makes everything a file: namespaces, mounts,
+`/proc`, `/agent`, `/srv`, and the aP protocol are the system substrate. That
+substrate is an excellent API, but it is not a user interaction model. Alan's
+primary audience is advanced personal users, not operators who think in mounts
+and namespaces. If the default experience asks users to understand "enter an
+OS, start a shell, mount things with commands", the file-native architecture
+becomes a barrier instead of a capability.
+
+Today the UX contract is only implied: ADR-0046/0047 fix renderer discipline,
+ADR-0050 defines grant-based host file access, and
+`macos-shell-ui-ux-conformance` defines visual treatment — but no spec defines
+how a user actually relates to Alan: what objects they manipulate, which
+interaction modes exist, and where OS concepts are allowed to surface. Without
+that contract, the macOS client, the TUI, and future Alan Apps will each invent
+their own answer, and OS vocabulary will leak into the default UI.
+
+## What Changes
+
+- Define the Alan Interaction Model as a durable product contract: the file
+  system is the API, never the default UI. Users manipulate intent, agents,
+  work results, folders, grants, and services — never mounts, fids,
+  namespaces, or PIDs.
+- Define three disclosure layers over one shared truth: **Intent** (state a
+  goal, an agent works), **Work** (agent file surfaces rendered as native
+  affordances — conversation, plan cards, approval sheets, result views),
+  and **Files** (the raw namespace as an explicit inspect/program layer for
+  power users). All layers are live views of the same files per ADR-0046;
+  no layer owns copied state.
+- Establish three first-class interaction modes: **conversation** (one mode,
+  not the entry assumption), **background servant** (agents run detached;
+  the user primarily reviews completed work and evidence), and
+  **event-driven** (agents act on events and proactively report; the user
+  manages rules and an inbox of outcomes).
+- Make permission the UX of mounting: giving an agent access to a host folder
+  is a grant flow (drag in, file picker, or approval sheet) through Host Mount
+  Service per ADR-0050; mount/bind are side effects, and revocation lives in a
+  single permissions surface. `mount` commands are confined to the Files layer.
+- Make the macOS entry a workspace of agents and services, not a shell: the
+  shell is one tab type among others; `/srv` services render as installed
+  services/apps; ADR-0039's system-level boot order is unchanged.
+- Define the vocabulary rule: default UI copy names user objects (agent,
+  conversation, folder, permission, service, result); OS vocabulary (mount,
+  namespace, fid, `/proc`, tape) is confined to the Files layer, power-user
+  surfaces, and documentation.
+
+## Capabilities
+
+### New Capabilities
+
+- `alan-interaction-model`: The product-level interaction contract — disclosure
+  layers, interaction modes, grant-as-permission UX, workspace-first entry,
+  and the vocabulary rule for all renderer hosts.
+
+### Modified Capabilities
+
+- `alan-renderer-host-contract`: Renderer hosts SHALL render agent and service
+  file surfaces as domain-native affordances, provide the three disclosure
+  layers, and keep OS vocabulary out of the default UI.
+
+## Impact
+
+- Normative for Alan for macOS (`clients/apple`), the Rust TUI
+  (`crates/tui`), and future Alan Apps; no kernel, aP, or AgentFS changes.
+- No system-architecture change: ADR-0039 (shell before agent views),
+  ADR-0045 (aP attachment), and ADR-0050 (Host Mount Service grants) remain
+  the system truth; this change defines the UX layered on top of them.
+- Existing `macos-shell-ui-ux-conformance` keeps owning visual treatment;
+  this change owns interaction structure and vocabulary, and the two must not
+  duplicate rules.
+- Future event-driven work (triggers, schedules, proactive reports) must
+  express its user-facing surface through this model; this change defines the
+  UX contract only, not the runtime event machinery.

--- a/openspec/changes/define-alan-interaction-model/proposal.md
+++ b/openspec/changes/define-alan-interaction-model/proposal.md
@@ -67,6 +67,15 @@ their own answer, and OS vocabulary will leak into the default UI.
   instead of hard-coding a terminal Tab, so the macOS persistence delta has a
   portable owner and no platform-private defaulting algorithm is
   reintroduced.
+- `macos-shell-content-containers`: Define the serializable, restorable
+  `workspace_home` content kind with home-specific capabilities, so default
+  manifests and restore can materialize the workspace home surface without
+  substituting a terminal.
+- `macos-shell-ui-ux-conformance`: Replace terminal-first assertions in the
+  visual-review, smoke-evidence, and automation-chrome requirements with the
+  workspace home presentation as the default selected content.
+- `macos-shell-build-test-contract`: Update the launch smoke to verify the
+  workspace home content area instead of a terminal content area.
 
 ## Impact
 

--- a/openspec/changes/define-alan-interaction-model/specs/alan-interaction-model/spec.md
+++ b/openspec/changes/define-alan-interaction-model/specs/alan-interaction-model/spec.md
@@ -80,7 +80,8 @@ agent-originated request — that creates a Host Mount Service grant per
 ADR-0050. Mount and bind SHALL be side effects invisible to the default UI.
 A single Permissions surface SHALL list active grants by label, scope, and
 access, and revocation SHALL remove the projection. Raw Host paths SHALL NOT
-appear in any layer; only grant labels and `/mnt` projections may be shown.
+appear in any layer; default layers SHALL show grant labels only, and `/mnt`
+projection paths MAY appear only in the Files layer and power-user surfaces.
 
 #### Scenario: A user shares a folder with an agent
 - **WHEN** a user gives an agent access to a folder through any default flow

--- a/openspec/changes/define-alan-interaction-model/specs/alan-interaction-model/spec.md
+++ b/openspec/changes/define-alan-interaction-model/specs/alan-interaction-model/spec.md
@@ -85,7 +85,9 @@ appear in any layer; only grant labels and `/mnt` projections may be shown.
 - **WHEN** a running agent needs access beyond its current grants
 - **THEN** the user is shown an approval sheet naming the folder label and
   requested access
-- **AND** approving creates the grant; denying changes nothing
+- **AND** approving creates the grant; denying publishes an immutable terminal
+  `rejected` result per the Host Mount Service contract, creating no grant
+  and no projection, so the waiting Agent Process resumes
 
 #### Scenario: The user audits and revokes access
 - **WHEN** a user opens the Permissions surface
@@ -99,14 +101,19 @@ installed services — not a bare shell or terminal. Alan Shell SHALL be
 available as one tab type among others, launched as an ordinary Process per
 ADR-0048/0049. Services under `/srv` SHALL be presented as installed
 services/apps that open their own file-backed interfaces. This UX ordering
-SHALL NOT change the system boot order defined by ADR-0039.
+governs renderer-presented defaults only: ADR-0039's system-level rule that
+the `alan` CLI and Local Entry start Alan Shell before agent views is
+unchanged, and this change carries the matching MODIFIED delta for the
+macOS default-manifest presentation contract.
 
 #### Scenario: The app opens
 - **WHEN** a user launches Alan for macOS
-- **THEN** the default view shows active agents, recent work, and installed
-  services
+- **THEN** the default presented view shows active agents, recent work, and
+  installed services
 - **AND** opening a shell is an explicit action that creates an ordinary
   shell Process
+- **AND** the system-level Local Entry and Shell Process startup per
+  ADR-0039/0049 proceeds independently of which view is presented first
 
 #### Scenario: A service is opened from the workspace
 - **WHEN** a user opens an installed service from the workspace

--- a/openspec/changes/define-alan-interaction-model/specs/alan-interaction-model/spec.md
+++ b/openspec/changes/define-alan-interaction-model/specs/alan-interaction-model/spec.md
@@ -24,9 +24,10 @@ SHALL render agent file surfaces as domain-native affordances: conversation
 views from tape surfaces, plan cards from plan surfaces, approval sheets from
 pending-action surfaces, result and evidence views from execution records,
 and lifecycle controls. A Stop control SHALL write `/proc/<pid>/ctl`
-(interrupt/cancel); a Pause or Resume control, where offered, SHALL write an
-agent-owned machine control surface such as `machine/ctl` and SHALL NOT be
-modeled as a kernel Process interrupt or cancel. The Files layer SHALL
+(interrupt/cancel). Any further lifecycle control SHALL write the control
+surface that owns the corresponding semantics per the canonical AgentFS and
+Agent Machine contracts and SHALL NOT be mapped onto `/proc/<pid>/ctl` unless
+that surface owns it. The Files layer SHALL
 expose the raw namespace as an explicit inspect-and-program mode. No layer
 SHALL own copied runtime state.
 

--- a/openspec/changes/define-alan-interaction-model/specs/alan-interaction-model/spec.md
+++ b/openspec/changes/define-alan-interaction-model/specs/alan-interaction-model/spec.md
@@ -46,14 +46,18 @@ SHALL own copied runtime state.
   service truth
 
 ### Requirement: Conversation is one of three interaction modes
-Alan renderer hosts SHALL support conversation, background-servant, and
-event-driven interaction as first-class modes. Conversation SHALL NOT be
-assumed as the entry or primary posture. Background-servant mode SHALL let
+Alan renderer hosts SHALL support conversation and background-servant
+interaction as first-class modes. Conversation SHALL NOT be assumed as the
+entry or primary posture. Background-servant mode SHALL let
 agents run detached — closing a view detaches per ADR-0047 and never implies
 stopping execution — and SHALL present completed work for review rather than
-requiring the user to watch execution. Event-driven mode SHALL present
-standing rules that cause agents to act and SHALL deliver proactive reports
-to the same review surface as dispatched work.
+requiring the user to watch execution. Event-driven interaction — standing
+rules that cause agents to act, with proactive reports — is the recorded
+third mode and the designated direction of this model; because no runtime or
+service contract yet owns rule storage and trigger semantics, renderer hosts
+SHALL implement it only once such an owning contract lands, and SHALL keep
+the review surface unified so event-driven outcomes join user-dispatched work
+when it does.
 
 #### Scenario: The user reviews instead of watching
 - **WHEN** a user dispatches work and closes its view
@@ -62,12 +66,12 @@ to the same review surface as dispatched work.
 - **AND** no UI element required the user to keep a conversation or execution
   view open
 
-#### Scenario: Event-driven outcomes share the review surface
-- **WHEN** an agent acts because a standing rule fired
-- **THEN** its report arrives in the same review surface as user-dispatched
-  work
-- **AND** consequential actions still pass through the same approval
-  mechanism
+#### Scenario: Event-driven mode awaits its owning contract
+- **WHEN** no runtime or service contract yet owns event rules and triggers
+- **THEN** renderer hosts are not required to present a rules surface or
+  proactive reports
+- **AND** the review surface remains the designated destination for
+  event-driven outcomes once the owning contract lands
 
 ### Requirement: Permission is the UX of mounting
 Granting an agent access to Host files SHALL be presented as a permission

--- a/openspec/changes/define-alan-interaction-model/specs/alan-interaction-model/spec.md
+++ b/openspec/changes/define-alan-interaction-model/specs/alan-interaction-model/spec.md
@@ -23,7 +23,10 @@ layer SHALL present stating goals and receiving outcomes. The Work layer
 SHALL render agent file surfaces as domain-native affordances: conversation
 views from tape surfaces, plan cards from plan surfaces, approval sheets from
 pending-action surfaces, result and evidence views from execution records,
-and Stop/Pause controls that write `/proc/<pid>/ctl`. The Files layer SHALL
+and lifecycle controls. A Stop control SHALL write `/proc/<pid>/ctl`
+(interrupt/cancel); a Pause or Resume control, where offered, SHALL write an
+agent-owned machine control surface such as `machine/ctl` and SHALL NOT be
+modeled as a kernel Process interrupt or cancel. The Files layer SHALL
 expose the raw namespace as an explicit inspect-and-program mode. No layer
 SHALL own copied runtime state.
 

--- a/openspec/changes/define-alan-interaction-model/specs/alan-interaction-model/spec.md
+++ b/openspec/changes/define-alan-interaction-model/specs/alan-interaction-model/spec.md
@@ -22,7 +22,8 @@ Files — as live views of the same mounted file state per ADR-0046. The Intent
 layer SHALL present stating goals and receiving outcomes. The Work layer
 SHALL render agent file surfaces as domain-native affordances: conversation
 views from tape surfaces, plan cards from plan surfaces, approval sheets from
-pending-action surfaces, result and evidence views from execution records,
+pending-action surfaces, result and evidence views from rollout and
+checkpoint evidence surfaces per the evidence-retention contracts,
 and lifecycle controls. A Stop control SHALL write `/proc/<pid>/ctl`
 (interrupt/cancel). Any further lifecycle control SHALL write the control
 surface that owns the corresponding semantics per the canonical AgentFS and

--- a/openspec/changes/define-alan-interaction-model/specs/alan-interaction-model/spec.md
+++ b/openspec/changes/define-alan-interaction-model/specs/alan-interaction-model/spec.md
@@ -1,0 +1,128 @@
+## ADDED Requirements
+
+### Requirement: The file system is the API, not the default UI
+Alan renderer hosts SHALL treat the namespace as the shared-truth substrate
+and SHALL NOT require users to understand OS concepts — entering an OS,
+starting a shell, mounting paths, walking namespaces, or addressing PIDs — to
+accomplish any default workflow. Default workflows SHALL be expressed through
+user objects: intent, agents, work, results, conversations, folders,
+permissions, services, and rules.
+
+#### Scenario: A new user completes a task without OS vocabulary
+- **WHEN** a user gives an intent, an agent works on it, and the user reviews
+  the outcome
+- **THEN** every step is presented through user objects and native
+  affordances
+- **AND** no step requires typing or understanding `mount`, namespace paths,
+  fids, or `/proc` addresses
+
+### Requirement: Three disclosure layers over one truth
+Alan renderer hosts SHALL provide three disclosure layers — Intent, Work, and
+Files — as live views of the same mounted file state per ADR-0046. The Intent
+layer SHALL present stating goals and receiving outcomes. The Work layer
+SHALL render agent file surfaces as domain-native affordances: conversation
+views from tape surfaces, plan cards from plan surfaces, approval sheets from
+pending-action surfaces, result and evidence views from execution records,
+and Stop/Pause controls that write `/proc/<pid>/ctl`. The Files layer SHALL
+expose the raw namespace as an explicit inspect-and-program mode. No layer
+SHALL own copied runtime state.
+
+#### Scenario: A user peels back an approval to its file truth
+- **WHEN** a user views an approval sheet in the Work layer and switches to
+  the Files layer
+- **THEN** the same pending action is visible as its backing files
+- **AND** acting in either layer is reflected in the other without
+  synchronization state
+
+#### Scenario: Renderer state remains references only
+- **WHEN** a renderer presents any layer
+- **THEN** its durable presentation state remains Process References, offsets,
+  and display state per ADR-0046
+- **AND** no layer introduces a renderer-owned copy of tape, machine, or
+  service truth
+
+### Requirement: Conversation is one of three interaction modes
+Alan renderer hosts SHALL support conversation, background-servant, and
+event-driven interaction as first-class modes. Conversation SHALL NOT be
+assumed as the entry or primary posture. Background-servant mode SHALL let
+agents run detached — closing a view detaches per ADR-0047 and never implies
+stopping execution — and SHALL present completed work for review rather than
+requiring the user to watch execution. Event-driven mode SHALL present
+standing rules that cause agents to act and SHALL deliver proactive reports
+to the same review surface as dispatched work.
+
+#### Scenario: The user reviews instead of watching
+- **WHEN** a user dispatches work and closes its view
+- **THEN** the agent keeps running and the finished result appears in the
+  review surface with its evidence
+- **AND** no UI element required the user to keep a conversation or execution
+  view open
+
+#### Scenario: Event-driven outcomes share the review surface
+- **WHEN** an agent acts because a standing rule fired
+- **THEN** its report arrives in the same review surface as user-dispatched
+  work
+- **AND** consequential actions still pass through the same approval
+  mechanism
+
+### Requirement: Permission is the UX of mounting
+Granting an agent access to Host files SHALL be presented as a permission
+flow — drag-in, system file picker, or an approval sheet for an
+agent-originated request — that creates a Host Mount Service grant per
+ADR-0050. Mount and bind SHALL be side effects invisible to the default UI.
+A single Permissions surface SHALL list active grants by label, scope, and
+access, and revocation SHALL remove the projection. Raw Host paths SHALL NOT
+appear in any layer; only grant labels and `/mnt` projections may be shown.
+
+#### Scenario: A user shares a folder with an agent
+- **WHEN** a user gives an agent access to a folder through any default flow
+- **THEN** a grant is created through Host Mount Service and the folder
+  appears to the agent under its `/mnt` projection
+- **AND** the user never names or sees a mount command, a bind, or the raw
+  Host path
+
+#### Scenario: An agent requests new access mid-run
+- **WHEN** a running agent needs access beyond its current grants
+- **THEN** the user is shown an approval sheet naming the folder label and
+  requested access
+- **AND** approving creates the grant; denying changes nothing
+
+#### Scenario: The user audits and revokes access
+- **WHEN** a user opens the Permissions surface
+- **THEN** every active grant is listed by label, scope, and access
+- **AND** revoking a grant removes its projection without affecting authored
+  content
+
+### Requirement: Workspace-first entry with shell as a tab type
+The Alan for macOS entry SHALL be a workspace of agents, recent work, and
+installed services — not a bare shell or terminal. Alan Shell SHALL be
+available as one tab type among others, launched as an ordinary Process per
+ADR-0048/0049. Services under `/srv` SHALL be presented as installed
+services/apps that open their own file-backed interfaces. This UX ordering
+SHALL NOT change the system boot order defined by ADR-0039.
+
+#### Scenario: The app opens
+- **WHEN** a user launches Alan for macOS
+- **THEN** the default view shows active agents, recent work, and installed
+  services
+- **AND** opening a shell is an explicit action that creates an ordinary
+  shell Process
+
+#### Scenario: A service is opened from the workspace
+- **WHEN** a user opens an installed service from the workspace
+- **THEN** its interface renders from the service's mounted file tree
+- **AND** the user never walks `/srv` paths to reach it
+
+### Requirement: OS vocabulary is quarantined from default UI copy
+Default UI copy in every renderer host SHALL name user objects and SHALL NOT
+name OS objects — mount, namespace, fid, descriptor, `/proc`, tape, rollout,
+or qid. Concepts that need user-facing names SHALL use them: execution
+records are "history" or "evidence"; grants are "permissions"; bound folders
+are "shared folders". OS vocabulary MAY appear in the Files layer, power-user
+surfaces, debugging views, and documentation.
+
+#### Scenario: A default screen is reviewed
+- **WHEN** any default-UI screen in a renderer host is reviewed
+- **THEN** its copy names only user objects
+- **AND** any OS term is confined to the Files layer, a power-user surface, or
+  a debug view

--- a/openspec/changes/define-alan-interaction-model/specs/alan-renderer-host-contract/spec.md
+++ b/openspec/changes/define-alan-interaction-model/specs/alan-renderer-host-contract/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Renderer hosts render file surfaces as domain-native affordances
+Renderer hosts SHALL translate agent and service file surfaces into
+domain-native UI affordances — conversation views, plan cards, approval
+sheets, result and evidence views, and lifecycle controls that write
+`/proc/<pid>/ctl` — instead of presenting raw file listings or raw protocol
+content as the default interface. User gestures on those affordances SHALL be
+expressed as file writes and `ctl` commands, never as renderer-local state
+mutation.
+
+#### Scenario: A user stops an agent from the Work layer
+- **WHEN** a user activates a Stop control in a renderer host
+- **THEN** the host writes the corresponding `/proc/<pid>/ctl` command
+- **AND** no renderer-local execution state is mutated to simulate the stop
+
+### Requirement: Renderer hosts implement the Alan Interaction Model layers
+Renderer hosts SHALL provide the Intent, Work, and Files disclosure layers
+defined by `alan-interaction-model`, present the conversation,
+background-servant, and event-driven modes, and keep OS vocabulary out of
+default UI copy. Hosts MAY differ in entry emphasis — a terminal-native host
+may center the shell — provided all three layers and modes remain reachable.
+
+#### Scenario: A renderer host is reviewed for interaction-model conformance
+- **WHEN** a renderer host's default UI is reviewed
+- **THEN** all three disclosure layers are reachable, all three interaction
+  modes are supported, and default copy passes the vocabulary rule
+- **AND** any host-specific entry emphasis does not remove a layer or mode

--- a/openspec/changes/define-alan-interaction-model/specs/alan-renderer-host-contract/spec.md
+++ b/openspec/changes/define-alan-interaction-model/specs/alan-renderer-host-contract/spec.md
@@ -28,3 +28,34 @@ may center the shell — provided all three layers and modes remain reachable.
 - **THEN** all three disclosure layers are reachable, all three interaction
   modes are supported, and default copy passes the vocabulary rule
 - **AND** any host-specific entry emphasis does not remove a layer or mode
+
+## MODIFIED Requirements
+
+### Requirement: A mounted namespace is sufficient for local renderer launch
+
+A local renderer host SHALL start from a mounted Alan OS root. Launching an
+agent view additionally requires a concrete Agent Process path. Launching the
+workspace home or a `/srv` service view SHALL require only the mounted
+namespace and the corresponding service paths and SHALL NOT require or invent
+an Agent Process.
+
+#### Scenario: Renderer opens a root Agent Process
+
+- **WHEN** the renderer receives a namespace root and `/agent/root`
+- **THEN** it reads and tails AgentFS output and state files
+- **AND** it writes input and Process control through the corresponding files
+
+#### Scenario: Renderer opens the workspace home
+
+- **WHEN** the renderer starts from a mounted namespace root without an Agent
+  Process path
+- **THEN** it presents the workspace home surface from mounted agent and
+  service file state
+- **AND** it does not create, require, or invent an Agent Process to do so
+
+#### Scenario: Renderer opens a service view
+
+- **WHEN** the renderer opens an installed service from the workspace home
+- **THEN** it renders the service interface from the service's mounted `/srv`
+  file tree
+- **AND** no Agent Process path is required

--- a/openspec/changes/define-alan-interaction-model/specs/alan-renderer-host-contract/spec.md
+++ b/openspec/changes/define-alan-interaction-model/specs/alan-renderer-host-contract/spec.md
@@ -7,20 +7,14 @@ sheets, result and evidence views, and lifecycle controls — instead of
 presenting raw file listings or raw protocol content as the default
 interface. User gestures on those affordances SHALL be expressed as file
 writes and `ctl` commands, never as renderer-local state mutation. Stop
-controls SHALL write `/proc/<pid>/ctl`; Pause/Resume controls SHALL target an
-agent-owned machine control surface rather than kernel Process lifecycle.
+controls SHALL write `/proc/<pid>/ctl`. Renderer hosts SHALL NOT expose
+lifecycle controls whose owning file surface the canonical AgentFS and Agent
+Machine contracts have not defined.
 
 #### Scenario: A user stops an agent from the Work layer
 - **WHEN** a user activates a Stop control in a renderer host
 - **THEN** the host writes the corresponding `/proc/<pid>/ctl` command
 - **AND** no renderer-local execution state is mutated to simulate the stop
-
-#### Scenario: A renderer offers a Pause control
-- **WHEN** a renderer host presents a Pause or Resume control for an agent
-- **THEN** the control writes an agent-owned machine control surface such as
-  `machine/ctl`
-- **AND** the gesture is not translated into a `/proc/<pid>/ctl` interrupt or
-  cancel
 
 ### Requirement: Renderer hosts implement the Alan Interaction Model layers
 Renderer hosts SHALL provide the Intent, Work, and Files disclosure layers

--- a/openspec/changes/define-alan-interaction-model/specs/alan-renderer-host-contract/spec.md
+++ b/openspec/changes/define-alan-interaction-model/specs/alan-renderer-host-contract/spec.md
@@ -18,16 +18,21 @@ Machine contracts have not defined.
 
 ### Requirement: Renderer hosts implement the Alan Interaction Model layers
 Renderer hosts SHALL provide the Intent, Work, and Files disclosure layers
-defined by `alan-interaction-model`, present the conversation,
-background-servant, and event-driven modes, and keep OS vocabulary out of
+defined by `alan-interaction-model`, present the conversation and
+background-servant modes, treat event-driven interaction as the recorded
+dependent mode per `alan-interaction-model`, and keep OS vocabulary out of
 default UI copy. Hosts MAY differ in entry emphasis — a terminal-native host
-may center the shell — provided all three layers and modes remain reachable.
+may center the shell — provided all three layers and both required modes
+remain reachable.
 
 #### Scenario: A renderer host is reviewed for interaction-model conformance
 - **WHEN** a renderer host's default UI is reviewed
-- **THEN** all three disclosure layers are reachable, all three interaction
-  modes are supported, and default copy passes the vocabulary rule
+- **THEN** all three disclosure layers are reachable, conversation and
+  background-servant modes are supported, and default copy passes the
+  vocabulary rule
 - **AND** any host-specific entry emphasis does not remove a layer or mode
+- **AND** event-driven surfaces are required only once their owning runtime
+  or service contract exists
 
 ## MODIFIED Requirements
 

--- a/openspec/changes/define-alan-interaction-model/specs/alan-renderer-host-contract/spec.md
+++ b/openspec/changes/define-alan-interaction-model/specs/alan-renderer-host-contract/spec.md
@@ -3,16 +3,24 @@
 ### Requirement: Renderer hosts render file surfaces as domain-native affordances
 Renderer hosts SHALL translate agent and service file surfaces into
 domain-native UI affordances — conversation views, plan cards, approval
-sheets, result and evidence views, and lifecycle controls that write
-`/proc/<pid>/ctl` — instead of presenting raw file listings or raw protocol
-content as the default interface. User gestures on those affordances SHALL be
-expressed as file writes and `ctl` commands, never as renderer-local state
-mutation.
+sheets, result and evidence views, and lifecycle controls — instead of
+presenting raw file listings or raw protocol content as the default
+interface. User gestures on those affordances SHALL be expressed as file
+writes and `ctl` commands, never as renderer-local state mutation. Stop
+controls SHALL write `/proc/<pid>/ctl`; Pause/Resume controls SHALL target an
+agent-owned machine control surface rather than kernel Process lifecycle.
 
 #### Scenario: A user stops an agent from the Work layer
 - **WHEN** a user activates a Stop control in a renderer host
 - **THEN** the host writes the corresponding `/proc/<pid>/ctl` command
 - **AND** no renderer-local execution state is mutated to simulate the stop
+
+#### Scenario: A renderer offers a Pause control
+- **WHEN** a renderer host presents a Pause or Resume control for an agent
+- **THEN** the control writes an agent-owned machine control surface such as
+  `machine/ctl`
+- **AND** the gesture is not translated into a `/proc/<pid>/ctl` interrupt or
+  cancel
 
 ### Requirement: Renderer hosts implement the Alan Interaction Model layers
 Renderer hosts SHALL provide the Intent, Work, and Files disclosure layers

--- a/openspec/changes/define-alan-interaction-model/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/define-alan-interaction-model/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: UI smoke coverage is repeatable
+The Apple client SHALL provide a repeatable UI smoke or screenshot flow for
+launch, space/tab switching, split creation, command UI, pane-scoped Find
+behavior, and basic terminal input when terminal runtime is available.
+
+#### Scenario: Launch smoke
+- **WHEN** the UI smoke flow starts the macOS app
+- **THEN** it verifies that the default light-mode window shows the unified sidebar column, top Space slider, active-space tab list, the workspace home content area as the selected content, and no persistent inspector pane or toggle
+
+#### Scenario: Split smoke
+- **WHEN** the UI smoke flow creates a split
+- **THEN** it verifies that multiple panes are visible and no raw pane IDs or debug labels dominate the default UI
+
+#### Scenario: Find smoke
+- **WHEN** the UI smoke flow opens pane-scoped Find for the focused terminal pane
+- **THEN** it verifies that a focused text field appears in pane chrome, result feedback is visible without raw debug labels, and dismissing Find returns focus to the owning terminal surface

--- a/openspec/changes/define-alan-interaction-model/specs/macos-shell-content-containers/spec.md
+++ b/openspec/changes/define-alan-interaction-model/specs/macos-shell-content-containers/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Workspace home content declares home capabilities
+alan SHALL 提供 `workspace_home` content kind 作为可序列化、可恢复的 ContentInstance
+kind,呈现 `alan-interaction-model` 定义的 workspace home surface(active agents、
+recent work、installed services)。Workspace home content 的 descriptor SHALL 暴露稳定
+`content_id`、`workspace_home` content kind、用户可见标题和 home-specific capabilities,
+并且 SHALL NOT 暴露 terminal-only capabilities。
+
+#### Scenario: Workspace home content declares home capabilities
+- **WHEN** control plane 或 UI 查询 workspace home content
+- **THEN** response 包含 `content_id`、`workspace_home` content kind 和 home capabilities
+- **AND** terminal input、terminal search、paste 等 terminal-only capabilities 不出现在该
+  content descriptor 中
+
+#### Scenario: App restores workspace home tab
+- **WHEN** alan 重新打开之前包含 workspace home pane 的窗口
+- **THEN** shell state 恢复同一 tab、split tree、PaneSlot IDs 和 `workspace_home`
+  content kind
+- **AND** workspace home content 从挂载的 Alan OS 文件状态渲染,不创建 terminal runtime
+- **AND** workspace home content 不会被误恢复为 terminal 或其他 viewer surface

--- a/openspec/changes/define-alan-interaction-model/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/define-alan-interaction-model/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: UI conformance is verified visually
+Mac shell UI changes SHALL be reviewed against the documented UI contract before
+the UI conformance tasks are marked complete.
+
+#### Scenario: Default screenshot review
+- **WHEN** a UI conformance implementation pass is ready for review
+- **THEN** maintainers can inspect a running-app screenshot of the default light-mode window showing the top Space slider, active-space tab list, the workspace home content area, and no inspector surface
+
+#### Scenario: Removed-inspector review
+- **WHEN** inspector-removal UI tasks are marked complete
+- **THEN** maintainers can inspect screenshots or recorded notes confirming the default shell has no right-side inspector and no inspector toggle
+
+### Requirement: UI conformance has repeatable smoke evidence
+Mac shell UI conformance work SHALL include repeatable smoke or screenshot
+evidence for launch, space/tab switching, split creation, pane-scoped Find
+behavior, and the absence of removed Ask alan and alan-tab surfaces.
+
+#### Scenario: Default launch evidence
+- **WHEN** a UI conformance implementation is ready
+- **THEN** maintainers can run or inspect a smoke artifact showing the light-mode default window with material sidebar and the workspace home surface as the selected content
+
+#### Scenario: Removed Ask alan evidence
+- **WHEN** Ask alan or alan-tab removal is marked complete
+- **THEN** maintainers can inspect evidence that the default shell has no
+  `Ask alan...`, `Go to or Command...`, Command-P command input, or `New alan
+  tab` surface
+
+#### Scenario: Find evidence
+- **WHEN** pane-scoped Find behavior changes
+- **THEN** maintainers can run or inspect evidence confirming the active pane shows a native-feeling Find surface without restoring inspector chrome or debug-first panels
+
+### Requirement: Automation surfaces do not add default chrome
+Adding App Intents and automation support SHALL not add visible default UI chrome
+or explanatory panels to the shell workflow.
+
+#### Scenario: App Intents installed
+- **WHEN** automation support is present in the app
+- **THEN** the default shell window keeps its workspace home presentation and does not show automation setup cards, implementation jargon, or dashboard sections
+
+#### Scenario: Intent result activates app
+- **WHEN** an App Intent activates a shell target
+- **THEN** the window opens to the relevant space, tab, or pane using normal shell UI rather than a special automation debug surface

--- a/openspec/changes/define-alan-interaction-model/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/define-alan-interaction-model/specs/macos-shell-ui-ux-conformance/spec.md
@@ -42,3 +42,32 @@ or explanatory panels to the shell workflow.
 #### Scenario: Intent result activates app
 - **WHEN** an App Intent activates a shell target
 - **THEN** the window opens to the relevant space, tab, or pane using normal shell UI rather than a special automation debug surface
+
+### Requirement: Terminal content is the center of gravity
+Within a terminal tab, the main content region SHALL make the active terminal
+canvas visually dominant and SHALL avoid nested decorative panels around the
+terminal in the default single-pane state. When the selected tab carries the
+workspace home content kind, the main content region SHALL present the
+workspace home surface as the dominant content instead; terminal dominance
+SHALL NOT be required for non-terminal content kinds.
+
+#### Scenario: Single-pane tab
+- **WHEN** a tab contains one pane
+- **THEN** the terminal appears nearly full-bleed within the content region and
+  does not show a pane selector strip
+
+#### Scenario: Split-pane tab
+- **WHEN** a tab contains multiple panes
+- **THEN** pane chrome stays lightweight and focus is conveyed by subtle
+  selection treatment rather than explicit engineering labels
+
+#### Scenario: alan as optional capability
+- **WHEN** a terminal tab is active and no alan-specific surface has been opened
+- **THEN** alan appears as an optional command or attachment capability layered
+  onto the terminal workflow, not as the structural center of the window
+
+#### Scenario: Workspace home tab
+- **WHEN** the selected tab carries the workspace home content kind
+- **THEN** the main content region presents the workspace home surface as the
+  dominant content
+- **AND** no terminal canvas is required to fill the region

--- a/openspec/changes/define-alan-interaction-model/specs/macos-shell-workspace-persistence/spec.md
+++ b/openspec/changes/define-alan-interaction-model/specs/macos-shell-workspace-persistence/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: Workspace manifest is the restore authority
+The macOS shell SHALL use the current versioned content-container workspace
+manifest as the sole authoritative source for restoring Spaces, Tabs, pin
+snapshots, Tab lifecycle metadata, and the last selected Space/Tab across app
+restarts. It SHALL NOT restore from a persistent shell-state snapshot or migrate
+an earlier manifest shape.
+
+#### Scenario: Manifest is present
+- **WHEN** Alan for macOS starts and a valid current workspace manifest exists
+  for `window_main`
+- **THEN** Alan loads Spaces, Tabs, pin snapshots, lifecycle metadata, and the
+  last selected Space/Tab from that manifest
+- **AND** Alan materializes the current shell state from the manifest rather
+  than another persisted snapshot
+
+#### Scenario: Manifest is missing
+- **WHEN** Alan for macOS starts and no workspace manifest exists for
+  `window_main`
+- **THEN** Alan creates a default current manifest with one default Space
+  whose selected Tab is the workspace home surface defined by
+  `alan-interaction-model`
+- **AND** no default terminal Tab is required; Alan Shell tabs are created
+  explicitly as one tab type among others
+- **AND** Alan uses that manifest as the restore authority for the launched
+  shell state
+
+#### Scenario: Unsupported manifest schema exists
+- **WHEN** the manifest path contains a terminal-only, `quick_terminal`, or
+  otherwise unsupported schema
+- **THEN** Alan preserves it as corrupt or unsupported evidence and creates a
+  default current manifest
+- **AND** Alan does not invoke a legacy decoder, upgrade, or fallback
+
+#### Scenario: Obsolete shell-state file exists
+- **WHEN** an Application Support `shell-state-*.json` file remains on disk
+- **THEN** Alan does not discover or read it during startup
+- **AND** the file cannot become workspace restore authority

--- a/openspec/changes/define-alan-interaction-model/specs/shell-workspace-core-contract/spec.md
+++ b/openspec/changes/define-alan-interaction-model/specs/shell-workspace-core-contract/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Shell core owns the workspace home default content
+The shell core SHALL define a platform-neutral workspace home content kind —
+the agents, recent work, and installed-services surface defined by
+`alan-interaction-model` — and SHALL construct the default manifest's initial
+selected Tab with that content kind. Default manifest creation SHALL NOT
+hard-code a terminal Tab as the initial content; terminal Tabs SHALL be
+created only through explicit user or platform actions. Platform adapters
+SHALL render the workspace home content kind from mounted Alan OS file state
+and SHALL NOT reimplement default-manifest selection outside shell core.
+
+#### Scenario: Default manifest is created
+- **WHEN** shell core creates a default workspace manifest
+- **THEN** the initial selected Tab carries the workspace home content kind
+- **AND** no terminal Tab is constructed as a default side effect
+
+#### Scenario: An adapter renders the workspace home tab
+- **WHEN** a platform adapter materializes a Tab with the workspace home
+  content kind
+- **THEN** it renders active agents, recent work, and installed services from
+  mounted file state
+- **AND** it does not substitute a terminal surface or a platform-private
+  default

--- a/openspec/changes/define-alan-interaction-model/tasks.md
+++ b/openspec/changes/define-alan-interaction-model/tasks.md
@@ -25,7 +25,7 @@
   scope, and access, with revocation; wire grant creation to drag-in, file
   picker, and agent-request approval sheet through Host Mount Service.
 - [ ] 2.4 Render existing agent Work-layer affordances (conversation, plan
-  card, approval sheet, Stop/Pause via `/proc/<pid>/ctl`) from their file
+  card, approval sheet, Stop via `/proc/<pid>/ctl`) from their file
   surfaces and remove any raw-file or OS-vocabulary presentation from the
   default UI.
 - [ ] 2.5 Add the Files-layer entry point ("view as files" inspector) that
@@ -50,5 +50,6 @@
 - [ ] 4.2 PR review confirms the change stays UX-only: no kernel, aP,
   AgentFS, or runtime event machinery is introduced.
 - [ ] 4.3 Sync delta specs into `openspec/specs/` (new
-  `alan-interaction-model`, updated `alan-renderer-host-contract`) and move
-  the change to `openspec/changes/archive/YYYY-MM-DD-define-alan-interaction-model/`.
+  `alan-interaction-model`, updated `alan-renderer-host-contract`, updated
+  `macos-shell-workspace-persistence`) and move the change to
+  `openspec/changes/archive/YYYY-MM-DD-define-alan-interaction-model/`.

--- a/openspec/changes/define-alan-interaction-model/tasks.md
+++ b/openspec/changes/define-alan-interaction-model/tasks.md
@@ -50,7 +50,8 @@
 - [ ] 4.2 PR review confirms the change stays UX-only: no kernel, aP,
   AgentFS, or runtime event machinery is introduced.
 - [ ] 4.3 Sync delta specs into `openspec/specs/` (new
-  `alan-interaction-model`, updated `alan-renderer-host-contract`, updated
-  `macos-shell-workspace-persistence`, updated
-  `shell-workspace-core-contract`) and move the change to
+  `alan-interaction-model`, updated `alan-renderer-host-contract`,
+  `macos-shell-workspace-persistence`, `shell-workspace-core-contract`,
+  `macos-shell-content-containers`, `macos-shell-ui-ux-conformance`, and
+  `macos-shell-build-test-contract`) and move the change to
   `openspec/changes/archive/YYYY-MM-DD-define-alan-interaction-model/`.

--- a/openspec/changes/define-alan-interaction-model/tasks.md
+++ b/openspec/changes/define-alan-interaction-model/tasks.md
@@ -19,7 +19,8 @@
   with no new runtime authority.
 - [ ] 2.2 Add the review surface (results inbox) that lists completed agent
   work with evidence links, shared by dispatched and event-driven outcomes;
-  data sourced from mounted execution-record files, never renderer-copied
+  data sourced from mounted rollout/checkpoint evidence files, never
+  renderer-copied
   state.
 - [ ] 2.3 Add the Permissions surface listing active host grants by label,
   scope, and access, with revocation; wire grant creation to drag-in, file

--- a/openspec/changes/define-alan-interaction-model/tasks.md
+++ b/openspec/changes/define-alan-interaction-model/tasks.md
@@ -51,5 +51,6 @@
   AgentFS, or runtime event machinery is introduced.
 - [ ] 4.3 Sync delta specs into `openspec/specs/` (new
   `alan-interaction-model`, updated `alan-renderer-host-contract`, updated
-  `macos-shell-workspace-persistence`) and move the change to
+  `macos-shell-workspace-persistence`, updated
+  `shell-workspace-core-contract`) and move the change to
   `openspec/changes/archive/YYYY-MM-DD-define-alan-interaction-model/`.

--- a/openspec/changes/define-alan-interaction-model/tasks.md
+++ b/openspec/changes/define-alan-interaction-model/tasks.md
@@ -1,0 +1,54 @@
+## 1. Contract Review
+
+- [ ] 1.1 Review the interaction-model contract against ADR-0039, ADR-0044,
+  ADR-0045, ADR-0046/0047, ADR-0048/0049, and ADR-0050 to confirm no
+  system-level decision is contradicted or duplicated.
+- [ ] 1.2 Review overlap with `macos-shell-ui-ux-conformance` (visual
+  treatment) and `agent-runtime-ui-file-surfaces` (runtime-owned UI files) and
+  confirm this change owns only interaction structure, modes, and vocabulary.
+- [ ] 1.3 Update the Alan product glossary (AGENTS.md canonical names) with
+  Alan Interaction Model, disclosure layers (Intent/Work/Files), interaction
+  modes (conversation/background-servant/event-driven), review surface, and
+  permission-as-grant terminology.
+
+## 2. macOS Interaction Skeleton
+
+- [ ] 2.1 Introduce the workspace entry view in Alan for macOS — active
+  agents, recent work, installed services — as the default app view, with the
+  shell demoted to an explicit tab type; keep the change presentation-only
+  with no new runtime authority.
+- [ ] 2.2 Add the review surface (results inbox) that lists completed agent
+  work with evidence links, shared by dispatched and event-driven outcomes;
+  data sourced from mounted execution-record files, never renderer-copied
+  state.
+- [ ] 2.3 Add the Permissions surface listing active host grants by label,
+  scope, and access, with revocation; wire grant creation to drag-in, file
+  picker, and agent-request approval sheet through Host Mount Service.
+- [ ] 2.4 Render existing agent Work-layer affordances (conversation, plan
+  card, approval sheet, Stop/Pause via `/proc/<pid>/ctl`) from their file
+  surfaces and remove any raw-file or OS-vocabulary presentation from the
+  default UI.
+- [ ] 2.5 Add the Files-layer entry point ("view as files" inspector) that
+  exposes the raw namespace as an explicit mode without becoming a second
+  authority.
+
+## 3. Conformance
+
+- [ ] 3.1 Add a vocabulary-rule check (lint or review checklist) covering
+  default-UI copy in `clients/apple` for quarantined OS terms.
+- [ ] 3.2 Add renderer-host conformance tests proving Work-layer gestures
+  become file writes and `ctl` commands with no renderer-local state
+  mutation.
+- [ ] 3.3 Verify the workspace entry, review surface, and Permissions surface
+  render exclusively from mounted file state per ADR-0046.
+
+## 4. Verification And Archive Readiness
+
+- [ ] 4.1 Run `just quality` and the macOS focused tests
+  (`just apple-shell-focused-tests`, `just apple-shell-ui-smoke`) with the new
+  surfaces covered.
+- [ ] 4.2 PR review confirms the change stays UX-only: no kernel, aP,
+  AgentFS, or runtime event machinery is introduced.
+- [ ] 4.3 Sync delta specs into `openspec/specs/` (new
+  `alan-interaction-model`, updated `alan-renderer-host-contract`) and move
+  the change to `openspec/changes/archive/YYYY-MM-DD-define-alan-interaction-model/`.


### PR DESCRIPTION
## Summary

Defines the Alan Interaction Model as a durable product contract: the file system is the API, never the default UI. Adds new capability `alan-interaction-model` and extends `alan-renderer-host-contract`.

- **Three disclosure layers over one truth**: Intent → Work → Files, all live views of the same mounted file state (ADR-0046); OS vocabulary is quarantined to the Files layer and docs.
- **Three interaction modes**: conversation is one mode, not the entry assumption; background-servant (dispatch, detach per ADR-0047, review results in a shared inbox) and event-driven (standing rules, proactive reports into the same review surface) are first-class.
- **Permission is the UX of mounting**: host file access is a grant flow (drag-in / picker / approval sheet) through Host Mount Service per ADR-0050; mount/bind are invisible side effects; one Permissions surface for audit and revocation.
- **Workspace-first entry**: Alan for macOS opens into a workspace of agents, work, and `/srv` services; Alan Shell is one tab type, launched as an ordinary Process (ADR-0048/0049). System boot order (ADR-0039) is unchanged.

No kernel, aP, AgentFS, or runtime changes — this is a UX contract only. Runtime event machinery and onboarding flows are explicitly out of scope.

## Validation

- `openspec validate define-alan-interaction-model --strict` passes
- Pre-commit `just quality` gate passed (0 warnings)