### PR TITLE
chore(macos): guard shell state ownership

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -573,14 +573,16 @@ mutable retained manifest and the existing transient load, projection, and FFI
 value containers are accepted. The inventory also follows inferred stored
 values back to a repository-wide inventory of manifest-returning helper
 factories by their declaring type and function name, including instance methods
-reached through a singleton accessor. Unqualified, `Self`-qualified,
-concrete-type-qualified, or `Factory.shared` calls are discovered throughout
-the complete initializer expression, including immediately invoked closures
-and nested wrappers. They therefore cannot hide a second retained manifest by
-omitting an explicit property type or moving the factory to another file. The
-FFI-produced manifest values used for default creation, corrupt-file recovery,
-and startup pruning remain explicit transient inventory entries. Controller-side
-manifest use, a second projector, or a second scheduler fails validation.
+reached through a singleton accessor and factories declared on the target type
+with a `Self` return. Unqualified, `Self`-qualified, concrete-type-qualified,
+or `Factory.shared` calls are discovered throughout the complete initializer
+expression, including direct target constructors, `.init`, immediately invoked
+closures, and nested wrappers. They therefore cannot hide a second retained
+manifest by omitting an explicit property type or moving the factory to another
+file. The FFI-produced manifest values used for default creation, corrupt-file
+recovery, and startup pruning remain explicit transient inventory entries.
+Controller-side manifest use, a second projector, or a second scheduler fails
+validation.
 
 The same gate rejects a replacement global Shell store. `ShellHostController`
 remains the only observable owner of a mutable `ShellStateSnapshot`; the two

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -584,7 +584,9 @@ recovery, and startup pruning remain explicit transient inventory entries. Each
 accepted manifest declaration is keyed by its file and declaring type and must
 appear exactly once, so a second owner cannot reuse another declaration's shape.
 Controller-side manifest use, a second projector, or a second scheduler fails
-validation.
+validation. Those code-ownership scans lex line and nested block comments out
+before matching, so architectural documentation in Swift comments remains valid
+without weakening executable-source enforcement.
 
 The same gate rejects a replacement global Shell store. `ShellHostController`
 remains the only observable owner of a mutable `ShellStateSnapshot`; the two

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -570,8 +570,10 @@ context, debounce state, scheduling, and manifest projection behind
 state and cadence markers to have that single owner. All production Swift files
 participate in an explicit manifest-storage inventory: only the coordinator's
 mutable retained manifest and the existing transient load, projection, and FFI
-value containers are accepted. Controller-side manifest use, a second
-projector, or a second scheduler fails validation.
+value containers are accepted. The inventory also follows inferred stored
+values back to manifest-returning helper factories, so omitting an explicit
+property type cannot hide a second retained manifest. Controller-side manifest
+use, a second projector, or a second scheduler fails validation.
 
 The same gate rejects a replacement global Shell store. `ShellHostController`
 remains the only observable owner of a mutable `ShellStateSnapshot`; the two
@@ -579,10 +581,14 @@ accepted transport cache files have fixed non-growing ownership ceilings, and
 all other mutable snapshot storage is rejected. No static stored snapshot is
 allowed under any property name. Files with accepted mutable snapshot storage
 also have an exact allowlist of non-owner static utility members, so a singleton
-entry point cannot bypass the rule by choosing a new alias. The current
-`ObservableObject` declarations and `@Published` projections form explicit
-owner allowlists, new `@Observable` owners require an architecture decision,
-and no singleton or catch-all `ShellStore` / `ShellModel` may wrap shell state.
+entry point cannot bypass the rule by choosing a new alias. Independently, every
+production Swift file is scanned for static/class storage of
+`ShellHostController`, including storage inferred from a local helper factory;
+that prevents a global controller singleton even when the file stores no
+snapshot directly. The current `ObservableObject` declarations and `@Published`
+projections form explicit owner allowlists, new `@Observable` owners require an
+architecture decision, and no singleton or catch-all `ShellStore` / `ShellModel`
+may wrap shell state.
 
 The current architecture gate treats
 `clients/apple/scripts/architecture-warning-baseline.txt` as a hard downward

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -580,7 +580,10 @@ factories declared on the target type with a `Self` return. Unqualified,
 expression, including direct target constructors, `.init`, immediately invoked
 closures, nested call arguments, and nested wrappers. They therefore cannot
 hide a second retained manifest by omitting an explicit property type or moving
-the factory to another file. The FFI-produced manifest values used for default
+the factory to another file. Factory return parsing starts only after the
+function's complete parameter list, so a closure parameter returning the target
+type does not turn a `Void` installer into a factory. The FFI-produced manifest
+values used for default
 creation, corrupt-file recovery, and startup pruning remain explicit transient
 inventory entries. Each
 accepted manifest declaration is keyed by its file and declaring type and must

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -572,11 +572,14 @@ participate in an explicit manifest-storage inventory: only the coordinator's
 mutable retained manifest and the existing transient load, projection, and FFI
 value containers are accepted. The inventory also follows inferred stored
 values back to a repository-wide inventory of manifest-returning helper
-factories by their declaring type and function name, so unqualified,
-`Self`-qualified, or concrete-type-qualified calls cannot hide a second retained
-manifest by omitting an explicit property type or moving the factory to another
-file. Controller-side manifest use, a second projector, or a second scheduler
-fails validation.
+factories by their declaring type and function name, including instance methods
+reached through a singleton accessor. Unqualified, `Self`-qualified,
+concrete-type-qualified, or `Factory.shared` calls therefore cannot hide a
+second retained manifest by omitting an explicit property type or moving the
+factory to another file. The FFI-produced manifest values used for default
+creation, corrupt-file recovery, and startup pruning remain explicit transient
+inventory entries. Controller-side manifest use, a second projector, or a
+second scheduler fails validation.
 
 The same gate rejects a replacement global Shell store. `ShellHostController`
 remains the only observable owner of a mutable `ShellStateSnapshot`; the two
@@ -587,11 +590,12 @@ also have an exact allowlist of non-owner static utility members, so a singleton
 entry point cannot bypass the rule by choosing a new alias. Independently, every
 production Swift file is scanned for static/class storage of
 `ShellHostController`, including storage inferred from an unqualified, `Self`,
-or concrete helper-factory owner; the same repository-wide, owner-qualified
-factory matching applies to snapshot storage. All production Swift files are
-scanned even when the stored property's source file contains no literal target
-type. That prevents a global controller singleton even when the file stores no
-snapshot directly. The current `ObservableObject` declarations and `@Published`
+concrete helper-factory, or singleton-instance factory owner; the same
+repository-wide, owner-qualified factory matching applies to snapshot storage.
+All production Swift files are scanned even when the stored property's source
+file contains no literal target type. That prevents a global controller
+singleton even when the file stores no snapshot directly. The current
+`ObservableObject` declarations and `@Published`
 projections form explicit owner allowlists, new `@Observable` owners require an
 architecture decision, and no catch-all type ending in `ShellStore`,
 `ShellStateStore`, `ShellWorkspaceStore`, or the corresponding `Model` form may

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -571,10 +571,11 @@ state and cadence markers to have that single owner. All production Swift files
 participate in an explicit manifest-storage inventory: only the coordinator's
 mutable retained manifest and the existing transient load, projection, and FFI
 value containers are accepted. The inventory also follows inferred stored
-values back to manifest-returning helper factories by their declaring type and
-function name, so unqualified, `Self`-qualified, or concrete-type-qualified
-calls cannot hide a second retained manifest by omitting an explicit property
-type. Controller-side manifest use, a second projector, or a second scheduler
+values back to a repository-wide inventory of manifest-returning helper
+factories by their declaring type and function name, so unqualified,
+`Self`-qualified, or concrete-type-qualified calls cannot hide a second retained
+manifest by omitting an explicit property type or moving the factory to another
+file. Controller-side manifest use, a second projector, or a second scheduler
 fails validation.
 
 The same gate rejects a replacement global Shell store. `ShellHostController`
@@ -586,12 +587,14 @@ also have an exact allowlist of non-owner static utility members, so a singleton
 entry point cannot bypass the rule by choosing a new alias. Independently, every
 production Swift file is scanned for static/class storage of
 `ShellHostController`, including storage inferred from an unqualified, `Self`,
-or concrete helper-factory owner; the same owner-qualified factory matching
-applies to snapshot storage. That prevents a global controller singleton even
-when the file stores no snapshot directly. The current `ObservableObject`
-declarations and `@Published` projections form explicit owner allowlists, new
-`@Observable` owners require an architecture decision, and no singleton or
-catch-all `ShellStore` / `ShellModel` may wrap shell state.
+or concrete helper-factory owner; the same repository-wide, owner-qualified
+factory matching applies to snapshot storage. All production Swift files are
+scanned even when the stored property's source file contains no literal target
+type. That prevents a global controller singleton even when the file stores no
+snapshot directly. The current `ObservableObject` declarations and `@Published`
+projections form explicit owner allowlists, new `@Observable` owners require an
+architecture decision, and no singleton or catch-all `ShellStore` / `ShellModel`
+may wrap shell state.
 
 The current architecture gate treats
 `clients/apple/scripts/architecture-warning-baseline.txt` as a hard downward

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -567,16 +567,22 @@ reintroduced controller caches, maps, queues, and publication-policy call sites.
 The persistence ownership slice moves the retained manifest, latest persistence
 context, debounce state, scheduling, and manifest projection behind
 `ShellWorkspacePersistenceCoordinator`. The architecture gate requires those
-state and cadence markers to have that single owner and rejects controller-side
-use of the `ShellContentWorkspaceManifest` type, manifest projection, or a
-second scheduler. It also rejects a replacement global Shell store:
-`ShellHostController` remains the only observable owner of a mutable
-`ShellStateSnapshot`; no static stored snapshot is allowed under any property
-name, and no singleton or catch-all `ShellStore` / `ShellModel` may wrap it. The
-current `ObservableObject` declarations and `@Published` projections form
-explicit owner allowlists, new `@Observable` owners require an architecture
-decision, and snapshot-referencing files cannot hide inferred state behind
-`shared`, `current`, or `default`.
+state and cadence markers to have that single owner. All production Swift files
+participate in an explicit manifest-storage inventory: only the coordinator's
+mutable retained manifest and the existing transient load, projection, and FFI
+value containers are accepted. Controller-side manifest use, a second
+projector, or a second scheduler fails validation.
+
+The same gate rejects a replacement global Shell store. `ShellHostController`
+remains the only observable owner of a mutable `ShellStateSnapshot`; the two
+accepted transport cache files have fixed non-growing ownership ceilings, and
+all other mutable snapshot storage is rejected. No static stored snapshot is
+allowed under any property name. Files with accepted mutable snapshot storage
+also have an exact allowlist of non-owner static utility members, so a singleton
+entry point cannot bypass the rule by choosing a new alias. The current
+`ObservableObject` declarations and `@Published` projections form explicit
+owner allowlists, new `@Observable` owners require an architecture decision,
+and no singleton or catch-all `ShellStore` / `ShellModel` may wrap shell state.
 
 The current architecture gate treats
 `clients/apple/scripts/architecture-warning-baseline.txt` as a hard downward

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -593,8 +593,10 @@ scanned even when the stored property's source file contains no literal target
 type. That prevents a global controller singleton even when the file stores no
 snapshot directly. The current `ObservableObject` declarations and `@Published`
 projections form explicit owner allowlists, new `@Observable` owners require an
-architecture decision, and no singleton or catch-all `ShellStore` / `ShellModel`
-may wrap shell state.
+architecture decision, and no catch-all type ending in `ShellStore`,
+`ShellStateStore`, `ShellWorkspaceStore`, or the corresponding `Model` form may
+wrap shell state, regardless of a product or platform prefix. Focused names such
+as `AlanShellEventStore` remain distinct from those global-wrapper forms.
 
 The current architecture gate treats
 `clients/apple/scripts/architecture-warning-baseline.txt` as a hard downward

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -584,9 +584,10 @@ recovery, and startup pruning remain explicit transient inventory entries. Each
 accepted manifest declaration is keyed by its file and declaring type and must
 appear exactly once, so a second owner cannot reuse another declaration's shape.
 Controller-side manifest use, a second projector, or a second scheduler fails
-validation. Those code-ownership scans lex line and nested block comments out
-before matching, so architectural documentation in Swift comments remains valid
-without weakening executable-source enforcement.
+validation. Those code-ownership scans lex line comments, nested block comments,
+and string-literal prose out before matching while preserving executable string
+interpolations. Architectural documentation and example text therefore remain
+valid without weakening executable-source enforcement.
 
 The same gate rejects a replacement global Shell store. `ShellHostController`
 remains the only observable owner of a mutable `ShellStateSnapshot`; the two

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -611,7 +611,10 @@ accepted mutable snapshot storage
 also have an exact allowlist of non-owner static utility members, so a singleton
 entry point cannot bypass the rule by choosing a new alias. Postfix-optional
 `.none` and `.some` type witnesses are treated as inferred target storage rather
-than harmless empty initializers.
+than harmless empty initializers. Property-wrapper attributes, including
+multiline initializer argument lists, are folded into their declarations and
+scanned with the same constructor, factory, projection, generic, and optional
+type-witness rules for snapshot and manifest storage.
 Independently, every production Swift file is scanned for module-scope or
 static/class storage of
 `ShellHostController`, including storage inferred from an unqualified, `Self`,

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -564,6 +564,15 @@ content identity, and clears that state during lifecycle release. Render
 priority effects continue through the registry. The architecture gate rejects
 reintroduced controller caches, maps, queues, and publication-policy call sites.
 
+The persistence ownership slice moves the retained manifest, latest persistence
+context, debounce state, scheduling, and manifest projection behind
+`ShellWorkspacePersistenceCoordinator`. The architecture gate requires those
+state and cadence markers to have that single owner and rejects controller-side
+manifest projection or a second scheduler. It also rejects a replacement global
+Shell store: `ShellHostController` remains the only observable owner of a
+mutable `ShellStateSnapshot`, and that snapshot cannot be placed behind a
+singleton or a new catch-all `ShellStore` / `ShellModel` type.
+
 The current architecture gate treats
 `clients/apple/scripts/architecture-warning-baseline.txt` as a hard downward
 ratchet. The report must exactly match its structured warning inventory, and

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -580,7 +580,9 @@ expression, including direct target constructors, `.init`, immediately invoked
 closures, and nested wrappers. They therefore cannot hide a second retained
 manifest by omitting an explicit property type or moving the factory to another
 file. The FFI-produced manifest values used for default creation, corrupt-file
-recovery, and startup pruning remain explicit transient inventory entries.
+recovery, and startup pruning remain explicit transient inventory entries. Each
+accepted manifest declaration is keyed by its file and declaring type and must
+appear exactly once, so a second owner cannot reuse another declaration's shape.
 Controller-side manifest use, a second projector, or a second scheduler fails
 validation.
 

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -571,11 +571,12 @@ state and cadence markers to have that single owner and rejects controller-side
 use of the `ShellContentWorkspaceManifest` type, manifest projection, or a
 second scheduler. It also rejects a replacement global Shell store:
 `ShellHostController` remains the only observable owner of a mutable
-`ShellStateSnapshot`, and that snapshot cannot be placed behind a singleton or
-a new catch-all `ShellStore` / `ShellModel` type. The current `ObservableObject`
-declarations and `@Published` projections form explicit owner allowlists, new
-`@Observable` owners require an architecture decision, and snapshot-referencing
-files cannot hide inferred state behind `shared`, `current`, or `default`.
+`ShellStateSnapshot`; no static stored snapshot is allowed under any property
+name, and no singleton or catch-all `ShellStore` / `ShellModel` may wrap it. The
+current `ObservableObject` declarations and `@Published` projections form
+explicit owner allowlists, new `@Observable` owners require an architecture
+decision, and snapshot-referencing files cannot hide inferred state behind
+`shared`, `current`, or `default`.
 
 The current architecture gate treats
 `clients/apple/scripts/architecture-warning-baseline.txt` as a hard downward

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -614,10 +614,14 @@ static/class storage of
 `ShellHostController`, including storage inferred from an unqualified, `Self`,
 concrete helper-factory, or singleton-instance factory owner; the same
 repository-wide, owner-qualified, full-initializer factory matching applies to
-snapshot storage. All production Swift files are scanned even when the stored
-property's source file contains no literal target type. That prevents a global
-controller singleton even when a closure or wrapper hides the factory call and
-the file stores no snapshot directly. Production aliases that reference
+snapshot storage. Explicit snapshot-valued properties also form a projection
+inventory, so inferred storage through member access is counted even when its
+initializer contains no snapshot constructor or factory. Storage classification
+stops before computed-property bodies, so ordinary projection reads in getters
+do not become owners. All production Swift files are scanned even when the
+stored property's source file contains no literal target type. That prevents a
+global controller singleton even when a closure or wrapper hides the factory
+call and the file stores no snapshot directly. Production aliases that reference
 `ShellHostController`, `ShellStateSnapshot`, or
 `ShellContentWorkspaceManifest` are rejected, keeping contextual factory calls
 such as `.live()` from hiding a guarded ownership type. The current `ObservableObject`

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -617,7 +617,10 @@ repository-wide, owner-qualified, full-initializer factory matching applies to
 snapshot storage. All production Swift files are scanned even when the stored
 property's source file contains no literal target type. That prevents a global
 controller singleton even when a closure or wrapper hides the factory call and
-the file stores no snapshot directly. The current `ObservableObject`
+the file stores no snapshot directly. Production aliases that reference
+`ShellHostController`, `ShellStateSnapshot`, or
+`ShellContentWorkspaceManifest` are rejected, keeping contextual factory calls
+such as `.live()` from hiding a guarded ownership type. The current `ObservableObject`
 declarations and `@Published`
 projections form explicit owner allowlists, new `@Observable` owners require an
 architecture decision, and no catch-all type ending in `ShellStore`,

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -574,12 +574,13 @@ value containers are accepted. The inventory also follows inferred stored
 values back to a repository-wide inventory of manifest-returning helper
 factories by their declaring type and function name, including instance methods
 reached through a singleton accessor. Unqualified, `Self`-qualified,
-concrete-type-qualified, or `Factory.shared` calls therefore cannot hide a
-second retained manifest by omitting an explicit property type or moving the
-factory to another file. The FFI-produced manifest values used for default
-creation, corrupt-file recovery, and startup pruning remain explicit transient
-inventory entries. Controller-side manifest use, a second projector, or a
-second scheduler fails validation.
+concrete-type-qualified, or `Factory.shared` calls are discovered throughout
+the complete initializer expression, including immediately invoked closures
+and nested wrappers. They therefore cannot hide a second retained manifest by
+omitting an explicit property type or moving the factory to another file. The
+FFI-produced manifest values used for default creation, corrupt-file recovery,
+and startup pruning remain explicit transient inventory entries. Controller-side
+manifest use, a second projector, or a second scheduler fails validation.
 
 The same gate rejects a replacement global Shell store. `ShellHostController`
 remains the only observable owner of a mutable `ShellStateSnapshot`; the two
@@ -591,11 +592,12 @@ entry point cannot bypass the rule by choosing a new alias. Independently, every
 production Swift file is scanned for static/class storage of
 `ShellHostController`, including storage inferred from an unqualified, `Self`,
 concrete helper-factory, or singleton-instance factory owner; the same
-repository-wide, owner-qualified factory matching applies to snapshot storage.
-All production Swift files are scanned even when the stored property's source
-file contains no literal target type. That prevents a global controller
-singleton even when the file stores no snapshot directly. The current
-`ObservableObject` declarations and `@Published`
+repository-wide, owner-qualified, full-initializer factory matching applies to
+snapshot storage. All production Swift files are scanned even when the stored
+property's source file contains no literal target type. That prevents a global
+controller singleton even when a closure or wrapper hides the factory call and
+the file stores no snapshot directly. The current `ObservableObject`
+declarations and `@Published`
 projections form explicit owner allowlists, new `@Observable` owners require an
 architecture decision, and no catch-all type ending in `ShellStore`,
 `ShellStateStore`, `ShellWorkspaceStore`, or the corresponding `Model` form may

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -609,7 +609,9 @@ later snapshot owner. Swift's trailing shared type annotation is propagated to
 each preceding uninitialized binding before owners are counted. Files with
 accepted mutable snapshot storage
 also have an exact allowlist of non-owner static utility members, so a singleton
-entry point cannot bypass the rule by choosing a new alias.
+entry point cannot bypass the rule by choosing a new alias. Postfix-optional
+`.none` and `.some` type witnesses are treated as inferred target storage rather
+than harmless empty initializers.
 Independently, every production Swift file is scanned for module-scope or
 static/class storage of
 `ShellHostController`, including storage inferred from an unqualified, `Self`,

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -573,14 +573,16 @@ mutable retained manifest and the existing transient load, projection, and FFI
 value containers are accepted. The inventory also follows inferred stored
 values back to a repository-wide inventory of manifest-returning helper
 factories by their declaring type and function name, including instance methods
-reached through a singleton accessor and factories declared on the target type
-with a `Self` return. Unqualified, `Self`-qualified, concrete-type-qualified,
-or `Factory.shared` calls are discovered throughout the complete initializer
+reached through a singleton accessor or a freshly constructed helper, and
+factories declared on the target type with a `Self` return. Unqualified,
+`Self`-qualified, concrete-type-qualified, `Factory.shared`, or
+`Factory().make()` calls are discovered throughout the complete initializer
 expression, including direct target constructors, `.init`, immediately invoked
-closures, and nested wrappers. They therefore cannot hide a second retained
-manifest by omitting an explicit property type or moving the factory to another
-file. The FFI-produced manifest values used for default creation, corrupt-file
-recovery, and startup pruning remain explicit transient inventory entries. Each
+closures, nested call arguments, and nested wrappers. They therefore cannot
+hide a second retained manifest by omitting an explicit property type or moving
+the factory to another file. The FFI-produced manifest values used for default
+creation, corrupt-file recovery, and startup pruning remain explicit transient
+inventory entries. Each
 accepted manifest declaration is keyed by its file and declaring type and must
 appear exactly once, so a second owner cannot reuse another declaration's shape.
 Controller-side manifest use, a second projector, or a second scheduler fails

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -587,11 +587,12 @@ validation.
 The same gate rejects a replacement global Shell store. `ShellHostController`
 remains the only observable owner of a mutable `ShellStateSnapshot`; the two
 accepted transport cache files have fixed non-growing ownership ceilings, and
-all other mutable snapshot storage is rejected. No static stored snapshot is
-allowed under any property name. Files with accepted mutable snapshot storage
-also have an exact allowlist of non-owner static utility members, so a singleton
-entry point cannot bypass the rule by choosing a new alias. Independently, every
-production Swift file is scanned for static/class storage of
+all other mutable snapshot storage is rejected. No module-scope, static, or
+class stored snapshot is allowed under any property name. Files with accepted
+mutable snapshot storage also have an exact allowlist of non-owner static utility
+members, so a singleton entry point cannot bypass the rule by choosing a new alias.
+Independently, every production Swift file is scanned for module-scope or
+static/class storage of
 `ShellHostController`, including storage inferred from an unqualified, `Self`,
 concrete helper-factory, or singleton-instance factory owner; the same
 repository-wide, owner-qualified, full-initializer factory matching applies to

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -595,9 +595,12 @@ The same gate rejects a replacement global Shell store. `ShellHostController`
 remains the only observable owner of a mutable `ShellStateSnapshot`; the two
 accepted transport cache files have fixed non-growing ownership ceilings, and
 all other mutable snapshot storage is rejected. No module-scope, static, or
-class stored snapshot is allowed under any property name. Files with accepted
-mutable snapshot storage also have an exact allowlist of non-owner static utility
-members, so a singleton entry point cannot bypass the rule by choosing a new alias.
+class stored snapshot is allowed under any property name. Module scope follows
+executable brace depth rather than source indentation, so formatting inside a
+conditional-compilation block cannot hide global state while function-local
+scratch values remain excluded. Files with accepted mutable snapshot storage
+also have an exact allowlist of non-owner static utility members, so a singleton
+entry point cannot bypass the rule by choosing a new alias.
 Independently, every production Swift file is scanned for module-scope or
 static/class storage of
 `ShellHostController`, including storage inferred from an unqualified, `Self`,

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -591,8 +591,9 @@ appear exactly once, so a second owner cannot reuse another declaration's shape.
 Controller-side manifest use, a second projector, or a second scheduler fails
 validation. Those code-ownership scans lex line comments, nested block comments,
 and string-literal prose out before matching while preserving executable string
-interpolations. Architectural documentation and example text therefore remain
-valid without weakening executable-source enforcement.
+interpolations, and normalize backtick-escaped Swift identifiers. Architectural
+documentation and example text therefore remain valid without weakening
+executable-source enforcement.
 
 The same gate rejects a replacement global Shell store. `ShellHostController`
 remains the only observable owner of a mutable `ShellStateSnapshot`; the two
@@ -618,10 +619,12 @@ snapshot storage. Explicit snapshot-valued properties also form a projection
 inventory, so inferred storage through member access is counted even when its
 initializer contains no snapshot constructor or factory. Storage classification
 stops before computed-property bodies, so ordinary projection reads in getters
-do not become owners. All production Swift files are scanned even when the
-stored property's source file contains no literal target type. That prevents a
-global controller singleton even when a closure or wrapper hides the factory
-call and the file stores no snapshot directly. Production aliases that reference
+do not become owners. An unrelated projection with the same member name can use
+an explicit non-snapshot type to disambiguate its stored value. All production
+Swift files are scanned even when the stored property's source file contains no
+literal target type. That prevents a global controller singleton even when a
+closure or wrapper hides the factory call and the file stores no snapshot
+directly. Production aliases that reference
 `ShellHostController`, `ShellStateSnapshot`, or
 `ShellContentWorkspaceManifest` are rejected, keeping contextual factory calls
 such as `.live()` from hiding a guarded ownership type. The current `ObservableObject`

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -571,7 +571,10 @@ state and cadence markers to have that single owner and rejects controller-side
 manifest projection or a second scheduler. It also rejects a replacement global
 Shell store: `ShellHostController` remains the only observable owner of a
 mutable `ShellStateSnapshot`, and that snapshot cannot be placed behind a
-singleton or a new catch-all `ShellStore` / `ShellModel` type.
+singleton or a new catch-all `ShellStore` / `ShellModel` type. The current
+`ObservableObject` declarations form an explicit owner allowlist, new
+`@Observable` owners require an architecture decision, and snapshot-referencing
+files cannot hide inferred state behind `shared`, `current`, or `default`.
 
 The current architecture gate treats
 `clients/apple/scripts/architecture-warning-baseline.txt` as a hard downward

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -601,7 +601,9 @@ conditional-compilation block cannot hide global state while function-local
 scratch values remain excluded. Comma-separated property bindings are inspected
 individually, while commas nested inside generic types, collections, calls, or
 closures remain part of their binding, so a harmless first binding cannot hide a
-later snapshot owner. Files with accepted mutable snapshot storage
+later snapshot owner. Swift's trailing shared type annotation is propagated to
+each preceding uninitialized binding before owners are counted. Files with
+accepted mutable snapshot storage
 also have an exact allowlist of non-owner static utility members, so a singleton
 entry point cannot bypass the rule by choosing a new alias.
 Independently, every production Swift file is scanned for module-scope or

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -571,9 +571,11 @@ state and cadence markers to have that single owner. All production Swift files
 participate in an explicit manifest-storage inventory: only the coordinator's
 mutable retained manifest and the existing transient load, projection, and FFI
 value containers are accepted. The inventory also follows inferred stored
-values back to manifest-returning helper factories, so omitting an explicit
-property type cannot hide a second retained manifest. Controller-side manifest
-use, a second projector, or a second scheduler fails validation.
+values back to manifest-returning helper factories by their declaring type and
+function name, so unqualified, `Self`-qualified, or concrete-type-qualified
+calls cannot hide a second retained manifest by omitting an explicit property
+type. Controller-side manifest use, a second projector, or a second scheduler
+fails validation.
 
 The same gate rejects a replacement global Shell store. `ShellHostController`
 remains the only observable owner of a mutable `ShellStateSnapshot`; the two
@@ -583,12 +585,13 @@ allowed under any property name. Files with accepted mutable snapshot storage
 also have an exact allowlist of non-owner static utility members, so a singleton
 entry point cannot bypass the rule by choosing a new alias. Independently, every
 production Swift file is scanned for static/class storage of
-`ShellHostController`, including storage inferred from a local helper factory;
-that prevents a global controller singleton even when the file stores no
-snapshot directly. The current `ObservableObject` declarations and `@Published`
-projections form explicit owner allowlists, new `@Observable` owners require an
-architecture decision, and no singleton or catch-all `ShellStore` / `ShellModel`
-may wrap shell state.
+`ShellHostController`, including storage inferred from an unqualified, `Self`,
+or concrete helper-factory owner; the same owner-qualified factory matching
+applies to snapshot storage. That prevents a global controller singleton even
+when the file stores no snapshot directly. The current `ObservableObject`
+declarations and `@Published` projections form explicit owner allowlists, new
+`@Observable` owners require an architecture decision, and no singleton or
+catch-all `ShellStore` / `ShellModel` may wrap shell state.
 
 The current architecture gate treats
 `clients/apple/scripts/architecture-warning-baseline.txt` as a hard downward

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -568,11 +568,12 @@ The persistence ownership slice moves the retained manifest, latest persistence
 context, debounce state, scheduling, and manifest projection behind
 `ShellWorkspacePersistenceCoordinator`. The architecture gate requires those
 state and cadence markers to have that single owner and rejects controller-side
-manifest projection or a second scheduler. It also rejects a replacement global
-Shell store: `ShellHostController` remains the only observable owner of a
-mutable `ShellStateSnapshot`, and that snapshot cannot be placed behind a
-singleton or a new catch-all `ShellStore` / `ShellModel` type. The current
-`ObservableObject` declarations form an explicit owner allowlist, new
+use of the `ShellContentWorkspaceManifest` type, manifest projection, or a
+second scheduler. It also rejects a replacement global Shell store:
+`ShellHostController` remains the only observable owner of a mutable
+`ShellStateSnapshot`, and that snapshot cannot be placed behind a singleton or
+a new catch-all `ShellStore` / `ShellModel` type. The current `ObservableObject`
+declarations and `@Published` projections form explicit owner allowlists, new
 `@Observable` owners require an architecture decision, and snapshot-referencing
 files cannot hide inferred state behind `shared`, `current`, or `default`.
 

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -598,7 +598,10 @@ all other mutable snapshot storage is rejected. No module-scope, static, or
 class stored snapshot is allowed under any property name. Module scope follows
 executable brace depth rather than source indentation, so formatting inside a
 conditional-compilation block cannot hide global state while function-local
-scratch values remain excluded. Files with accepted mutable snapshot storage
+scratch values remain excluded. Comma-separated property bindings are inspected
+individually, while commas nested inside generic types, collections, calls, or
+closures remain part of their binding, so a harmless first binding cannot hide a
+later snapshot owner. Files with accepted mutable snapshot storage
 also have an exact allowlist of non-owner static utility members, so a singleton
 entry point cannot bypass the rule by choosing a new alias.
 Independently, every production Swift file is scanned for module-scope or

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -358,8 +358,4 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         return controller
     }
 }
-
-extension ShellHostController {
-    static let spikePreview = ShellHostController(shellState: .bootstrapDefault())
-}
 #endif

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -602,10 +602,22 @@ reject_shell_host_duplicate_persistence_state() {
 mutable_shell_snapshot_declaration_count() {
     local file="$1"
 
-    grep -Ec \
-        -e 'var[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*:[[:space:]]*ShellStateSnapshot[?]?' \
-        -e 'var[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=[[:space:]]*ShellStateSnapshot([.(]|$)' \
-        "$file" || true
+    awk '
+        {
+            source = source " " $0
+        }
+        END {
+            gsub(/[[:space:]]+/, " ", source)
+            pattern = "var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*" \
+                "(:[ ]*ShellStateSnapshot[?]?|=[ ]*ShellStateSnapshot([.(]|$))"
+            count = 0
+            while (match(source, pattern)) {
+                count++
+                source = substr(source, RSTART + RLENGTH)
+            }
+            print count
+        }
+    ' "$file"
 }
 
 reject_replacement_global_shell_store() {

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -693,6 +693,10 @@ shell_snapshot_stored_property_counts() {
             return value ~ /^[[:space:]]*[^\/]*func[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*\(/ ||
                 is_static_property_start(value)
         }
+        function is_same_indent_function_signature_continuation(value) {
+            return value ~ /^[[:space:]]*(\)|->|[{])/ ||
+                value ~ /^[[:space:]]*(async|throws|rethrows|where)([^A-Za-z0-9_]|$)/
+        }
         function record_buffered_factory(    name, signature, header) {
             if (factory_buffer == "") {
                 return
@@ -717,6 +721,7 @@ shell_snapshot_stored_property_counts() {
                 snapshot_factories[name] = 1
             }
             factory_buffer = ""
+            factory_is_function = 0
         }
         function uses_snapshot_factory(property,    expression, name) {
             if (property !~ /=/) {
@@ -772,8 +777,13 @@ shell_snapshot_stored_property_counts() {
                 record_buffered_factory()
                 factory_buffer = line
                 factory_indent = leading_space_count(line)
+                factory_is_function = line ~ /(^|[ ])func[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*\(/
             } else if (factory_buffer != "" &&
-                (line ~ /^[[:space:]]*$/ || leading_space_count(line) > factory_indent))
+                (line ~ /^[[:space:]]*$/ ||
+                    leading_space_count(line) > factory_indent ||
+                    (factory_is_function &&
+                        leading_space_count(line) == factory_indent &&
+                        is_same_indent_function_signature_continuation(line))))
             {
                 factory_buffer = factory_buffer " " line
             } else {

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -872,6 +872,21 @@ shell_snapshot_stored_property_counts() {
             return expression ~ /^[A-Za-z_][A-Za-z0-9_.]*[ ]*<[^>]*ShellStateSnapshot/ ||
                 expression ~ /^\[[^]]*ShellStateSnapshot/
         }
+        function typed_storage_contains_snapshot(property,    type) {
+            if (property !~ /:/) {
+                return 0
+            }
+            if (property !~ /=/ &&
+                property ~ /[{]/ &&
+                property !~ /[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/)
+            {
+                return 0
+            }
+            type = property
+            sub(/^[^:]*:[ ]*/, "", type)
+            sub(/[=].*$/, "", type)
+            return type ~ /ShellStateSnapshot([^A-Za-z0-9_]|$)/ && type !~ /->/
+        }
         function count_buffered_instance_property(    property) {
             if (instance_buffer == "") {
                 return
@@ -879,7 +894,8 @@ shell_snapshot_stored_property_counts() {
             property = instance_buffer
             gsub(/[[:space:]]+/, " ", property)
             if (property !~ /(^| )(static|class)[ ]/ &&
-                (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*($|=)/ ||
+                ((property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:/ &&
+                    typed_storage_contains_snapshot(property)) ||
                 property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/ ||
                 property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
                 (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ &&
@@ -896,7 +912,8 @@ shell_snapshot_stored_property_counts() {
             }
             property = static_buffer
             gsub(/[[:space:]]+/, " ", property)
-            if (property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*($|=)/ ||
+            if ((property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:/ &&
+                    typed_storage_contains_snapshot(property)) ||
                 property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/ ||
                 property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
                 (property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ &&

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -316,6 +316,10 @@ swift_code_lines() {
                     column++
                     continue
                 }
+                if (character == "`") {
+                    column++
+                    continue
+                }
 
                 if (interpolation_depth > 0 && character == "(") {
                     interpolation_depth++
@@ -1850,11 +1854,16 @@ shell_snapshot_stored_property_counts() {
             return value !~ /[{]/ ||
                 value ~ /[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/
         }
+        function binding_has_explicit_type(binding,    type) {
+            type = binding_type_annotation(binding)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", type)
+            return type != ""
+        }
         function snapshot_binding_contains_storage(binding, owner) {
             return typed_storage_contains_snapshot(binding) ||
                 binding ~ /=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
                 inferred_generic_contains_snapshot(binding) ||
-                uses_snapshot_projection(binding) ||
+                (!binding_has_explicit_type(binding) && uses_snapshot_projection(binding)) ||
                 uses_snapshot_factory(binding, owner)
         }
         function snapshot_storage_count(property, owner,    binding_count, binding_end, binding_index, bindings, binding_start, count, effective_binding, explicit_type, inherited_types, shared_type) {

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -1444,7 +1444,7 @@ reject_replacement_global_shell_store() {
     done < <(grep -RInH --include='*.swift' -F '@Published' "$SOURCE_ROOT" || true)
 
     if grep -RIn --include='*.swift' -E \
-        '(class|struct|actor|enum)[[:space:]]+((Alan|Global)Shell|Shell)(State|Workspace)?(Store|Model)([^A-Za-z0-9_]|$)' \
+        '(class|struct|actor|enum)[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)?Shell(State|Workspace)?(Store|Model)([^A-Za-z0-9_]|$)' \
         "$SOURCE_ROOT" >&2
     then
         fail \

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -679,7 +679,7 @@ reject_replacement_global_shell_store() {
     done < <(grep -RIl --include='*.swift' -F "ShellStateSnapshot" "$SOURCE_ROOT" || true)
 
     if grep -RIn --include='*.swift' -E \
-        '(class|struct|actor)[[:space:]]+((Alan|Global)Shell|Shell)(State|Workspace)?(Store|Model)([^A-Za-z0-9_]|$)' \
+        '(class|struct|actor|enum)[[:space:]]+((Alan|Global)Shell|Shell)(State|Workspace)?(Store|Model)([^A-Za-z0-9_]|$)' \
         "$SOURCE_ROOT" >&2
     then
         fail \

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -546,7 +546,7 @@ typed_factory_declarations() {
     local file="$1"
     local target_type="$2"
 
-    awk -v target_type="$target_type" '
+    awk -v target_type="$target_type" "$OWNERSHIP_AWK_HELPERS"'
         function leading_space_count(value,    prefix) {
             prefix = value
             sub(/[^ ].*$/, "", prefix)
@@ -563,26 +563,50 @@ typed_factory_declarations() {
             return name
         }
         function is_factory_candidate(value) {
-            return value ~ /^[[:space:]]*[^\/]*func[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*\(/
+            return value ~ /^[[:space:]]*[^\/]*func[ ]+[A-Za-z_][A-Za-z0-9_]*/
         }
         function is_same_indent_function_signature_continuation(value) {
-            return value ~ /^[[:space:]]*(\)|->|[{])/ ||
+            return value ~ /^[[:space:]]*(\(|\)|<|>|->|[{])/ ||
                 value ~ /^[[:space:]]*(async|throws|rethrows|where)([^A-Za-z0-9_]|$)/
         }
-        function record_buffered_factory(    header, name, return_type, signature) {
+        function declared_function_return_type(signature,    arrow, body, closing, function_tail, opening, where_clause) {
+            function_tail = signature
+            sub(/^.*func[ ]+[A-Za-z_][A-Za-z0-9_]*/, "", function_tail)
+            opening = index(function_tail, "(")
+            if (opening == 0) {
+                return ""
+            }
+            opening += length(signature) - length(function_tail)
+            closing = matching_call_end(signature, opening)
+            if (closing == 0) {
+                return ""
+            }
+            function_tail = substr(signature, closing + 1)
+            body = top_level_character_position(function_tail, "{")
+            if (body > 0) {
+                function_tail = substr(function_tail, 1, body - 1)
+            }
+            where_clause = match(function_tail, /[ ]where([ ]|$)/)
+            if (where_clause > 0) {
+                function_tail = substr(function_tail, 1, where_clause - 1)
+            }
+            arrow = index(function_tail, "->")
+            if (arrow == 0) {
+                return ""
+            }
+            return substr(function_tail, arrow + 2)
+        }
+        function record_buffered_factory(    name, return_type, signature) {
             if (factory_buffer == "") {
                 return
             }
             signature = factory_buffer
             gsub(/[[:space:]]+/, " ", signature)
-            header = signature
-            sub(/[{].*$/, "", header)
-            return_type = header
-            if (return_type !~ /->/) {
+            return_type = declared_function_return_type(signature)
+            if (return_type == "" || return_type ~ /->/) {
                 factory_buffer = ""
                 return
             }
-            sub(/^.*->[ ]*/, "", return_type)
             if (return_type !~ ("(^|[^A-Za-z0-9_])" target_type "([^A-Za-z0-9_]|$)") &&
                 !(factory_owner == target_type &&
                     return_type ~ /(^|[^A-Za-z0-9_])Self([^A-Za-z0-9_]|$)/))
@@ -590,7 +614,7 @@ typed_factory_declarations() {
                 factory_buffer = ""
                 return
             }
-            name = header
+            name = signature
             sub(/^.*func[ ]+/, "", name)
             sub(/[^A-Za-z0-9_].*$/, "", name)
             print factory_owner "|" name

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -681,6 +681,18 @@ shell_snapshot_stored_property_counts() {
     local file="$1"
 
     awk '
+        function leading_space_count(value,    prefix) {
+            prefix = value
+            sub(/[^ ].*$/, "", prefix)
+            return length(prefix)
+        }
+        function is_static_property_start(value) {
+            return value ~ /^[[:space:]]*[^\/]*(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
+        }
+        function is_factory_candidate(value) {
+            return value ~ /^[[:space:]]*[^\/]*func[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*\(/ ||
+                is_static_property_start(value)
+        }
         function record_buffered_factory(    name, signature, header) {
             if (factory_buffer == "") {
                 return
@@ -722,19 +734,28 @@ shell_snapshot_stored_property_counts() {
             sub(/[ ]*\(.*/, "", name)
             return name in snapshot_factories
         }
-        function count_buffered_property(    property) {
-            if (buffer == "") {
+        function count_buffered_instance_property(    property) {
+            if (instance_buffer == "") {
                 return
             }
-            property = buffer
+            property = instance_buffer
             gsub(/[[:space:]]+/, " ", property)
-            if (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*($|=)/ ||
+            if (property !~ /(^| )(static|class)[ ]/ &&
+                (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*($|=)/ ||
                 property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/ ||
                 property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
-                (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ && uses_snapshot_factory(property)))
+                (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ && uses_snapshot_factory(property))))
             {
-                count++
+                instance_count++
             }
+            instance_buffer = ""
+        }
+        function count_buffered_static_property(    property) {
+            if (static_buffer == "") {
+                return
+            }
+            property = static_buffer
+            gsub(/[[:space:]]+/, " ", property)
             if (property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*($|=)/ ||
                 property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/ ||
                 property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
@@ -742,16 +763,17 @@ shell_snapshot_stored_property_counts() {
             {
                 static_count++
             }
-            buffer = ""
+            static_buffer = ""
         }
         NR == FNR {
             line = $0
             sub(/\/\/.*/, "", line)
-            if (line ~ /^    [^ ]/) {
+            if (is_factory_candidate(line)) {
                 record_buffered_factory()
                 factory_buffer = line
+                factory_indent = leading_space_count(line)
             } else if (factory_buffer != "" &&
-                (line ~ /^        / || line ~ /^[[:space:]]*$/))
+                (line ~ /^[[:space:]]*$/ || leading_space_count(line) > factory_indent))
             {
                 factory_buffer = factory_buffer " " line
             } else {
@@ -770,21 +792,37 @@ shell_snapshot_stored_property_counts() {
             # spaces. Collect only those property declarations and their deeper
             # continuation lines so method-local scratch variables are ignored.
             if (line ~ /^    [^ ]/) {
-                count_buffered_property()
+                count_buffered_instance_property()
                 if (line ~ /^    .*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/) {
-                    buffer = line
+                    instance_buffer = line
                 }
-            } else if (buffer != "" &&
+            } else if (instance_buffer != "" &&
                 (line ~ /^        / || line ~ /^[[:space:]]*$/))
             {
-                buffer = buffer " " line
+                instance_buffer = instance_buffer " " line
             } else {
-                count_buffered_property()
+                count_buffered_instance_property()
+            }
+
+            # Static/class storage is necessarily a type member, so scan it at
+            # every nesting depth without confusing method-local variables for
+            # globally addressable state.
+            if (is_static_property_start(line)) {
+                count_buffered_static_property()
+                static_buffer = line
+                static_indent = leading_space_count(line)
+            } else if (static_buffer != "" &&
+                (line ~ /^[[:space:]]*$/ || leading_space_count(line) > static_indent))
+            {
+                static_buffer = static_buffer " " line
+            } else {
+                count_buffered_static_property()
             }
         }
         END {
-            count_buffered_property()
-            print count, static_count
+            count_buffered_instance_property()
+            count_buffered_static_property()
+            print instance_count, static_count
         }
     ' "$file" "$file"
 }
@@ -895,6 +933,7 @@ reject_replacement_global_shell_store() {
     while IFS=: read -r file line_number source_line; do
         rel="${file#$SOURCE_ROOT/}"
         source_line="${source_line%%//*}"
+        [[ "$source_line" == *"@Published"* ]] || continue
 
         if [[ "$source_line" =~ @Published[^[:cntrl:]]*var[[:space:]]+([A-Za-z_][A-Za-z0-9_]*) ]]; then
             published_projection="$rel|${BASH_REMATCH[1]}"
@@ -906,9 +945,7 @@ reject_replacement_global_shell_store() {
             printf '%s:%s:%s\n' "$file" "$line_number" "$source_line" >&2
             fail "unrecognized @Published property declaration in $rel"
         fi
-    done < <(grep -RInH --include='*.swift' -E \
-        '^[[:space:]]*@Published([^A-Za-z0-9_]|$)' \
-        "$SOURCE_ROOT" || true)
+    done < <(grep -RInH --include='*.swift' -F '@Published' "$SOURCE_ROOT" || true)
 
     if grep -RIn --include='*.swift' -E \
         '(class|struct|actor|enum)[[:space:]]+((Alan|Global)Shell|Shell)(State|Workspace)?(Store|Model)([^A-Za-z0-9_]|$)' \

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -421,7 +421,19 @@ normalized_file_matches() {
     ' < <(swift_code_lines "$file")
 }
 
-readonly FACTORY_INSTANCE_AWK_HELPERS='
+readonly OWNERSHIP_AWK_HELPERS='
+    function brace_delta(value,    character, column, delta) {
+        delta = 0
+        for (column = 1; column <= length(value); column++) {
+            character = substr(value, column, 1)
+            if (character == "{") {
+                delta++
+            } else if (character == "}") {
+                delta--
+            }
+        }
+        return delta
+    }
     function matching_call_end(value, opening,    character, column, depth) {
         depth = 0
         for (column = opening; column <= length(value); column++) {
@@ -571,7 +583,7 @@ manifest_state_declarations() {
     local file="$1"
     local factory_inventory="$2"
 
-    awk -v factory_inventory="$factory_inventory" "$FACTORY_INSTANCE_AWK_HELPERS"'
+    awk -v factory_inventory="$factory_inventory" "$OWNERSHIP_AWK_HELPERS"'
         BEGIN {
             factory_count = split(factory_inventory, factory_entries, ";")
             for (factory_index = 1; factory_index <= factory_count; factory_index++) {
@@ -765,7 +777,7 @@ shell_host_global_storage_declarations() {
     local file="$1"
     local factory_inventory="$2"
 
-    awk -v factory_inventory="$factory_inventory" "$FACTORY_INSTANCE_AWK_HELPERS"'
+    awk -v factory_inventory="$factory_inventory" "$OWNERSHIP_AWK_HELPERS"'
         BEGIN {
             factory_count = split(factory_inventory, factory_entries, ";")
             for (factory_index = 1; factory_index <= factory_count; factory_index++) {
@@ -783,7 +795,7 @@ shell_host_global_storage_declarations() {
             return value ~ /^[[:space:]]*[^\/]*(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
         }
         function is_module_property_start(value) {
-            return value ~ /^[^\/]*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
+            return value ~ /^[^\/{]*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
         }
         function is_type_declaration(value) {
             return value ~ /^[[:space:]]*[^\/]*(class|struct|actor|enum|extension|protocol)[ ]+[A-Za-z_][A-Za-z0-9_.]*/
@@ -888,7 +900,7 @@ shell_host_global_storage_declarations() {
             }
 
             if (is_static_property_start(line) ||
-                (type_depth == 0 && line_indent == 0 && is_module_property_start(line)))
+                (brace_depth == 0 && is_module_property_start(line)))
             {
                 record_buffered_property()
                 property_buffer = line
@@ -902,6 +914,7 @@ shell_host_global_storage_declarations() {
             } else {
                 record_buffered_property()
             }
+            brace_depth += brace_delta(line)
         }
         END { record_buffered_property() }
     ' < <(swift_code_lines "$file")
@@ -1392,7 +1405,7 @@ shell_snapshot_stored_property_counts() {
     local file="$1"
     local factory_inventory="$2"
 
-    awk -v factory_inventory="$factory_inventory" "$FACTORY_INSTANCE_AWK_HELPERS"'
+    awk -v factory_inventory="$factory_inventory" "$OWNERSHIP_AWK_HELPERS"'
         BEGIN {
             factory_count = split(factory_inventory, factory_entries, ";")
             for (factory_index = 1; factory_index <= factory_count; factory_index++) {
@@ -1410,7 +1423,7 @@ shell_snapshot_stored_property_counts() {
             return value ~ /^[[:space:]]*[^\/]*(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
         }
         function is_module_property_start(value) {
-            return value ~ /^[^\/]*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
+            return value ~ /^[^\/{]*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
         }
         function is_type_declaration(value) {
             return value ~ /^[[:space:]]*[^\/]*(class|struct|actor|enum|extension|protocol)[ ]+[A-Za-z_][A-Za-z0-9_.]*/
@@ -1576,7 +1589,7 @@ shell_snapshot_stored_property_counts() {
             # or a static/class type member. Method-local variables remain out
             # of this inventory.
             if (is_static_property_start(line) ||
-                (type_depth == 0 && line_indent == 0 && is_module_property_start(line)))
+                (brace_depth == 0 && is_module_property_start(line)))
             {
                 count_buffered_global_property()
                 global_buffer = line
@@ -1589,6 +1602,7 @@ shell_snapshot_stored_property_counts() {
             } else {
                 count_buffered_global_property()
             }
+            brace_depth += brace_delta(line)
         }
         END {
             count_buffered_instance_property()

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -664,7 +664,7 @@ shell_snapshot_stored_property_count() {
             gsub(/[[:space:]]+/, " ", property)
             if (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?]?[ ]*($|=)/ ||
                 property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?]?[ ]*[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/ ||
-                property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot([.(]|$)/)
+                property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot[ ]*([.(]|$)/)
             {
                 count++
             }

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -599,9 +599,19 @@ reject_shell_host_duplicate_persistence_state() {
     fi
 }
 
+mutable_shell_snapshot_declaration_count() {
+    local file="$1"
+
+    grep -Ec \
+        -e 'var[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*:[[:space:]]*ShellStateSnapshot[?]?' \
+        -e 'var[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=[[:space:]]*ShellStateSnapshot([.(]|$)' \
+        "$file" || true
+}
+
 reject_replacement_global_shell_store() {
     local controller_owner="ShellHostController.swift"
     local file
+    local mutable_snapshot_declarations
     local rel
 
     require_existing_single_owner_pattern \
@@ -611,16 +621,22 @@ reject_replacement_global_shell_store() {
 
     while IFS= read -r file; do
         rel="${file#$SOURCE_ROOT/}"
+        mutable_snapshot_declarations="$(mutable_shell_snapshot_declaration_count "$file")"
 
-        if [[ "$rel" != "$controller_owner" ]] \
+        if [[ "$rel" == "$controller_owner" ]] \
+            && (( mutable_snapshot_declarations != 1 ))
+        then
+            fail \
+                "ShellHostController must keep exactly one mutable ShellStateSnapshot projection"
+        elif [[ "$rel" != "$controller_owner" ]] \
             && grep -Eq 'ObservableObject|@Observable' "$file" \
-            && grep -Eq 'var[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*:[[:space:]]*ShellStateSnapshot[?]?' "$file"
+            && (( mutable_snapshot_declarations > 0 ))
         then
             fail \
                 "mutable observable ShellStateSnapshot must stay in ShellHostController; found in $rel"
         fi
 
-        if grep -Eq 'var[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*:[[:space:]]*ShellStateSnapshot[?]?' "$file" \
+        if (( mutable_snapshot_declarations > 0 )) \
             && grep -Eq 'static[[:space:]]+(let|var)[[:space:]]+(shared|current|default)([^A-Za-z0-9_]|$)' "$file"
         then
             fail "mutable ShellStateSnapshot must not become a global singleton; found in $rel"

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -449,6 +449,40 @@ readonly OWNERSHIP_AWK_HELPERS='
         }
         return 0
     }
+    function is_generic_angle_open(value, column,    next_character, previous_character) {
+        previous_character = substr(value, column - 1, 1)
+        next_character = substr(value, column + 1, 1)
+        return (previous_character ~ /[A-Za-z0-9_.>]/ || previous_character == ")" ||
+                previous_character == "]") &&
+            next_character != "" && next_character !~ /[[:space:]=<>]/
+    }
+    function top_level_binding_end(value, start,    angle_depth, brace_depth, bracket_depth, character, column, parenthesis_depth) {
+        for (column = start; column <= length(value); column++) {
+            character = substr(value, column, 1)
+            if (character == "(") {
+                parenthesis_depth++
+            } else if (character == ")" && parenthesis_depth > 0) {
+                parenthesis_depth--
+            } else if (character == "[") {
+                bracket_depth++
+            } else if (character == "]" && bracket_depth > 0) {
+                bracket_depth--
+            } else if (character == "{") {
+                brace_depth++
+            } else if (character == "}" && brace_depth > 0) {
+                brace_depth--
+            } else if (character == "<" && is_generic_angle_open(value, column)) {
+                angle_depth++
+            } else if (character == ">" && angle_depth > 0) {
+                angle_depth--
+            } else if (character == "," && parenthesis_depth == 0 &&
+                bracket_depth == 0 && brace_depth == 0 && angle_depth == 0)
+            {
+                return column
+            }
+        }
+        return length(value) + 1
+    }
     function instance_receiver_invokes_factory(value, factories,    call_end, pattern, entry, fields, method, opening, receiver, remainder, suffix) {
         for (entry in factories) {
             split(entry, fields, "|")
@@ -679,13 +713,11 @@ manifest_state_declarations() {
             return expression ~ /^[A-Za-z_][A-Za-z0-9_.]*[ ]*<[^>]*ShellContentWorkspaceManifest/ ||
                 expression ~ /^\[[^]]*ShellContentWorkspaceManifest/
         }
-        function record_declaration(    declaration, header, prefix, kind) {
-            if (buffer == "") {
+        function record_manifest_binding(declaration,    header, prefix, kind) {
+            declaration = trim(declaration)
+            if (declaration == "") {
                 return
             }
-            declaration = buffer
-            gsub(/[[:space:]]+/, " ", declaration)
-            declaration = trim(declaration)
             header = declaration
             sub(/[=].*$/, "", header)
 
@@ -706,12 +738,26 @@ manifest_state_declarations() {
                 sub(/[ ]*=.*/, "", prefix)
                 kind = "inferred-factory"
             } else {
-                buffer = ""
                 return
             }
 
             printf "%d|%s|%d|%s|%s\n", \
                 start_line, declaration_owner_key, declaration_indent, trim(prefix), kind
+        }
+        function record_declaration(    binding, binding_end, binding_start, declaration) {
+            if (buffer == "") {
+                return
+            }
+            declaration = buffer
+            gsub(/[[:space:]]+/, " ", declaration)
+            declaration = trim(declaration)
+            binding_start = 1
+            while (binding_start <= length(declaration)) {
+                binding_end = top_level_binding_end(declaration, binding_start)
+                binding = substr(declaration, binding_start, binding_end - binding_start)
+                record_manifest_binding(binding)
+                binding_start = binding_end + 1
+            }
             buffer = ""
         }
         {
@@ -1508,6 +1554,24 @@ shell_snapshot_stored_property_counts() {
             sub(/[=].*$/, "", type)
             return type ~ /ShellStateSnapshot([^A-Za-z0-9_]|$)/ && type !~ /->/
         }
+        function snapshot_binding_contains_storage(binding, owner) {
+            return typed_storage_contains_snapshot(binding) ||
+                binding ~ /=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
+                inferred_generic_contains_snapshot(binding) ||
+                uses_snapshot_factory(binding, owner)
+        }
+        function snapshot_storage_count(property, owner,    binding, binding_end, binding_start, count) {
+            binding_start = 1
+            while (binding_start <= length(property)) {
+                binding_end = top_level_binding_end(property, binding_start)
+                binding = substr(property, binding_start, binding_end - binding_start)
+                if (snapshot_binding_contains_storage(binding, owner)) {
+                    count++
+                }
+                binding_start = binding_end + 1
+            }
+            return count
+        }
         function count_buffered_instance_property(    property) {
             if (instance_buffer == "") {
                 return
@@ -1515,16 +1579,9 @@ shell_snapshot_stored_property_counts() {
             property = instance_buffer
             gsub(/[[:space:]]+/, " ", property)
             if (property !~ /(^| )(static|class)[ ]/ &&
-                ((property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:/ &&
-                    typed_storage_contains_snapshot(property)) ||
-                property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/ ||
-                property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
-                (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ &&
-                    inferred_generic_contains_snapshot(property)) ||
-                (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ &&
-                    uses_snapshot_factory(property, instance_owner))))
+                property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*/)
             {
-                instance_count++
+                instance_count += snapshot_storage_count(property, instance_owner)
             }
             instance_buffer = ""
         }
@@ -1534,16 +1591,9 @@ shell_snapshot_stored_property_counts() {
             }
             property = global_buffer
             gsub(/[[:space:]]+/, " ", property)
-            if ((property ~ /(^| )(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:/ &&
-                    typed_storage_contains_snapshot(property)) ||
-                property ~ /(^| )var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/ ||
-                property ~ /(^| )(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
-                (property ~ /(^| )(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ &&
-                    inferred_generic_contains_snapshot(property)) ||
-                (property ~ /(^| )(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ &&
-                    uses_snapshot_factory(property, global_owner)))
+            if (property ~ /(^| )(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/)
             {
-                global_count++
+                global_count += snapshot_storage_count(property, global_owner)
             }
             global_buffer = ""
         }

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -654,8 +654,11 @@ manifest_state_declarations() {
             buffer = ""
         }
         {
-            line = $0
-            sub(/\/\/.*/, "", line)
+            first_separator = index($0, "\t")
+            remainder = substr($0, first_separator + 1)
+            second_separator = index(remainder, "\t")
+            source_line_number = substr(remainder, 1, second_separator - 1)
+            line = substr(remainder, second_separator + 1)
             line_indent = leading_space_count(line)
             if (line !~ /^[[:space:]]*$/) {
                 while (type_depth > 0 && line_indent <= type_indent[type_depth]) {
@@ -673,7 +676,7 @@ manifest_state_declarations() {
             if (line ~ /^[[:space:]]*[^\/]*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/) {
                 record_declaration()
                 buffer = line
-                start_line = FNR
+                start_line = source_line_number
                 declaration_indent = line_indent
                 declaration_owner = type_depth > 0 ? type_name[type_depth] : ""
                 declaration_owner_key = current_type_owner()
@@ -686,7 +689,7 @@ manifest_state_declarations() {
             }
         }
         END { record_declaration() }
-    ' "$file"
+    ' < <(swift_code_lines "$file")
 }
 
 static_property_declarations() {

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -662,8 +662,8 @@ shell_snapshot_stored_property_count() {
             }
             property = buffer
             gsub(/[[:space:]]+/, " ", property)
-            if (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?]?[ ]*($|=)/ ||
-                property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?]?[ ]*[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/ ||
+            if (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*($|=)/ ||
+                property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/ ||
                 property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot[ ]*([.(]|$)/)
             {
                 count++

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -699,8 +699,21 @@ shell_snapshot_stored_property_count() {
 
 reject_replacement_global_shell_store() {
     local controller_owner="ShellHostController.swift"
+    local observable_owner_allowlist=(
+        "App/AlanMacPrimaryShellOwner.swift|AlanMacPrimaryShellOwner"
+        "App/AlanMacUpdateController.swift|AlanMacUpdateController"
+        "Models/Shell/ShellSpaceCreationProfileOptions.swift|ShellSpaceCreationProfileOptionStore"
+        "Services/AlanOS/AlanOSAttachmentService.swift|AlanOSAttachmentController"
+        "ShellHostController.swift|ShellHostController"
+        "Support/ShellSidebarSpaceSliderWheelMonitor.swift|ShellSidebarTabListWheelRouter"
+        "Support/ShellVoiceCommandController.swift|ShellVoiceCommandController"
+        "TerminalRuntimeRegistry.swift|TerminalRuntimeRegistry"
+    )
     local file
+    local line_number
+    local observable_owner
     local snapshot_stored_properties
+    local source_line
     local rel
 
     require_existing_single_owner_pattern \
@@ -725,12 +738,34 @@ reject_replacement_global_shell_store() {
                 "stored observable ShellStateSnapshot must stay in ShellHostController; found in $rel"
         fi
 
-        if (( snapshot_stored_properties > 0 )) \
-            && grep -Eq 'static[[:space:]]+(let|var)[[:space:]]+(shared|current|default)([^A-Za-z0-9_]|$)' "$file"
+        if grep -Eq \
+            'static[[:space:]]+(let|var)[[:space:]]+(shared|current|default)([^A-Za-z0-9_]|$)' \
+            "$file"
         then
-            fail "stored ShellStateSnapshot must not become a global singleton; found in $rel"
+            fail "ShellStateSnapshot-referencing code must not become a global singleton; found in $rel"
         fi
     done < <(grep -RIl --include='*.swift' -F "ShellStateSnapshot" "$SOURCE_ROOT" || true)
+
+    while IFS=: read -r file line_number source_line; do
+        rel="${file#$SOURCE_ROOT/}"
+        source_line="${source_line%%//*}"
+
+        if [[ "$source_line" == *"@Observable"* ]]; then
+            printf '%s:%s:%s\n' "$file" "$line_number" "$source_line" >&2
+            fail "new @Observable owners require an explicit architecture ownership decision"
+        elif [[ "$source_line" =~ (class|struct|actor)[[:space:]]+([A-Za-z_][A-Za-z0-9_]*) ]]; then
+            observable_owner="$rel|${BASH_REMATCH[2]}"
+            if ! contains_line "$observable_owner" "${observable_owner_allowlist[@]}"; then
+                printf '%s:%s:%s\n' "$file" "$line_number" "$source_line" >&2
+                fail "new ObservableObject owner is not in the accepted architecture: $observable_owner"
+            fi
+        else
+            printf '%s:%s:%s\n' "$file" "$line_number" "$source_line" >&2
+            fail "unrecognized ObservableObject ownership declaration in $rel"
+        fi
+    done < <(grep -RInH --include='*.swift' -E \
+        'ObservableObject|@Observable' \
+        "$SOURCE_ROOT" || true)
 
     if grep -RIn --include='*.swift' -E \
         '(class|struct|actor|enum)[[:space:]]+((Alan|Global)Shell|Shell)(State|Workspace)?(Store|Model)([^A-Za-z0-9_]|$)' \

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -610,6 +610,7 @@ shell_snapshot_stored_property_count() {
             property = buffer
             gsub(/[[:space:]]+/, " ", property)
             if (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?]?[ ]*($|=)/ ||
+                property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?]?[ ]*[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/ ||
                 property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot([.(]|$)/)
             {
                 count++

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -421,6 +421,50 @@ normalized_file_matches() {
     ' < <(swift_code_lines "$file")
 }
 
+readonly FACTORY_INSTANCE_AWK_HELPERS='
+    function matching_call_end(value, opening,    character, column, depth) {
+        depth = 0
+        for (column = opening; column <= length(value); column++) {
+            character = substr(value, column, 1)
+            if (character == "(") {
+                depth++
+            } else if (character == ")") {
+                depth--
+                if (depth == 0) {
+                    return column
+                }
+            }
+        }
+        return 0
+    }
+    function instance_receiver_invokes_factory(value, factories,    call_end, pattern, entry, fields, method, opening, receiver, remainder, suffix) {
+        for (entry in factories) {
+            split(entry, fields, "|")
+            receiver = fields[1]
+            method = fields[2]
+            if (receiver == "" || method == "") {
+                continue
+            }
+            pattern = "(^|[^A-Za-z0-9_])" receiver \
+                "([ ]*<[^>]+>)?([ ]*[.][ ]*init)?[ ]*\\("
+            remainder = value
+            while (match(remainder, pattern)) {
+                opening = RSTART + RLENGTH - 1
+                call_end = matching_call_end(remainder, opening)
+                if (call_end == 0) {
+                    break
+                }
+                suffix = substr(remainder, call_end + 1)
+                if (suffix ~ ("^[ ]*[!?]?[ ]*[.][ ]*" method "[ ]*\\(")) {
+                    return 1
+                }
+                remainder = substr(remainder, RSTART + 1)
+            }
+        }
+        return 0
+    }
+'
+
 typed_factory_declarations() {
     local file="$1"
     local target_type="$2"
@@ -476,8 +520,10 @@ typed_factory_declarations() {
             factory_buffer = ""
         }
         {
-            line = $0
-            sub(/\/\/.*/, "", line)
+            first_separator = index($0, "\t")
+            remainder = substr($0, first_separator + 1)
+            second_separator = index(remainder, "\t")
+            line = substr(remainder, second_separator + 1)
             line_indent = leading_space_count(line)
             if (line !~ /^[[:space:]]*$/) {
                 while (type_depth > 0 && line_indent <= type_indent[type_depth]) {
@@ -509,7 +555,7 @@ typed_factory_declarations() {
             }
         }
         END { record_buffered_factory() }
-    ' "$file"
+    ' < <(swift_code_lines "$file")
 }
 
 typed_factory_inventory() {
@@ -525,7 +571,7 @@ manifest_state_declarations() {
     local file="$1"
     local factory_inventory="$2"
 
-    awk -v factory_inventory="$factory_inventory" '
+    awk -v factory_inventory="$factory_inventory" "$FACTORY_INSTANCE_AWK_HELPERS"'
         BEGIN {
             factory_count = split(factory_inventory, factory_entries, ";")
             for (factory_index = 1; factory_index <= factory_count; factory_index++) {
@@ -597,6 +643,9 @@ manifest_state_declarations() {
             expression = value
             sub(/^[^=]*=[ ]*/, "", expression)
             gsub(/[ ]*[.][ ]*/, ".", expression)
+            if (instance_receiver_invokes_factory(expression, manifest_factories)) {
+                return 1
+            }
             while (match(expression, /[A-Za-z_][A-Za-z0-9_.]*[ ]*\(/)) {
                 call = substr(expression, RSTART, RLENGTH)
                 sub(/[ ]*\($/, "", call)
@@ -697,8 +746,10 @@ static_property_declarations() {
 
     awk '
         {
-            line = $0
-            sub(/\/\/.*/, "", line)
+            first_separator = index($0, "\t")
+            remainder = substr($0, first_separator + 1)
+            second_separator = index(remainder, "\t")
+            line = substr(remainder, second_separator + 1)
             if (line !~ /^[[:space:]]*[^\/]*(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/) {
                 next
             }
@@ -707,14 +758,14 @@ static_property_declarations() {
             sub(/ $/, "", line)
             print line
         }
-    ' "$file"
+    ' < <(swift_code_lines "$file")
 }
 
 shell_host_global_storage_declarations() {
     local file="$1"
     local factory_inventory="$2"
 
-    awk -v factory_inventory="$factory_inventory" '
+    awk -v factory_inventory="$factory_inventory" "$FACTORY_INSTANCE_AWK_HELPERS"'
         BEGIN {
             factory_count = split(factory_inventory, factory_entries, ";")
             for (factory_index = 1; factory_index <= factory_count; factory_index++) {
@@ -778,6 +829,9 @@ shell_host_global_storage_declarations() {
             expression = value
             sub(/^[^=]*=[ ]*/, "", expression)
             gsub(/[ ]*[.][ ]*/, ".", expression)
+            if (instance_receiver_invokes_factory(expression, shell_host_factories)) {
+                return 1
+            }
             while (match(expression, /[A-Za-z_][A-Za-z0-9_.]*[ ]*\(/)) {
                 call = substr(expression, RSTART, RLENGTH)
                 sub(/[ ]*\($/, "", call)
@@ -814,8 +868,11 @@ shell_host_global_storage_declarations() {
             property_buffer = ""
         }
         {
-            line = $0
-            sub(/\/\/.*/, "", line)
+            first_separator = index($0, "\t")
+            remainder = substr($0, first_separator + 1)
+            second_separator = index(remainder, "\t")
+            source_line_number = substr(remainder, 1, second_separator - 1)
+            line = substr(remainder, second_separator + 1)
             line_indent = leading_space_count(line)
             if (line !~ /^[[:space:]]*$/) {
                 while (type_depth > 0 && line_indent <= type_indent[type_depth]) {
@@ -835,7 +892,7 @@ shell_host_global_storage_declarations() {
             {
                 record_buffered_property()
                 property_buffer = line
-                property_start_line = FNR
+                property_start_line = source_line_number
                 property_indent = line_indent
                 property_owner = type_depth > 0 ? type_name[type_depth] : ""
             } else if (property_buffer != "" &&
@@ -847,7 +904,7 @@ shell_host_global_storage_declarations() {
             }
         }
         END { record_buffered_property() }
-    ' "$file"
+    ' < <(swift_code_lines "$file")
 }
 
 check_appkit_import_gate() {
@@ -1335,7 +1392,7 @@ shell_snapshot_stored_property_counts() {
     local file="$1"
     local factory_inventory="$2"
 
-    awk -v factory_inventory="$factory_inventory" '
+    awk -v factory_inventory="$factory_inventory" "$FACTORY_INSTANCE_AWK_HELPERS"'
         BEGIN {
             factory_count = split(factory_inventory, factory_entries, ";")
             for (factory_index = 1; factory_index <= factory_count; factory_index++) {
@@ -1399,6 +1456,9 @@ shell_snapshot_stored_property_counts() {
             expression = property
             sub(/^[^=]*=[ ]*/, "", expression)
             gsub(/[ ]*[.][ ]*/, ".", expression)
+            if (instance_receiver_invokes_factory(expression, snapshot_factories)) {
+                return 1
+            }
             while (match(expression, /[A-Za-z_][A-Za-z0-9_.]*[ ]*\(/)) {
                 call = substr(expression, RSTART, RLENGTH)
                 sub(/[ ]*\($/, "", call)
@@ -1475,8 +1535,10 @@ shell_snapshot_stored_property_counts() {
             global_buffer = ""
         }
         {
-            line = $0
-            sub(/\/\/.*/, "", line)
+            first_separator = index($0, "\t")
+            remainder = substr($0, first_separator + 1)
+            second_separator = index(remainder, "\t")
+            line = substr(remainder, second_separator + 1)
 
             # Follow the formatted type nesting so instance members of both
             # top-level and nested types are counted, while method-local scratch
@@ -1533,7 +1595,7 @@ shell_snapshot_stored_property_counts() {
             count_buffered_global_property()
             print instance_count, global_count
         }
-    ' "$file"
+    ' < <(swift_code_lines "$file")
 }
 
 reject_replacement_global_shell_store() {

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -272,6 +272,46 @@ manifest_state_declarations() {
             sub(/[[:space:]]+$/, "", value)
             return value
         }
+        function is_factory_candidate(value) {
+            return value ~ /^[[:space:]]*[^\/]*func[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*\(/
+        }
+        function is_same_indent_function_signature_continuation(value) {
+            return value ~ /^[[:space:]]*(\)|->|[{])/ ||
+                value ~ /^[[:space:]]*(async|throws|rethrows|where)([^A-Za-z0-9_]|$)/
+        }
+        function record_buffered_factory(    name, signature, header) {
+            if (factory_buffer == "") {
+                return
+            }
+            signature = factory_buffer
+            gsub(/[[:space:]]+/, " ", signature)
+            header = signature
+            sub(/[{].*$/, "", header)
+            if (header ~ /(^| )func[ ]+[A-Za-z_][A-Za-z0-9_]*.*->[^{}]*ShellContentWorkspaceManifest([^A-Za-z0-9_]|$)/) {
+                name = header
+                sub(/^.*func[ ]+/, "", name)
+                sub(/[^A-Za-z0-9_].*$/, "", name)
+                manifest_factories[name] = 1
+            }
+            factory_buffer = ""
+        }
+        function inferred_factory_contains_manifest(value,    expression, name) {
+            if (value !~ /=/) {
+                return 0
+            }
+            expression = value
+            sub(/^[^=]*=[ ]*/, "", expression)
+            while (expression ~ /^(try[!?]?|await)[ ]+/) {
+                sub(/^(try[!?]?|await)[ ]+/, "", expression)
+            }
+            sub(/^Self[.]/, "", expression)
+            if (expression !~ /^[A-Za-z_][A-Za-z0-9_]*[ ]*\(/) {
+                return 0
+            }
+            name = expression
+            sub(/[ ]*\(.*/, "", name)
+            return name in manifest_factories
+        }
         function inferred_generic_contains_manifest(value,    expression) {
             if (value !~ /=/) {
                 return 0
@@ -305,6 +345,10 @@ manifest_state_declarations() {
                 prefix = declaration
                 sub(/[ ]*=.*/, "", prefix)
                 kind = "inferred-generic"
+            } else if (inferred_factory_contains_manifest(declaration)) {
+                prefix = declaration
+                sub(/[ ]*=.*/, "", prefix)
+                kind = "inferred-factory"
             } else {
                 buffer = ""
                 return
@@ -313,13 +357,35 @@ manifest_state_declarations() {
             printf "%d|%d|%s|%s\n", start_line, declaration_indent, trim(prefix), kind
             buffer = ""
         }
+        NR == FNR {
+            line = $0
+            sub(/\/\/.*/, "", line)
+            if (is_factory_candidate(line)) {
+                record_buffered_factory()
+                factory_buffer = line
+                factory_indent = leading_space_count(line)
+            } else if (factory_buffer != "" &&
+                (line ~ /^[[:space:]]*$/ ||
+                    leading_space_count(line) > factory_indent ||
+                    (leading_space_count(line) == factory_indent &&
+                        is_same_indent_function_signature_continuation(line))))
+            {
+                factory_buffer = factory_buffer " " line
+            } else {
+                record_buffered_factory()
+            }
+            next
+        }
+        FNR == 1 {
+            record_buffered_factory()
+        }
         {
             line = $0
             sub(/\/\/.*/, "", line)
             if (line ~ /^[[:space:]]*[^\/]*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/) {
                 record_declaration()
                 buffer = line
-                start_line = NR
+                start_line = FNR
                 declaration_indent = leading_space_count(line)
             } else if (buffer != "" &&
                 (line ~ /^[[:space:]]*$/ ||
@@ -331,7 +397,7 @@ manifest_state_declarations() {
             }
         }
         END { record_declaration() }
-    ' "$file"
+    ' "$file" "$file"
 }
 
 static_property_declarations() {
@@ -350,6 +416,125 @@ static_property_declarations() {
             print line
         }
     ' "$file"
+}
+
+shell_host_static_storage_declarations() {
+    local file="$1"
+
+    awk '
+        function leading_space_count(value,    prefix) {
+            prefix = value
+            sub(/[^ ].*$/, "", prefix)
+            return length(prefix)
+        }
+        function is_static_property_start(value) {
+            return value ~ /^[[:space:]]*[^\/]*(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
+        }
+        function is_factory_candidate(value) {
+            return value ~ /^[[:space:]]*[^\/]*func[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*\(/
+        }
+        function is_same_indent_function_signature_continuation(value) {
+            return value ~ /^[[:space:]]*(\)|->|[{])/ ||
+                value ~ /^[[:space:]]*(async|throws|rethrows|where)([^A-Za-z0-9_]|$)/
+        }
+        function record_buffered_factory(    name, signature, header) {
+            if (factory_buffer == "") {
+                return
+            }
+            signature = factory_buffer
+            gsub(/[[:space:]]+/, " ", signature)
+            header = signature
+            sub(/[{].*$/, "", header)
+            if (header ~ /(^| )func[ ]+[A-Za-z_][A-Za-z0-9_]*.*->[^{}]*ShellHostController([^A-Za-z0-9_]|$)/) {
+                name = header
+                sub(/^.*func[ ]+/, "", name)
+                sub(/[^A-Za-z0-9_].*$/, "", name)
+                shell_host_factories[name] = 1
+            }
+            factory_buffer = ""
+        }
+        function uses_shell_host_factory(value,    expression, name) {
+            if (value !~ /=/) {
+                return 0
+            }
+            expression = value
+            sub(/^[^=]*=[ ]*/, "", expression)
+            while (expression ~ /^(try[!?]?|await)[ ]+/) {
+                sub(/^(try[!?]?|await)[ ]+/, "", expression)
+            }
+            sub(/^Self[.]/, "", expression)
+            if (expression !~ /^[A-Za-z_][A-Za-z0-9_]*[ ]*\(/) {
+                return 0
+            }
+            name = expression
+            sub(/[ ]*\(.*/, "", name)
+            return name in shell_host_factories
+        }
+        function is_stored_property(value,    declaration_header) {
+            declaration_header = value
+            sub(/[{].*$/, "", declaration_header)
+            if (declaration_header ~ /=/) {
+                return 1
+            }
+            return value !~ /[{]/ ||
+                value ~ /[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/
+        }
+        function record_buffered_property(    property) {
+            if (property_buffer == "") {
+                return
+            }
+            property = property_buffer
+            gsub(/[[:space:]]+/, " ", property)
+            sub(/^ /, "", property)
+            sub(/ $/, "", property)
+            if (is_stored_property(property) &&
+                (property ~ /ShellHostController([^A-Za-z0-9_]|$)/ ||
+                    uses_shell_host_factory(property)))
+            {
+                printf "%d|%s\n", property_start_line, property
+            }
+            property_buffer = ""
+        }
+        NR == FNR {
+            line = $0
+            sub(/\/\/.*/, "", line)
+            if (is_factory_candidate(line)) {
+                record_buffered_factory()
+                factory_buffer = line
+                factory_indent = leading_space_count(line)
+            } else if (factory_buffer != "" &&
+                (line ~ /^[[:space:]]*$/ ||
+                    leading_space_count(line) > factory_indent ||
+                    (leading_space_count(line) == factory_indent &&
+                        is_same_indent_function_signature_continuation(line))))
+            {
+                factory_buffer = factory_buffer " " line
+            } else {
+                record_buffered_factory()
+            }
+            next
+        }
+        FNR == 1 {
+            record_buffered_factory()
+        }
+        {
+            line = $0
+            sub(/\/\/.*/, "", line)
+            if (is_static_property_start(line)) {
+                record_buffered_property()
+                property_buffer = line
+                property_start_line = FNR
+                property_indent = leading_space_count(line)
+            } else if (property_buffer != "" &&
+                (line ~ /^[[:space:]]*$/ || leading_space_count(line) > property_indent))
+            {
+                property_buffer = property_buffer " " line
+            } else {
+                record_buffered_property()
+            }
+        }
+        END { record_buffered_property() }
+    ' "$file" "$file"
 }
 
 check_appkit_import_gate() {
@@ -1112,6 +1297,16 @@ reject_replacement_global_shell_store() {
         fi
 
     done < <(grep -RIl --include='*.swift' -F "ShellStateSnapshot" "$SOURCE_ROOT" || true)
+
+    while IFS= read -r file; do
+        rel="${file#$SOURCE_ROOT/}"
+        while IFS='|' read -r line_number source_line; do
+            [[ -n "$line_number" ]] || continue
+            printf '%s:%s:%s\n' "$file" "$line_number" "$source_line" >&2
+            fail \
+                "ShellHostController must not be retained by static/class storage; found in $rel"
+        done < <(shell_host_static_storage_declarations "$file")
+    done < <(find "$SOURCE_ROOT" -type f -name '*.swift' -print | sort)
 
     while IFS=: read -r file line_number source_line; do
         rel="${file#$SOURCE_ROOT/}"

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -668,6 +668,97 @@ typed_factory_inventory() {
     done < <(find "$SOURCE_ROOT" -type f -name '*.swift' -print | sort)
 }
 
+typed_value_member_declarations() {
+    local file="$1"
+    local target_type="$2"
+
+    awk -v target_type="$target_type" "$OWNERSHIP_AWK_HELPERS"'
+        function leading_space_count(value,    prefix) {
+            prefix = value
+            sub(/[^ ].*$/, "", prefix)
+            return length(prefix)
+        }
+        function is_type_declaration(value) {
+            return value ~ /^[[:space:]]*[^\/]*(class|struct|actor|enum|extension|protocol)[ ]+[A-Za-z_][A-Za-z0-9_.]*/
+        }
+        function declared_type_name(value,    name) {
+            name = value
+            sub(/^.*(class|struct|actor|enum|extension|protocol)[ ]+/, "", name)
+            sub(/[^A-Za-z0-9_.].*$/, "", name)
+            sub(/^.*[.]/, "", name)
+            return name
+        }
+        function is_property_start(value) {
+            return value ~ /(^|[ ])(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
+        }
+        function record_member(    declaration, member_name, member_type) {
+            if (member_buffer == "") {
+                return
+            }
+            declaration = member_buffer
+            gsub(/[[:space:]]+/, " ", declaration)
+            member_type = binding_type_annotation(declaration)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", member_type)
+            if (member_type ~ ("(^|[^A-Za-z0-9_])" target_type "([^A-Za-z0-9_]|$)") &&
+                member_type !~ /->/)
+            {
+                member_name = declaration
+                sub(/^.*(let|var)[ ]+/, "", member_name)
+                sub(/[^A-Za-z0-9_].*$/, "", member_name)
+                if (member_name != "") {
+                    print member_name
+                }
+            }
+            member_buffer = ""
+        }
+        {
+            first_separator = index($0, "\t")
+            remainder = substr($0, first_separator + 1)
+            second_separator = index(remainder, "\t")
+            line = substr(remainder, second_separator + 1)
+            line_indent = leading_space_count(line)
+
+            if (line !~ /^[[:space:]]*$/) {
+                while (type_depth > 0 && line_indent <= type_indent[type_depth]) {
+                    delete type_indent[type_depth]
+                    delete type_name[type_depth]
+                    type_depth--
+                }
+                if (is_type_declaration(line)) {
+                    type_depth++
+                    type_indent[type_depth] = line_indent
+                    type_name[type_depth] = declared_type_name(line)
+                }
+            }
+
+            if (type_depth > 0 &&
+                line_indent == type_indent[type_depth] + 4 &&
+                is_property_start(line))
+            {
+                record_member()
+                member_buffer = line
+                member_indent = line_indent
+            } else if (member_buffer != "" &&
+                (line ~ /^[[:space:]]*$/ || line_indent > member_indent))
+            {
+                member_buffer = member_buffer " " line
+            } else {
+                record_member()
+            }
+        }
+        END { record_member() }
+    ' < <(swift_code_lines "$file")
+}
+
+typed_value_member_inventory() {
+    local target_type="$1"
+    local file
+
+    while IFS= read -r file; do
+        typed_value_member_declarations "$file" "$target_type"
+    done < <(find "$SOURCE_ROOT" -type f -name '*.swift' -print | sort)
+}
+
 manifest_state_declarations() {
     local file="$1"
     local factory_inventory="$2"
@@ -1614,13 +1705,23 @@ reject_shell_host_duplicate_persistence_state() {
 shell_snapshot_stored_property_counts() {
     local file="$1"
     local factory_inventory="$2"
+    local projection_inventory="$3"
 
-    awk -v factory_inventory="$factory_inventory" "$OWNERSHIP_AWK_HELPERS"'
+    awk \
+        -v factory_inventory="$factory_inventory" \
+        -v projection_inventory="$projection_inventory" \
+        "$OWNERSHIP_AWK_HELPERS"'
         BEGIN {
             factory_count = split(factory_inventory, factory_entries, ";")
             for (factory_index = 1; factory_index <= factory_count; factory_index++) {
                 if (factory_entries[factory_index] != "") {
                     snapshot_factories[factory_entries[factory_index]] = 1
+                }
+            }
+            projection_count = split(projection_inventory, projection_entries, ";")
+            for (projection_index = 1; projection_index <= projection_count; projection_index++) {
+                if (projection_entries[projection_index] != "") {
+                    snapshot_projections[projection_entries[projection_index]] = 1
                 }
             }
         }
@@ -1703,6 +1804,21 @@ shell_snapshot_stored_property_counts() {
             return expression ~ /^[A-Za-z_][A-Za-z0-9_.]*[ ]*<[^>]*ShellStateSnapshot/ ||
                 expression ~ /^\[[^]]*ShellStateSnapshot/
         }
+        function uses_snapshot_projection(property,    expression, pattern, projection) {
+            if (property !~ /=/) {
+                return 0
+            }
+            expression = property
+            sub(/^[^=]*=[ ]*/, "", expression)
+            gsub(/[ ]*[.][ ]*/, ".", expression)
+            for (projection in snapshot_projections) {
+                pattern = "[^[:space:].][.]" projection "([^A-Za-z0-9_]|$)"
+                if (expression ~ pattern) {
+                    return 1
+                }
+            }
+            return 0
+        }
         function typed_storage_contains_snapshot(property,    type) {
             if (property !~ /:/) {
                 return 0
@@ -1718,13 +1834,26 @@ shell_snapshot_stored_property_counts() {
             sub(/[=].*$/, "", type)
             return type ~ /ShellStateSnapshot([^A-Za-z0-9_]|$)/ && type !~ /->/
         }
+        function is_stored_property(value,    declaration_header) {
+            declaration_header = value
+            sub(/[{].*$/, "", declaration_header)
+            if (declaration_header ~ /=/) {
+                return 1
+            }
+            return value !~ /[{]/ ||
+                value ~ /[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/
+        }
         function snapshot_binding_contains_storage(binding, owner) {
             return typed_storage_contains_snapshot(binding) ||
                 binding ~ /=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
                 inferred_generic_contains_snapshot(binding) ||
+                uses_snapshot_projection(binding) ||
                 uses_snapshot_factory(binding, owner)
         }
         function snapshot_storage_count(property, owner,    binding_count, binding_end, binding_index, bindings, binding_start, count, effective_binding, explicit_type, inherited_types, shared_type) {
+            if (!is_stored_property(property)) {
+                return 0
+            }
             binding_start = 1
             while (binding_start <= length(property)) {
                 binding_end = top_level_binding_end(property, binding_start)
@@ -1888,6 +2017,7 @@ reject_replacement_global_shell_store() {
     local published_projection
     local snapshot_property_counts
     local snapshot_factory_inventory
+    local snapshot_projection_inventory
     local snapshot_stored_properties
     local static_member
     local static_member_key
@@ -1902,6 +2032,9 @@ reject_replacement_global_shell_store() {
 
     snapshot_factory_inventory="$(
         typed_factory_inventory "ShellStateSnapshot" | sort -u | tr '\n' ';'
+    )"
+    snapshot_projection_inventory="$(
+        typed_value_member_inventory "ShellStateSnapshot" | sort -u | tr '\n' ';'
     )"
     host_factory_inventory="$(
         typed_factory_inventory "ShellHostController" | sort -u | tr '\n' ';'
@@ -1920,7 +2053,10 @@ reject_replacement_global_shell_store() {
         done < <(guarded_shell_owner_typealias_declarations "$file")
 
         snapshot_property_counts="$(
-            shell_snapshot_stored_property_counts "$file" "$snapshot_factory_inventory"
+            shell_snapshot_stored_property_counts \
+                "$file" \
+                "$snapshot_factory_inventory" \
+                "$snapshot_projection_inventory"
         )"
         snapshot_stored_properties="${snapshot_property_counts%% *}"
         global_snapshot_stored_properties="${snapshot_property_counts##* }"

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -241,6 +241,23 @@ reject_unapproved_symbol_lines() {
     fi
 }
 
+normalized_file_matches() {
+    local file="$1"
+    local pattern="$2"
+
+    awk -v pattern="$pattern" '
+        {
+            line = $0
+            sub(/\/\/.*/, "", line)
+            source = source " " line
+        }
+        END {
+            gsub(/[[:space:]]+/, " ", source)
+            exit source ~ pattern ? 0 : 1
+        }
+    ' "$file"
+}
+
 check_appkit_import_gate() {
     local rel="$1"
     local file="$2"
@@ -643,6 +660,14 @@ reject_shell_host_duplicate_persistence_state() {
         'ShellWorkspaceManifestProjector' \
         "$SOURCE_ROOT" || true)
 
+    if grep -RIn --include='*.swift' -F \
+        'ShellContentWorkspaceManifest' \
+        "$controller" "$controller_dir" >&2
+    then
+        fail \
+            "shell host must not retain or construct workspace manifests outside $persistence_owner"
+    fi
+
     if grep -RIn --include='*.swift' -E \
         '^[[:space:]]*(private[[:space:]]+)?var[[:space:]]+workspaceManifest|ManifestFlushScheduling|DebouncedManifestFlushScheduler|manifestFlushScheduler|contentFlush(Scheduled|Pending)|scheduleContentFlush|flushPendingPersistence|syncManifestFromShellState|makeWorkspaceManifestFromShellState|ShellWorkspaceManifestProjector[[:space:]]*\(' \
         "$controller" "$controller_dir" >&2
@@ -709,9 +734,25 @@ reject_replacement_global_shell_store() {
         "Support/ShellVoiceCommandController.swift|ShellVoiceCommandController"
         "TerminalRuntimeRegistry.swift|TerminalRuntimeRegistry"
     )
+    local published_projection_allowlist=(
+        "App/AlanMacUpdateController.swift|decision"
+        "Models/Shell/ShellSpaceCreationProfileOptions.swift|options"
+        "Services/AlanOS/AlanOSAttachmentService.swift|state"
+        "ShellHostController.swift|activityNotifications"
+        "ShellHostController.swift|controlPlaneDiagnostics"
+        "ShellHostController.swift|isPresentingSpaceCreation"
+        "ShellHostController.swift|lastCopiedAt"
+        "ShellHostController.swift|shellState"
+        "ShellHostController.swift|spaceDraftIcon"
+        "ShellHostController.swift|spaceDraftName"
+        "ShellHostController.swift|spaceDraftProfileID"
+        "ShellHostController.swift|zoomedPaneIDByTabID"
+        "Support/ShellVoiceCommandController.swift|isListening"
+    )
     local file
     local line_number
     local observable_owner
+    local published_projection
     local snapshot_stored_properties
     local source_line
     local rel
@@ -736,6 +777,15 @@ reject_replacement_global_shell_store() {
         then
             fail \
                 "stored observable ShellStateSnapshot must stay in ShellHostController; found in $rel"
+        fi
+
+        if [[ "$rel" != "$controller_owner" ]] \
+            && grep -Eq 'ObservableObject|@Observable' "$file" \
+            && normalized_file_matches "$file" \
+                '->[ ]*ShellStateSnapshot[?!]?|static[ ]+(var|let)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?'
+        then
+            fail \
+                "non-controller observable owners must not manufacture ShellStateSnapshot state; found in $rel"
         fi
 
         if grep -Eq \
@@ -765,6 +815,24 @@ reject_replacement_global_shell_store() {
         fi
     done < <(grep -RInH --include='*.swift' -E \
         'ObservableObject|@Observable' \
+        "$SOURCE_ROOT" || true)
+
+    while IFS=: read -r file line_number source_line; do
+        rel="${file#$SOURCE_ROOT/}"
+        source_line="${source_line%%//*}"
+
+        if [[ "$source_line" =~ @Published[^[:cntrl:]]*var[[:space:]]+([A-Za-z_][A-Za-z0-9_]*) ]]; then
+            published_projection="$rel|${BASH_REMATCH[1]}"
+            if ! contains_line "$published_projection" "${published_projection_allowlist[@]}"; then
+                printf '%s:%s:%s\n' "$file" "$line_number" "$source_line" >&2
+                fail "new @Published projection is not in the accepted architecture: $published_projection"
+            fi
+        else
+            printf '%s:%s:%s\n' "$file" "$line_number" "$source_line" >&2
+            fail "unrecognized @Published property declaration in $rel"
+        fi
+    done < <(grep -RInH --include='*.swift' -E \
+        '^[[:space:]]*@Published([^A-Za-z0-9_]|$)' \
         "$SOURCE_ROOT" || true)
 
     if grep -RIn --include='*.swift' -E \

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -217,12 +217,9 @@ contains_line() {
     return 1
 }
 
-swift_code_matching_lines() {
-    local pattern="$1"
-    shift
-
-    awk -v pattern="$pattern" '
-        function code_without_comments(value,    character, code, column, pair, triple) {
+swift_code_lines() {
+    awk '
+        function executable_code(value,    character, code, column, pair, triple) {
             code = ""
             column = 1
             while (column <= length(value)) {
@@ -243,27 +240,49 @@ swift_code_matching_lines() {
                     continue
                 }
 
-                # Keep string contents so comment delimiters inside Swift
-                # strings cannot hide executable source later on the line.
-                if (multiline_string) {
-                    if (triple == "\"\"\"") {
-                        code = code triple
-                        multiline_string = 0
+                if (string_width > 0 && interpolation_depth == 0) {
+                    if (string_width == 3 && triple == "\"\"\"") {
+                        string_width = 0
+                        code = code " "
                         column += 3
-                    } else {
-                        code = code character
-                        column++
+                        continue
                     }
+                    if (string_width == 1 && character == "\"") {
+                        string_width = 0
+                        code = code " "
+                        column++
+                        continue
+                    }
+                    if (pair == "\\(") {
+                        interpolation_depth = 1
+                        code = code " "
+                        column += 2
+                        continue
+                    }
+                    if (character == "\\") {
+                        column += (column < length(value) ? 2 : 1)
+                        continue
+                    }
+                    column++
                     continue
                 }
-                if (quoted_string) {
-                    code = code character
-                    if (escaped_character) {
-                        escaped_character = 0
-                    } else if (character == "\\") {
-                        escaped_character = 1
-                    } else if (character == "\"") {
-                        quoted_string = 0
+
+                if (interpolation_string_width > 0) {
+                    if (interpolation_string_width == 3 && triple == "\"\"\"") {
+                        interpolation_string_width = 0
+                        code = code " "
+                        column += 3
+                        continue
+                    }
+                    if (interpolation_string_width == 1 && character == "\"") {
+                        interpolation_string_width = 0
+                        code = code " "
+                        column++
+                        continue
+                    }
+                    if (character == "\\") {
+                        column += (column < length(value) ? 2 : 1)
+                        continue
                     }
                     column++
                     continue
@@ -278,17 +297,35 @@ swift_code_matching_lines() {
                     continue
                 }
                 if (triple == "\"\"\"") {
-                    code = code triple
-                    multiline_string = 1
+                    code = code " "
+                    if (interpolation_depth > 0) {
+                        interpolation_string_width = 3
+                    } else {
+                        string_width = 3
+                    }
                     column += 3
                     continue
                 }
                 if (character == "\"") {
-                    code = code character
-                    quoted_string = 1
-                    escaped_character = 0
+                    code = code " "
+                    if (interpolation_depth > 0) {
+                        interpolation_string_width = 1
+                    } else {
+                        string_width = 1
+                    }
                     column++
                     continue
+                }
+
+                if (interpolation_depth > 0 && character == "(") {
+                    interpolation_depth++
+                } else if (interpolation_depth > 0 && character == ")") {
+                    interpolation_depth--
+                    if (interpolation_depth == 0) {
+                        code = code " "
+                        column++
+                        continue
+                    }
                 }
 
                 code = code character
@@ -298,19 +335,50 @@ swift_code_matching_lines() {
         }
         FNR == 1 {
             block_comment_depth = 0
-            multiline_string = 0
-            quoted_string = 0
-            escaped_character = 0
+            interpolation_depth = 0
+            interpolation_string_width = 0
+            string_width = 0
         }
         {
-            code = code_without_comments($0)
+            printf "%s\t%d\t%s\n", FILENAME, FNR, executable_code($0)
+        }
+    ' "$@"
+}
+
+swift_code_matching_lines() {
+    local pattern="$1"
+    shift
+
+    awk -v pattern="$pattern" '
+        {
+            first_separator = index($0, "\t")
+            remainder = substr($0, first_separator + 1)
+            second_separator = index(remainder, "\t")
+            file = substr($0, 1, first_separator - 1)
+            line_number = substr(remainder, 1, second_separator - 1)
+            code = substr(remainder, second_separator + 1)
             if (code ~ pattern) {
-                printf "%s:%d:%s\n", FILENAME, FNR, code
+                printf "%s:%s:%s\n", file, line_number, code
                 matched = 1
             }
         }
         END { exit matched ? 0 : 1 }
-    ' "$@"
+    ' < <(swift_code_lines "$@")
+}
+
+swift_tree_code_matching_lines() {
+    local pattern="$1"
+    local root="$2"
+    local file
+    local matched=0
+
+    while IFS= read -r file; do
+        if swift_code_matching_lines "$pattern" "$file"; then
+            matched=1
+        fi
+    done < <(grep -RIl --include='*.swift' -E "$pattern" "$root" || true)
+
+    (( matched > 0 ))
 }
 
 reject_unapproved_symbol_lines() {
@@ -341,15 +409,16 @@ normalized_file_matches() {
 
     awk -v pattern="$pattern" '
         {
-            line = $0
-            sub(/\/\/.*/, "", line)
-            source = source " " line
+            first_separator = index($0, "\t")
+            remainder = substr($0, first_separator + 1)
+            second_separator = index(remainder, "\t")
+            source = source " " substr(remainder, second_separator + 1)
         }
         END {
             gsub(/[[:space:]]+/, " ", source)
             exit source ~ pattern ? 0 : 1
         }
-    ' "$file"
+    ' < <(swift_code_lines "$file")
 }
 
 typed_factory_declarations() {
@@ -1575,7 +1644,8 @@ reject_replacement_global_shell_store() {
         fi
 
         if [[ "$rel" != "$controller_owner" ]] \
-            && grep -Eq 'ObservableObject|@Observable' "$file" \
+            && swift_code_matching_lines \
+                'ObservableObject|@Observable' "$file" >/dev/null \
             && normalized_file_matches "$file" \
                 '->[ ]*ShellStateSnapshot[?!]?|static[ ]+(var|let)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?'
         then
@@ -1597,7 +1667,6 @@ reject_replacement_global_shell_store() {
 
     while IFS=: read -r file line_number source_line; do
         rel="${file#$SOURCE_ROOT/}"
-        source_line="${source_line%%//*}"
 
         if [[ "$source_line" == *"@Observable"* ]]; then
             printf '%s:%s:%s\n' "$file" "$line_number" "$source_line" >&2
@@ -1612,14 +1681,14 @@ reject_replacement_global_shell_store() {
             printf '%s:%s:%s\n' "$file" "$line_number" "$source_line" >&2
             fail "unrecognized ObservableObject ownership declaration in $rel"
         fi
-    done < <(grep -RInH --include='*.swift' -E \
-        'ObservableObject|@Observable' \
-        "$SOURCE_ROOT" || true)
+    done < <(
+        swift_tree_code_matching_lines \
+            'ObservableObject|@Observable' \
+            "$SOURCE_ROOT" || true
+    )
 
     while IFS=: read -r file line_number source_line; do
         rel="${file#$SOURCE_ROOT/}"
-        source_line="${source_line%%//*}"
-        [[ "$source_line" == *"@Published"* ]] || continue
 
         if [[ "$source_line" =~ @Published[^[:cntrl:]]*var[[:space:]]+([A-Za-z_][A-Za-z0-9_]*) ]]; then
             published_projection="$rel|${BASH_REMATCH[1]}"
@@ -1631,9 +1700,9 @@ reject_replacement_global_shell_store() {
             printf '%s:%s:%s\n' "$file" "$line_number" "$source_line" >&2
             fail "unrecognized @Published property declaration in $rel"
         fi
-    done < <(grep -RInH --include='*.swift' -F '@Published' "$SOURCE_ROOT" || true)
+    done < <(swift_tree_code_matching_lines '@Published' "$SOURCE_ROOT" || true)
 
-    if grep -RIn --include='*.swift' -E \
+    if swift_tree_code_matching_lines \
         '(class|struct|actor|enum)[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)?Shell(State|Workspace)?(Store|Model)([^A-Za-z0-9_]|$)' \
         "$SOURCE_ROOT" >&2
     then

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -272,6 +272,17 @@ manifest_state_declarations() {
             sub(/[[:space:]]+$/, "", value)
             return value
         }
+        function inferred_generic_contains_manifest(value,    expression) {
+            if (value !~ /=/) {
+                return 0
+            }
+            expression = value
+            sub(/^[^=]*=[ ]*/, "", expression)
+            sub(/^try[!?]?[ ]+/, "", expression)
+            sub(/^await[ ]+/, "", expression)
+            return expression ~ /^[A-Za-z_][A-Za-z0-9_.]*[ ]*<[^>]*ShellContentWorkspaceManifest/ ||
+                expression ~ /^\[[^]]*ShellContentWorkspaceManifest/
+        }
         function record_declaration(    declaration, header, prefix, kind) {
             if (buffer == "") {
                 return
@@ -290,6 +301,10 @@ manifest_state_declarations() {
                 prefix = declaration
                 sub(/[ ]*=[ ]*ShellContentWorkspaceManifest.*/, "", prefix)
                 kind = "constructed"
+            } else if (inferred_generic_contains_manifest(declaration)) {
+                prefix = declaration
+                sub(/[ ]*=.*/, "", prefix)
+                kind = "inferred-generic"
             } else {
                 buffer = ""
                 return
@@ -846,6 +861,17 @@ shell_snapshot_stored_property_counts() {
             sub(/[ ]*\(.*/, "", name)
             return name in snapshot_factories
         }
+        function inferred_generic_contains_snapshot(property,    expression) {
+            if (property !~ /=/) {
+                return 0
+            }
+            expression = property
+            sub(/^[^=]*=[ ]*/, "", expression)
+            sub(/^try[!?]?[ ]+/, "", expression)
+            sub(/^await[ ]+/, "", expression)
+            return expression ~ /^[A-Za-z_][A-Za-z0-9_.]*[ ]*<[^>]*ShellStateSnapshot/ ||
+                expression ~ /^\[[^]]*ShellStateSnapshot/
+        }
         function count_buffered_instance_property(    property) {
             if (instance_buffer == "") {
                 return
@@ -856,6 +882,8 @@ shell_snapshot_stored_property_counts() {
                 (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*($|=)/ ||
                 property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/ ||
                 property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
+                (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ &&
+                    inferred_generic_contains_snapshot(property)) ||
                 (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ && uses_snapshot_factory(property))))
             {
                 instance_count++
@@ -871,6 +899,8 @@ shell_snapshot_stored_property_counts() {
             if (property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*($|=)/ ||
                 property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/ ||
                 property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
+                (property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ &&
+                    inferred_generic_contains_snapshot(property)) ||
                 (property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ && uses_snapshot_factory(property)))
             {
                 static_count++

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -388,24 +388,7 @@ manifest_state_declarations() {
             sub(/^.*[.]/, "", name)
             return name
         }
-        function inferred_factory_contains_manifest(value, owner,    call, expression, name, parts, qualifier, segment_count, qualifier_index) {
-            if (value !~ /=/) {
-                return 0
-            }
-            expression = value
-            sub(/^[^=]*=[ ]*/, "", expression)
-            while (expression ~ /^(try[!?]?|await)[ ]+/) {
-                sub(/^(try[!?]?|await)[ ]+/, "", expression)
-            }
-            if (expression !~ /\(/) {
-                return 0
-            }
-            call = expression
-            sub(/[ ]*\(.*/, "", call)
-            gsub(/[ ]*[.][ ]*/, ".", call)
-            if (call !~ /^[A-Za-z_][A-Za-z0-9_.]*$/) {
-                return 0
-            }
+        function manifest_factory_call_matches(call, owner,    name, parts, qualifier, segment_count, qualifier_index) {
             segment_count = split(call, parts, ".")
             name = parts[segment_count]
             if (segment_count == 1) {
@@ -422,6 +405,23 @@ manifest_state_declarations() {
                 }
             }
             return parts[1] == "shared" && ((owner "|" name) in manifest_factories)
+        }
+        function inferred_factory_contains_manifest(value, owner,    call, expression) {
+            if (value !~ /=/) {
+                return 0
+            }
+            expression = value
+            sub(/^[^=]*=[ ]*/, "", expression)
+            gsub(/[ ]*[.][ ]*/, ".", expression)
+            while (match(expression, /[A-Za-z_][A-Za-z0-9_.]*[ ]*\(/)) {
+                call = substr(expression, RSTART, RLENGTH)
+                sub(/[ ]*\($/, "", call)
+                if (manifest_factory_call_matches(call, owner)) {
+                    return 1
+                }
+                expression = substr(expression, RSTART + RLENGTH)
+            }
+            return 0
         }
         function inferred_generic_contains_manifest(value,    expression) {
             if (value !~ /=/) {
@@ -552,24 +552,7 @@ shell_host_static_storage_declarations() {
             sub(/^.*[.]/, "", name)
             return name
         }
-        function uses_shell_host_factory(value, owner,    call, expression, name, parts, qualifier, segment_count, qualifier_index) {
-            if (value !~ /=/) {
-                return 0
-            }
-            expression = value
-            sub(/^[^=]*=[ ]*/, "", expression)
-            while (expression ~ /^(try[!?]?|await)[ ]+/) {
-                sub(/^(try[!?]?|await)[ ]+/, "", expression)
-            }
-            if (expression !~ /\(/) {
-                return 0
-            }
-            call = expression
-            sub(/[ ]*\(.*/, "", call)
-            gsub(/[ ]*[.][ ]*/, ".", call)
-            if (call !~ /^[A-Za-z_][A-Za-z0-9_.]*$/) {
-                return 0
-            }
+        function shell_host_factory_call_matches(call, owner,    name, parts, qualifier, segment_count, qualifier_index) {
             segment_count = split(call, parts, ".")
             name = parts[segment_count]
             if (segment_count == 1) {
@@ -586,6 +569,23 @@ shell_host_static_storage_declarations() {
                 }
             }
             return parts[1] == "shared" && ((owner "|" name) in shell_host_factories)
+        }
+        function uses_shell_host_factory(value, owner,    call, expression) {
+            if (value !~ /=/) {
+                return 0
+            }
+            expression = value
+            sub(/^[^=]*=[ ]*/, "", expression)
+            gsub(/[ ]*[.][ ]*/, ".", expression)
+            while (match(expression, /[A-Za-z_][A-Za-z0-9_.]*[ ]*\(/)) {
+                call = substr(expression, RSTART, RLENGTH)
+                sub(/[ ]*\($/, "", call)
+                if (shell_host_factory_call_matches(call, owner)) {
+                    return 1
+                }
+                expression = substr(expression, RSTART + RLENGTH)
+            }
+            return 0
         }
         function is_stored_property(value,    declaration_header) {
             declaration_header = value
@@ -1127,24 +1127,7 @@ shell_snapshot_stored_property_counts() {
             sub(/^.*[.]/, "", name)
             return name
         }
-        function uses_snapshot_factory(property, owner,    call, expression, name, parts, qualifier, segment_count, qualifier_index) {
-            if (property !~ /=/) {
-                return 0
-            }
-            expression = property
-            sub(/^[^=]*=[ ]*/, "", expression)
-            while (expression ~ /^(try[!?]?|await)[ ]+/) {
-                sub(/^(try[!?]?|await)[ ]+/, "", expression)
-            }
-            if (expression !~ /\(/) {
-                return 0
-            }
-            call = expression
-            sub(/[ ]*\(.*/, "", call)
-            gsub(/[ ]*[.][ ]*/, ".", call)
-            if (call !~ /^[A-Za-z_][A-Za-z0-9_.]*$/) {
-                return 0
-            }
+        function snapshot_factory_call_matches(call, owner,    name, parts, qualifier, segment_count, qualifier_index) {
             segment_count = split(call, parts, ".")
             name = parts[segment_count]
             if (segment_count == 1) {
@@ -1161,6 +1144,23 @@ shell_snapshot_stored_property_counts() {
                 }
             }
             return parts[1] == "shared" && ((owner "|" name) in snapshot_factories)
+        }
+        function uses_snapshot_factory(property, owner,    call, expression) {
+            if (property !~ /=/) {
+                return 0
+            }
+            expression = property
+            sub(/^[^=]*=[ ]*/, "", expression)
+            gsub(/[ ]*[.][ ]*/, ".", expression)
+            while (match(expression, /[A-Za-z_][A-Za-z0-9_.]*[ ]*\(/)) {
+                call = substr(expression, RSTART, RLENGTH)
+                sub(/[ ]*\($/, "", call)
+                if (snapshot_factory_call_matches(call, owner)) {
+                    return 1
+                }
+                expression = substr(expression, RSTART + RLENGTH)
+            }
+            return 0
         }
         function inferred_generic_contains_snapshot(property,    expression) {
             if (property !~ /=/) {

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -518,6 +518,20 @@ readonly OWNERSHIP_AWK_HELPERS='
         return top_level_character_position(value, "=") > 0 ||
             top_level_character_position(value, "{") > 0
     }
+    function inferred_optional_case_contains_target(value, target_type,    expression, pattern) {
+        if (value !~ /=/) {
+            return 0
+        }
+        expression = value
+        sub(/^[^=]*=[ ]*/, "", expression)
+        sub(/^try[!?]?[ ]+/, "", expression)
+        sub(/^await[ ]+/, "", expression)
+        gsub(/[ ]*[?][ ]*/, "?", expression)
+        gsub(/[ ]*[!][ ]*/, "!", expression)
+        gsub(/[ ]*[.][ ]*/, ".", expression)
+        pattern = "^" target_type "[?!][.](none|some)([^A-Za-z0-9_]|$)"
+        return expression ~ pattern
+    }
     function instance_receiver_invokes_factory(value, factories,    call_end, pattern, entry, fields, method, opening, receiver, remainder, suffix) {
         for (entry in factories) {
             split(entry, fields, "|")
@@ -890,6 +904,10 @@ manifest_state_declarations() {
                 prefix = declaration
                 sub(/[ ]*=.*/, "", prefix)
                 kind = "inferred-generic"
+            } else if (inferred_optional_case_contains_target(declaration, "ShellContentWorkspaceManifest")) {
+                prefix = declaration
+                sub(/[ ]*=.*/, "", prefix)
+                kind = "inferred-optional"
             } else if (inferred_factory_contains_manifest(declaration, declaration_owner)) {
                 prefix = declaration
                 sub(/[ ]*=.*/, "", prefix)
@@ -1863,6 +1881,7 @@ shell_snapshot_stored_property_counts() {
             return typed_storage_contains_snapshot(binding) ||
                 binding ~ /=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
                 inferred_generic_contains_snapshot(binding) ||
+                inferred_optional_case_contains_target(binding, "ShellStateSnapshot") ||
                 (!binding_has_explicit_type(binding) && uses_snapshot_projection(binding)) ||
                 uses_snapshot_factory(binding, owner)
         }

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -599,22 +599,45 @@ reject_shell_host_duplicate_persistence_state() {
     fi
 }
 
-mutable_shell_snapshot_declaration_count() {
+shell_snapshot_stored_property_count() {
     local file="$1"
 
     awk '
+        function count_buffered_property(    property) {
+            if (buffer == "") {
+                return
+            }
+            property = buffer
+            gsub(/[[:space:]]+/, " ", property)
+            if (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?]?[ ]*($|=)/ ||
+                property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot([.(]|$)/)
+            {
+                count++
+            }
+            buffer = ""
+        }
         {
-            source = source " " $0
+            line = $0
+            sub(/\/\/.*/, "", line)
+
+            # Production Swift formatting keeps top-level type members at four
+            # spaces. Collect only those property declarations and their deeper
+            # continuation lines so method-local scratch variables are ignored.
+            if (line ~ /^    [^ ]/) {
+                count_buffered_property()
+                if (line ~ /^    .*var[ ]+[A-Za-z_][A-Za-z0-9_]*/) {
+                    buffer = line
+                }
+            } else if (buffer != "" &&
+                (line ~ /^        / || line ~ /^[[:space:]]*$/))
+            {
+                buffer = buffer " " line
+            } else {
+                count_buffered_property()
+            }
         }
         END {
-            gsub(/[[:space:]]+/, " ", source)
-            pattern = "var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*" \
-                "(:[ ]*ShellStateSnapshot[?]?|=[ ]*ShellStateSnapshot([.(]|$))"
-            count = 0
-            while (match(source, pattern)) {
-                count++
-                source = substr(source, RSTART + RLENGTH)
-            }
+            count_buffered_property()
             print count
         }
     ' "$file"
@@ -623,7 +646,7 @@ mutable_shell_snapshot_declaration_count() {
 reject_replacement_global_shell_store() {
     local controller_owner="ShellHostController.swift"
     local file
-    local mutable_snapshot_declarations
+    local snapshot_stored_properties
     local rel
 
     require_existing_single_owner_pattern \
@@ -633,25 +656,25 @@ reject_replacement_global_shell_store() {
 
     while IFS= read -r file; do
         rel="${file#$SOURCE_ROOT/}"
-        mutable_snapshot_declarations="$(mutable_shell_snapshot_declaration_count "$file")"
+        snapshot_stored_properties="$(shell_snapshot_stored_property_count "$file")"
 
         if [[ "$rel" == "$controller_owner" ]] \
-            && (( mutable_snapshot_declarations != 1 ))
+            && (( snapshot_stored_properties != 1 ))
         then
             fail \
-                "ShellHostController must keep exactly one mutable ShellStateSnapshot projection"
+                "ShellHostController must keep exactly one stored ShellStateSnapshot projection"
         elif [[ "$rel" != "$controller_owner" ]] \
             && grep -Eq 'ObservableObject|@Observable' "$file" \
-            && (( mutable_snapshot_declarations > 0 ))
+            && (( snapshot_stored_properties > 0 ))
         then
             fail \
-                "mutable observable ShellStateSnapshot must stay in ShellHostController; found in $rel"
+                "stored observable ShellStateSnapshot must stay in ShellHostController; found in $rel"
         fi
 
-        if (( mutable_snapshot_declarations > 0 )) \
+        if (( snapshot_stored_properties > 0 )) \
             && grep -Eq 'static[[:space:]]+(let|var)[[:space:]]+(shared|current|default)([^A-Za-z0-9_]|$)' "$file"
         then
-            fail "mutable ShellStateSnapshot must not become a global singleton; found in $rel"
+            fail "stored ShellStateSnapshot must not become a global singleton; found in $rel"
         fi
     done < <(grep -RIl --include='*.swift' -F "ShellStateSnapshot" "$SOURCE_ROOT" || true)
 

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -543,6 +543,99 @@ reject_shell_host_duplicate_selection_state() {
     fi
 }
 
+reject_shell_host_duplicate_persistence_state() {
+    local controller="$SOURCE_ROOT/ShellHostController.swift"
+    local controller_dir="$SOURCE_ROOT/Controllers/Shell"
+    local persistence_owner="Services/Shell/ShellWorkspacePersistenceCoordinator.swift"
+    local persistence_type_owners=(
+        "Services/Shell/ShellWorkspaceManifestProjector.swift"
+        "Services/Shell/ShellWorkspaceManifestStore.swift"
+        "$persistence_owner"
+    )
+    local file
+    local rel
+
+    require_existing_single_owner_pattern \
+        "var workspaceManifest: ShellContentWorkspaceManifest?" \
+        "$persistence_owner" \
+        "mutable workspace manifest state"
+    require_existing_single_owner_pattern \
+        "var latestContext: PersistenceContext?" \
+        "$persistence_owner" \
+        "latest workspace persistence context"
+    require_existing_single_owner_pattern \
+        "var contentFlushScheduled = false" \
+        "$persistence_owner" \
+        "workspace persistence scheduled-flush state"
+    require_existing_single_owner_pattern \
+        "var contentFlushPending = false" \
+        "$persistence_owner" \
+        "workspace persistence pending-content state"
+    require_existing_single_owner_pattern \
+        "manifestFlushScheduler.schedule" \
+        "$persistence_owner" \
+        "workspace persistence debounce scheduling"
+    require_existing_single_owner_pattern \
+        "manifestProjector.makeManifest(" \
+        "$persistence_owner" \
+        "workspace manifest projection invocation"
+
+    while IFS= read -r file; do
+        rel="${file#$SOURCE_ROOT/}"
+        if ! contains_line "$rel" "${persistence_type_owners[@]}"; then
+            fail \
+                "workspace persistence scheduler/projector types must stay behind the persistence owner; found in $rel"
+        fi
+    done < <(grep -RIl --include='*.swift' -E \
+        'ManifestFlushScheduling|ShellWorkspaceManifestProjector' \
+        "$SOURCE_ROOT" || true)
+
+    if grep -RIn --include='*.swift' -E \
+        '^[[:space:]]*(private[[:space:]]+)?var[[:space:]]+workspaceManifest|ManifestFlushScheduling|manifestFlushScheduler|contentFlush(Scheduled|Pending)|scheduleContentFlush|flushPendingPersistence|syncManifestFromShellState|makeWorkspaceManifestFromShellState|ShellWorkspaceManifestProjector[[:space:]]*\(' \
+        "$controller" "$controller_dir" >&2
+    then
+        fail \
+            "shell host persistence state, projection, and scheduling must remain in ShellWorkspacePersistenceCoordinator"
+    fi
+}
+
+reject_replacement_global_shell_store() {
+    local controller_owner="ShellHostController.swift"
+    local file
+    local rel
+
+    require_existing_single_owner_pattern \
+        "var shellState: ShellStateSnapshot" \
+        "$controller_owner" \
+        "observable shell snapshot state"
+
+    while IFS= read -r file; do
+        rel="${file#$SOURCE_ROOT/}"
+
+        if [[ "$rel" != "$controller_owner" ]] \
+            && grep -Eq 'ObservableObject|@Observable' "$file" \
+            && grep -Eq 'var[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*:[[:space:]]*ShellStateSnapshot[?]?' "$file"
+        then
+            fail \
+                "mutable observable ShellStateSnapshot must stay in ShellHostController; found in $rel"
+        fi
+
+        if grep -Eq 'var[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*:[[:space:]]*ShellStateSnapshot[?]?' "$file" \
+            && grep -Eq 'static[[:space:]]+(let|var)[[:space:]]+(shared|current|default)([^A-Za-z0-9_]|$)' "$file"
+        then
+            fail "mutable ShellStateSnapshot must not become a global singleton; found in $rel"
+        fi
+    done < <(grep -RIl --include='*.swift' -F "ShellStateSnapshot" "$SOURCE_ROOT" || true)
+
+    if grep -RIn --include='*.swift' -E \
+        '(class|struct|actor)[[:space:]]+((Alan|Global)Shell|Shell)(State|Workspace)?(Store|Model)([^A-Za-z0-9_]|$)' \
+        "$SOURCE_ROOT" >&2
+    then
+        fail \
+            "a replacement global Shell store/model must not sit above the accepted shell state owners"
+    fi
+}
+
 reject_swiftui_shell_hot_path_sync_boundaries() {
     local matched=0
     local pattern
@@ -733,6 +826,8 @@ require_shell_core_ffi_raw_symbol_owners
 require_shell_core_action_metadata_query_owners
 reject_shell_host_duplicate_terminal_runtime_state
 reject_shell_host_duplicate_selection_state
+reject_shell_host_duplicate_persistence_state
+reject_replacement_global_shell_store
 reject_swiftui_shell_hot_path_sync_boundaries
 
 printf 'Current Swift inventory:\n'

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -352,16 +352,22 @@ typed_factory_declarations() {
     ' "$file"
 }
 
+typed_factory_inventory() {
+    local target_type="$1"
+    local file
+
+    while IFS= read -r file; do
+        typed_factory_declarations "$file" "$target_type"
+    done < <(find "$SOURCE_ROOT" -type f -name '*.swift' -print | sort)
+}
+
 manifest_state_declarations() {
     local file="$1"
-    local factory_inventory
-    factory_inventory="$(
-        typed_factory_declarations "$file" "ShellContentWorkspaceManifest"
-    )"
+    local factory_inventory="$2"
 
     awk -v factory_inventory="$factory_inventory" '
         BEGIN {
-            factory_count = split(factory_inventory, factory_entries, "\n")
+            factory_count = split(factory_inventory, factory_entries, ";")
             for (factory_index = 1; factory_index <= factory_count; factory_index++) {
                 if (factory_entries[factory_index] != "") {
                     manifest_factories[factory_entries[factory_index]] = 1
@@ -518,12 +524,11 @@ static_property_declarations() {
 
 shell_host_static_storage_declarations() {
     local file="$1"
-    local factory_inventory
-    factory_inventory="$(typed_factory_declarations "$file" "ShellHostController")"
+    local factory_inventory="$2"
 
     awk -v factory_inventory="$factory_inventory" '
         BEGIN {
-            factory_count = split(factory_inventory, factory_entries, "\n")
+            factory_count = split(factory_inventory, factory_entries, ";")
             for (factory_index = 1; factory_index <= factory_count; factory_index++) {
                 if (factory_entries[factory_index] != "") {
                     shell_host_factories[factory_entries[factory_index]] = 1
@@ -980,6 +985,7 @@ reject_shell_host_duplicate_persistence_state() {
     local declaration_indent
     local declaration_kind
     local declaration_line
+    local factory_inventory
     local file
     local manifest_state
     local rel
@@ -1009,6 +1015,9 @@ reject_shell_host_duplicate_persistence_state() {
         "$persistence_owner" \
         "workspace manifest projection invocation"
 
+    factory_inventory="$(
+        typed_factory_inventory "ShellContentWorkspaceManifest" | sort -u | tr '\n' ';'
+    )"
     while IFS= read -r file; do
         rel="${file#$SOURCE_ROOT/}"
         while IFS='|' read -r declaration_line declaration_indent declaration declaration_kind; do
@@ -1018,10 +1027,8 @@ reject_shell_host_duplicate_persistence_state() {
                 fail \
                     "ShellContentWorkspaceManifest storage is not in the accepted ownership inventory: $manifest_state"
             fi
-        done < <(manifest_state_declarations "$file")
-    done < <(grep -RIl --include='*.swift' -F \
-        'ShellContentWorkspaceManifest' \
-        "$SOURCE_ROOT" || true)
+        done < <(manifest_state_declarations "$file" "$factory_inventory")
+    done < <(find "$SOURCE_ROOT" -type f -name '*.swift' -print | sort)
 
     while IFS= read -r file; do
         rel="${file#$SOURCE_ROOT/}"
@@ -1084,12 +1091,11 @@ reject_shell_host_duplicate_persistence_state() {
 
 shell_snapshot_stored_property_counts() {
     local file="$1"
-    local factory_inventory
-    factory_inventory="$(typed_factory_declarations "$file" "ShellStateSnapshot")"
+    local factory_inventory="$2"
 
     awk -v factory_inventory="$factory_inventory" '
         BEGIN {
-            factory_count = split(factory_inventory, factory_entries, "\n")
+            factory_count = split(factory_inventory, factory_entries, ";")
             for (factory_index = 1; factory_index <= factory_count; factory_index++) {
                 if (factory_entries[factory_index] != "") {
                     snapshot_factories[factory_entries[factory_index]] = 1
@@ -1306,10 +1312,12 @@ reject_replacement_global_shell_store() {
         "ShellHostController.swift|static let terminalSelectionFirst = ShellPaneMovementInteractionPolicy()"
     )
     local file
+    local host_factory_inventory
     local line_number
     local observable_owner
     local published_projection
     local snapshot_property_counts
+    local snapshot_factory_inventory
     local snapshot_stored_properties
     local static_member
     local static_member_key
@@ -1322,9 +1330,18 @@ reject_replacement_global_shell_store() {
         "$controller_owner" \
         "observable shell snapshot state"
 
+    snapshot_factory_inventory="$(
+        typed_factory_inventory "ShellStateSnapshot" | sort -u | tr '\n' ';'
+    )"
+    host_factory_inventory="$(
+        typed_factory_inventory "ShellHostController" | sort -u | tr '\n' ';'
+    )"
+
     while IFS= read -r file; do
         rel="${file#$SOURCE_ROOT/}"
-        snapshot_property_counts="$(shell_snapshot_stored_property_counts "$file")"
+        snapshot_property_counts="$(
+            shell_snapshot_stored_property_counts "$file" "$snapshot_factory_inventory"
+        )"
         snapshot_stored_properties="${snapshot_property_counts%% *}"
         static_snapshot_stored_properties="${snapshot_property_counts##* }"
 
@@ -1376,7 +1393,7 @@ reject_replacement_global_shell_store() {
                 "non-controller observable owners must not manufacture ShellStateSnapshot state; found in $rel"
         fi
 
-    done < <(grep -RIl --include='*.swift' -F "ShellStateSnapshot" "$SOURCE_ROOT" || true)
+    done < <(find "$SOURCE_ROOT" -type f -name '*.swift' -print | sort)
 
     while IFS= read -r file; do
         rel="${file#$SOURCE_ROOT/}"
@@ -1385,7 +1402,7 @@ reject_replacement_global_shell_store() {
             printf '%s:%s:%s\n' "$file" "$line_number" "$source_line" >&2
             fail \
                 "ShellHostController must not be retained by static/class storage; found in $rel"
-        done < <(shell_host_static_storage_declarations "$file")
+        done < <(shell_host_static_storage_declarations "$file" "$host_factory_inventory")
     done < <(find "$SOURCE_ROOT" -type f -name '*.swift' -print | sort)
 
     while IFS=: read -r file line_number source_line; do

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -533,7 +533,7 @@ static_property_declarations() {
     ' "$file"
 }
 
-shell_host_static_storage_declarations() {
+shell_host_global_storage_declarations() {
     local file="$1"
     local factory_inventory="$2"
 
@@ -553,6 +553,9 @@ shell_host_static_storage_declarations() {
         }
         function is_static_property_start(value) {
             return value ~ /^[[:space:]]*[^\/]*(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
+        }
+        function is_module_property_start(value) {
+            return value ~ /^[^\/]*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
         }
         function is_type_declaration(value) {
             return value ~ /^[[:space:]]*[^\/]*(class|struct|actor|enum|extension|protocol)[ ]+[A-Za-z_][A-Za-z0-9_.]*/
@@ -650,7 +653,9 @@ shell_host_static_storage_declarations() {
                 }
             }
 
-            if (is_static_property_start(line)) {
+            if (is_static_property_start(line) ||
+                (type_depth == 0 && line_indent == 0 && is_module_property_start(line)))
+            {
                 record_buffered_property()
                 property_buffer = line
                 property_start_line = FNR
@@ -1138,6 +1143,9 @@ shell_snapshot_stored_property_counts() {
         function is_static_property_start(value) {
             return value ~ /^[[:space:]]*[^\/]*(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
         }
+        function is_module_property_start(value) {
+            return value ~ /^[^\/]*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
+        }
         function is_type_declaration(value) {
             return value ~ /^[[:space:]]*[^\/]*(class|struct|actor|enum|extension|protocol)[ ]+[A-Za-z_][A-Za-z0-9_.]*/
         }
@@ -1238,24 +1246,24 @@ shell_snapshot_stored_property_counts() {
             }
             instance_buffer = ""
         }
-        function count_buffered_static_property(    property) {
-            if (static_buffer == "") {
+        function count_buffered_global_property(    property) {
+            if (global_buffer == "") {
                 return
             }
-            property = static_buffer
+            property = global_buffer
             gsub(/[[:space:]]+/, " ", property)
-            if ((property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:/ &&
+            if ((property ~ /(^| )(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:/ &&
                     typed_storage_contains_snapshot(property)) ||
-                property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/ ||
-                property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
-                (property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ &&
+                property ~ /(^| )var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/ ||
+                property ~ /(^| )(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
+                (property ~ /(^| )(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ &&
                     inferred_generic_contains_snapshot(property)) ||
-                (property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ &&
-                    uses_snapshot_factory(property, static_owner)))
+                (property ~ /(^| )(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ &&
+                    uses_snapshot_factory(property, global_owner)))
             {
-                static_count++
+                global_count++
             }
-            static_buffer = ""
+            global_buffer = ""
         }
         {
             line = $0
@@ -1293,26 +1301,28 @@ shell_snapshot_stored_property_counts() {
                 count_buffered_instance_property()
             }
 
-            # Static/class storage is necessarily a type member, so scan it at
-            # every nesting depth without confusing method-local variables for
-            # globally addressable state.
-            if (is_static_property_start(line)) {
-                count_buffered_static_property()
-                static_buffer = line
-                static_indent = leading_space_count(line)
-                static_owner = type_depth > 0 ? type_name[type_depth] : ""
-            } else if (static_buffer != "" &&
-                (line ~ /^[[:space:]]*$/ || leading_space_count(line) > static_indent))
+            # Globally addressable storage is either a module-scope declaration
+            # or a static/class type member. Method-local variables remain out
+            # of this inventory.
+            if (is_static_property_start(line) ||
+                (type_depth == 0 && line_indent == 0 && is_module_property_start(line)))
             {
-                static_buffer = static_buffer " " line
+                count_buffered_global_property()
+                global_buffer = line
+                global_indent = line_indent
+                global_owner = type_depth > 0 ? type_name[type_depth] : ""
+            } else if (global_buffer != "" &&
+                (line ~ /^[[:space:]]*$/ || leading_space_count(line) > global_indent))
+            {
+                global_buffer = global_buffer " " line
             } else {
-                count_buffered_static_property()
+                count_buffered_global_property()
             }
         }
         END {
             count_buffered_instance_property()
-            count_buffered_static_property()
-            print instance_count, static_count
+            count_buffered_global_property()
+            print instance_count, global_count
         }
     ' "$file"
 }
@@ -1363,7 +1373,7 @@ reject_replacement_global_shell_store() {
     local snapshot_stored_properties
     local static_member
     local static_member_key
-    local static_snapshot_stored_properties
+    local global_snapshot_stored_properties
     local source_line
     local rel
 
@@ -1385,7 +1395,7 @@ reject_replacement_global_shell_store() {
             shell_snapshot_stored_property_counts "$file" "$snapshot_factory_inventory"
         )"
         snapshot_stored_properties="${snapshot_property_counts%% *}"
-        static_snapshot_stored_properties="${snapshot_property_counts##* }"
+        global_snapshot_stored_properties="${snapshot_property_counts##* }"
 
         case "$rel" in
             "$controller_owner")
@@ -1408,8 +1418,9 @@ reject_replacement_global_shell_store() {
                 ;;
         esac
 
-        if (( static_snapshot_stored_properties > 0 )); then
-            fail "ShellStateSnapshot must not have a static stored owner; found in $rel"
+        if (( global_snapshot_stored_properties > 0 )); then
+            fail \
+                "ShellStateSnapshot must not have a module/static/class stored owner; found in $rel"
         fi
 
         if (( snapshot_stored_properties > 0 )); then
@@ -1443,8 +1454,8 @@ reject_replacement_global_shell_store() {
             [[ -n "$line_number" ]] || continue
             printf '%s:%s:%s\n' "$file" "$line_number" "$source_line" >&2
             fail \
-                "ShellHostController must not be retained by static/class storage; found in $rel"
-        done < <(shell_host_static_storage_declarations "$file" "$host_factory_inventory")
+                "ShellHostController must not be retained by module/static/class storage; found in $rel"
+        done < <(shell_host_global_storage_declarations "$file" "$host_factory_inventory")
     done < <(find "$SOURCE_ROOT" -type f -name '*.swift' -print | sort)
 
     while IFS=: read -r file line_number source_line; do

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -587,11 +587,11 @@ reject_shell_host_duplicate_persistence_state() {
                 "workspace persistence scheduler/projector types must stay behind the persistence owner; found in $rel"
         fi
     done < <(grep -RIl --include='*.swift' -E \
-        'ManifestFlushScheduling|ShellWorkspaceManifestProjector' \
+        'ManifestFlushScheduling|DebouncedManifestFlushScheduler|ShellWorkspaceManifestProjector' \
         "$SOURCE_ROOT" || true)
 
     if grep -RIn --include='*.swift' -E \
-        '^[[:space:]]*(private[[:space:]]+)?var[[:space:]]+workspaceManifest|ManifestFlushScheduling|manifestFlushScheduler|contentFlush(Scheduled|Pending)|scheduleContentFlush|flushPendingPersistence|syncManifestFromShellState|makeWorkspaceManifestFromShellState|ShellWorkspaceManifestProjector[[:space:]]*\(' \
+        '^[[:space:]]*(private[[:space:]]+)?var[[:space:]]+workspaceManifest|ManifestFlushScheduling|DebouncedManifestFlushScheduler|manifestFlushScheduler|contentFlush(Scheduled|Pending)|scheduleContentFlush|flushPendingPersistence|syncManifestFromShellState|makeWorkspaceManifestFromShellState|ShellWorkspaceManifestProjector[[:space:]]*\(' \
         "$controller" "$controller_dir" >&2
     then
         fail \

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -303,12 +303,6 @@ typed_factory_declarations() {
                 factory_buffer = ""
                 return
             }
-            if (factory_owner != "" &&
-                header !~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*func[ ]+/)
-            {
-                factory_buffer = ""
-                return
-            }
             name = header
             sub(/^.*func[ ]+/, "", name)
             sub(/[^A-Za-z0-9_].*$/, "", name)
@@ -394,7 +388,7 @@ manifest_state_declarations() {
             sub(/^.*[.]/, "", name)
             return name
         }
-        function inferred_factory_contains_manifest(value, owner,    call, expression, name, parts, qualifier, segment_count) {
+        function inferred_factory_contains_manifest(value, owner,    call, expression, name, parts, qualifier, segment_count, qualifier_index) {
             if (value !~ /=/) {
                 return 0
             }
@@ -418,11 +412,16 @@ manifest_state_declarations() {
                 return ((owner "|" name) in manifest_factories) ||
                     (("|" name) in manifest_factories)
             }
-            qualifier = parts[segment_count - 1]
-            if (qualifier == "Self" || qualifier == "self") {
-                qualifier = owner
+            for (qualifier_index = 1; qualifier_index < segment_count; qualifier_index++) {
+                qualifier = parts[qualifier_index]
+                if (qualifier == "Self" || qualifier == "self") {
+                    qualifier = owner
+                }
+                if ((qualifier "|" name) in manifest_factories) {
+                    return 1
+                }
             }
-            return (qualifier "|" name) in manifest_factories
+            return parts[1] == "shared" && ((owner "|" name) in manifest_factories)
         }
         function inferred_generic_contains_manifest(value,    expression) {
             if (value !~ /=/) {
@@ -553,7 +552,7 @@ shell_host_static_storage_declarations() {
             sub(/^.*[.]/, "", name)
             return name
         }
-        function uses_shell_host_factory(value, owner,    call, expression, name, parts, qualifier, segment_count) {
+        function uses_shell_host_factory(value, owner,    call, expression, name, parts, qualifier, segment_count, qualifier_index) {
             if (value !~ /=/) {
                 return 0
             }
@@ -577,11 +576,16 @@ shell_host_static_storage_declarations() {
                 return ((owner "|" name) in shell_host_factories) ||
                     (("|" name) in shell_host_factories)
             }
-            qualifier = parts[segment_count - 1]
-            if (qualifier == "Self" || qualifier == "self") {
-                qualifier = owner
+            for (qualifier_index = 1; qualifier_index < segment_count; qualifier_index++) {
+                qualifier = parts[qualifier_index]
+                if (qualifier == "Self" || qualifier == "self") {
+                    qualifier = owner
+                }
+                if ((qualifier "|" name) in shell_host_factories) {
+                    return 1
+                }
             }
-            return (qualifier "|" name) in shell_host_factories
+            return parts[1] == "shared" && ((owner "|" name) in shell_host_factories)
         }
         function is_stored_property(value,    declaration_header) {
             declaration_header = value
@@ -978,8 +982,11 @@ reject_shell_host_duplicate_persistence_state() {
     local manifest_state_allowlist=(
         "Services/Shell/ShellCoreFFIManifestAdapter.swift|4|let manifest|typed"
         "Services/Shell/ShellWorkspaceManifestProjector.swift|8|var manifest|constructed"
+        "Services/Shell/ShellWorkspaceManifestStore.swift|8|let manifest|inferred-factory"
+        "Services/Shell/ShellWorkspaceManifestStore.swift|12|let manifest|inferred-factory"
         "Services/Shell/ShellWorkspaceManifestStore.swift|4|var manifest|typed"
         "Services/Shell/ShellWorkspacePersistenceCoordinator.swift|4|private var workspaceManifest|typed"
+        "Services/Shell/ShellWorkspacePersistenceStartup.swift|12|let retainedManifest|inferred-factory"
     )
     local declaration
     local declaration_indent
@@ -1120,7 +1127,7 @@ shell_snapshot_stored_property_counts() {
             sub(/^.*[.]/, "", name)
             return name
         }
-        function uses_snapshot_factory(property, owner,    call, expression, name, parts, qualifier, segment_count) {
+        function uses_snapshot_factory(property, owner,    call, expression, name, parts, qualifier, segment_count, qualifier_index) {
             if (property !~ /=/) {
                 return 0
             }
@@ -1144,11 +1151,16 @@ shell_snapshot_stored_property_counts() {
                 return ((owner "|" name) in snapshot_factories) ||
                     (("|" name) in snapshot_factories)
             }
-            qualifier = parts[segment_count - 1]
-            if (qualifier == "Self" || qualifier == "self") {
-                qualifier = owner
+            for (qualifier_index = 1; qualifier_index < segment_count; qualifier_index++) {
+                qualifier = parts[qualifier_index]
+                if (qualifier == "Self" || qualifier == "self") {
+                    qualifier = owner
+                }
+                if ((qualifier "|" name) in snapshot_factories) {
+                    return 1
+                }
             }
-            return (qualifier "|" name) in snapshot_factories
+            return parts[1] == "shared" && ((owner "|" name) in snapshot_factories)
         }
         function inferred_generic_contains_snapshot(property,    expression) {
             if (property !~ /=/) {

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -217,26 +217,120 @@ contains_line() {
     return 1
 }
 
+swift_code_matching_lines() {
+    local pattern="$1"
+    shift
+
+    awk -v pattern="$pattern" '
+        function code_without_comments(value,    character, code, column, pair, triple) {
+            code = ""
+            column = 1
+            while (column <= length(value)) {
+                pair = substr(value, column, 2)
+                triple = substr(value, column, 3)
+                character = substr(value, column, 1)
+
+                if (block_comment_depth > 0) {
+                    if (pair == "/*") {
+                        block_comment_depth++
+                        column += 2
+                    } else if (pair == "*/") {
+                        block_comment_depth--
+                        column += 2
+                    } else {
+                        column++
+                    }
+                    continue
+                }
+
+                # Keep string contents so comment delimiters inside Swift
+                # strings cannot hide executable source later on the line.
+                if (multiline_string) {
+                    if (triple == "\"\"\"") {
+                        code = code triple
+                        multiline_string = 0
+                        column += 3
+                    } else {
+                        code = code character
+                        column++
+                    }
+                    continue
+                }
+                if (quoted_string) {
+                    code = code character
+                    if (escaped_character) {
+                        escaped_character = 0
+                    } else if (character == "\\") {
+                        escaped_character = 1
+                    } else if (character == "\"") {
+                        quoted_string = 0
+                    }
+                    column++
+                    continue
+                }
+
+                if (pair == "//") {
+                    break
+                }
+                if (pair == "/*") {
+                    block_comment_depth = 1
+                    column += 2
+                    continue
+                }
+                if (triple == "\"\"\"") {
+                    code = code triple
+                    multiline_string = 1
+                    column += 3
+                    continue
+                }
+                if (character == "\"") {
+                    code = code character
+                    quoted_string = 1
+                    escaped_character = 0
+                    column++
+                    continue
+                }
+
+                code = code character
+                column++
+            }
+            return code
+        }
+        FNR == 1 {
+            block_comment_depth = 0
+            multiline_string = 0
+            quoted_string = 0
+            escaped_character = 0
+        }
+        {
+            code = code_without_comments($0)
+            if (code ~ pattern) {
+                printf "%s:%d:%s\n", FILENAME, FNR, code
+                matched = 1
+            }
+        }
+        END { exit matched ? 0 : 1 }
+    ' "$@"
+}
+
 reject_unapproved_symbol_lines() {
     local file="$1"
     local symbol_pattern="$2"
     local allowed_pattern="$3"
     local description="$4"
+    local match_file
+    local match_line
+    local rejected=0
+    local source_line
 
-    if ! awk \
-        -v symbol_pattern="$symbol_pattern" \
-        -v allowed_pattern="$allowed_pattern" '
-            {
-                line = $0
-                sub(/\/\/.*/, "", line)
-                if (line ~ symbol_pattern && line !~ allowed_pattern) {
-                    printf "%s:%d:%s\n", FILENAME, NR, $0 > "/dev/stderr"
-                    rejected = 1
-                }
-            }
-            END { exit rejected ? 1 : 0 }
-        ' "$file"
-    then
+    while IFS=: read -r match_file match_line source_line; do
+        if [[ ! "$source_line" =~ $allowed_pattern ]]; then
+            printf '%s:%s:%s\n' "$match_file" "$match_line" "$source_line" >&2
+            rejected=1
+        fi
+    done < <(swift_code_matching_lines "$symbol_pattern" "$file" || true)
+
+    if (( rejected > 0 )); then
         fail "$description"
     fi
 }
@@ -1013,6 +1107,7 @@ reject_shell_host_duplicate_selection_state() {
 reject_shell_host_duplicate_persistence_state() {
     local controller="$SOURCE_ROOT/ShellHostController.swift"
     local controller_dir="$SOURCE_ROOT/Controllers/Shell"
+    local controller_sources=("$controller" "$controller_dir"/*.swift)
     local persistence_owner="Services/Shell/ShellWorkspacePersistenceCoordinator.swift"
     local scheduler_definition_owner="Services/Shell/ShellWorkspaceManifestStore.swift"
     local projector_definition_owner="Services/Shell/ShellWorkspaceManifestProjector.swift"
@@ -1094,6 +1189,12 @@ reject_shell_host_duplicate_persistence_state() {
     done
 
     while IFS= read -r file; do
+        if ! swift_code_matching_lines \
+            'ManifestFlushScheduling|DebouncedManifestFlushScheduler' \
+            "$file" >/dev/null
+        then
+            continue
+        fi
         rel="${file#$SOURCE_ROOT/}"
         case "$rel" in
             "$persistence_owner")
@@ -1115,6 +1216,12 @@ reject_shell_host_duplicate_persistence_state() {
         "$SOURCE_ROOT" || true)
 
     while IFS= read -r file; do
+        if ! swift_code_matching_lines \
+            'ShellWorkspaceManifestProjector' \
+            "$file" >/dev/null
+        then
+            continue
+        fi
         rel="${file#$SOURCE_ROOT/}"
         case "$rel" in
             "$persistence_owner")
@@ -1135,17 +1242,17 @@ reject_shell_host_duplicate_persistence_state() {
         'ShellWorkspaceManifestProjector' \
         "$SOURCE_ROOT" || true)
 
-    if grep -RIn --include='*.swift' -F \
-        'ShellContentWorkspaceManifest' \
-        "$controller" "$controller_dir" >&2
+    if swift_code_matching_lines \
+        '(^|[^A-Za-z0-9_])ShellContentWorkspaceManifest([^A-Za-z0-9_]|$)' \
+        "${controller_sources[@]}" >&2
     then
         fail \
             "shell host must not retain or construct workspace manifests outside $persistence_owner"
     fi
 
-    if grep -RIn --include='*.swift' -E \
-        '^[[:space:]]*(private[[:space:]]+)?var[[:space:]]+workspaceManifest|ManifestFlushScheduling|DebouncedManifestFlushScheduler|manifestFlushScheduler|contentFlush(Scheduled|Pending)|scheduleContentFlush|flushPendingPersistence|syncManifestFromShellState|makeWorkspaceManifestFromShellState|ShellWorkspaceManifestProjector[[:space:]]*\(' \
-        "$controller" "$controller_dir" >&2
+    if swift_code_matching_lines \
+        '^[[:space:]]*(private[[:space:]]+)?var[[:space:]]+workspaceManifest|ManifestFlushScheduling|DebouncedManifestFlushScheduler|manifestFlushScheduler|contentFlush(Scheduled|Pending)|scheduleContentFlush|flushPendingPersistence|syncManifestFromShellState|makeWorkspaceManifestFromShellState|ShellWorkspaceManifestProjector[[:space:]]*\\(' \
+        "${controller_sources[@]}" >&2
     then
         fail \
             "shell host persistence state, projection, and scheduling must remain in ShellWorkspacePersistenceCoordinator"

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -456,9 +456,17 @@ readonly OWNERSHIP_AWK_HELPERS='
                 previous_character == "]") &&
             next_character != "" && next_character !~ /[[:space:]=<>]/
     }
-    function top_level_binding_end(value, start,    angle_depth, brace_depth, bracket_depth, character, column, parenthesis_depth) {
+    function top_level_character_position(value, target, start,    angle_depth, brace_depth, bracket_depth, character, column, parenthesis_depth) {
+        if (start < 1) {
+            start = 1
+        }
         for (column = start; column <= length(value); column++) {
             character = substr(value, column, 1)
+            if (character == target && parenthesis_depth == 0 && bracket_depth == 0 &&
+                brace_depth == 0 && angle_depth == 0)
+            {
+                return column
+            }
             if (character == "(") {
                 parenthesis_depth++
             } else if (character == ")" && parenthesis_depth > 0) {
@@ -475,13 +483,36 @@ readonly OWNERSHIP_AWK_HELPERS='
                 angle_depth++
             } else if (character == ">" && angle_depth > 0) {
                 angle_depth--
-            } else if (character == "," && parenthesis_depth == 0 &&
-                bracket_depth == 0 && brace_depth == 0 && angle_depth == 0)
-            {
-                return column
             }
         }
-        return length(value) + 1
+        return 0
+    }
+    function top_level_binding_end(value, start,    position) {
+        position = top_level_character_position(value, ",", start)
+        return position > 0 ? position : length(value) + 1
+    }
+    function binding_type_annotation(value,    assignment, body, colon, end) {
+        colon = top_level_character_position(value, ":")
+        if (colon == 0) {
+            return ""
+        }
+        assignment = top_level_character_position(value, "=")
+        body = top_level_character_position(value, "{")
+        if ((assignment > 0 && assignment < colon) || (body > 0 && body < colon)) {
+            return ""
+        }
+        end = length(value) + 1
+        if (assignment > colon && assignment < end) {
+            end = assignment
+        }
+        if (body > colon && body < end) {
+            end = body
+        }
+        return substr(value, colon + 1, end - colon - 1)
+    }
+    function binding_stops_shared_type(value) {
+        return top_level_character_position(value, "=") > 0 ||
+            top_level_character_position(value, "{") > 0
     }
     function instance_receiver_invokes_factory(value, factories,    call_end, pattern, entry, fields, method, opening, receiver, remainder, suffix) {
         for (entry in factories) {
@@ -744,7 +775,7 @@ manifest_state_declarations() {
             printf "%d|%s|%d|%s|%s\n", \
                 start_line, declaration_owner_key, declaration_indent, trim(prefix), kind
         }
-        function record_declaration(    binding, binding_end, binding_start, declaration) {
+        function record_declaration(    binding_count, binding_end, binding_index, bindings, binding_start, declaration, effective_binding, explicit_type, inherited_types, shared_type) {
             if (buffer == "") {
                 return
             }
@@ -754,9 +785,25 @@ manifest_state_declarations() {
             binding_start = 1
             while (binding_start <= length(declaration)) {
                 binding_end = top_level_binding_end(declaration, binding_start)
-                binding = substr(declaration, binding_start, binding_end - binding_start)
-                record_manifest_binding(binding)
+                bindings[++binding_count] = substr(declaration, binding_start, binding_end - binding_start)
                 binding_start = binding_end + 1
+            }
+            for (binding_index = binding_count; binding_index >= 1; binding_index--) {
+                explicit_type = trim(binding_type_annotation(bindings[binding_index]))
+                if (explicit_type != "") {
+                    shared_type = explicit_type
+                } else if (binding_stops_shared_type(bindings[binding_index])) {
+                    shared_type = ""
+                } else if (shared_type != "") {
+                    inherited_types[binding_index] = shared_type
+                }
+            }
+            for (binding_index = 1; binding_index <= binding_count; binding_index++) {
+                effective_binding = bindings[binding_index]
+                if (inherited_types[binding_index] != "") {
+                    effective_binding = effective_binding ": " inherited_types[binding_index]
+                }
+                record_manifest_binding(effective_binding)
             }
             buffer = ""
         }
@@ -1560,15 +1607,32 @@ shell_snapshot_stored_property_counts() {
                 inferred_generic_contains_snapshot(binding) ||
                 uses_snapshot_factory(binding, owner)
         }
-        function snapshot_storage_count(property, owner,    binding, binding_end, binding_start, count) {
+        function snapshot_storage_count(property, owner,    binding_count, binding_end, binding_index, bindings, binding_start, count, effective_binding, explicit_type, inherited_types, shared_type) {
             binding_start = 1
             while (binding_start <= length(property)) {
                 binding_end = top_level_binding_end(property, binding_start)
-                binding = substr(property, binding_start, binding_end - binding_start)
-                if (snapshot_binding_contains_storage(binding, owner)) {
+                bindings[++binding_count] = substr(property, binding_start, binding_end - binding_start)
+                binding_start = binding_end + 1
+            }
+            for (binding_index = binding_count; binding_index >= 1; binding_index--) {
+                explicit_type = binding_type_annotation(bindings[binding_index])
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", explicit_type)
+                if (explicit_type != "") {
+                    shared_type = explicit_type
+                } else if (binding_stops_shared_type(bindings[binding_index])) {
+                    shared_type = ""
+                } else if (shared_type != "") {
+                    inherited_types[binding_index] = shared_type
+                }
+            }
+            for (binding_index = 1; binding_index <= binding_count; binding_index++) {
+                effective_binding = bindings[binding_index]
+                if (inherited_types[binding_index] != "") {
+                    effective_binding = effective_binding ": " inherited_types[binding_index]
+                }
+                if (snapshot_binding_contains_storage(effective_binding, owner)) {
                     count++
                 }
-                binding_start = binding_end + 1
             }
             return count
         }

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -677,10 +677,51 @@ reject_shell_host_duplicate_persistence_state() {
     fi
 }
 
-shell_snapshot_stored_property_count() {
+shell_snapshot_stored_property_counts() {
     local file="$1"
 
     awk '
+        function record_buffered_factory(    name, signature, header) {
+            if (factory_buffer == "") {
+                return
+            }
+            signature = factory_buffer
+            gsub(/[[:space:]]+/, " ", signature)
+            header = signature
+            sub(/[{].*$/, "", header)
+            if (header ~ /(^| )func[ ]+[A-Za-z_][A-Za-z0-9_]*.*->[ ]*ShellStateSnapshot[?!]?/) {
+                name = header
+                sub(/^.*func[ ]+/, "", name)
+                sub(/[^A-Za-z0-9_].*$/, "", name)
+                snapshot_factories[name] = 1
+            }
+
+            header = signature
+            sub(/[={].*$/, "", header)
+            if (header ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*$/) {
+                name = header
+                sub(/^.*(let|var)[ ]+/, "", name)
+                sub(/[^A-Za-z0-9_].*$/, "", name)
+                snapshot_factories[name] = 1
+            }
+            factory_buffer = ""
+        }
+        function uses_snapshot_factory(property,    expression, name) {
+            if (property !~ /=/) {
+                return 0
+            }
+            expression = property
+            sub(/^[^=]*=[ ]*/, "", expression)
+            sub(/^try[!?]?[ ]+/, "", expression)
+            sub(/^await[ ]+/, "", expression)
+            sub(/^Self[.]/, "", expression)
+            if (expression !~ /^[A-Za-z_][A-Za-z0-9_]*[ ]*\(/) {
+                return 0
+            }
+            name = expression
+            sub(/[ ]*\(.*/, "", name)
+            return name in snapshot_factories
+        }
         function count_buffered_property(    property) {
             if (buffer == "") {
                 return
@@ -689,11 +730,37 @@ shell_snapshot_stored_property_count() {
             gsub(/[[:space:]]+/, " ", property)
             if (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*($|=)/ ||
                 property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/ ||
-                property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot[ ]*([.(]|$)/)
+                property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
+                (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ && uses_snapshot_factory(property)))
             {
                 count++
             }
+            if (property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*($|=)/ ||
+                property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*[{][ ]*(didSet|willSet)([^A-Za-z0-9_]|$)/ ||
+                property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
+                (property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ && uses_snapshot_factory(property)))
+            {
+                static_count++
+            }
             buffer = ""
+        }
+        NR == FNR {
+            line = $0
+            sub(/\/\/.*/, "", line)
+            if (line ~ /^    [^ ]/) {
+                record_buffered_factory()
+                factory_buffer = line
+            } else if (factory_buffer != "" &&
+                (line ~ /^        / || line ~ /^[[:space:]]*$/))
+            {
+                factory_buffer = factory_buffer " " line
+            } else {
+                record_buffered_factory()
+            }
+            next
+        }
+        FNR == 1 {
+            record_buffered_factory()
         }
         {
             line = $0
@@ -704,7 +771,7 @@ shell_snapshot_stored_property_count() {
             # continuation lines so method-local scratch variables are ignored.
             if (line ~ /^    [^ ]/) {
                 count_buffered_property()
-                if (line ~ /^    .*var[ ]+[A-Za-z_][A-Za-z0-9_]*/) {
+                if (line ~ /^    .*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/) {
                     buffer = line
                 }
             } else if (buffer != "" &&
@@ -717,9 +784,9 @@ shell_snapshot_stored_property_count() {
         }
         END {
             count_buffered_property()
-            print count
+            print count, static_count
         }
-    ' "$file"
+    ' "$file" "$file"
 }
 
 reject_replacement_global_shell_store() {
@@ -753,7 +820,9 @@ reject_replacement_global_shell_store() {
     local line_number
     local observable_owner
     local published_projection
+    local snapshot_property_counts
     local snapshot_stored_properties
+    local static_snapshot_stored_properties
     local source_line
     local rel
 
@@ -764,7 +833,9 @@ reject_replacement_global_shell_store() {
 
     while IFS= read -r file; do
         rel="${file#$SOURCE_ROOT/}"
-        snapshot_stored_properties="$(shell_snapshot_stored_property_count "$file")"
+        snapshot_property_counts="$(shell_snapshot_stored_property_counts "$file")"
+        snapshot_stored_properties="${snapshot_property_counts%% *}"
+        static_snapshot_stored_properties="${snapshot_property_counts##* }"
 
         if [[ "$rel" == "$controller_owner" ]] \
             && (( snapshot_stored_properties != 1 ))
@@ -777,6 +848,10 @@ reject_replacement_global_shell_store() {
         then
             fail \
                 "stored observable ShellStateSnapshot must stay in ShellHostController; found in $rel"
+        fi
+
+        if (( static_snapshot_stored_properties > 0 )); then
+            fail "ShellStateSnapshot must not have a static stored owner; found in $rel"
         fi
 
         if [[ "$rel" != "$controller_owner" ]] \

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -299,7 +299,10 @@ typed_factory_declarations() {
                 return
             }
             sub(/^.*->[ ]*/, "", return_type)
-            if (return_type !~ ("(^|[^A-Za-z0-9_])" target_type "([^A-Za-z0-9_]|$)")) {
+            if (return_type !~ ("(^|[^A-Za-z0-9_])" target_type "([^A-Za-z0-9_]|$)") &&
+                !(factory_owner == target_type &&
+                    return_type ~ /(^|[^A-Za-z0-9_])Self([^A-Za-z0-9_]|$)/))
+            {
                 factory_buffer = ""
                 return
             }
@@ -391,7 +394,13 @@ manifest_state_declarations() {
         function manifest_factory_call_matches(call, owner,    name, parts, qualifier, segment_count, qualifier_index) {
             segment_count = split(call, parts, ".")
             name = parts[segment_count]
+            if (name == "ShellContentWorkspaceManifest") {
+                return 1
+            }
             if (segment_count == 1) {
+                if (name == "init" && owner == "ShellContentWorkspaceManifest") {
+                    return 1
+                }
                 return ((owner "|" name) in manifest_factories) ||
                     (("|" name) in manifest_factories)
             }
@@ -399,6 +408,9 @@ manifest_state_declarations() {
                 qualifier = parts[qualifier_index]
                 if (qualifier == "Self" || qualifier == "self") {
                     qualifier = owner
+                }
+                if (name == "init" && qualifier == "ShellContentWorkspaceManifest") {
+                    return 1
                 }
                 if ((qualifier "|" name) in manifest_factories) {
                     return 1
@@ -555,7 +567,13 @@ shell_host_static_storage_declarations() {
         function shell_host_factory_call_matches(call, owner,    name, parts, qualifier, segment_count, qualifier_index) {
             segment_count = split(call, parts, ".")
             name = parts[segment_count]
+            if (name == "ShellHostController") {
+                return 1
+            }
             if (segment_count == 1) {
+                if (name == "init" && owner == "ShellHostController") {
+                    return 1
+                }
                 return ((owner "|" name) in shell_host_factories) ||
                     (("|" name) in shell_host_factories)
             }
@@ -563,6 +581,9 @@ shell_host_static_storage_declarations() {
                 qualifier = parts[qualifier_index]
                 if (qualifier == "Self" || qualifier == "self") {
                     qualifier = owner
+                }
+                if (name == "init" && qualifier == "ShellHostController") {
+                    return 1
                 }
                 if ((qualifier "|" name) in shell_host_factories) {
                     return 1
@@ -1130,7 +1151,13 @@ shell_snapshot_stored_property_counts() {
         function snapshot_factory_call_matches(call, owner,    name, parts, qualifier, segment_count, qualifier_index) {
             segment_count = split(call, parts, ".")
             name = parts[segment_count]
+            if (name == "ShellStateSnapshot") {
+                return 1
+            }
             if (segment_count == 1) {
+                if (name == "init" && owner == "ShellStateSnapshot") {
+                    return 1
+                }
                 return ((owner "|" name) in snapshot_factories) ||
                     (("|" name) in snapshot_factories)
             }
@@ -1138,6 +1165,9 @@ shell_snapshot_stored_property_counts() {
                 qualifier = parts[qualifier_index]
                 if (qualifier == "Self" || qualifier == "self") {
                     qualifier = owner
+                }
+                if (name == "init" && qualifier == "ShellStateSnapshot") {
+                    return 1
                 }
                 if ((qualifier "|" name) in snapshot_factories) {
                     return 1

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -258,10 +258,116 @@ normalized_file_matches() {
     ' "$file"
 }
 
+typed_factory_declarations() {
+    local file="$1"
+    local target_type="$2"
+
+    awk -v target_type="$target_type" '
+        function leading_space_count(value,    prefix) {
+            prefix = value
+            sub(/[^ ].*$/, "", prefix)
+            return length(prefix)
+        }
+        function is_type_declaration(value) {
+            return value ~ /^[[:space:]]*[^\/]*(class|struct|actor|enum|extension|protocol)[ ]+[A-Za-z_][A-Za-z0-9_.]*/
+        }
+        function declared_type_name(value,    name) {
+            name = value
+            sub(/^.*(class|struct|actor|enum|extension|protocol)[ ]+/, "", name)
+            sub(/[^A-Za-z0-9_.].*$/, "", name)
+            sub(/^.*[.]/, "", name)
+            return name
+        }
+        function is_factory_candidate(value) {
+            return value ~ /^[[:space:]]*[^\/]*func[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*\(/
+        }
+        function is_same_indent_function_signature_continuation(value) {
+            return value ~ /^[[:space:]]*(\)|->|[{])/ ||
+                value ~ /^[[:space:]]*(async|throws|rethrows|where)([^A-Za-z0-9_]|$)/
+        }
+        function record_buffered_factory(    header, name, return_type, signature) {
+            if (factory_buffer == "") {
+                return
+            }
+            signature = factory_buffer
+            gsub(/[[:space:]]+/, " ", signature)
+            header = signature
+            sub(/[{].*$/, "", header)
+            return_type = header
+            if (return_type !~ /->/) {
+                factory_buffer = ""
+                return
+            }
+            sub(/^.*->[ ]*/, "", return_type)
+            if (return_type !~ ("(^|[^A-Za-z0-9_])" target_type "([^A-Za-z0-9_]|$)")) {
+                factory_buffer = ""
+                return
+            }
+            if (factory_owner != "" &&
+                header !~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*func[ ]+/)
+            {
+                factory_buffer = ""
+                return
+            }
+            name = header
+            sub(/^.*func[ ]+/, "", name)
+            sub(/[^A-Za-z0-9_].*$/, "", name)
+            print factory_owner "|" name
+            factory_buffer = ""
+        }
+        {
+            line = $0
+            sub(/\/\/.*/, "", line)
+            line_indent = leading_space_count(line)
+            if (line !~ /^[[:space:]]*$/) {
+                while (type_depth > 0 && line_indent <= type_indent[type_depth]) {
+                    delete type_indent[type_depth]
+                    delete type_name[type_depth]
+                    type_depth--
+                }
+                if (is_type_declaration(line)) {
+                    type_depth++
+                    type_indent[type_depth] = line_indent
+                    type_name[type_depth] = declared_type_name(line)
+                }
+            }
+
+            if (is_factory_candidate(line)) {
+                record_buffered_factory()
+                factory_buffer = line
+                factory_indent = line_indent
+                factory_owner = type_depth > 0 ? type_name[type_depth] : ""
+            } else if (factory_buffer != "" &&
+                (line ~ /^[[:space:]]*$/ ||
+                    line_indent > factory_indent ||
+                    (line_indent == factory_indent &&
+                        is_same_indent_function_signature_continuation(line))))
+            {
+                factory_buffer = factory_buffer " " line
+            } else {
+                record_buffered_factory()
+            }
+        }
+        END { record_buffered_factory() }
+    ' "$file"
+}
+
 manifest_state_declarations() {
     local file="$1"
+    local factory_inventory
+    factory_inventory="$(
+        typed_factory_declarations "$file" "ShellContentWorkspaceManifest"
+    )"
 
-    awk '
+    awk -v factory_inventory="$factory_inventory" '
+        BEGIN {
+            factory_count = split(factory_inventory, factory_entries, "\n")
+            for (factory_index = 1; factory_index <= factory_count; factory_index++) {
+                if (factory_entries[factory_index] != "") {
+                    manifest_factories[factory_entries[factory_index]] = 1
+                }
+            }
+        }
         function leading_space_count(value,    prefix) {
             prefix = value
             sub(/[^ ].*$/, "", prefix)
@@ -272,30 +378,17 @@ manifest_state_declarations() {
             sub(/[[:space:]]+$/, "", value)
             return value
         }
-        function is_factory_candidate(value) {
-            return value ~ /^[[:space:]]*[^\/]*func[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*\(/
+        function is_type_declaration(value) {
+            return value ~ /^[[:space:]]*[^\/]*(class|struct|actor|enum|extension|protocol)[ ]+[A-Za-z_][A-Za-z0-9_.]*/
         }
-        function is_same_indent_function_signature_continuation(value) {
-            return value ~ /^[[:space:]]*(\)|->|[{])/ ||
-                value ~ /^[[:space:]]*(async|throws|rethrows|where)([^A-Za-z0-9_]|$)/
+        function declared_type_name(value,    name) {
+            name = value
+            sub(/^.*(class|struct|actor|enum|extension|protocol)[ ]+/, "", name)
+            sub(/[^A-Za-z0-9_.].*$/, "", name)
+            sub(/^.*[.]/, "", name)
+            return name
         }
-        function record_buffered_factory(    name, signature, header) {
-            if (factory_buffer == "") {
-                return
-            }
-            signature = factory_buffer
-            gsub(/[[:space:]]+/, " ", signature)
-            header = signature
-            sub(/[{].*$/, "", header)
-            if (header ~ /(^| )func[ ]+[A-Za-z_][A-Za-z0-9_]*.*->[^{}]*ShellContentWorkspaceManifest([^A-Za-z0-9_]|$)/) {
-                name = header
-                sub(/^.*func[ ]+/, "", name)
-                sub(/[^A-Za-z0-9_].*$/, "", name)
-                manifest_factories[name] = 1
-            }
-            factory_buffer = ""
-        }
-        function inferred_factory_contains_manifest(value,    expression, name) {
+        function inferred_factory_contains_manifest(value, owner,    call, expression, name, parts, qualifier, segment_count) {
             if (value !~ /=/) {
                 return 0
             }
@@ -304,13 +397,22 @@ manifest_state_declarations() {
             while (expression ~ /^(try[!?]?|await)[ ]+/) {
                 sub(/^(try[!?]?|await)[ ]+/, "", expression)
             }
-            sub(/^Self[.]/, "", expression)
-            if (expression !~ /^[A-Za-z_][A-Za-z0-9_]*[ ]*\(/) {
+            if (expression !~ /^[A-Za-z_][A-Za-z0-9_.]*[ ]*\(/) {
                 return 0
             }
-            name = expression
-            sub(/[ ]*\(.*/, "", name)
-            return name in manifest_factories
+            call = expression
+            sub(/[ ]*\(.*/, "", call)
+            segment_count = split(call, parts, ".")
+            name = parts[segment_count]
+            if (segment_count == 1) {
+                return ((owner "|" name) in manifest_factories) ||
+                    (("|" name) in manifest_factories)
+            }
+            qualifier = parts[segment_count - 1]
+            if (qualifier == "Self" || qualifier == "self") {
+                qualifier = owner
+            }
+            return (qualifier "|" name) in manifest_factories
         }
         function inferred_generic_contains_manifest(value,    expression) {
             if (value !~ /=/) {
@@ -345,7 +447,7 @@ manifest_state_declarations() {
                 prefix = declaration
                 sub(/[ ]*=.*/, "", prefix)
                 kind = "inferred-generic"
-            } else if (inferred_factory_contains_manifest(declaration)) {
+            } else if (inferred_factory_contains_manifest(declaration, declaration_owner)) {
                 prefix = declaration
                 sub(/[ ]*=.*/, "", prefix)
                 kind = "inferred-factory"
@@ -357,39 +459,31 @@ manifest_state_declarations() {
             printf "%d|%d|%s|%s\n", start_line, declaration_indent, trim(prefix), kind
             buffer = ""
         }
-        NR == FNR {
-            line = $0
-            sub(/\/\/.*/, "", line)
-            if (is_factory_candidate(line)) {
-                record_buffered_factory()
-                factory_buffer = line
-                factory_indent = leading_space_count(line)
-            } else if (factory_buffer != "" &&
-                (line ~ /^[[:space:]]*$/ ||
-                    leading_space_count(line) > factory_indent ||
-                    (leading_space_count(line) == factory_indent &&
-                        is_same_indent_function_signature_continuation(line))))
-            {
-                factory_buffer = factory_buffer " " line
-            } else {
-                record_buffered_factory()
-            }
-            next
-        }
-        FNR == 1 {
-            record_buffered_factory()
-        }
         {
             line = $0
             sub(/\/\/.*/, "", line)
+            line_indent = leading_space_count(line)
+            if (line !~ /^[[:space:]]*$/) {
+                while (type_depth > 0 && line_indent <= type_indent[type_depth]) {
+                    delete type_indent[type_depth]
+                    delete type_name[type_depth]
+                    type_depth--
+                }
+                if (is_type_declaration(line)) {
+                    type_depth++
+                    type_indent[type_depth] = line_indent
+                    type_name[type_depth] = declared_type_name(line)
+                }
+            }
+
             if (line ~ /^[[:space:]]*[^\/]*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/) {
                 record_declaration()
                 buffer = line
                 start_line = FNR
-                declaration_indent = leading_space_count(line)
+                declaration_indent = line_indent
+                declaration_owner = type_depth > 0 ? type_name[type_depth] : ""
             } else if (buffer != "" &&
-                (line ~ /^[[:space:]]*$/ ||
-                    leading_space_count(line) > declaration_indent))
+                (line ~ /^[[:space:]]*$/ || line_indent > declaration_indent))
             {
                 buffer = buffer " " line
             } else {
@@ -397,7 +491,7 @@ manifest_state_declarations() {
             }
         }
         END { record_declaration() }
-    ' "$file" "$file"
+    ' "$file"
 }
 
 static_property_declarations() {
@@ -420,8 +514,18 @@ static_property_declarations() {
 
 shell_host_static_storage_declarations() {
     local file="$1"
+    local factory_inventory
+    factory_inventory="$(typed_factory_declarations "$file" "ShellHostController")"
 
-    awk '
+    awk -v factory_inventory="$factory_inventory" '
+        BEGIN {
+            factory_count = split(factory_inventory, factory_entries, "\n")
+            for (factory_index = 1; factory_index <= factory_count; factory_index++) {
+                if (factory_entries[factory_index] != "") {
+                    shell_host_factories[factory_entries[factory_index]] = 1
+                }
+            }
+        }
         function leading_space_count(value,    prefix) {
             prefix = value
             sub(/[^ ].*$/, "", prefix)
@@ -430,30 +534,17 @@ shell_host_static_storage_declarations() {
         function is_static_property_start(value) {
             return value ~ /^[[:space:]]*[^\/]*(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
         }
-        function is_factory_candidate(value) {
-            return value ~ /^[[:space:]]*[^\/]*func[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*\(/
+        function is_type_declaration(value) {
+            return value ~ /^[[:space:]]*[^\/]*(class|struct|actor|enum|extension|protocol)[ ]+[A-Za-z_][A-Za-z0-9_.]*/
         }
-        function is_same_indent_function_signature_continuation(value) {
-            return value ~ /^[[:space:]]*(\)|->|[{])/ ||
-                value ~ /^[[:space:]]*(async|throws|rethrows|where)([^A-Za-z0-9_]|$)/
+        function declared_type_name(value,    name) {
+            name = value
+            sub(/^.*(class|struct|actor|enum|extension|protocol)[ ]+/, "", name)
+            sub(/[^A-Za-z0-9_.].*$/, "", name)
+            sub(/^.*[.]/, "", name)
+            return name
         }
-        function record_buffered_factory(    name, signature, header) {
-            if (factory_buffer == "") {
-                return
-            }
-            signature = factory_buffer
-            gsub(/[[:space:]]+/, " ", signature)
-            header = signature
-            sub(/[{].*$/, "", header)
-            if (header ~ /(^| )func[ ]+[A-Za-z_][A-Za-z0-9_]*.*->[^{}]*ShellHostController([^A-Za-z0-9_]|$)/) {
-                name = header
-                sub(/^.*func[ ]+/, "", name)
-                sub(/[^A-Za-z0-9_].*$/, "", name)
-                shell_host_factories[name] = 1
-            }
-            factory_buffer = ""
-        }
-        function uses_shell_host_factory(value,    expression, name) {
+        function uses_shell_host_factory(value, owner,    call, expression, name, parts, qualifier, segment_count) {
             if (value !~ /=/) {
                 return 0
             }
@@ -462,13 +553,22 @@ shell_host_static_storage_declarations() {
             while (expression ~ /^(try[!?]?|await)[ ]+/) {
                 sub(/^(try[!?]?|await)[ ]+/, "", expression)
             }
-            sub(/^Self[.]/, "", expression)
-            if (expression !~ /^[A-Za-z_][A-Za-z0-9_]*[ ]*\(/) {
+            if (expression !~ /^[A-Za-z_][A-Za-z0-9_.]*[ ]*\(/) {
                 return 0
             }
-            name = expression
-            sub(/[ ]*\(.*/, "", name)
-            return name in shell_host_factories
+            call = expression
+            sub(/[ ]*\(.*/, "", call)
+            segment_count = split(call, parts, ".")
+            name = parts[segment_count]
+            if (segment_count == 1) {
+                return ((owner "|" name) in shell_host_factories) ||
+                    (("|" name) in shell_host_factories)
+            }
+            qualifier = parts[segment_count - 1]
+            if (qualifier == "Self" || qualifier == "self") {
+                qualifier = owner
+            }
+            return (qualifier "|" name) in shell_host_factories
         }
         function is_stored_property(value,    declaration_header) {
             declaration_header = value
@@ -489,44 +589,37 @@ shell_host_static_storage_declarations() {
             sub(/ $/, "", property)
             if (is_stored_property(property) &&
                 (property ~ /ShellHostController([^A-Za-z0-9_]|$)/ ||
-                    uses_shell_host_factory(property)))
+                    uses_shell_host_factory(property, property_owner)))
             {
                 printf "%d|%s\n", property_start_line, property
             }
             property_buffer = ""
         }
-        NR == FNR {
-            line = $0
-            sub(/\/\/.*/, "", line)
-            if (is_factory_candidate(line)) {
-                record_buffered_factory()
-                factory_buffer = line
-                factory_indent = leading_space_count(line)
-            } else if (factory_buffer != "" &&
-                (line ~ /^[[:space:]]*$/ ||
-                    leading_space_count(line) > factory_indent ||
-                    (leading_space_count(line) == factory_indent &&
-                        is_same_indent_function_signature_continuation(line))))
-            {
-                factory_buffer = factory_buffer " " line
-            } else {
-                record_buffered_factory()
-            }
-            next
-        }
-        FNR == 1 {
-            record_buffered_factory()
-        }
         {
             line = $0
             sub(/\/\/.*/, "", line)
+            line_indent = leading_space_count(line)
+            if (line !~ /^[[:space:]]*$/) {
+                while (type_depth > 0 && line_indent <= type_indent[type_depth]) {
+                    delete type_indent[type_depth]
+                    delete type_name[type_depth]
+                    type_depth--
+                }
+                if (is_type_declaration(line)) {
+                    type_depth++
+                    type_indent[type_depth] = line_indent
+                    type_name[type_depth] = declared_type_name(line)
+                }
+            }
+
             if (is_static_property_start(line)) {
                 record_buffered_property()
                 property_buffer = line
                 property_start_line = FNR
-                property_indent = leading_space_count(line)
+                property_indent = line_indent
+                property_owner = type_depth > 0 ? type_name[type_depth] : ""
             } else if (property_buffer != "" &&
-                (line ~ /^[[:space:]]*$/ || leading_space_count(line) > property_indent))
+                (line ~ /^[[:space:]]*$/ || line_indent > property_indent))
             {
                 property_buffer = property_buffer " " line
             } else {
@@ -534,7 +627,7 @@ shell_host_static_storage_declarations() {
             }
         }
         END { record_buffered_property() }
-    ' "$file" "$file"
+    ' "$file"
 }
 
 check_appkit_import_gate() {
@@ -983,8 +1076,18 @@ reject_shell_host_duplicate_persistence_state() {
 
 shell_snapshot_stored_property_counts() {
     local file="$1"
+    local factory_inventory
+    factory_inventory="$(typed_factory_declarations "$file" "ShellStateSnapshot")"
 
-    awk '
+    awk -v factory_inventory="$factory_inventory" '
+        BEGIN {
+            factory_count = split(factory_inventory, factory_entries, "\n")
+            for (factory_index = 1; factory_index <= factory_count; factory_index++) {
+                if (factory_entries[factory_index] != "") {
+                    snapshot_factories[factory_entries[factory_index]] = 1
+                }
+            }
+        }
         function leading_space_count(value,    prefix) {
             prefix = value
             sub(/[^ ].*$/, "", prefix)
@@ -994,57 +1097,40 @@ shell_snapshot_stored_property_counts() {
             return value ~ /^[[:space:]]*[^\/]*(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
         }
         function is_type_declaration(value) {
-            return value ~ /^[[:space:]]*[^\/]*(class|struct|actor|enum|extension)[ ]+[A-Za-z_][A-Za-z0-9_]*/
+            return value ~ /^[[:space:]]*[^\/]*(class|struct|actor|enum|extension|protocol)[ ]+[A-Za-z_][A-Za-z0-9_.]*/
         }
-        function is_factory_candidate(value) {
-            return value ~ /^[[:space:]]*[^\/]*func[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*\(/ ||
-                is_static_property_start(value)
+        function declared_type_name(value,    name) {
+            name = value
+            sub(/^.*(class|struct|actor|enum|extension|protocol)[ ]+/, "", name)
+            sub(/[^A-Za-z0-9_.].*$/, "", name)
+            sub(/^.*[.]/, "", name)
+            return name
         }
-        function is_same_indent_function_signature_continuation(value) {
-            return value ~ /^[[:space:]]*(\)|->|[{])/ ||
-                value ~ /^[[:space:]]*(async|throws|rethrows|where)([^A-Za-z0-9_]|$)/
-        }
-        function record_buffered_factory(    name, signature, header) {
-            if (factory_buffer == "") {
-                return
-            }
-            signature = factory_buffer
-            gsub(/[[:space:]]+/, " ", signature)
-            header = signature
-            sub(/[{].*$/, "", header)
-            if (header ~ /(^| )func[ ]+[A-Za-z_][A-Za-z0-9_]*.*->[ ]*ShellStateSnapshot[?!]?/) {
-                name = header
-                sub(/^.*func[ ]+/, "", name)
-                sub(/[^A-Za-z0-9_].*$/, "", name)
-                snapshot_factories[name] = 1
-            }
-
-            header = signature
-            sub(/[={].*$/, "", header)
-            if (header ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*:[ ]*ShellStateSnapshot[?!]?[ ]*$/) {
-                name = header
-                sub(/^.*(let|var)[ ]+/, "", name)
-                sub(/[^A-Za-z0-9_].*$/, "", name)
-                snapshot_factories[name] = 1
-            }
-            factory_buffer = ""
-            factory_is_function = 0
-        }
-        function uses_snapshot_factory(property,    expression, name) {
+        function uses_snapshot_factory(property, owner,    call, expression, name, parts, qualifier, segment_count) {
             if (property !~ /=/) {
                 return 0
             }
             expression = property
             sub(/^[^=]*=[ ]*/, "", expression)
-            sub(/^try[!?]?[ ]+/, "", expression)
-            sub(/^await[ ]+/, "", expression)
-            sub(/^Self[.]/, "", expression)
-            if (expression !~ /^[A-Za-z_][A-Za-z0-9_]*[ ]*\(/) {
+            while (expression ~ /^(try[!?]?|await)[ ]+/) {
+                sub(/^(try[!?]?|await)[ ]+/, "", expression)
+            }
+            if (expression !~ /^[A-Za-z_][A-Za-z0-9_.]*[ ]*\(/) {
                 return 0
             }
-            name = expression
-            sub(/[ ]*\(.*/, "", name)
-            return name in snapshot_factories
+            call = expression
+            sub(/[ ]*\(.*/, "", call)
+            segment_count = split(call, parts, ".")
+            name = parts[segment_count]
+            if (segment_count == 1) {
+                return ((owner "|" name) in snapshot_factories) ||
+                    (("|" name) in snapshot_factories)
+            }
+            qualifier = parts[segment_count - 1]
+            if (qualifier == "Self" || qualifier == "self") {
+                qualifier = owner
+            }
+            return (qualifier "|" name) in snapshot_factories
         }
         function inferred_generic_contains_snapshot(property,    expression) {
             if (property !~ /=/) {
@@ -1085,7 +1171,8 @@ shell_snapshot_stored_property_counts() {
                 property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
                 (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ &&
                     inferred_generic_contains_snapshot(property)) ||
-                (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ && uses_snapshot_factory(property))))
+                (property ~ /var[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ &&
+                    uses_snapshot_factory(property, instance_owner))))
             {
                 instance_count++
             }
@@ -1103,35 +1190,12 @@ shell_snapshot_stored_property_counts() {
                 property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
                 (property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ &&
                     inferred_generic_contains_snapshot(property)) ||
-                (property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ && uses_snapshot_factory(property)))
+                (property ~ /(^| )(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*=/ &&
+                    uses_snapshot_factory(property, static_owner)))
             {
                 static_count++
             }
             static_buffer = ""
-        }
-        NR == FNR {
-            line = $0
-            sub(/\/\/.*/, "", line)
-            if (is_factory_candidate(line)) {
-                record_buffered_factory()
-                factory_buffer = line
-                factory_indent = leading_space_count(line)
-                factory_is_function = line ~ /(^|[ ])func[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*\(/
-            } else if (factory_buffer != "" &&
-                (line ~ /^[[:space:]]*$/ ||
-                    leading_space_count(line) > factory_indent ||
-                    (factory_is_function &&
-                        leading_space_count(line) == factory_indent &&
-                        is_same_indent_function_signature_continuation(line))))
-            {
-                factory_buffer = factory_buffer " " line
-            } else {
-                record_buffered_factory()
-            }
-            next
-        }
-        FNR == 1 {
-            record_buffered_factory()
         }
         {
             line = $0
@@ -1144,11 +1208,13 @@ shell_snapshot_stored_property_counts() {
             if (line !~ /^[[:space:]]*$/) {
                 while (type_depth > 0 && line_indent <= type_indent[type_depth]) {
                     delete type_indent[type_depth]
+                    delete type_name[type_depth]
                     type_depth--
                 }
                 if (is_type_declaration(line)) {
                     type_depth++
                     type_indent[type_depth] = line_indent
+                    type_name[type_depth] = declared_type_name(line)
                 }
             }
 
@@ -1157,6 +1223,7 @@ shell_snapshot_stored_property_counts() {
                 if (line ~ /(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/) {
                     instance_buffer = line
                     instance_indent = line_indent
+                    instance_owner = type_name[type_depth]
                 }
             } else if (instance_buffer != "" &&
                 (line ~ /^[[:space:]]*$/ || line_indent > instance_indent))
@@ -1173,6 +1240,7 @@ shell_snapshot_stored_property_counts() {
                 count_buffered_static_property()
                 static_buffer = line
                 static_indent = leading_space_count(line)
+                static_owner = type_depth > 0 ? type_name[type_depth] : ""
             } else if (static_buffer != "" &&
                 (line ~ /^[[:space:]]*$/ || leading_space_count(line) > static_indent))
             {
@@ -1186,7 +1254,7 @@ shell_snapshot_stored_property_counts() {
             count_buffered_static_property()
             print instance_count, static_count
         }
-    ' "$file" "$file"
+    ' "$file"
 }
 
 reject_replacement_global_shell_store() {

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -691,6 +691,15 @@ typed_value_member_declarations() {
         function is_property_start(value) {
             return value ~ /(^|[ ])(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
         }
+        function declared_property_name(value,    declaration_head, name) {
+            if (!match(value, /(^|[ ])(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/)) {
+                return ""
+            }
+            declaration_head = substr(value, RSTART, RLENGTH)
+            name = declaration_head
+            sub(/^.*(let|var)[ ]+/, "", name)
+            return name
+        }
         function record_member(    declaration, member_name, member_type) {
             if (member_buffer == "") {
                 return
@@ -702,9 +711,7 @@ typed_value_member_declarations() {
             if (member_type ~ ("(^|[^A-Za-z0-9_])" target_type "([^A-Za-z0-9_]|$)") &&
                 member_type !~ /->/)
             {
-                member_name = declaration
-                sub(/^.*(let|var)[ ]+/, "", member_name)
-                sub(/[^A-Za-z0-9_].*$/, "", member_name)
+                member_name = declared_property_name(declaration)
                 if (member_name != "") {
                     print member_name
                 }

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -258,6 +258,85 @@ normalized_file_matches() {
     ' "$file"
 }
 
+manifest_state_declarations() {
+    local file="$1"
+
+    awk '
+        function leading_space_count(value,    prefix) {
+            prefix = value
+            sub(/[^ ].*$/, "", prefix)
+            return length(prefix)
+        }
+        function trim(value) {
+            sub(/^[[:space:]]+/, "", value)
+            sub(/[[:space:]]+$/, "", value)
+            return value
+        }
+        function record_declaration(    declaration, header, prefix, kind) {
+            if (buffer == "") {
+                return
+            }
+            declaration = buffer
+            gsub(/[[:space:]]+/, " ", declaration)
+            declaration = trim(declaration)
+            header = declaration
+            sub(/[=].*$/, "", header)
+
+            if (header ~ /:[^=]*ShellContentWorkspaceManifest([^A-Za-z0-9_]|$)/) {
+                prefix = header
+                sub(/[ ]*:.*/, "", prefix)
+                kind = "typed"
+            } else if (declaration ~ /=[ ]*(try[!?]?[ ]+)?ShellContentWorkspaceManifest([.]init)?[ ]*\(/) {
+                prefix = declaration
+                sub(/[ ]*=[ ]*ShellContentWorkspaceManifest.*/, "", prefix)
+                kind = "constructed"
+            } else {
+                buffer = ""
+                return
+            }
+
+            printf "%d|%d|%s|%s\n", start_line, declaration_indent, trim(prefix), kind
+            buffer = ""
+        }
+        {
+            line = $0
+            sub(/\/\/.*/, "", line)
+            if (line ~ /^[[:space:]]*[^\/]*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/) {
+                record_declaration()
+                buffer = line
+                start_line = NR
+                declaration_indent = leading_space_count(line)
+            } else if (buffer != "" &&
+                (line ~ /^[[:space:]]*$/ ||
+                    leading_space_count(line) > declaration_indent))
+            {
+                buffer = buffer " " line
+            } else {
+                record_declaration()
+            }
+        }
+        END { record_declaration() }
+    ' "$file"
+}
+
+static_property_declarations() {
+    local file="$1"
+
+    awk '
+        {
+            line = $0
+            sub(/\/\/.*/, "", line)
+            if (line !~ /^[[:space:]]*[^\/]*(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/) {
+                next
+            }
+            gsub(/[[:space:]]+/, " ", line)
+            sub(/^ /, "", line)
+            sub(/ $/, "", line)
+            print line
+        }
+    ' "$file"
+}
+
 check_appkit_import_gate() {
     local rel="$1"
     local file="$2"
@@ -590,7 +669,18 @@ reject_shell_host_duplicate_persistence_state() {
     local persistence_owner="Services/Shell/ShellWorkspacePersistenceCoordinator.swift"
     local scheduler_definition_owner="Services/Shell/ShellWorkspaceManifestStore.swift"
     local projector_definition_owner="Services/Shell/ShellWorkspaceManifestProjector.swift"
+    local manifest_state_allowlist=(
+        "Services/Shell/ShellCoreFFIManifestAdapter.swift|4|let manifest|typed"
+        "Services/Shell/ShellWorkspaceManifestProjector.swift|8|var manifest|constructed"
+        "Services/Shell/ShellWorkspaceManifestStore.swift|4|var manifest|typed"
+        "Services/Shell/ShellWorkspacePersistenceCoordinator.swift|4|private var workspaceManifest|typed"
+    )
+    local declaration
+    local declaration_indent
+    local declaration_kind
+    local declaration_line
     local file
+    local manifest_state
     local rel
 
     require_existing_single_owner_pattern \
@@ -617,6 +707,20 @@ reject_shell_host_duplicate_persistence_state() {
         "manifestProjector.makeManifest(" \
         "$persistence_owner" \
         "workspace manifest projection invocation"
+
+    while IFS= read -r file; do
+        rel="${file#$SOURCE_ROOT/}"
+        while IFS='|' read -r declaration_line declaration_indent declaration declaration_kind; do
+            manifest_state="$rel|$declaration_indent|$declaration|$declaration_kind"
+            if ! contains_line "$manifest_state" "${manifest_state_allowlist[@]}"; then
+                printf '%s:%s:%s\n' "$file" "$declaration_line" "$declaration" >&2
+                fail \
+                    "ShellContentWorkspaceManifest storage is not in the accepted ownership inventory: $manifest_state"
+            fi
+        done < <(manifest_state_declarations "$file")
+    done < <(grep -RIl --include='*.swift' -F \
+        'ShellContentWorkspaceManifest' \
+        "$SOURCE_ROOT" || true)
 
     while IFS= read -r file; do
         rel="${file#$SOURCE_ROOT/}"
@@ -688,6 +792,9 @@ shell_snapshot_stored_property_counts() {
         }
         function is_static_property_start(value) {
             return value ~ /^[[:space:]]*[^\/]*(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
+        }
+        function is_type_declaration(value) {
+            return value ~ /^[[:space:]]*[^\/]*(class|struct|actor|enum|extension)[ ]+[A-Za-z_][A-Za-z0-9_]*/
         }
         function is_factory_candidate(value) {
             return value ~ /^[[:space:]]*[^\/]*func[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*\(/ ||
@@ -798,16 +905,29 @@ shell_snapshot_stored_property_counts() {
             line = $0
             sub(/\/\/.*/, "", line)
 
-            # Production Swift formatting keeps top-level type members at four
-            # spaces. Collect only those property declarations and their deeper
-            # continuation lines so method-local scratch variables are ignored.
-            if (line ~ /^    [^ ]/) {
+            # Follow the formatted type nesting so instance members of both
+            # top-level and nested types are counted, while method-local scratch
+            # variables remain deeper than their enclosing type member level.
+            line_indent = leading_space_count(line)
+            if (line !~ /^[[:space:]]*$/) {
+                while (type_depth > 0 && line_indent <= type_indent[type_depth]) {
+                    delete type_indent[type_depth]
+                    type_depth--
+                }
+                if (is_type_declaration(line)) {
+                    type_depth++
+                    type_indent[type_depth] = line_indent
+                }
+            }
+
+            if (type_depth > 0 && line_indent == type_indent[type_depth] + 4) {
                 count_buffered_instance_property()
-                if (line ~ /^    .*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/) {
+                if (line ~ /(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/) {
                     instance_buffer = line
+                    instance_indent = line_indent
                 }
             } else if (instance_buffer != "" &&
-                (line ~ /^        / || line ~ /^[[:space:]]*$/))
+                (line ~ /^[[:space:]]*$/ || line_indent > instance_indent))
             {
                 instance_buffer = instance_buffer " " line
             } else {
@@ -864,12 +984,23 @@ reject_replacement_global_shell_store() {
         "ShellHostController.swift|zoomedPaneIDByTabID"
         "Support/ShellVoiceCommandController.swift|isListening"
     )
+    local snapshot_static_member_allowlist=(
+        "Services/Shell/ShellSocketServer.swift|private static let commandResponseTimeoutSeconds: TimeInterval = 5"
+        "Services/Shell/ShellSocketServer.swift|private static let maxConcurrentClients = 4"
+        "Services/Shell/ShellSocketServer.swift|private static let maxRequestBytes = 1_048_576"
+        "Services/Shell/ShellSocketServer.swift|private static let readTimeoutSeconds = 5"
+        "ShellHostController.swift|static let gracefulShutdownPollInterval: TimeInterval = 0.05"
+        "ShellHostController.swift|static let iso8601Formatter = ISO8601DateFormatter()"
+        "ShellHostController.swift|static let terminalSelectionFirst = ShellPaneMovementInteractionPolicy()"
+    )
     local file
     local line_number
     local observable_owner
     local published_projection
     local snapshot_property_counts
     local snapshot_stored_properties
+    local static_member
+    local static_member_key
     local static_snapshot_stored_properties
     local source_line
     local rel
@@ -885,21 +1016,43 @@ reject_replacement_global_shell_store() {
         snapshot_stored_properties="${snapshot_property_counts%% *}"
         static_snapshot_stored_properties="${snapshot_property_counts##* }"
 
-        if [[ "$rel" == "$controller_owner" ]] \
-            && (( snapshot_stored_properties != 1 ))
-        then
-            fail \
-                "ShellHostController must keep exactly one stored ShellStateSnapshot projection"
-        elif [[ "$rel" != "$controller_owner" ]] \
-            && grep -Eq 'ObservableObject|@Observable' "$file" \
-            && (( snapshot_stored_properties > 0 ))
-        then
-            fail \
-                "stored observable ShellStateSnapshot must stay in ShellHostController; found in $rel"
-        fi
+        case "$rel" in
+            "$controller_owner")
+                if (( snapshot_stored_properties != 1 )); then
+                    fail \
+                        "ShellHostController must keep exactly one stored ShellStateSnapshot projection"
+                fi
+                ;;
+            "ShellControlPlane.swift"|"Services/Shell/ShellSocketServer.swift")
+                if (( snapshot_stored_properties > 2 )); then
+                    fail \
+                        "accepted shell transport snapshot caches must not grow in $rel"
+                fi
+                ;;
+            *)
+                if (( snapshot_stored_properties > 0 )); then
+                    fail \
+                        "mutable ShellStateSnapshot storage is not an accepted owner: $rel"
+                fi
+                ;;
+        esac
 
         if (( static_snapshot_stored_properties > 0 )); then
             fail "ShellStateSnapshot must not have a static stored owner; found in $rel"
+        fi
+
+        if (( snapshot_stored_properties > 0 )); then
+            while IFS= read -r static_member; do
+                static_member_key="$rel|$static_member"
+                if ! contains_line \
+                    "$static_member_key" \
+                    "${snapshot_static_member_allowlist[@]}"
+                then
+                    printf '%s:%s\n' "$file" "$static_member" >&2
+                    fail \
+                        "mutable ShellStateSnapshot owners must not add static/class entry points: $static_member_key"
+                fi
+            done < <(static_property_declarations "$file")
         fi
 
         if [[ "$rel" != "$controller_owner" ]] \
@@ -911,12 +1064,6 @@ reject_replacement_global_shell_store() {
                 "non-controller observable owners must not manufacture ShellStateSnapshot state; found in $rel"
         fi
 
-        if grep -Eq \
-            'static[[:space:]]+(let|var)[[:space:]]+(shared|current|default)([^A-Za-z0-9_]|$)' \
-            "$file"
-        then
-            fail "ShellStateSnapshot-referencing code must not become a global singleton; found in $rel"
-        fi
     done < <(grep -RIl --include='*.swift' -F "ShellStateSnapshot" "$SOURCE_ROOT" || true)
 
     while IFS=: read -r file line_number source_line; do

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -438,6 +438,18 @@ readonly OWNERSHIP_AWK_HELPERS='
         }
         return delta
     }
+    function parenthesis_delta(value,    character, column, delta) {
+        delta = 0
+        for (column = 1; column <= length(value); column++) {
+            character = substr(value, column, 1)
+            if (character == "(") {
+                delta++
+            } else if (character == ")") {
+                delta--
+            }
+        }
+        return delta
+    }
     function matching_call_end(value, opening,    character, column, depth) {
         depth = 0
         for (column = opening; column <= length(value); column++) {
@@ -494,6 +506,106 @@ readonly OWNERSHIP_AWK_HELPERS='
     function top_level_binding_end(value, start,    position) {
         position = top_level_character_position(value, ",", start)
         return position > 0 ? position : length(value) + 1
+    }
+    function variable_declaration_position(value,    angle_depth, brace_depth, bracket_depth, character, column, keyword, next_character, parenthesis_depth, previous_character) {
+        for (column = 1; column <= length(value); column++) {
+            character = substr(value, column, 1)
+            if (parenthesis_depth == 0 && bracket_depth == 0 &&
+                brace_depth == 0 && angle_depth == 0)
+            {
+                keyword = substr(value, column, 3)
+                previous_character = substr(value, column - 1, 1)
+                next_character = substr(value, column + 3, 1)
+                if ((keyword == "let" || keyword == "var") &&
+                    (column == 1 || previous_character !~ /[A-Za-z0-9_]/) &&
+                    next_character ~ /[[:space:]]/ &&
+                    substr(value, column + 4) ~ /^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*/)
+                {
+                    return column
+                }
+            }
+            if (character == "(") {
+                parenthesis_depth++
+            } else if (character == ")" && parenthesis_depth > 0) {
+                parenthesis_depth--
+            } else if (character == "[") {
+                bracket_depth++
+            } else if (character == "]" && bracket_depth > 0) {
+                bracket_depth--
+            } else if (character == "{") {
+                brace_depth++
+            } else if (character == "}" && brace_depth > 0) {
+                brace_depth--
+            } else if (character == "<" && is_generic_angle_open(value, column)) {
+                angle_depth++
+            } else if (character == ">" && angle_depth > 0) {
+                angle_depth--
+            }
+        }
+        return 0
+    }
+    function property_attribute_prefix(value,    position, prefix) {
+        position = variable_declaration_position(value)
+        if (position == 0) {
+            return ""
+        }
+        prefix = substr(value, 1, position - 1)
+        return prefix ~ /(^|[[:space:]])@[A-Za-z_]/ ? prefix : ""
+    }
+    function clear_pending_property_attributes() {
+        pending_property_attributes = ""
+        pending_property_attribute_depth = 0
+        pending_property_attribute_indent = -1
+        pending_property_attribute_start_line = 0
+    }
+    # Preserve multiline wrapper initializer arguments until their property
+    # declaration arrives, without attaching attributes to unrelated symbols.
+    function declaration_with_pending_attributes(value, line_number, indent,    has_declaration, is_attribute, result) {
+        combined_declaration_start_line = line_number
+        has_declaration = variable_declaration_position(value) > 0
+        is_attribute = value ~ /^[[:space:]]*@[A-Za-z_][A-Za-z0-9_.]*/
+
+        if (pending_property_attributes != "") {
+            if (pending_property_attribute_depth > 0) {
+                pending_property_attributes = pending_property_attributes " " value
+                pending_property_attribute_depth += parenthesis_delta(value)
+                if (has_declaration && indent == pending_property_attribute_indent &&
+                    pending_property_attribute_depth <= 0)
+                {
+                    result = pending_property_attributes
+                    combined_declaration_start_line = pending_property_attribute_start_line
+                    clear_pending_property_attributes()
+                    return result
+                }
+                return ""
+            }
+            if (is_attribute && !has_declaration &&
+                indent == pending_property_attribute_indent)
+            {
+                pending_property_attributes = pending_property_attributes " " value
+                pending_property_attribute_depth += parenthesis_delta(value)
+                return ""
+            }
+            if (has_declaration && indent == pending_property_attribute_indent) {
+                result = pending_property_attributes " " value
+                combined_declaration_start_line = pending_property_attribute_start_line
+                clear_pending_property_attributes()
+                return result
+            }
+            if (value ~ /^[[:space:]]*$/) {
+                return ""
+            }
+            clear_pending_property_attributes()
+        }
+
+        if (is_attribute && !has_declaration) {
+            pending_property_attributes = value
+            pending_property_attribute_depth = parenthesis_delta(value)
+            pending_property_attribute_indent = indent
+            pending_property_attribute_start_line = line_number
+            return ""
+        }
+        return value
     }
     function binding_type_annotation(value,    assignment, body, colon, end) {
         colon = top_level_character_position(value, ":")
@@ -853,12 +965,7 @@ manifest_state_declarations() {
             }
             return parts[1] == "shared" && ((owner "|" name) in manifest_factories)
         }
-        function inferred_factory_contains_manifest(value, owner,    call, expression) {
-            if (value !~ /=/) {
-                return 0
-            }
-            expression = value
-            sub(/^[^=]*=[ ]*/, "", expression)
+        function manifest_factory_expression_contains(expression, owner,    call) {
             gsub(/[ ]*[.][ ]*/, ".", expression)
             if (instance_receiver_invokes_factory(expression, manifest_factories)) {
                 return 1
@@ -873,6 +980,14 @@ manifest_state_declarations() {
             }
             return 0
         }
+        function inferred_factory_contains_manifest(value, owner,    expression) {
+            if (value !~ /=/) {
+                return 0
+            }
+            expression = value
+            sub(/^[^=]*=[ ]*/, "", expression)
+            return manifest_factory_expression_contains(expression, owner)
+        }
         function inferred_generic_contains_manifest(value,    expression) {
             if (value !~ /=/) {
                 return 0
@@ -884,7 +999,21 @@ manifest_state_declarations() {
             return expression ~ /^[A-Za-z_][A-Za-z0-9_.]*[ ]*<[^>]*ShellContentWorkspaceManifest/ ||
                 expression ~ /^\[[^]]*ShellContentWorkspaceManifest/
         }
-        function record_manifest_binding(declaration,    header, prefix, kind) {
+        function wrapper_attributes_contain_manifest(declaration, owner,    attributes, normalized) {
+            attributes = property_attribute_prefix(declaration)
+            if (attributes == "") {
+                return 0
+            }
+            normalized = attributes
+            gsub(/[ ]*[?][ ]*/, "?", normalized)
+            gsub(/[ ]*[!][ ]*/, "!", normalized)
+            gsub(/[ ]*[.][ ]*/, ".", normalized)
+            return manifest_factory_expression_contains(attributes, owner) ||
+                normalized ~ /(^|[^A-Za-z0-9_])ShellContentWorkspaceManifest[?!][.](none|some)([^A-Za-z0-9_]|$)/ ||
+                attributes ~ /<[^>]*ShellContentWorkspaceManifest/ ||
+                attributes ~ /\[[^]]*ShellContentWorkspaceManifest/
+        }
+        function record_manifest_binding(declaration,    header, prefix, kind, property_position) {
             declaration = trim(declaration)
             if (declaration == "") {
                 return
@@ -892,7 +1021,13 @@ manifest_state_declarations() {
             header = declaration
             sub(/[=].*$/, "", header)
 
-            if (header ~ /:[^=]*ShellContentWorkspaceManifest([^A-Za-z0-9_]|$)/) {
+            if (wrapper_attributes_contain_manifest(declaration, declaration_owner)) {
+                property_position = variable_declaration_position(declaration)
+                prefix = substr(declaration, property_position)
+                sub(/[=:{].*$/, "", prefix)
+                prefix = trim(prefix)
+                kind = "wrapper-initialized"
+            } else if (header ~ /:[^=]*ShellContentWorkspaceManifest([^A-Za-z0-9_]|$)/) {
                 prefix = header
                 sub(/[ ]*:.*/, "", prefix)
                 kind = "typed"
@@ -958,6 +1093,7 @@ manifest_state_declarations() {
             source_line_number = substr(remainder, 1, second_separator - 1)
             line = substr(remainder, second_separator + 1)
             line_indent = leading_space_count(line)
+            declaration_line = declaration_with_pending_attributes(line, source_line_number, line_indent)
             if (line !~ /^[[:space:]]*$/) {
                 while (type_depth > 0 && line_indent <= type_indent[type_depth]) {
                     delete type_indent[type_depth]
@@ -971,10 +1107,12 @@ manifest_state_declarations() {
                 }
             }
 
-            if (line ~ /^[[:space:]]*[^\/]*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/) {
+            if (declaration_line != "" &&
+                variable_declaration_position(declaration_line) > 0)
+            {
                 record_declaration()
-                buffer = line
-                start_line = source_line_number
+                buffer = declaration_line
+                start_line = combined_declaration_start_line
                 declaration_indent = line_indent
                 declaration_owner = type_depth > 0 ? type_name[type_depth] : ""
                 declaration_owner_key = current_type_owner()
@@ -1125,7 +1263,7 @@ shell_host_global_storage_declarations() {
             return value ~ /^[[:space:]]*[^\/]*(static|class)[ ]+([^ ]+[ ]+)*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
         }
         function is_module_property_start(value) {
-            return value ~ /^[^\/{]*(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/
+            return variable_declaration_position(value) > 0
         }
         function is_type_declaration(value) {
             return value ~ /^[[:space:]]*[^\/]*(class|struct|actor|enum|extension|protocol)[ ]+[A-Za-z_][A-Za-z0-9_.]*/
@@ -1802,12 +1940,7 @@ shell_snapshot_stored_property_counts() {
             }
             return parts[1] == "shared" && ((owner "|" name) in snapshot_factories)
         }
-        function uses_snapshot_factory(property, owner,    call, expression) {
-            if (property !~ /=/) {
-                return 0
-            }
-            expression = property
-            sub(/^[^=]*=[ ]*/, "", expression)
+        function snapshot_factory_expression_contains(expression, owner,    call) {
             gsub(/[ ]*[.][ ]*/, ".", expression)
             if (instance_receiver_invokes_factory(expression, snapshot_factories)) {
                 return 1
@@ -1822,6 +1955,14 @@ shell_snapshot_stored_property_counts() {
             }
             return 0
         }
+        function uses_snapshot_factory(property, owner,    expression) {
+            if (property !~ /=/) {
+                return 0
+            }
+            expression = property
+            sub(/^[^=]*=[ ]*/, "", expression)
+            return snapshot_factory_expression_contains(expression, owner)
+        }
         function inferred_generic_contains_snapshot(property,    expression) {
             if (property !~ /=/) {
                 return 0
@@ -1833,12 +1974,7 @@ shell_snapshot_stored_property_counts() {
             return expression ~ /^[A-Za-z_][A-Za-z0-9_.]*[ ]*<[^>]*ShellStateSnapshot/ ||
                 expression ~ /^\[[^]]*ShellStateSnapshot/
         }
-        function uses_snapshot_projection(property,    expression, pattern, projection) {
-            if (property !~ /=/) {
-                return 0
-            }
-            expression = property
-            sub(/^[^=]*=[ ]*/, "", expression)
+        function snapshot_expression_uses_projection(expression,    pattern, projection) {
             gsub(/[ ]*[.][ ]*/, ".", expression)
             for (projection in snapshot_projections) {
                 pattern = "[^[:space:].][.]" projection "([^A-Za-z0-9_]|$)"
@@ -1847,6 +1983,14 @@ shell_snapshot_stored_property_counts() {
                 }
             }
             return 0
+        }
+        function uses_snapshot_projection(property,    expression) {
+            if (property !~ /=/) {
+                return 0
+            }
+            expression = property
+            sub(/^[^=]*=[ ]*/, "", expression)
+            return snapshot_expression_uses_projection(expression)
         }
         function typed_storage_contains_snapshot(property,    type) {
             if (property !~ /:/) {
@@ -1877,8 +2021,24 @@ shell_snapshot_stored_property_counts() {
             gsub(/^[[:space:]]+|[[:space:]]+$/, "", type)
             return type != ""
         }
+        function wrapper_attributes_contain_snapshot(binding, owner,    attributes, normalized) {
+            attributes = property_attribute_prefix(binding)
+            if (attributes == "") {
+                return 0
+            }
+            normalized = attributes
+            gsub(/[ ]*[?][ ]*/, "?", normalized)
+            gsub(/[ ]*[!][ ]*/, "!", normalized)
+            gsub(/[ ]*[.][ ]*/, ".", normalized)
+            return snapshot_factory_expression_contains(attributes, owner) ||
+                snapshot_expression_uses_projection(attributes) ||
+                normalized ~ /(^|[^A-Za-z0-9_])ShellStateSnapshot[?!][.](none|some)([^A-Za-z0-9_]|$)/ ||
+                attributes ~ /<[^>]*ShellStateSnapshot/ ||
+                attributes ~ /\[[^]]*ShellStateSnapshot/
+        }
         function snapshot_binding_contains_storage(binding, owner) {
-            return typed_storage_contains_snapshot(binding) ||
+            return wrapper_attributes_contain_snapshot(binding, owner) ||
+                typed_storage_contains_snapshot(binding) ||
                 binding ~ /=[ ]*ShellStateSnapshot[ ]*([.(]|$)/ ||
                 inferred_generic_contains_snapshot(binding) ||
                 inferred_optional_case_contains_target(binding, "ShellStateSnapshot") ||
@@ -1947,11 +2107,13 @@ shell_snapshot_stored_property_counts() {
             remainder = substr($0, first_separator + 1)
             second_separator = index(remainder, "\t")
             line = substr(remainder, second_separator + 1)
+            source_line_number = substr(remainder, 1, second_separator - 1)
 
             # Follow the formatted type nesting so instance members of both
             # top-level and nested types are counted, while method-local scratch
             # variables remain deeper than their enclosing type member level.
             line_indent = leading_space_count(line)
+            declaration_line = declaration_with_pending_attributes(line, source_line_number, line_indent)
             if (line !~ /^[[:space:]]*$/) {
                 while (type_depth > 0 && line_indent <= type_indent[type_depth]) {
                     delete type_indent[type_depth]
@@ -1967,8 +2129,10 @@ shell_snapshot_stored_property_counts() {
 
             if (type_depth > 0 && line_indent == type_indent[type_depth] + 4) {
                 count_buffered_instance_property()
-                if (line ~ /(let|var)[ ]+[A-Za-z_][A-Za-z0-9_]*/) {
-                    instance_buffer = line
+                if (declaration_line != "" &&
+                    variable_declaration_position(declaration_line) > 0)
+                {
+                    instance_buffer = declaration_line
                     instance_indent = line_indent
                     instance_owner = type_name[type_depth]
                 }
@@ -1983,11 +2147,11 @@ shell_snapshot_stored_property_counts() {
             # Globally addressable storage is either a module-scope declaration
             # or a static/class type member. Method-local variables remain out
             # of this inventory.
-            if (is_static_property_start(line) ||
-                (brace_depth == 0 && is_module_property_start(line)))
+            if (is_static_property_start(declaration_line) ||
+                (brace_depth == 0 && is_module_property_start(declaration_line)))
             {
                 count_buffered_global_property()
-                global_buffer = line
+                global_buffer = declaration_line
                 global_indent = line_indent
                 global_owner = type_depth > 0 ? type_name[type_depth] : ""
             } else if (global_buffer != "" &&

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -391,6 +391,15 @@ manifest_state_declarations() {
             sub(/^.*[.]/, "", name)
             return name
         }
+        function current_type_owner(    depth, owner) {
+            if (type_depth == 0) {
+                return "<module>"
+            }
+            for (depth = 1; depth <= type_depth; depth++) {
+                owner = owner (owner == "" ? "" : ".") type_name[depth]
+            }
+            return owner
+        }
         function manifest_factory_call_matches(call, owner,    name, parts, qualifier, segment_count, qualifier_index) {
             segment_count = split(call, parts, ".")
             name = parts[segment_count]
@@ -477,7 +486,8 @@ manifest_state_declarations() {
                 return
             }
 
-            printf "%d|%d|%s|%s\n", start_line, declaration_indent, trim(prefix), kind
+            printf "%d|%s|%d|%s|%s\n", \
+                start_line, declaration_owner_key, declaration_indent, trim(prefix), kind
             buffer = ""
         }
         {
@@ -503,6 +513,7 @@ manifest_state_declarations() {
                 start_line = FNR
                 declaration_indent = line_indent
                 declaration_owner = type_depth > 0 ? type_name[type_depth] : ""
+                declaration_owner_key = current_type_owner()
             } else if (buffer != "" &&
                 (line ~ /^[[:space:]]*$/ || line_indent > declaration_indent))
             {
@@ -1006,21 +1017,25 @@ reject_shell_host_duplicate_persistence_state() {
     local scheduler_definition_owner="Services/Shell/ShellWorkspaceManifestStore.swift"
     local projector_definition_owner="Services/Shell/ShellWorkspaceManifestProjector.swift"
     local manifest_state_allowlist=(
-        "Services/Shell/ShellCoreFFIManifestAdapter.swift|4|let manifest|typed"
-        "Services/Shell/ShellWorkspaceManifestProjector.swift|8|var manifest|constructed"
-        "Services/Shell/ShellWorkspaceManifestStore.swift|8|let manifest|inferred-factory"
-        "Services/Shell/ShellWorkspaceManifestStore.swift|12|let manifest|inferred-factory"
-        "Services/Shell/ShellWorkspaceManifestStore.swift|4|var manifest|typed"
-        "Services/Shell/ShellWorkspacePersistenceCoordinator.swift|4|private var workspaceManifest|typed"
-        "Services/Shell/ShellWorkspacePersistenceStartup.swift|12|let retainedManifest|inferred-factory"
+        "Services/Shell/ShellCoreFFIManifestAdapter.swift|PruningExpiredTabsPayload|4|let manifest|typed"
+        "Services/Shell/ShellCoreFFIManifestAdapter.swift|MaterializeManifestPayload|4|let manifest|typed"
+        "Services/Shell/ShellCoreFFIManifestAdapter.swift|ManifestPayload|4|let manifest|typed"
+        "Services/Shell/ShellWorkspaceManifestProjector.swift|ShellWorkspaceManifestProjector|8|var manifest|constructed"
+        "Services/Shell/ShellWorkspaceManifestStore.swift|ShellWorkspaceManifestStore|8|let manifest|inferred-factory"
+        "Services/Shell/ShellWorkspaceManifestStore.swift|ShellWorkspaceManifestStore|12|let manifest|inferred-factory"
+        "Services/Shell/ShellWorkspaceManifestStore.swift|ShellWorkspaceManifestLoadResult|4|var manifest|typed"
+        "Services/Shell/ShellWorkspacePersistenceCoordinator.swift|ShellWorkspacePersistenceCoordinator|4|private var workspaceManifest|typed"
+        "Services/Shell/ShellWorkspacePersistenceStartup.swift|ShellWorkspacePersistenceCoordinator|12|let retainedManifest|inferred-factory"
     )
     local declaration
     local declaration_indent
     local declaration_kind
     local declaration_line
+    local declaration_owner
     local factory_inventory
     local file
     local manifest_state
+    local -a manifest_state_seen=("<inventory-sentinel>")
     local rel
 
     require_existing_single_owner_pattern \
@@ -1053,15 +1068,30 @@ reject_shell_host_duplicate_persistence_state() {
     )"
     while IFS= read -r file; do
         rel="${file#$SOURCE_ROOT/}"
-        while IFS='|' read -r declaration_line declaration_indent declaration declaration_kind; do
-            manifest_state="$rel|$declaration_indent|$declaration|$declaration_kind"
+        while IFS='|' read -r \
+            declaration_line declaration_owner declaration_indent declaration declaration_kind
+        do
+            manifest_state="$rel|$declaration_owner|$declaration_indent|$declaration|$declaration_kind"
             if ! contains_line "$manifest_state" "${manifest_state_allowlist[@]}"; then
                 printf '%s:%s:%s\n' "$file" "$declaration_line" "$declaration" >&2
                 fail \
                     "ShellContentWorkspaceManifest storage is not in the accepted ownership inventory: $manifest_state"
+            elif contains_line "$manifest_state" "${manifest_state_seen[@]}"; then
+                printf '%s:%s:%s\n' "$file" "$declaration_line" "$declaration" >&2
+                fail \
+                    "ShellContentWorkspaceManifest ownership inventory entries must be unique: $manifest_state"
+            else
+                manifest_state_seen+=("$manifest_state")
             fi
         done < <(manifest_state_declarations "$file" "$factory_inventory")
     done < <(find "$SOURCE_ROOT" -type f -name '*.swift' -print | sort)
+
+    for manifest_state in "${manifest_state_allowlist[@]}"; do
+        if ! contains_line "$manifest_state" "${manifest_state_seen[@]}"; then
+            fail \
+                "accepted ShellContentWorkspaceManifest inventory entry must remain present: $manifest_state"
+        fi
+    done
 
     while IFS= read -r file; do
         rel="${file#$SOURCE_ROOT/}"

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -890,6 +890,99 @@ static_property_declarations() {
     ' < <(swift_code_lines "$file")
 }
 
+guarded_shell_owner_typealias_declarations() {
+    local file="$1"
+
+    awk '
+        function leading_space_count(value,    prefix) {
+            prefix = value
+            sub(/[^ ].*$/, "", prefix)
+            return length(prefix)
+        }
+        function is_typealias_start(value) {
+            return value ~ /(^|[^A-Za-z0-9_])typealias([[:space:]]|$)/
+        }
+        function is_same_indent_continuation(value) {
+            return value ~ /^[[:space:]]*(=|[(]|[)]|\[|\]|<|>|->|@|where)([^A-Za-z0-9_]|$)/
+        }
+        function declaration_is_incomplete(value,    angle, brackets, character, column, parens, rhs) {
+            if (value !~ /=/) {
+                return 1
+            }
+            rhs = value
+            sub(/^[^=]*=/, "", rhs)
+            gsub(/[[:space:]]+/, " ", rhs)
+            sub(/^ /, "", rhs)
+            sub(/ $/, "", rhs)
+            if (rhs == "") {
+                return 1
+            }
+            for (column = 1; column <= length(rhs); column++) {
+                character = substr(rhs, column, 1)
+                if (character == "(") {
+                    parens++
+                } else if (character == ")" && parens > 0) {
+                    parens--
+                } else if (character == "[") {
+                    brackets++
+                } else if (character == "]" && brackets > 0) {
+                    brackets--
+                } else if (character == "<") {
+                    angle++
+                } else if (character == ">" && angle > 0) {
+                    angle--
+                }
+            }
+            return parens > 0 || brackets > 0 || angle > 0 ||
+                rhs ~ /(=|,|&|[.]|->|[(]|\[|<)$/
+        }
+        function record_typealias(    declaration) {
+            if (typealias_buffer == "") {
+                return
+            }
+            declaration = typealias_buffer
+            gsub(/[[:space:]]+/, " ", declaration)
+            sub(/^ /, "", declaration)
+            sub(/ $/, "", declaration)
+            if (declaration ~ guarded_type_pattern) {
+                printf "%d|%s\n", typealias_start_line, declaration
+            }
+            typealias_buffer = ""
+        }
+        BEGIN {
+            guarded_type_pattern = "(^|[^A-Za-z0-9_])" \
+                "(ShellHostController|ShellStateSnapshot|ShellContentWorkspaceManifest)" \
+                "([^A-Za-z0-9_]|$)"
+        }
+        {
+            first_separator = index($0, "\t")
+            remainder = substr($0, first_separator + 1)
+            second_separator = index(remainder, "\t")
+            source_line_number = substr(remainder, 1, second_separator - 1)
+            line = substr(remainder, second_separator + 1)
+            line_indent = leading_space_count(line)
+
+            if (is_typealias_start(line)) {
+                record_typealias()
+                typealias_buffer = line
+                typealias_start_line = source_line_number
+                typealias_indent = line_indent
+            } else if (typealias_buffer != "" &&
+                (line ~ /^[[:space:]]*$/ ||
+                    line_indent > typealias_indent ||
+                    (line_indent == typealias_indent &&
+                        (declaration_is_incomplete(typealias_buffer) ||
+                            is_same_indent_continuation(line)))))
+            {
+                typealias_buffer = typealias_buffer " " line
+            } else {
+                record_typealias()
+            }
+        }
+        END { record_typealias() }
+    ' < <(swift_code_lines "$file")
+}
+
 shell_host_global_storage_declarations() {
     local file="$1"
     local factory_inventory="$2"
@@ -1787,6 +1880,8 @@ reject_replacement_global_shell_store() {
         "ShellHostController.swift|static let terminalSelectionFirst = ShellPaneMovementInteractionPolicy()"
     )
     local file
+    local guarded_alias_declaration
+    local guarded_alias_line
     local host_factory_inventory
     local line_number
     local observable_owner
@@ -1814,6 +1909,16 @@ reject_replacement_global_shell_store() {
 
     while IFS= read -r file; do
         rel="${file#$SOURCE_ROOT/}"
+        while IFS='|' read -r guarded_alias_line guarded_alias_declaration; do
+            [[ -n "$guarded_alias_line" ]] || continue
+            printf '%s:%s:%s\n' \
+                "$file" \
+                "$guarded_alias_line" \
+                "$guarded_alias_declaration" >&2
+            fail \
+                "guarded shell ownership types must remain explicit instead of hidden behind typealias: $rel"
+        done < <(guarded_shell_owner_typealias_declarations "$file")
+
         snapshot_property_counts="$(
             shell_snapshot_stored_property_counts "$file" "$snapshot_factory_inventory"
         )"

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -217,6 +217,30 @@ contains_line() {
     return 1
 }
 
+reject_unapproved_symbol_lines() {
+    local file="$1"
+    local symbol_pattern="$2"
+    local allowed_pattern="$3"
+    local description="$4"
+
+    if ! awk \
+        -v symbol_pattern="$symbol_pattern" \
+        -v allowed_pattern="$allowed_pattern" '
+            {
+                line = $0
+                sub(/\/\/.*/, "", line)
+                if (line ~ symbol_pattern && line !~ allowed_pattern) {
+                    printf "%s:%d:%s\n", FILENAME, NR, $0 > "/dev/stderr"
+                    rejected = 1
+                }
+            }
+            END { exit rejected ? 1 : 0 }
+        ' "$file"
+    then
+        fail "$description"
+    fi
+}
+
 check_appkit_import_gate() {
     local rel="$1"
     local file="$2"
@@ -547,11 +571,8 @@ reject_shell_host_duplicate_persistence_state() {
     local controller="$SOURCE_ROOT/ShellHostController.swift"
     local controller_dir="$SOURCE_ROOT/Controllers/Shell"
     local persistence_owner="Services/Shell/ShellWorkspacePersistenceCoordinator.swift"
-    local persistence_type_owners=(
-        "Services/Shell/ShellWorkspaceManifestProjector.swift"
-        "Services/Shell/ShellWorkspaceManifestStore.swift"
-        "$persistence_owner"
-    )
+    local scheduler_definition_owner="Services/Shell/ShellWorkspaceManifestStore.swift"
+    local projector_definition_owner="Services/Shell/ShellWorkspaceManifestProjector.swift"
     local file
     local rel
 
@@ -582,12 +603,44 @@ reject_shell_host_duplicate_persistence_state() {
 
     while IFS= read -r file; do
         rel="${file#$SOURCE_ROOT/}"
-        if ! contains_line "$rel" "${persistence_type_owners[@]}"; then
-            fail \
-                "workspace persistence scheduler/projector types must stay behind the persistence owner; found in $rel"
-        fi
+        case "$rel" in
+            "$persistence_owner")
+                ;;
+            "$scheduler_definition_owner")
+                reject_unapproved_symbol_lines \
+                    "$file" \
+                    'ManifestFlushScheduling|DebouncedManifestFlushScheduler' \
+                    '^[[:space:]]*(protocol[[:space:]]+ManifestFlushScheduling([^A-Za-z0-9_]|$)|final[[:space:]]+class[[:space:]]+DebouncedManifestFlushScheduler[[:space:]]*:[[:space:]]*ManifestFlushScheduling([^A-Za-z0-9_]|$))' \
+                    "workspace manifest store may define but must not use persistence scheduling"
+                ;;
+            *)
+                fail \
+                    "workspace persistence scheduler usage must stay in $persistence_owner; found in $rel"
+                ;;
+        esac
     done < <(grep -RIl --include='*.swift' -E \
-        'ManifestFlushScheduling|DebouncedManifestFlushScheduler|ShellWorkspaceManifestProjector' \
+        'ManifestFlushScheduling|DebouncedManifestFlushScheduler' \
+        "$SOURCE_ROOT" || true)
+
+    while IFS= read -r file; do
+        rel="${file#$SOURCE_ROOT/}"
+        case "$rel" in
+            "$persistence_owner")
+                ;;
+            "$projector_definition_owner")
+                reject_unapproved_symbol_lines \
+                    "$file" \
+                    'ShellWorkspaceManifestProjector' \
+                    '^[[:space:]]*struct[[:space:]]+ShellWorkspaceManifestProjector([^A-Za-z0-9_]|$)' \
+                    "workspace manifest projector file may define but must not construct a second projector"
+                ;;
+            *)
+                fail \
+                    "workspace manifest projector usage must stay in $persistence_owner; found in $rel"
+                ;;
+        esac
+    done < <(grep -RIl --include='*.swift' -E \
+        'ShellWorkspaceManifestProjector' \
         "$SOURCE_ROOT" || true)
 
     if grep -RIn --include='*.swift' -E \

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -397,11 +397,15 @@ manifest_state_declarations() {
             while (expression ~ /^(try[!?]?|await)[ ]+/) {
                 sub(/^(try[!?]?|await)[ ]+/, "", expression)
             }
-            if (expression !~ /^[A-Za-z_][A-Za-z0-9_.]*[ ]*\(/) {
+            if (expression !~ /\(/) {
                 return 0
             }
             call = expression
             sub(/[ ]*\(.*/, "", call)
+            gsub(/[ ]*[.][ ]*/, ".", call)
+            if (call !~ /^[A-Za-z_][A-Za-z0-9_.]*$/) {
+                return 0
+            }
             segment_count = split(call, parts, ".")
             name = parts[segment_count]
             if (segment_count == 1) {
@@ -553,11 +557,15 @@ shell_host_static_storage_declarations() {
             while (expression ~ /^(try[!?]?|await)[ ]+/) {
                 sub(/^(try[!?]?|await)[ ]+/, "", expression)
             }
-            if (expression !~ /^[A-Za-z_][A-Za-z0-9_.]*[ ]*\(/) {
+            if (expression !~ /\(/) {
                 return 0
             }
             call = expression
             sub(/[ ]*\(.*/, "", call)
+            gsub(/[ ]*[.][ ]*/, ".", call)
+            if (call !~ /^[A-Za-z_][A-Za-z0-9_.]*$/) {
+                return 0
+            }
             segment_count = split(call, parts, ".")
             name = parts[segment_count]
             if (segment_count == 1) {
@@ -1115,11 +1123,15 @@ shell_snapshot_stored_property_counts() {
             while (expression ~ /^(try[!?]?|await)[ ]+/) {
                 sub(/^(try[!?]?|await)[ ]+/, "", expression)
             }
-            if (expression !~ /^[A-Za-z_][A-Za-z0-9_.]*[ ]*\(/) {
+            if (expression !~ /\(/) {
                 return 0
             }
             call = expression
             sub(/[ ]*\(.*/, "", call)
+            gsub(/[ ]*[.][ ]*/, ".", call)
+            if (call !~ /^[A-Za-z_][A-Za-z0-9_.]*$/) {
+                return 0
+            }
             segment_count = split(call, parts, ".")
             name = parts[segment_count]
             if (segment_count == 1) {

--- a/openspec/changes/deepen-macos-shell-host-ownership/tasks.md
+++ b/openspec/changes/deepen-macos-shell-host-ownership/tasks.md
@@ -33,7 +33,7 @@
 - [x] 3.3 Keep manifest loading and write scheduling in
   `ShellWorkspacePersistenceCoordinator`; remove controller-owned persistence
   workflow state and forwarding.
-- [ ] 3.4 Add architecture checks that reject reintroduced duplicate state or a
+- [x] 3.4 Add architecture checks that reject reintroduced duplicate state or a
   replacement global shell store.
 
 ## 4. Consolidate Workflows And Audit Adapters


### PR DESCRIPTION
## Summary

- keep manifest state, projection, and debounce scheduling behind `ShellWorkspacePersistenceCoordinator`
- reject a second observable or singleton-backed `ShellStateSnapshot` store and catch-all `ShellStore` / `ShellModel` replacements
- document the enforced ownership boundary and complete OpenSpec task 3.4

## Verification

- `just quality`
- `bash clients/apple/scripts/check-architecture-maintainability.sh`
- negative architecture probes for duplicate persistence state and a global Shell store (both rejected as expected)
- `bash clients/apple/scripts/check-shell-contracts.sh`
- `openspec validate deepen-macos-shell-host-ownership --strict`
- `git diff --check`