### PR TITLE
refactor(macos): remove terminal lifecycle adapter

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -55,7 +55,7 @@ Xcode target.
 | `Services/Terminal/TerminalRuntimePublicationPolicy.swift` | 46 | macOS gates | Shell-facing runtime snapshot publication policy | `Services/Terminal/` |
 | `Services/Terminal/TerminalHostRuntimeReporter.swift` | 48 | Foundation; macOS gates | Runtime snapshot deduplication and main-queue publication for terminal host updates | `Services/Terminal/` |
 | `Services/Terminal/TerminalHostWindowObserver.swift` | 55 | AppKit; macOS gates | Terminal host window key, screen, and occlusion notification ownership | `Services/Terminal/` |
-| `TerminalRuntimeRegistry.swift` | 752 | SwiftUI; macOS gates | Content-keyed terminal host/runtime, active-task, lifecycle, and shell-projection registry | `Services/Terminal/` |
+| `TerminalRuntimeRegistry.swift` | 729 | SwiftUI; macOS gates | Content-keyed terminal host/runtime, active-task, lifecycle, and shell-projection registry | `Services/Terminal/` |
 | `Services/Terminal/DarwinTerminalPtyRuntime.swift` | 820 | Darwin, Foundation; macOS gates | Local Darwin PTY handle, renderer proxy, nonblocking IO, process launch, and exit observation | `Services/Terminal/` |
 | `Services/Terminal/GhosttyProcessBootstrap.swift` | 143 | Darwin, Foundation, GhosttyKit; macOS/Ghostty gates | Process-wide Ghostty initialization and inherited terminal-environment scrubbing | `Services/Terminal/` |
 | `Services/Terminal/GhosttyTerminalSurfaceHandle.swift` | 541 | AppKit, Foundation, GhosttyKit; macOS/Ghostty gates | Ghostty surface lifecycle, PTY attachment, delivery, renderer updates, and event-engine adaptation | `Services/Terminal/` |
@@ -99,6 +99,7 @@ Xcode target.
 | `Services/Terminal/TerminalAgentActivityAdapter.swift` | 177 | Foundation | Sanitized agent-event to terminal-activity projection | `Services/Terminal/` |
 | `Models/Shell/ShellPaneSnapshots.swift` | 127 | Foundation | Pane identity, viewport, Alan binding, and pane-local runtime metadata DTOs | `Models/Shell/` |
 | `Models/Shell/ShellContentSnapshots.swift` | 555 | CoreGraphics, Foundation | Terminal transcript, renderer state, content payload, and content-instance DTOs | `Models/Shell/` |
+| `Models/Shell/TerminalContentMount.swift` | 52 | None | Terminal mount identity and active-mount projection from canonical shell content state | `Models/Shell/` |
 | `Models/Shell/ShellPaneTreeSnapshots.swift` | 492 | Foundation | Pane-slot split-tree and portable slot-tree query models | `Models/Shell/` |
 | `Models/Shell/ShellTabSpaceSnapshots.swift` | 310 | Foundation | Tab, content-tab, Space identity, icon, and default-name DTOs | `Models/Shell/` |
 | `Models/Shell/ShellWorkspaceSnapshots.swift` | 666 | Foundation | Workspace state snapshots and cross-family snapshot query helpers | `Models/Shell/` |
@@ -114,13 +115,13 @@ Xcode target.
 | `Models/Shell/ManagedTerminalAccountCatalog.swift` | 91 | Foundation; macOS gates | Durable managed-account catalog normalization and storage | `Models/Shell/` |
 | `Models/Shell/ManagedTerminalUserSettings.swift` | 240 | Foundation; macOS gates | Managed-user readiness, creation preview, validation, and approved provisioning flow | `Models/Shell/` |
 | `Models/Shell/ShellSettingsHostSummaries.swift` | 131 | Foundation; macOS gates | Local app/runtime/storage identity and performance-diagnostics summaries | `Models/Shell/` |
-| `ShellHostController.swift` | 362 | Foundation, Combine; macOS gates | Observable adopted shell state, dependency assembly, startup, shutdown, and root lifecycle | Root controller with focused `Controllers/Shell/` responsibility extensions |
+| `ShellHostController.swift` | 360 | Foundation, Combine; macOS gates | Observable adopted shell state, dependency assembly, startup, shutdown, and root lifecycle | Root controller with focused `Controllers/Shell/` responsibility extensions |
 | `Controllers/Shell/ShellHostControlProjection.swift` | 268 | Foundation; macOS gates | Control response, list, routing-candidate, and terminal-delivery projection | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostPlatformControlCommandHandling.swift` | 431 | Foundation; macOS gates | Shared-executor state adoption plus close guard, terminal delivery, events, render metrics, and performance diagnostics | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostProjectionAndSelection.swift` | 511 | Foundation; macOS gates | Snapshot-derived shell and selection projection, focus, zoom, and shell-surface close requests | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostSpaceAndTabLifecycle.swift` | 734 | Foundation; macOS gates | Space, tab, content, and split creation plus tab ordering and movement | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostActionAndTerminalCommandHandling.swift` | 494 | Foundation; macOS gates | Shell action execution, spatial focus, and terminal semantic-command routing | `Controllers/Shell/` |
-| `Controllers/Shell/ShellHostRuntimeProjection.swift` | 616 | Foundation; macOS gates | Registry-backed terminal runtime and metadata projection, activity routing, state adoption, and render-priority refresh | `Controllers/Shell/` |
+| `Controllers/Shell/ShellHostRuntimeProjection.swift` | 615 | Foundation; macOS gates | Registry-backed terminal runtime and metadata projection, activity routing, state adoption, and render-priority refresh | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostCloseAndPaneLifecycle.swift` | 444 | Foundation; macOS gates | Close guards, shell-core pane lifecycle/movement, and control-plane state publication | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostAutomationCommandHandling.swift` | 309 | Foundation; macOS gates | External shell automation command adaptation and response projection | `Controllers/Shell/` |
 | `Services/Shell/ShellCloseWorkflow.swift` | 202 | AppKit, Foundation; macOS gates | Close confirmation, auto-close suppression, graceful terminal shutdown, and transcript-capture ordering | `Services/Shell/` |

--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -115,7 +115,7 @@
 		000000000000000000000032 /* Services/Terminal/TerminalHostOverlayPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000132 /* Services/Terminal/TerminalHostOverlayPresenter.swift */; };
 		000000000000000000000033 /* Services/Terminal/TerminalHostViewSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000133 /* Services/Terminal/TerminalHostViewSupport.swift */; };
 		000000000000000000000040 /* Services/Terminal/TerminalContentProjectionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000140 /* Services/Terminal/TerminalContentProjectionAdapter.swift */; };
-		000000000000000000000041 /* Services/Terminal/TerminalContentLifecycleAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000141 /* Services/Terminal/TerminalContentLifecycleAdapter.swift */; };
+		000000000000000000000041 /* Models/Shell/TerminalContentMount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000141 /* Models/Shell/TerminalContentMount.swift */; };
 		000000000000000000000042 /* Services/Shell/ShellContentRenderingRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000142 /* Services/Shell/ShellContentRenderingRegistry.swift */; };
 		00000000000000000000007A /* Services/AlanOS/AlanOSAttachmentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000017A /* Services/AlanOS/AlanOSAttachmentService.swift */; };
 		000000000000000000000043 /* Models/Shell/ShellAutomationCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000143 /* Models/Shell/ShellAutomationCommand.swift */; };
@@ -322,7 +322,7 @@
 		000000000000000000000132 /* Services/Terminal/TerminalHostOverlayPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalHostOverlayPresenter.swift; sourceTree = "<group>"; };
 		000000000000000000000133 /* Services/Terminal/TerminalHostViewSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalHostViewSupport.swift; sourceTree = "<group>"; };
 		000000000000000000000140 /* Services/Terminal/TerminalContentProjectionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalContentProjectionAdapter.swift; sourceTree = "<group>"; };
-		000000000000000000000141 /* Services/Terminal/TerminalContentLifecycleAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalContentLifecycleAdapter.swift; sourceTree = "<group>"; };
+		000000000000000000000141 /* Models/Shell/TerminalContentMount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/TerminalContentMount.swift; sourceTree = "<group>"; };
 		000000000000000000000142 /* Services/Shell/ShellContentRenderingRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellContentRenderingRegistry.swift; sourceTree = "<group>"; };
 		00000000000000000000017A /* Services/AlanOS/AlanOSAttachmentService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/AlanOS/AlanOSAttachmentService.swift; sourceTree = "<group>"; };
 		000000000000000000000143 /* Models/Shell/ShellAutomationCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellAutomationCommand.swift; sourceTree = "<group>"; };
@@ -543,6 +543,7 @@
 				A12000000000000000000109 /* Models/Shell/ShellContextSnapshot.swift */,
 				000000000000000000000122 /* Models/Shell/ShellPaneSnapshots.swift */,
 				A11F00000000000000000101 /* Models/Shell/ShellContentSnapshots.swift */,
+				000000000000000000000141 /* Models/Shell/TerminalContentMount.swift */,
 				A11F00000000000000000102 /* Models/Shell/ShellPaneTreeSnapshots.swift */,
 				A11F00000000000000000103 /* Models/Shell/ShellTabSpaceSnapshots.swift */,
 				A11F00000000000000000104 /* Models/Shell/ShellWorkspaceSnapshots.swift */,
@@ -664,7 +665,6 @@
 				A12000000000000000000108 /* Services/Terminal/TerminalAgentActivityAdapter.swift */,
 				000000000000000000000127 /* Services/Terminal/TerminalHostRuntimeReporter.swift */,
 				000000000000000000000128 /* Services/Terminal/TerminalHostWindowObserver.swift */,
-				000000000000000000000141 /* Services/Terminal/TerminalContentLifecycleAdapter.swift */,
 				000000000000000000000140 /* Services/Terminal/TerminalContentProjectionAdapter.swift */,
 				000000000000000000000132 /* Services/Terminal/TerminalHostOverlayPresenter.swift */,
 				000000000000000000000133 /* Services/Terminal/TerminalHostViewSupport.swift */,
@@ -984,7 +984,7 @@
 				A11C00000000000000000002 /* Services/Shell/ShellCloseWorkflow.swift in Sources */,
 				000000000000000000000042 /* Services/Shell/ShellContentRenderingRegistry.swift in Sources */,
 				00000000000000000000007A /* Services/AlanOS/AlanOSAttachmentService.swift in Sources */,
-				000000000000000000000041 /* Services/Terminal/TerminalContentLifecycleAdapter.swift in Sources */,
+				000000000000000000000041 /* Models/Shell/TerminalContentMount.swift in Sources */,
 				000000000000000000000040 /* Services/Terminal/TerminalContentProjectionAdapter.swift in Sources */,
 				000000000000000000000031 /* Services/Terminal/TerminalNativeScrollViewAdapter.swift in Sources */,
 				000000000000000000000032 /* Services/Terminal/TerminalHostOverlayPresenter.swift in Sources */,

--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostRuntimeProjection.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostRuntimeProjection.swift
@@ -469,9 +469,8 @@ extension ShellHostController {
         let previousPanesByID = Dictionary(
             uniqueKeysWithValues: shellState.panes.map { ($0.paneID, $0) }
         )
-        terminalContentLifecycle.reconcileRuntimes(
-            afterAdopting: state,
-            registry: terminalRuntimeRegistry
+        terminalRuntimeRegistry.releaseRuntimes(
+            excluding: state.contentStateProjection().activeTerminalMounts
         )
 
         shellState = platformMetadataPreserver.preservingPlatformMetadata(in: state) { [weak self] paneID in

--- a/clients/apple/alan-macos/Models/Shell/TerminalContentMount.swift
+++ b/clients/apple/alan-macos/Models/Shell/TerminalContentMount.swift
@@ -1,31 +1,38 @@
-import Foundation
+struct TerminalContentMount: Equatable {
+    let contentID: String
+    let paneSlotID: String
+    let tabID: String
+    let spaceID: String
 
-#if os(macOS)
-@MainActor
-struct TerminalContentLifecycleAdapter {
-    func reconcileRuntimes(
-        afterAdopting state: ShellStateSnapshot,
-        registry: TerminalRuntimeRegistry
-    ) {
-        registry.releaseRuntimes(excluding: activeTerminalMounts(in: state))
+    init(contentID: String, paneSlotID: String, tabID: String, spaceID: String) {
+        self.contentID = contentID
+        self.paneSlotID = paneSlotID
+        self.tabID = tabID
+        self.spaceID = spaceID
     }
 
-    func finalizeAllRuntimes(registry: TerminalRuntimeRegistry) {
-        registry.releaseAllRuntimes()
+    init(pane: ShellPane) {
+        self.init(
+            contentID: pane.terminalContentID,
+            paneSlotID: pane.paneID,
+            tabID: pane.tabID,
+            spaceID: pane.spaceID
+        )
     }
+}
 
-    func activeTerminalMounts(in state: ShellStateSnapshot) -> [TerminalContentMount] {
-        let contentState = state.contentStateProjection()
+extension ShellContentStateSnapshot {
+    var activeTerminalMounts: [TerminalContentMount] {
         var contentsByID: [String: ShellContentInstance] = [:]
-        contentState.contents.forEach { content in
+        contents.forEach { content in
             contentsByID[content.contentID] = content
         }
         let mountedPaneSlotIDs = Set(
-            contentState.spaces
+            spaces
                 .flatMap(\.tabs)
                 .flatMap(\.paneTree.paneSlotIDs)
         )
-        return contentState.paneSlots.compactMap { slot -> TerminalContentMount? in
+        return paneSlots.compactMap { slot -> TerminalContentMount? in
             guard mountedPaneSlotIDs.contains(slot.paneSlotID),
                   let content = contentsByID[slot.contentID],
                   content.kind == .terminal,
@@ -43,4 +50,3 @@ struct TerminalContentLifecycleAdapter {
         }
     }
 }
-#endif

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -117,7 +117,6 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     private let paneProjection: ShellPaneProjectionService
     let platformMetadataPreserver: ShellPlatformMetadataPreserver
     let terminalContentProjection: TerminalContentProjectionAdapter
-    let terminalContentLifecycle = TerminalContentLifecycleAdapter()
     let pasteboard: ShellPasteboardAccessing
     let closeWorkflow: ShellCloseWorkflow
     let performanceDiagnosticsRecorder: AlanPerformanceDiagnosticsRecorder?
@@ -291,14 +290,13 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
     deinit {
         let terminalRuntimeRegistry = terminalRuntimeRegistry
-        let terminalContentLifecycle = terminalContentLifecycle
         Task { @MainActor in
-            terminalContentLifecycle.finalizeAllRuntimes(registry: terminalRuntimeRegistry)
+            terminalRuntimeRegistry.releaseAllRuntimes()
         }
     }
 
     func shutdownTerminalRuntimes() {
-        terminalContentLifecycle.finalizeAllRuntimes(registry: terminalRuntimeRegistry)
+        terminalRuntimeRegistry.releaseAllRuntimes()
     }
 
     /// Persist only renderer-owned Agent offsets and presentation. Process identity is immutable.

--- a/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
@@ -33,29 +33,6 @@ final class MockTerminalRuntimeHandle: TerminalRuntimeHandle {
     }
 }
 
-struct TerminalContentMount: Equatable {
-    let contentID: String
-    let paneSlotID: String
-    let tabID: String
-    let spaceID: String
-
-    init(contentID: String, paneSlotID: String, tabID: String, spaceID: String) {
-        self.contentID = contentID
-        self.paneSlotID = paneSlotID
-        self.tabID = tabID
-        self.spaceID = spaceID
-    }
-
-    init(pane: ShellPane) {
-        self.init(
-            contentID: pane.terminalContentID,
-            paneSlotID: pane.paneID,
-            tabID: pane.tabID,
-            spaceID: pane.spaceID
-        )
-    }
-}
-
 enum TerminalHostAttachmentPolicy: Equatable {
     case immediate
     case deferUntilWindowAttached

--- a/clients/apple/scripts/test-shell-runtime-metadata.sh
+++ b/clients/apple/scripts/test-shell-runtime-metadata.sh
@@ -34,6 +34,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/scripts/support/ManagedTerminalAccountTestSupport.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellPaneSnapshots.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellContentSnapshots.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/TerminalContentMount.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellPaneTreeSnapshots.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellTabSpaceSnapshots.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellWorkspaceSnapshots.swift" \
@@ -104,7 +105,6 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalBootResolution.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalRenderCoordinator.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalRuntimePublicationPolicy.swift" \
-    "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalContentLifecycleAdapter.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalContentProjectionAdapter.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalNativeScrollViewAdapter.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalSemanticCommands.swift" \

--- a/openspec/changes/deepen-macos-shell-host-ownership/tasks.md
+++ b/openspec/changes/deepen-macos-shell-host-ownership/tasks.md
@@ -40,10 +40,10 @@
 
 - [x] 4.1 Move close confirmation and graceful shutdown into one concrete close
   workflow owner while keeping pane mutation in shell-core authority.
-- [ ] 4.2 Move terminal release/finalization, buffering, active-task state, and
+- [x] 4.2 Move terminal release/finalization, buffering, active-task state, and
   publication deduplication to `TerminalRuntimeRegistry` or the existing
   stateful reporter.
-- [ ] 4.3 Delete `TerminalContentLifecycleAdapter` after its active-mount
+- [x] 4.3 Delete `TerminalContentLifecycleAdapter` after its active-mount
   projection and lifecycle calls move to shell state and the runtime registry.
 - [ ] 4.4 Verify and retain the projection, publication-policy, metadata,
   activity-normalization, stateful reporter, and C ABI adapters only at their


### PR DESCRIPTION
## Summary
- move active terminal mount projection onto canonical shell content state
- route reconciliation and shutdown finalization directly through TerminalRuntimeRegistry
- delete TerminalContentLifecycleAdapter without adding a replacement workflow or protocol

## Validation
- just quality
- just apple-shell-focused-tests
- openspec validate deepen-macos-shell-host-ownership --strict
- just install-dev
- just apple-shell-ui-smoke

OpenSpec tasks 4.2 and 4.3.