### PR TITLE
refactor(macos): consolidate terminal runtime state

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -55,7 +55,7 @@ Xcode target.
 | `Services/Terminal/TerminalRuntimePublicationPolicy.swift` | 46 | macOS gates | Shell-facing runtime snapshot publication policy | `Services/Terminal/` |
 | `Services/Terminal/TerminalHostRuntimeReporter.swift` | 48 | Foundation; macOS gates | Runtime snapshot deduplication and main-queue publication for terminal host updates | `Services/Terminal/` |
 | `Services/Terminal/TerminalHostWindowObserver.swift` | 55 | AppKit; macOS gates | Terminal host window key, screen, and occlusion notification ownership | `Services/Terminal/` |
-| `TerminalRuntimeRegistry.swift` | 598 | SwiftUI; macOS gates | Pane/content-keyed terminal host/runtime registry | `Services/Terminal/` |
+| `TerminalRuntimeRegistry.swift` | 694 | SwiftUI; macOS gates | Content-keyed terminal host/runtime, active-task, lifecycle, and shell-projection registry | `Services/Terminal/` |
 | `Services/Terminal/DarwinTerminalPtyRuntime.swift` | 820 | Darwin, Foundation; macOS gates | Local Darwin PTY handle, renderer proxy, nonblocking IO, process launch, and exit observation | `Services/Terminal/` |
 | `Services/Terminal/GhosttyProcessBootstrap.swift` | 143 | Darwin, Foundation, GhosttyKit; macOS/Ghostty gates | Process-wide Ghostty initialization and inherited terminal-environment scrubbing | `Services/Terminal/` |
 | `Services/Terminal/GhosttyTerminalSurfaceHandle.swift` | 541 | AppKit, Foundation, GhosttyKit; macOS/Ghostty gates | Ghostty surface lifecycle, PTY attachment, delivery, renderer updates, and event-engine adaptation | `Services/Terminal/` |
@@ -114,14 +114,14 @@ Xcode target.
 | `Models/Shell/ManagedTerminalAccountCatalog.swift` | 91 | Foundation; macOS gates | Durable managed-account catalog normalization and storage | `Models/Shell/` |
 | `Models/Shell/ManagedTerminalUserSettings.swift` | 240 | Foundation; macOS gates | Managed-user readiness, creation preview, validation, and approved provisioning flow | `Models/Shell/` |
 | `Models/Shell/ShellSettingsHostSummaries.swift` | 131 | Foundation; macOS gates | Local app/runtime/storage identity and performance-diagnostics summaries | `Models/Shell/` |
-| `ShellHostController.swift` | 379 | Foundation, Combine; macOS gates | Observable adopted shell state, dependency assembly, startup, shutdown, and root lifecycle | Root controller with focused `Controllers/Shell/` responsibility extensions |
+| `ShellHostController.swift` | 375 | Foundation, Combine; macOS gates | Observable adopted shell state, dependency assembly, startup, shutdown, and root lifecycle | Root controller with focused `Controllers/Shell/` responsibility extensions |
 | `Controllers/Shell/ShellHostControlProjection.swift` | 268 | Foundation; macOS gates | Control response, list, routing-candidate, and terminal-delivery projection | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostPlatformControlCommandHandling.swift` | 431 | Foundation; macOS gates | Shared-executor state adoption plus close guard, terminal delivery, events, render metrics, and performance diagnostics | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostProjectionAndSelection.swift` | 511 | Foundation; macOS gates | Snapshot-derived shell and selection projection, focus, zoom, and shell-surface close requests | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostSpaceAndTabLifecycle.swift` | 727 | Foundation; macOS gates | Space, tab, content, and split creation plus tab ordering and movement | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostActionAndTerminalCommandHandling.swift` | 494 | Foundation; macOS gates | Shell action execution, spatial focus, and terminal semantic-command routing | `Controllers/Shell/` |
-| `Controllers/Shell/ShellHostRuntimeProjection.swift` | 662 | Foundation; macOS gates | Terminal runtime and metadata projection, activity routing, state adoption, and selection-dependent runtime refresh | `Controllers/Shell/` |
-| `Controllers/Shell/ShellHostWorkspacePersistence.swift` | 328 | Foundation; macOS gates | Workspace-manifest projection, transcript capture, pinned snapshots, and active-task persistence | `Controllers/Shell/` |
+| `Controllers/Shell/ShellHostRuntimeProjection.swift` | 616 | Foundation; macOS gates | Registry-backed terminal runtime and metadata projection, activity routing, state adoption, and render-priority refresh | `Controllers/Shell/` |
+| `Controllers/Shell/ShellHostWorkspacePersistence.swift` | 289 | Foundation; macOS gates | Workspace-manifest projection, transcript capture, pinned snapshots, and registry-backed active-task persistence | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostCloseAndPaneLifecycle.swift` | 551 | Foundation; macOS gates | Close guards, graceful shutdown, pane lifecycle/movement, and control-plane state publication | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostAutomationCommandHandling.swift` | 309 | Foundation; macOS gates | External shell automation command adaptation and response projection | `Controllers/Shell/` |
 | `Services/Shell/ShellControlFilePoller.swift` | 182 | Foundation; macOS gates | File-backed command/result polling and alan binding-file projection | `Services/Shell/` |
@@ -529,7 +529,7 @@ Rust-owned Swift legacy cleanup targets at this baseline:
 | `Models/Shell/ShellValueTypes.swift` | Removed | Cleaned: shell, Terminal Profile, managed-account, activity, context, helper-contract, planning, and effect families now have named model/service owners. Request validation, provisioning, and rollback call shell-core FFI and fail closed. Script-only managed-account state/fakes remain outside the app target, and the unused local command runner is deleted. |
 | `Models/Shell/ShellSettingsSurfaceModel.swift` | 531 | Cleaned below the report threshold: settings navigation/grouping and fail-closed row composition remain here, while Terminal Profile/helper summaries, managed-account discovery, catalog persistence, managed-user creation/provisioning, and local/diagnostics summaries live in adjacent domain modules. Managed terminal account row projection still calls `settings.managed_terminal_account_rows` through `Services/Shell/ShellCoreFFISettingsAdapter.swift`. |
 | `Services/Shell/ShellCoreFFIAdapter.swift` | 12 | Cleaned as transport facade: loader, envelope, materialization, manifest, control, action, settings, and Terminal Profile operations remain in sibling owners; reducer and managed-terminal-account callers use dedicated operation-family adapter types, with no Swift domain fallback. |
-| `ShellHostController.swift` | 379 | Cleaned below the report threshold: the root keeps the adopted observable shell snapshot, dependency assembly, startup, shutdown, and root lifecycle. Selected Space/Tab IDs are read-only snapshot projections rather than duplicate published fields. Selection, space/tab lifecycle, actions, runtime projection, persistence, close/pane lifecycle, and automation adaptation live in focused `Controllers/Shell/ShellHost*` extensions while Rust shell-core and existing service coordinators retain domain authority. |
+| `ShellHostController.swift` | 375 | Cleaned below the report threshold: the root keeps the adopted observable shell snapshot, dependency assembly, startup, shutdown, and root lifecycle. Selected Space/Tab IDs are read-only snapshot projections, and selected terminal runtime, active-task, and projection-buffer state come from `TerminalRuntimeRegistry` rather than duplicate controller fields. Selection, space/tab lifecycle, actions, runtime projection, persistence, close/pane lifecycle, and automation adaptation live in focused `Controllers/Shell/ShellHost*` extensions while Rust shell-core and existing service coordinators retain domain authority. |
 | `Controllers/Shell/ShellHostControlCommandHandling.swift` | Removed | Deleted after in-process and socket-facing portable commands converged on `AlanShellLocalCommandExecutor`; no second portable mutation switch remains. |
 | `Controllers/Shell/ShellHostPlatformControlCommandHandling.swift` | 431 | Keeps only executor-result adoption, close guarding, descriptor-targeted terminal delivery, event/render diagnostics, and explicit platform effects. |
 
@@ -548,11 +548,18 @@ command owner and by `check-shell-contracts.sh` rejecting a replacement switch.
 
 The next host-ownership slice removes independently mutable controller
 `selectedSpaceID` and `selectedTabID` publications. Selected Space, tab, and
-pane now resolve directly from the adopted `ShellStateSnapshot`; the remaining
-selection-dependent helper refreshes only the transitional terminal runtime
-projection and render priorities. The architecture gate rejects reintroduced
-published selection IDs, direct controller assignments, or a replacement
-`synchronizeSelection` workflow.
+pane now resolve directly from the adopted `ShellStateSnapshot`; the
+architecture gate rejects reintroduced published selection IDs, direct
+controller assignments, or a replacement `synchronizeSelection` workflow.
+
+The following terminal-runtime slice removes the controller's selected-runtime
+cache, PaneSlot-keyed active-task map, and visible-background projection queue.
+`TerminalRuntimeRegistry` now retains the latest snapshot even when shell
+publication policy suppresses timestamp-only churn, keeps active-task state with
+terminal content across PaneSlot remounts, coalesces background projection by
+content identity, and clears that state during lifecycle release. Render
+priority effects continue through the registry. The architecture gate rejects
+reintroduced controller caches, maps, queues, and publication-policy call sites.
 
 The current architecture gate treats
 `clients/apple/scripts/architecture-warning-baseline.txt` as a hard downward

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -55,7 +55,7 @@ Xcode target.
 | `Services/Terminal/TerminalRuntimePublicationPolicy.swift` | 46 | macOS gates | Shell-facing runtime snapshot publication policy | `Services/Terminal/` |
 | `Services/Terminal/TerminalHostRuntimeReporter.swift` | 48 | Foundation; macOS gates | Runtime snapshot deduplication and main-queue publication for terminal host updates | `Services/Terminal/` |
 | `Services/Terminal/TerminalHostWindowObserver.swift` | 55 | AppKit; macOS gates | Terminal host window key, screen, and occlusion notification ownership | `Services/Terminal/` |
-| `TerminalRuntimeRegistry.swift` | 694 | SwiftUI; macOS gates | Content-keyed terminal host/runtime, active-task, lifecycle, and shell-projection registry | `Services/Terminal/` |
+| `TerminalRuntimeRegistry.swift` | 702 | SwiftUI; macOS gates | Content-keyed terminal host/runtime, active-task, lifecycle, and shell-projection registry | `Services/Terminal/` |
 | `Services/Terminal/DarwinTerminalPtyRuntime.swift` | 820 | Darwin, Foundation; macOS gates | Local Darwin PTY handle, renderer proxy, nonblocking IO, process launch, and exit observation | `Services/Terminal/` |
 | `Services/Terminal/GhosttyProcessBootstrap.swift` | 143 | Darwin, Foundation, GhosttyKit; macOS/Ghostty gates | Process-wide Ghostty initialization and inherited terminal-environment scrubbing | `Services/Terminal/` |
 | `Services/Terminal/GhosttyTerminalSurfaceHandle.swift` | 541 | AppKit, Foundation, GhosttyKit; macOS/Ghostty gates | Ghostty surface lifecycle, PTY attachment, delivery, renderer updates, and event-engine adaptation | `Services/Terminal/` |

--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostActionAndTerminalCommandHandling.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostActionAndTerminalCommandHandling.swift
@@ -443,13 +443,15 @@ extension ShellHostController {
 
     var focusedPaneHasReliableSemanticCommands: Bool {
         guard focusedContentSupportsTerminalCommands else { return false }
-        guard let paneID = selectedPane?.paneID,
-              paneID == terminalRuntime.paneID
-        else {
+        guard let paneID = selectedPane?.paneID else {
             return false
         }
-        return terminalRuntime.surfaceState.terminalMode == .normalBuffer
-            && terminalRuntime.surfaceState.semanticCommands.hasReliableCommandBoundaries
+        let runtime = terminalRuntimeRegistry.snapshot(for: paneID)
+        guard paneID == runtime.paneID else {
+            return false
+        }
+        return runtime.surfaceState.terminalMode == .normalBuffer
+            && runtime.surfaceState.semanticCommands.hasReliableCommandBoundaries
     }
 
     @discardableResult

--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostRuntimeProjection.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostRuntimeProjection.swift
@@ -13,8 +13,7 @@ extension ShellHostController {
                 )
             }
         }
-        let previousRuntime = runtime.paneID.map { self.runtime(for: $0) }
-        terminalRuntimeRegistry.updateSnapshot(runtime)
+        let shouldProjectToShell = terminalRuntimeRegistry.updateSnapshot(runtime)
 
         if let paneID = runtime.paneID,
            runtime.isFocused,
@@ -24,19 +23,10 @@ extension ShellHostController {
             return
         }
 
-        guard TerminalRuntimePublicationPolicy.shouldProjectToShell(
-            previous: previousRuntime,
-            next: runtime
-        ) else {
-            return
+        guard shouldProjectToShell else { return }
+        terminalRuntimeRegistry.publishShellProjection(runtime) { [weak self] snapshot in
+            self?.projectTerminalRuntime(snapshot)
         }
-
-        if runtime.renderPriority == .visibleBackground {
-            scheduleVisibleBackgroundRuntimeProjection(runtime)
-            return
-        }
-
-        projectTerminalRuntime(runtime)
     }
 
     private func projectTerminalRuntime(_ runtime: TerminalHostRuntimeSnapshot) {
@@ -50,10 +40,6 @@ extension ShellHostController {
                 )
             }
         }
-        if runtime.paneID == selectedPane?.paneID || runtime.paneID == shellState.focusedPaneID {
-            setSelectedTerminalRuntime(runtime)
-        }
-
         if let paneID = runtime.paneID,
            let pane = pane(paneID: paneID)
         {
@@ -63,10 +49,10 @@ extension ShellHostController {
                 for: pane,
                 bootProfile: bootProfile
             )
-            let activeTaskChanged = recordTerminalActiveTask(
+            let activeTaskChanged = terminalRuntimeRegistry.recordActiveTask(
                 runtime.paneMetadata.activeTaskState,
                 processExited: effectProjection.processExited,
-                for: paneID
+                forPaneID: paneID
             )
             if effectProjection.processExited {
                 routeActivityNotificationIfNeeded(from: pane, nextActivity: effectProjection.activity)
@@ -160,28 +146,6 @@ extension ShellHostController {
         return AlanPerformanceDiagnosticsController.shared.isEnabled ? DispatchTime.now() : nil
     }
 
-    private func scheduleVisibleBackgroundRuntimeProjection(_ runtime: TerminalHostRuntimeSnapshot) {
-        guard let paneID = runtime.paneID else {
-            projectTerminalRuntime(runtime)
-            return
-        }
-        pendingVisibleBackgroundRuntimeByPaneID[paneID] = runtime
-        guard !visibleBackgroundRuntimeProjectionScheduled else { return }
-        visibleBackgroundRuntimeProjectionScheduled = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(16)) { [weak self] in
-            self?.flushVisibleBackgroundRuntimeProjections()
-        }
-    }
-
-    private func flushVisibleBackgroundRuntimeProjections() {
-        let pending = pendingVisibleBackgroundRuntimeByPaneID
-        pendingVisibleBackgroundRuntimeByPaneID.removeAll()
-        visibleBackgroundRuntimeProjectionScheduled = false
-        for runtime in pending.values.sorted(by: { ($0.paneID ?? "") < ($1.paneID ?? "") }) {
-            projectTerminalRuntime(runtime)
-        }
-    }
-
     func updateTerminalMetadata(_ metadata: TerminalPaneMetadataSnapshot, for paneID: String) {
         let metadataStartedAt = performanceDiagnosticsStartTime()
         guard let pane = pane(paneID: paneID) else { return }
@@ -202,10 +166,10 @@ extension ShellHostController {
             for: pane,
             bootProfile: bootProfile
         )
-        let activeTaskChanged = recordTerminalActiveTask(
+        let activeTaskChanged = terminalRuntimeRegistry.recordActiveTask(
             metadata.activeTaskState,
             processExited: effectProjection.processExited,
-            for: paneID
+            forPaneID: paneID
         )
         if effectProjection.processExited {
             routeActivityNotificationIfNeeded(from: pane, nextActivity: effectProjection.activity)
@@ -541,24 +505,14 @@ extension ShellHostController {
                 recordPerformanceDiagnostic(
                     .shellSelectionChange,
                     durationMs: performanceDurationMs(since: selectionStartedAt),
-                    runtime: terminalRuntime,
+                    runtime: selectedPaneRuntime,
                     fallbackPaneID: selectedPane?.paneID,
                     fallbackContentID: selectedPane?.terminalContentID,
                     fallbackPriority: selectedPane.map { terminalRenderPriority(for: $0) }
                 )
             }
         }
-        setSelectedTerminalRuntime(runtime(for: selectedPane?.paneID))
         synchronizeTerminalRenderPriorities()
-    }
-
-    /// Assigns the selected-pane runtime snapshot only when it differs from the
-    /// current one in something other than its publish timestamp. This stays off
-    /// the host's broad `@Published` surface so terminal-output churn does not
-    /// invalidate unrelated SwiftUI chrome.
-    private func setSelectedTerminalRuntime(_ runtime: TerminalHostRuntimeSnapshot) {
-        guard !terminalRuntime.equalsIgnoringTimestamp(runtime) else { return }
-        terminalRuntime = runtime
     }
 
     func synchronizeTerminalRenderPriorities() {
@@ -578,7 +532,7 @@ extension ShellHostController {
             recordPerformanceDiagnostic(
                 .shellPrioritySynchronization,
                 durationMs: performanceDurationMs(since: synchronizationStartedAt),
-                runtime: terminalRuntime,
+                runtime: selectedPaneRuntime,
                 fallbackPaneID: selectedPane?.paneID,
                 fallbackContentID: selectedPane?.terminalContentID,
                 fallbackPriority: selectedPane.map { terminalRenderPriority(for: $0) },

--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostWorkspacePersistence.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostWorkspacePersistence.swift
@@ -227,8 +227,11 @@ extension ShellHostController {
         for tab: ShellTab,
         panes: [ShellPane]
     ) -> ShellTabActiveTaskState {
-        if let terminalActiveTask = strongestTerminalActiveTask(
-            in: panes.filter { tab.contains(paneID: $0.paneID) }
+        let tabPaneIDs = panes
+            .filter { tab.contains(paneID: $0.paneID) }
+            .map(\.paneID)
+        if let terminalActiveTask = terminalRuntimeRegistry.strongestActiveTask(
+            forPaneIDs: tabPaneIDs
         ),
            terminalActiveTask.protectsFromPruning
         {
@@ -260,48 +263,6 @@ extension ShellHostController {
             .reduce(into: [String: ShellTabActiveTaskState]()) { result, tab in
                 result[tab.tabID] = projectedActiveTask(for: tab, panes: shellState.panes)
             }
-    }
-
-    @discardableResult
-    func recordTerminalActiveTask(
-        _ activeTaskState: ShellTabActiveTaskState?,
-        processExited: Bool,
-        for paneID: String
-    ) -> Bool {
-        let nextState: ShellTabActiveTaskState?
-        if processExited {
-            nextState = .inactive
-        } else {
-            nextState = activeTaskState
-        }
-
-        guard let nextState else { return false }
-        guard terminalActiveTasksByPaneID[paneID] != nextState else { return false }
-        terminalActiveTasksByPaneID[paneID] = nextState
-        return true
-    }
-
-    private func strongestTerminalActiveTask(in panes: [ShellPane]) -> ShellTabActiveTaskState? {
-        panes
-            .compactMap { terminalActiveTasksByPaneID[$0.paneID] }
-            .max { activeTaskRank($0) < activeTaskRank($1) }
-    }
-
-    private func activeTaskRank(_ state: ShellTabActiveTaskState) -> Int {
-        switch state {
-        case .inactive:
-            return 0
-        case .unknown:
-            return 1
-        case .foregroundCommand:
-            return 2
-        case .alanRunning:
-            return 3
-        case .alanProcess:
-            return 4
-        case .alanPendingYield:
-            return 5
-        }
     }
 
     private static let inactiveAlanMachineStates: Set<String> = [

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -115,7 +115,6 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     let persistenceCoordinator: ShellWorkspacePersistenceCoordinator
     let actionCoordinator = ShellActionCoordinator()
     let reducerAdapter = ShellCoreReducerAdapter()
-    var terminalActiveTasksByPaneID: [String: ShellTabActiveTaskState] = [:]
     var terminalContentIDsSuppressingAutoClose: Set<String> = []
     private let paneProjection: ShellPaneProjectionService
     let platformMetadataPreserver: ShellPlatformMetadataPreserver
@@ -163,7 +162,6 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
     @Published var shellState: ShellStateSnapshot
     @Published var lastCopiedAt: Date?
-    var terminalRuntime: TerminalHostRuntimeSnapshot = .placeholder
     @Published var controlPlaneDiagnostics: [String] = []
     @Published var activityNotifications: [ShellActivityNotificationRoute] = []
     @Published var zoomedPaneIDByTabID: [String: String] = [:]
@@ -224,8 +222,6 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     let bootProfileCache: AlanShellBootProfileCache
     let appIsActiveProvider: @MainActor () -> Bool
     var routedActivityNotificationKeys: Set<String> = []
-    var pendingVisibleBackgroundRuntimeByPaneID: [String: TerminalHostRuntimeSnapshot] = [:]
-    var visibleBackgroundRuntimeProjectionScheduled = false
     var shellWindowIsVisibleForRendering = true
     var workspaceManifest: ShellContentWorkspaceManifest? {
         persistenceCoordinator.currentManifest()

--- a/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
@@ -67,9 +67,12 @@ final class TerminalRuntimeRegistry: ObservableObject {
 
     private var hostViewsByContentID: [String: AlanTerminalHostNSView] = [:]
     private var snapshotsByContentID: [String: TerminalHostRuntimeSnapshot] = [:]
+    private var activeTasksByContentID: [String: ShellTabActiveTaskState] = [:]
     private var paneSlotIDByContentID: [String: String] = [:]
     private var contentIDByPaneSlotID: [String: String] = [:]
     private var pendingFocusPaneSlotIDs: Set<String> = []
+    private var pendingShellProjectionsByContentID: [String: TerminalHostRuntimeSnapshot] = [:]
+    private var shellProjectionFlushScheduled = false
     private let runtimeService: AlanTerminalRuntimeService
     private let mockDeliveryHandler: MockDeliveryHandler?
     private let performanceDiagnosticsRecorder: AlanPerformanceDiagnosticsRecorder?
@@ -216,10 +219,16 @@ final class TerminalRuntimeRegistry: ObservableObject {
         )
     }
 
-    func updateSnapshot(_ snapshot: TerminalHostRuntimeSnapshot) {
+    /// Records the runtime snapshot and reports whether its shell-facing
+    /// projection changed. The registry remains authoritative even when the
+    /// shell projection is suppressed as timestamp-only churn.
+    @discardableResult
+    func updateSnapshot(_ snapshot: TerminalHostRuntimeSnapshot) -> Bool {
         guard let contentID = snapshot.contentID ?? snapshot.paneID.map(terminalContentID(forPaneID:)) else {
-            return
+            return false
         }
+        let previous = snapshotsByContentID[contentID]
+            ?? runtimeSnapshot(from: runtimeService.snapshot(forTerminalContentID: contentID))
         if let paneID = snapshot.paneID {
             recordMount(contentID: contentID, paneSlotID: paneID)
         }
@@ -227,6 +236,43 @@ final class TerminalRuntimeRegistry: ObservableObject {
         runtimeService
             .existingSurfaceHandle(forTerminalContentID: contentID)?
             .updateHostRuntimeSnapshot(snapshot)
+        return TerminalRuntimePublicationPolicy.shouldProjectToShell(
+            previous: previous,
+            next: snapshot
+        )
+    }
+
+    /// Publishes immediately for foreground/hidden runtimes and coalesces
+    /// visible-background churn by terminal content identity for one frame.
+    func publishShellProjection(
+        _ snapshot: TerminalHostRuntimeSnapshot,
+        observer: @escaping (TerminalHostRuntimeSnapshot) -> Void
+    ) {
+        guard snapshot.renderPriority == .visibleBackground,
+              let contentID = snapshot.contentID
+                  ?? snapshot.paneID.map(terminalContentID(mountedAtPaneID:))
+        else {
+            observer(snapshot)
+            return
+        }
+
+        pendingShellProjectionsByContentID[contentID] = snapshot
+        guard !shellProjectionFlushScheduled else { return }
+        shellProjectionFlushScheduled = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(16)) { [weak self] in
+            self?.flushShellProjections(to: observer)
+        }
+    }
+
+    func flushShellProjections(
+        to observer: (TerminalHostRuntimeSnapshot) -> Void
+    ) {
+        let pending = pendingShellProjectionsByContentID
+        pendingShellProjectionsByContentID.removeAll()
+        shellProjectionFlushScheduled = false
+        for snapshot in pending.values.sorted(by: { ($0.paneID ?? "") < ($1.paneID ?? "") }) {
+            observer(snapshot)
+        }
     }
 
     func updateRenderPriorities(
@@ -302,6 +348,32 @@ final class TerminalRuntimeRegistry: ObservableObject {
         guard let contentID else { return .placeholder }
         return snapshotsByContentID[contentID]
             ?? runtimeSnapshot(from: runtimeService.snapshot(forTerminalContentID: contentID))
+    }
+
+    @discardableResult
+    func recordActiveTask(
+        _ activeTaskState: ShellTabActiveTaskState?,
+        processExited: Bool,
+        forPaneID paneID: String
+    ) -> Bool {
+        let nextState: ShellTabActiveTaskState?
+        if processExited {
+            nextState = .inactive
+        } else {
+            nextState = activeTaskState
+        }
+
+        guard let nextState else { return false }
+        let contentID = terminalContentID(mountedAtPaneID: paneID)
+        guard activeTasksByContentID[contentID] != nextState else { return false }
+        activeTasksByContentID[contentID] = nextState
+        return true
+    }
+
+    func strongestActiveTask(forPaneIDs paneIDs: [String]) -> ShellTabActiveTaskState? {
+        paneIDs
+            .compactMap { activeTasksByContentID[terminalContentID(mountedAtPaneID: $0)] }
+            .max { Self.activeTaskRank($0) < Self.activeTaskRank($1) }
     }
 
     func captureTranscriptSnapshot(
@@ -513,11 +585,18 @@ final class TerminalRuntimeRegistry: ObservableObject {
     }
 
     private func releaseTerminalContent(_ contentID: String) {
+        let paneSlotID = paneSlotIDByContentID[contentID]
+            ?? snapshotsByContentID[contentID]?.paneID
         if let hostView = hostViewsByContentID.removeValue(forKey: contentID) {
             hostView.teardownTerminalRuntime()
         }
         runtimeService.finalizeTerminalContent(contentID)
         snapshotsByContentID.removeValue(forKey: contentID)
+        activeTasksByContentID.removeValue(forKey: contentID)
+        pendingShellProjectionsByContentID.removeValue(forKey: contentID)
+        if let paneSlotID {
+            pendingFocusPaneSlotIDs.remove(paneSlotID)
+        }
         if let paneSlotID = paneSlotIDByContentID.removeValue(forKey: contentID),
            contentIDByPaneSlotID[paneSlotID] == contentID
         {
@@ -570,6 +649,23 @@ final class TerminalRuntimeRegistry: ObservableObject {
         }
         paneSlotIDByContentID[contentID] = paneSlotID
         contentIDByPaneSlotID[paneSlotID] = contentID
+    }
+
+    private static func activeTaskRank(_ state: ShellTabActiveTaskState) -> Int {
+        switch state {
+        case .inactive:
+            return 0
+        case .unknown:
+            return 1
+        case .foregroundCommand:
+            return 2
+        case .alanRunning:
+            return 3
+        case .alanProcess:
+            return 4
+        case .alanPendingYield:
+            return 5
+        }
     }
 
     private func runtimeSnapshot(

--- a/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
@@ -65,13 +65,18 @@ enum TerminalHostAttachmentPolicy: Equatable {
 final class TerminalRuntimeRegistry: ObservableObject {
     typealias MockDeliveryHandler = (String, String) -> TerminalRuntimeDeliveryResult
 
+    private struct PendingShellProjection {
+        let snapshot: TerminalHostRuntimeSnapshot
+        let observer: (TerminalHostRuntimeSnapshot) -> Void
+    }
+
     private var hostViewsByContentID: [String: AlanTerminalHostNSView] = [:]
     private var snapshotsByContentID: [String: TerminalHostRuntimeSnapshot] = [:]
     private var activeTasksByContentID: [String: ShellTabActiveTaskState] = [:]
     private var paneSlotIDByContentID: [String: String] = [:]
     private var contentIDByPaneSlotID: [String: String] = [:]
     private var pendingFocusPaneSlotIDs: Set<String> = []
-    private var pendingShellProjectionsByContentID: [String: TerminalHostRuntimeSnapshot] = [:]
+    private var pendingShellProjectionsByContentID: [String: PendingShellProjection] = [:]
     private var shellProjectionFlushScheduled = false
     private let runtimeService: AlanTerminalRuntimeService
     private let mockDeliveryHandler: MockDeliveryHandler?
@@ -256,22 +261,25 @@ final class TerminalRuntimeRegistry: ObservableObject {
             return
         }
 
-        pendingShellProjectionsByContentID[contentID] = snapshot
+        pendingShellProjectionsByContentID[contentID] = PendingShellProjection(
+            snapshot: snapshot,
+            observer: observer
+        )
         guard !shellProjectionFlushScheduled else { return }
         shellProjectionFlushScheduled = true
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(16)) { [weak self] in
-            self?.flushShellProjections(to: observer)
+            self?.flushShellProjections()
         }
     }
 
-    func flushShellProjections(
-        to observer: (TerminalHostRuntimeSnapshot) -> Void
-    ) {
+    func flushShellProjections() {
         let pending = pendingShellProjectionsByContentID
         pendingShellProjectionsByContentID.removeAll()
         shellProjectionFlushScheduled = false
-        for snapshot in pending.values.sorted(by: { ($0.paneID ?? "") < ($1.paneID ?? "") }) {
-            observer(snapshot)
+        for projection in pending.values.sorted(
+            by: { ($0.snapshot.paneID ?? "") < ($1.snapshot.paneID ?? "") }
+        ) {
+            projection.observer(projection.snapshot)
         }
     }
 

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -478,12 +478,40 @@ require_shell_core_action_metadata_query_owners() {
     fi
 }
 
-reject_shell_host_published_terminal_runtime() {
-    local file="$SOURCE_ROOT/ShellHostController.swift"
+reject_shell_host_duplicate_terminal_runtime_state() {
+    local controller="$SOURCE_ROOT/ShellHostController.swift"
+    local controller_dir="$SOURCE_ROOT/Controllers/Shell"
+    local registry="$SOURCE_ROOT/TerminalRuntimeRegistry.swift"
+    local selection_owner="$controller_dir/ShellHostProjectionAndSelection.swift"
 
-    if grep -En '@Published[^[:cntrl:]]*terminalRuntime' "$file" >&2; then
-        fail "ShellHostController.terminalRuntime must not be @Published; high-frequency terminal runtime state must not invalidate the whole SwiftUI shell"
+    if grep -En 'var[[:space:]]+terminalRuntime[[:space:]]*:' "$controller" >&2; then
+        fail \
+            "ShellHostController terminal runtime must derive from TerminalRuntimeRegistry instead of cached state"
     fi
+    if grep -RIn --include='*.swift' -E \
+        'terminalActiveTasksByPaneID|pendingVisibleBackgroundRuntimeByPaneID|visibleBackgroundRuntimeProjectionScheduled|setSelectedTerminalRuntime|scheduleVisibleBackgroundRuntimeProjection' \
+        "$controller" "$controller_dir" >&2
+    then
+        fail \
+            "shell host runtime, active-task, and projection queue state must remain in TerminalRuntimeRegistry"
+    fi
+    if ! grep -Fq 'private var activeTasksByContentID:' "$registry" \
+        || ! grep -Fq 'private var pendingShellProjectionsByContentID:' "$registry"
+    then
+        fail \
+            "TerminalRuntimeRegistry must own content-keyed active-task and shell-projection state"
+    fi
+    if ! grep -Fq 'var selectedPaneRuntime: TerminalHostRuntimeSnapshot {' "$selection_owner" \
+        || ! grep -Fq 'terminalRuntimeRegistry.snapshot(for: paneID)' "$selection_owner"
+    then
+        fail \
+            "selected terminal runtime must be a direct TerminalRuntimeRegistry projection"
+    fi
+
+    require_existing_single_owner_pattern \
+        "TerminalRuntimePublicationPolicy.shouldProjectToShell" \
+        "TerminalRuntimeRegistry.swift" \
+        "shell-facing terminal runtime publication policy"
 }
 
 reject_shell_host_duplicate_selection_state() {
@@ -703,7 +731,7 @@ require_shell_core_ffi_shared_callsite_owners
 require_shell_core_ffi_direct_init_owners
 require_shell_core_ffi_raw_symbol_owners
 require_shell_core_action_metadata_query_owners
-reject_shell_host_published_terminal_runtime
+reject_shell_host_duplicate_terminal_runtime_state
 reject_shell_host_duplicate_selection_state
 reject_swiftui_shell_hot_path_sync_boundaries
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -1173,7 +1173,7 @@ private enum ShellRuntimeMetadataTests {
         registry.publishShellProjection(second) { projected.append($0) }
 
         expect(projected.isEmpty, "visible-background runtime projection must wait for coalescing")
-        registry.flushShellProjections { projected.append($0) }
+        registry.flushShellProjections()
         expect(
             projected.count == 1 && projected.first?.paneMetadata.title == "second",
             "registry must publish only the latest background snapshot per terminal content"

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -29,7 +29,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesFailedStructuralManifestSaveIsReported()
         verifiesAsyncPersistenceWriteFailureRoutesToDiagnostics()
         verifiesPaneSupportDirectoryIsCreatedPromptlyAtBoot()
-        verifiesSelectedRuntimeAssignmentIgnoresTimestampOnlyChanges()
+        verifiesRegistryRuntimeProjectionIgnoresTimestampOnlyChanges()
         verifiesRuntimeProjectsTerminalStatusIntoPaneMetadata()
         verifiesRuntimeProjectionRecordsPerformanceDiagnostics()
         verifiesShellSelectionAndFocusRecordPerformanceDiagnostics()
@@ -42,6 +42,8 @@ private enum ShellRuntimeMetadataTests {
         verifiesPaneTitleBarSuppressesInternalTitles()
         verifiesOpeningTabSkipsStaleRuntimePaneIDs()
         verifiesRuntimeRegistryKeepsContentIdentityAcrossPaneMounts()
+        verifiesRuntimeRegistryKeepsActiveTaskWithContentAcrossPaneMounts()
+        verifiesRuntimeRegistryCoalescesVisibleBackgroundShellProjection()
         verifiesRuntimeRegistryPreservesInteractiveBehaviorAcrossPaneRemount()
         verifiesRuntimeRegistryCleanupUsesCurrentMountContentIDs()
         verifiesRuntimeRegistryRekeysHostViewAcrossContentReplacement()
@@ -1085,6 +1087,97 @@ private enum ShellRuntimeMetadataTests {
         registry.releaseRuntime(for: "pane_right")
         expect(handle.teardownCount == 1, "pane convenience release must finalize the mounted content")
         expect(registry.registeredContentIDs.isEmpty, "released content must leave the registry")
+    }
+
+    private static func verifiesRuntimeRegistryKeepsActiveTaskWithContentAcrossPaneMounts() {
+        let registry = TerminalRuntimeRegistry(runtimeService: FakeAlanTerminalRuntimeService())
+        let contentID = "content_terminal_active_task"
+        let firstMount = TerminalContentMount(
+            contentID: contentID,
+            paneSlotID: "pane_left",
+            tabID: "tab_1",
+            spaceID: "space_main"
+        )
+        let secondMount = TerminalContentMount(
+            contentID: contentID,
+            paneSlotID: "pane_right",
+            tabID: "tab_2",
+            spaceID: "space_main"
+        )
+
+        _ = registry.surfaceHandle(forTerminalContent: firstMount, bootProfile: nil)
+        expect(
+            registry.recordActiveTask(
+                .foregroundCommand,
+                processExited: false,
+                forPaneID: firstMount.paneSlotID
+            ),
+            "first active-task observation must update registry truth"
+        )
+
+        _ = registry.surfaceHandle(forTerminalContent: secondMount, bootProfile: nil)
+        expect(
+            registry.strongestActiveTask(forPaneIDs: [secondMount.paneSlotID])
+                == .foregroundCommand,
+            "active task must follow terminal content identity across PaneSlot remounts"
+        )
+        expect(
+            registry.strongestActiveTask(forPaneIDs: [firstMount.paneSlotID]) == nil,
+            "the previous PaneSlot must not retain duplicate active-task state"
+        )
+
+        registry.releaseRuntime(for: secondMount.paneSlotID)
+        expect(
+            registry.strongestActiveTask(forPaneIDs: [secondMount.paneSlotID]) == nil,
+            "terminal lifecycle release must remove registry-owned active-task state"
+        )
+    }
+
+    private static func verifiesRuntimeRegistryCoalescesVisibleBackgroundShellProjection() {
+        let registry = TerminalRuntimeRegistry(runtimeService: FakeAlanTerminalRuntimeService())
+
+        func snapshot(title: String, timestamp: TimeInterval) -> TerminalHostRuntimeSnapshot {
+            TerminalHostRuntimeSnapshot(
+                stage: .windowAttached,
+                contentID: "content_background",
+                paneID: "pane_background",
+                tabID: "tab_background",
+                renderPriority: .visibleBackground,
+                logicalSize: .zero,
+                backingSize: .zero,
+                displayName: nil,
+                displayID: nil,
+                attachedWindowTitle: nil,
+                isFocused: false,
+                renderer: .placeholder,
+                paneMetadata: TerminalPaneMetadataSnapshot(
+                    title: title,
+                    workingDirectory: "/repo/app",
+                    summary: nil,
+                    attention: .idle,
+                    processExited: false,
+                    lastCommandExitCode: nil,
+                    lastUpdatedAt: Date(timeIntervalSince1970: timestamp)
+                ),
+                surfaceState: .placeholder,
+                lastUpdatedAt: Date(timeIntervalSince1970: timestamp)
+            )
+        }
+
+        var projected: [TerminalHostRuntimeSnapshot] = []
+        let first = snapshot(title: "first", timestamp: 1)
+        let second = snapshot(title: "second", timestamp: 2)
+        expect(registry.updateSnapshot(first), "first runtime must require shell projection")
+        registry.publishShellProjection(first) { projected.append($0) }
+        expect(registry.updateSnapshot(second), "changed runtime must require shell projection")
+        registry.publishShellProjection(second) { projected.append($0) }
+
+        expect(projected.isEmpty, "visible-background runtime projection must wait for coalescing")
+        registry.flushShellProjections { projected.append($0) }
+        expect(
+            projected.count == 1 && projected.first?.paneMetadata.title == "second",
+            "registry must publish only the latest background snapshot per terminal content"
+        )
     }
 
     private static func verifiesRuntimeRegistryPreservesInteractiveBehaviorAcrossPaneRemount() {
@@ -9595,7 +9688,7 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
-    private static func verifiesSelectedRuntimeAssignmentIgnoresTimestampOnlyChanges() {
+    private static func verifiesRegistryRuntimeProjectionIgnoresTimestampOnlyChanges() {
         let controller = makeController()
         guard let pane = controller.selectedPane else {
             fail("bootstrap shell must expose a selected pane")
@@ -9644,6 +9737,10 @@ private enum ShellRuntimeMetadataTests {
             changeCount == afterFirst,
             "runtime snapshot identical except for its timestamp must not re-notify "
                 + "shell observers (delta \(changeCount - afterFirst))"
+        )
+        expect(
+            controller.selectedPaneRuntime.lastUpdatedAt == Date(timeIntervalSince1970: 2),
+            "selected runtime must derive the latest registry snapshot even when shell projection is suppressed"
         )
     }
 

--- a/openspec/changes/deepen-macos-shell-host-ownership/tasks.md
+++ b/openspec/changes/deepen-macos-shell-host-ownership/tasks.md
@@ -27,7 +27,7 @@
 - [x] 3.1 Make controller workspace and selection publications derive directly
   from the adopted `ShellStateSnapshot`; remove independently mutable selected
   Space/Tab fields and synchronization logic.
-- [ ] 3.2 Make terminal runtime, active-task, render, and lifecycle publications
+- [x] 3.2 Make terminal runtime, active-task, render, and lifecycle publications
   derive from `TerminalRuntimeRegistry`; remove duplicate controller maps and
   queued projection state.
 - [ ] 3.3 Keep manifest loading and write scheduling in


### PR DESCRIPTION
## Summary
- make `TerminalRuntimeRegistry` the single owner of terminal snapshots, active-task state, and visible-background shell projection buffering
- remove the controller selected-runtime cache, PaneSlot active-task map, and projection queue
- preserve active work across content remounts and clear registry-owned state during runtime release
- add focused behavior and architecture regressions, and complete OpenSpec task 3.2

## Verification
- `just quality`
- `just apple-shell-focused-tests`
- `just shell-core-test`
- `just shell-core-ffi-test`
- `bash clients/apple/scripts/check-shell-contracts.sh`
- `bash clients/apple/scripts/check-architecture-maintainability.sh`
- `openspec validate deepen-macos-shell-host-ownership --type change --strict --json`
- `just install-dev`
- `just apple-shell-ui-smoke` plus manual inspection of tab selection, split input, restart restore, and post-clear relaunch screenshots

Alan stable was not touched.