### PR TITLE
refactor(macos): derive shell selection from snapshot

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -114,13 +114,13 @@ Xcode target.
 | `Models/Shell/ManagedTerminalAccountCatalog.swift` | 91 | Foundation; macOS gates | Durable managed-account catalog normalization and storage | `Models/Shell/` |
 | `Models/Shell/ManagedTerminalUserSettings.swift` | 240 | Foundation; macOS gates | Managed-user readiness, creation preview, validation, and approved provisioning flow | `Models/Shell/` |
 | `Models/Shell/ShellSettingsHostSummaries.swift` | 131 | Foundation; macOS gates | Local app/runtime/storage identity and performance-diagnostics summaries | `Models/Shell/` |
-| `ShellHostController.swift` | 383 | Foundation, Combine; macOS gates | Observable shell state, dependency assembly, startup, shutdown, and root lifecycle | Root controller with focused `Controllers/Shell/` responsibility extensions |
+| `ShellHostController.swift` | 379 | Foundation, Combine; macOS gates | Observable adopted shell state, dependency assembly, startup, shutdown, and root lifecycle | Root controller with focused `Controllers/Shell/` responsibility extensions |
 | `Controllers/Shell/ShellHostControlProjection.swift` | 268 | Foundation; macOS gates | Control response, list, routing-candidate, and terminal-delivery projection | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostPlatformControlCommandHandling.swift` | 431 | Foundation; macOS gates | Shared-executor state adoption plus close guard, terminal delivery, events, render metrics, and performance diagnostics | `Controllers/Shell/` |
-| `Controllers/Shell/ShellHostProjectionAndSelection.swift` | 494 | Foundation; macOS gates | Derived shell projection, focus, selection, zoom, and shell-surface close requests | `Controllers/Shell/` |
+| `Controllers/Shell/ShellHostProjectionAndSelection.swift` | 511 | Foundation; macOS gates | Snapshot-derived shell and selection projection, focus, zoom, and shell-surface close requests | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostSpaceAndTabLifecycle.swift` | 727 | Foundation; macOS gates | Space, tab, content, and split creation plus tab ordering and movement | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostActionAndTerminalCommandHandling.swift` | 494 | Foundation; macOS gates | Shell action execution, spatial focus, and terminal semantic-command routing | `Controllers/Shell/` |
-| `Controllers/Shell/ShellHostRuntimeProjection.swift` | 653 | Foundation; macOS gates | Terminal runtime and metadata projection, activity routing, state adoption, and selection synchronization | `Controllers/Shell/` |
+| `Controllers/Shell/ShellHostRuntimeProjection.swift` | 662 | Foundation; macOS gates | Terminal runtime and metadata projection, activity routing, state adoption, and selection-dependent runtime refresh | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostWorkspacePersistence.swift` | 328 | Foundation; macOS gates | Workspace-manifest projection, transcript capture, pinned snapshots, and active-task persistence | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostCloseAndPaneLifecycle.swift` | 551 | Foundation; macOS gates | Close guards, graceful shutdown, pane lifecycle/movement, and control-plane state publication | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostAutomationCommandHandling.swift` | 309 | Foundation; macOS gates | External shell automation command adaptation and response projection | `Controllers/Shell/` |
@@ -529,7 +529,7 @@ Rust-owned Swift legacy cleanup targets at this baseline:
 | `Models/Shell/ShellValueTypes.swift` | Removed | Cleaned: shell, Terminal Profile, managed-account, activity, context, helper-contract, planning, and effect families now have named model/service owners. Request validation, provisioning, and rollback call shell-core FFI and fail closed. Script-only managed-account state/fakes remain outside the app target, and the unused local command runner is deleted. |
 | `Models/Shell/ShellSettingsSurfaceModel.swift` | 531 | Cleaned below the report threshold: settings navigation/grouping and fail-closed row composition remain here, while Terminal Profile/helper summaries, managed-account discovery, catalog persistence, managed-user creation/provisioning, and local/diagnostics summaries live in adjacent domain modules. Managed terminal account row projection still calls `settings.managed_terminal_account_rows` through `Services/Shell/ShellCoreFFISettingsAdapter.swift`. |
 | `Services/Shell/ShellCoreFFIAdapter.swift` | 12 | Cleaned as transport facade: loader, envelope, materialization, manifest, control, action, settings, and Terminal Profile operations remain in sibling owners; reducer and managed-terminal-account callers use dedicated operation-family adapter types, with no Swift domain fallback. |
-| `ShellHostController.swift` | 383 | Cleaned below the report threshold: the root keeps observable state, dependency assembly, startup, shutdown, and root lifecycle. Selection, space/tab lifecycle, actions, runtime projection, persistence, close/pane lifecycle, and automation adaptation live in focused `Controllers/Shell/ShellHost*` extensions while Rust shell-core and existing service coordinators retain domain authority. |
+| `ShellHostController.swift` | 379 | Cleaned below the report threshold: the root keeps the adopted observable shell snapshot, dependency assembly, startup, shutdown, and root lifecycle. Selected Space/Tab IDs are read-only snapshot projections rather than duplicate published fields. Selection, space/tab lifecycle, actions, runtime projection, persistence, close/pane lifecycle, and automation adaptation live in focused `Controllers/Shell/ShellHost*` extensions while Rust shell-core and existing service coordinators retain domain authority. |
 | `Controllers/Shell/ShellHostControlCommandHandling.swift` | Removed | Deleted after in-process and socket-facing portable commands converged on `AlanShellLocalCommandExecutor`; no second portable mutation switch remains. |
 | `Controllers/Shell/ShellHostPlatformControlCommandHandling.swift` | 431 | Keeps only executor-result adoption, close guarding, descriptor-targeted terminal delivery, event/render diagnostics, and explicit platform effects. |
 
@@ -545,6 +545,14 @@ construction remain inside `AlanShellLocalCommandExecutor`, while terminal
 intents preserve both PaneSlot and ContentInstance identity through delivery.
 The reduced line count is a byproduct; success is defined by one portable
 command owner and by `check-shell-contracts.sh` rejecting a replacement switch.
+
+The next host-ownership slice removes independently mutable controller
+`selectedSpaceID` and `selectedTabID` publications. Selected Space, tab, and
+pane now resolve directly from the adopted `ShellStateSnapshot`; the remaining
+selection-dependent helper refreshes only the transitional terminal runtime
+projection and render priorities. The architecture gate rejects reintroduced
+published selection IDs, direct controller assignments, or a replacement
+`synchronizeSelection` workflow.
 
 The current architecture gate treats
 `clients/apple/scripts/architecture-warning-baseline.txt` as a hard downward

--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostProjectionAndSelection.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostProjectionAndSelection.swift
@@ -7,14 +7,31 @@ extension ShellHostController {
     }
 
     var selectedSpace: ShellSpace? {
-        shellState.spaces.first { $0.spaceID == selectedSpaceID } ?? shellState.spaces.first
+        if let focusedSpaceID = shellState.focusedSpaceID,
+           let focusedSpace = shellState.spaces.first(where: { $0.spaceID == focusedSpaceID })
+        {
+            return focusedSpace
+        }
+        return shellState.spaces.first
+    }
+
+    var selectedSpaceID: String? {
+        selectedSpace?.spaceID
     }
 
     var selectedTab: ShellTab? {
-        guard let selectedTabID else {
-            return selectedSpace?.tabs.first
+        guard let selectedSpace else { return nil }
+        if let focusedTabID = shellState.focusedTabID,
+           let focusedTab = selectedSpace.tabs.first(where: { $0.tabID == focusedTabID })
+        {
+            return focusedTab
         }
-        return selectedSpace?.tabs.first { $0.tabID == selectedTabID } ?? selectedSpace?.tabs.first
+        guard let selectedTabID = selectedSpace.resolvedSelectedTabID else { return nil }
+        return selectedSpace.tabs.first { $0.tabID == selectedTabID }
+    }
+
+    var selectedTabID: String? {
+        selectedTab?.tabID
     }
 
     var selectedTabPaneTree: ShellPaneTreeNode? {
@@ -310,7 +327,7 @@ extension ShellHostController {
                 contents: shellState.contents,
                 zoomedPaneIDByTabID: shellState.zoomedPaneIDByTabID
             )
-            synchronizeSelection()
+            refreshSelectionRuntimeProjection()
             publishControlPlaneState()
             return
         }

--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostRuntimeProjection.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostRuntimeProjection.swift
@@ -322,7 +322,7 @@ extension ShellHostController {
             contents: shellState.contents,
             zoomedPaneIDByTabID: shellState.zoomedPaneIDByTabID
         )
-        synchronizeSelection()
+        refreshSelectionRuntimeProjection()
         routeActivityNotificationIfNeeded(from: existingPane, to: transformedPane)
         publishControlPlaneState(coalesced: true)
         return true
@@ -483,7 +483,7 @@ extension ShellHostController {
             contents: shellState.contents,
             zoomedPaneIDByTabID: shellState.zoomedPaneIDByTabID
         )
-        synchronizeSelection()
+        refreshSelectionRuntimeProjection()
         publishControlPlaneState()
     }
 
@@ -518,7 +518,7 @@ extension ShellHostController {
             routeActivityNotificationIfNeeded(from: previousPane, to: pane)
         }
         reconcilePaneZoomState()
-        synchronizeSelection()
+        refreshSelectionRuntimeProjection()
         if publish {
             publishControlPlaneState()
         }
@@ -533,7 +533,7 @@ extension ShellHostController {
         }
     }
 
-    func synchronizeSelection() {
+    func refreshSelectionRuntimeProjection() {
         let selectionStartedAt = performanceDiagnosticsStartTime()
         defer {
             if let selectionStartedAt {
@@ -548,16 +548,6 @@ extension ShellHostController {
                 )
             }
         }
-        if let focusedPane = focusedPane {
-            selectedSpaceID = focusedPane.spaceID
-            selectedTabID = focusedPane.tabID
-            setSelectedTerminalRuntime(runtime(for: focusedPane.paneID))
-            synchronizeTerminalRenderPriorities()
-            return
-        }
-
-        selectedSpaceID = shellState.focusedSpaceID ?? selectedSpaceID ?? shellState.spaces.first?.spaceID
-        selectedTabID = shellState.focusedTabID ?? selectedSpace?.tabs.first?.tabID
         setSelectedTerminalRuntime(runtime(for: selectedPane?.paneID))
         synchronizeTerminalRenderPriorities()
     }

--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostWorkspacePersistence.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostWorkspacePersistence.swift
@@ -127,7 +127,7 @@ extension ShellHostController {
             schemaVersion: ShellContentWorkspaceManifest.currentSchemaVersion,
             contentContractVersion: ShellContentWorkspaceManifest.currentContentContractVersion,
             windowID: shellState.windowID,
-            selectedSpaceID: shellState.focusedSpaceID ?? selectedSpaceID,
+            selectedSpaceID: selectedSpaceID,
             selectedTabID: shellState.focusedTabID,
             spaces: spaces
         )

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -162,8 +162,6 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     @Published var shellState: ShellStateSnapshot
-    @Published var selectedSpaceID: String?
-    @Published var selectedTabID: String?
     @Published var lastCopiedAt: Date?
     var terminalRuntime: TerminalHostRuntimeSnapshot = .placeholder
     @Published var controlPlaneDiagnostics: [String] = []
@@ -281,8 +279,6 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         self.terminalRuntimeRegistry =
             terminalRuntimeRegistry
             ?? resolvedContext.terminalRuntimeRegistry
-        self.selectedSpaceID = shellState.focusedSpaceID ?? shellState.spaces.first?.spaceID
-        self.selectedTabID = shellState.focusedTabID ?? shellState.spaces.first?.tabs.first?.tabID
 
         // Route async persistence-write failures (debounced restore content) to the
         // control-plane diagnostics surface, mirroring the synchronous paths.
@@ -295,7 +291,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         } else {
             shellState.panes.map(\.paneID).forEach(primeBootContext)
         }
-        synchronizeSelection()
+        refreshSelectionRuntimeProjection()
     }
 
     deinit {

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -486,6 +486,35 @@ reject_shell_host_published_terminal_runtime() {
     fi
 }
 
+reject_shell_host_duplicate_selection_state() {
+    local controller="$SOURCE_ROOT/ShellHostController.swift"
+    local selection_owner="$SOURCE_ROOT/Controllers/Shell/ShellHostProjectionAndSelection.swift"
+
+    if grep -En '@Published[^[:cntrl:]]*selected(Space|Tab)ID' "$controller" >&2; then
+        fail \
+            "ShellHostController selection IDs must derive from ShellStateSnapshot instead of duplicate @Published state"
+    fi
+    if grep -RIn --include='*.swift' -E \
+        '^[[:space:]]*(self\.)?selected(Space|Tab)ID[[:space:]]*=' \
+        "$controller" "$SOURCE_ROOT/Controllers/Shell" >&2
+    then
+        fail "shell host selection IDs must not regain independently mutable controller state"
+    fi
+    if grep -RIn --include='*.swift' -E \
+        'func[[:space:]]+synchronizeSelection' \
+        "$controller" "$SOURCE_ROOT/Controllers/Shell" >&2
+    then
+        fail \
+            "shell host selection must derive from ShellStateSnapshot without synchronization logic"
+    fi
+    if ! grep -Fq 'var selectedSpaceID: String? {' "$selection_owner" \
+        || ! grep -Fq 'var selectedTabID: String? {' "$selection_owner"
+    then
+        fail \
+            "ShellHostProjectionAndSelection must expose selection IDs as derived snapshot projections"
+    fi
+}
+
 reject_swiftui_shell_hot_path_sync_boundaries() {
     local matched=0
     local pattern
@@ -675,6 +704,7 @@ require_shell_core_ffi_direct_init_owners
 require_shell_core_ffi_raw_symbol_owners
 require_shell_core_action_metadata_query_owners
 reject_shell_host_published_terminal_runtime
+reject_shell_host_duplicate_selection_state
 reject_swiftui_shell_hot_path_sync_boundaries
 
 printf 'Current Swift inventory:\n'

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -148,6 +148,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesControlPlaneCloseTabReportsRequiresConfirmation()
         verifiesControlPlaneCloseIdlePaneSucceeds()
         verifiesControlPlaneBackgroundPaneClosePreservesRemovedSubject()
+        verifiesSelectionProjectionDerivesFromShellState()
         verifiesTabSelectionCommitsAuthoritativeFocus()
         verifiesShellActionTabNavigationTargetsCurrentSelection()
         verifiesSpaceSelectionCommitsAuthoritativeFocus()
@@ -5683,6 +5684,47 @@ private enum ShellRuntimeMetadataTests {
         expect(
             targetHostView.focusCount == 1,
             "tab selection must request focus for the target terminal runtime"
+        )
+    }
+
+    private static func verifiesSelectionProjectionDerivesFromShellState() {
+        let controller = makeController()
+        _ = controller.createTerminalSpace(title: "Second", workingDirectory: "/tmp")
+
+        expect(
+            controller.selectedSpaceID == "space_2",
+            "test setup must select the second Space"
+        )
+        expect(
+            controller.selectedTabID == "tab_2",
+            "test setup must select the second Space tab"
+        )
+
+        let state = controller.shellState
+        controller.shellState = ShellStateSnapshot(
+            contractVersion: state.contractVersion,
+            windowID: state.windowID,
+            focusedSpaceID: "space_main",
+            focusedTabID: "tab_main",
+            focusedPaneID: "pane_1",
+            spaces: state.spaces,
+            panes: state.panes,
+            paneSlots: state.paneSlots,
+            contents: state.contents,
+            zoomedPaneIDByTabID: state.zoomedPaneIDByTabID
+        )
+
+        expect(
+            controller.selectedSpaceID == "space_main",
+            "selected Space publication must derive directly from the adopted shell state"
+        )
+        expect(
+            controller.selectedTabID == "tab_main",
+            "selected tab publication must derive directly from the adopted shell state"
+        )
+        expect(
+            controller.selectedPane?.paneID == "pane_1",
+            "selected pane publication must derive directly from the adopted shell state"
         )
     }
 

--- a/openspec/changes/deepen-macos-shell-host-ownership/tasks.md
+++ b/openspec/changes/deepen-macos-shell-host-ownership/tasks.md
@@ -24,7 +24,7 @@
 
 ## 3. Remove Duplicate Shell Host State
 
-- [ ] 3.1 Make controller workspace and selection publications derive directly
+- [x] 3.1 Make controller workspace and selection publications derive directly
   from the adopted `ShellStateSnapshot`; remove independently mutable selected
   Space/Tab fields and synchronization logic.
 - [ ] 3.2 Make terminal runtime, active-task, render, and lifecycle publications


### PR DESCRIPTION
## Summary
- remove independently mutable selected Space and Tab fields from ShellHostController
- derive selected Space, Tab, and pane directly from the adopted ShellStateSnapshot
- keep only selection-dependent terminal runtime projection refresh and add architecture guards against duplicate state
- mark OpenSpec task 3.1 complete and update Apple architecture evidence

## Verification
- just quality
- just apple-shell-focused-tests
- just shell-core-test
- just shell-core-ffi-test
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate deepen-macos-shell-host-ownership --type change --strict --json
- just install-dev
- just apple-shell-ui-smoke

Alan Dev.app was freshly installed and relaunched. Space creation/selection, tab creation/selection, split terminal input, and restart restore screenshots were inspected. Alan stable was not touched.