### PR TITLE
refactor(macos): audit shell adapters

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -117,12 +117,12 @@ Xcode target.
 | `Models/Shell/ShellSettingsHostSummaries.swift` | 131 | Foundation; macOS gates | Local app/runtime/storage identity and performance-diagnostics summaries | `Models/Shell/` |
 | `ShellHostController.swift` | 360 | Foundation, Combine; macOS gates | Observable adopted shell state, dependency assembly, startup, shutdown, and root lifecycle | Root controller with focused `Controllers/Shell/` responsibility extensions |
 | `Controllers/Shell/ShellHostControlProjection.swift` | 268 | Foundation; macOS gates | Control response, list, routing-candidate, and terminal-delivery projection | `Controllers/Shell/` |
-| `Controllers/Shell/ShellHostPlatformControlCommandHandling.swift` | 431 | Foundation; macOS gates | Shared-executor state adoption plus close guard, terminal delivery, events, render metrics, and performance diagnostics | `Controllers/Shell/` |
-| `Controllers/Shell/ShellHostProjectionAndSelection.swift` | 511 | Foundation; macOS gates | Snapshot-derived shell and selection projection, focus, zoom, and shell-surface close requests | `Controllers/Shell/` |
-| `Controllers/Shell/ShellHostSpaceAndTabLifecycle.swift` | 734 | Foundation; macOS gates | Space, tab, content, and split creation plus tab ordering and movement | `Controllers/Shell/` |
-| `Controllers/Shell/ShellHostActionAndTerminalCommandHandling.swift` | 494 | Foundation; macOS gates | Shell action execution, spatial focus, and terminal semantic-command routing | `Controllers/Shell/` |
-| `Controllers/Shell/ShellHostRuntimeProjection.swift` | 615 | Foundation; macOS gates | Registry-backed terminal runtime and metadata projection, activity routing, state adoption, and render-priority refresh | `Controllers/Shell/` |
-| `Controllers/Shell/ShellHostCloseAndPaneLifecycle.swift` | 444 | Foundation; macOS gates | Close guards, shell-core pane lifecycle/movement, and control-plane state publication | `Controllers/Shell/` |
+| `Controllers/Shell/ShellHostPlatformControlCommandHandling.swift` | 479 | Foundation; macOS gates | Shared-executor state adoption plus close guard, terminal delivery, events, render metrics, and performance diagnostics | `Controllers/Shell/` |
+| `Controllers/Shell/ShellHostProjectionAndSelection.swift` | 494 | Foundation; macOS gates | Snapshot-derived shell and selection projection, focus, zoom, and terminal activation | `Controllers/Shell/` |
+| `Controllers/Shell/ShellHostSpaceAndTabLifecycle.swift` | 747 | Foundation; macOS gates | Space, tab, content, and split creation plus tab ordering, movement, and launch-context resolution | `Controllers/Shell/` |
+| `Controllers/Shell/ShellHostActionAndTerminalCommandHandling.swift` | 496 | Foundation; macOS gates | Shell action execution, spatial focus, and terminal semantic-command routing | `Controllers/Shell/` |
+| `Controllers/Shell/ShellHostRuntimeProjection.swift` | 647 | Foundation; macOS gates | Registry-backed terminal runtime, metadata, attention, control-plane publication, state adoption, and render-priority refresh | `Controllers/Shell/` |
+| `Controllers/Shell/ShellHostCloseAndPaneLifecycle.swift` | 375 | Foundation; macOS gates | Window, app, tab, and pane close coordination plus shell-core pane lifecycle and movement | `Controllers/Shell/` |
 | `Controllers/Shell/ShellHostAutomationCommandHandling.swift` | 309 | Foundation; macOS gates | External shell automation command adaptation and response projection | `Controllers/Shell/` |
 | `Services/Shell/ShellCloseWorkflow.swift` | 202 | AppKit, Foundation; macOS gates | Close confirmation, auto-close suppression, graceful terminal shutdown, and transcript-capture ordering | `Services/Shell/` |
 | `Services/Shell/ShellControlFilePoller.swift` | 182 | Foundation; macOS gates | File-backed command/result polling and alan binding-file projection | `Services/Shell/` |
@@ -313,6 +313,29 @@ Swift around `ShellCoreFFIAdapter` is classified as follows:
 - Runtime exceptions to track: command-failure activity acknowledgement remains
   Swift adapter-layer behavior until the core has explicit portable semantics
   for that case.
+
+## Terminal Adapter Audit
+
+The remaining terminal and shell-core adapters each retain a concrete boundary;
+none is a lifecycle-only pass-through:
+
+| Owner | Retained boundary |
+| --- | --- |
+| `TerminalContentProjectionAdapter` | Rebuilds pane, context, viewport, activity, Alan binding, process-exit, and launch-directory projections from runtime and metadata inputs. |
+| `TerminalRuntimePublicationPolicy` | Defines which snapshot changes are shell-visible while excluding timestamp-only churn. |
+| `AlanTerminalMetadataAdapter` | Normalizes renderer, process, and surface-readiness state into user-facing overlay policy. |
+| `TerminalAgentActivityAdapter` | Maps external agent events while bounding, sanitizing, and redacting display metadata. |
+| `TerminalHostRuntimeReporter` | Owns last-reported state, timestamp-insensitive deduplication, and main-queue delivery. |
+| `ShellCoreFFI*` operation-family adapters | Isolate the C ABI envelope, typed operation families, decoding, failure translation, and Swift DTO materialization described in the shell-core authority audit above. |
+
+`TerminalContentLifecycleAdapter` is removed. Active terminal mounts project
+from canonical shell content state, and `TerminalRuntimeRegistry` directly owns
+release, finalization, buffering, active-task state, and publication
+deduplication. The controller extension audit also colocates window/app close
+entry points with close and pane lifecycle, launch-context resolution with
+Space/tab creation, and attention/control-plane publication with runtime
+projection. Duplicate terminal-exit close forwarding and unused controller
+helpers are deleted without adding a new adapter or workflow type.
 
 Swift workspace-manifest and runtime-metadata tests now call the shell-core
 adapter for default manifest creation, pruning, materialization, and legacy
@@ -534,9 +557,9 @@ Rust-owned Swift legacy cleanup targets at this baseline:
 | `Models/Shell/ShellValueTypes.swift` | Removed | Cleaned: shell, Terminal Profile, managed-account, activity, context, helper-contract, planning, and effect families now have named model/service owners. Request validation, provisioning, and rollback call shell-core FFI and fail closed. Script-only managed-account state/fakes remain outside the app target, and the unused local command runner is deleted. |
 | `Models/Shell/ShellSettingsSurfaceModel.swift` | 531 | Cleaned below the report threshold: settings navigation/grouping and fail-closed row composition remain here, while Terminal Profile/helper summaries, managed-account discovery, catalog persistence, managed-user creation/provisioning, and local/diagnostics summaries live in adjacent domain modules. Managed terminal account row projection still calls `settings.managed_terminal_account_rows` through `Services/Shell/ShellCoreFFISettingsAdapter.swift`. |
 | `Services/Shell/ShellCoreFFIAdapter.swift` | 12 | Cleaned as transport facade: loader, envelope, materialization, manifest, control, action, settings, and Terminal Profile operations remain in sibling owners; reducer and managed-terminal-account callers use dedicated operation-family adapter types, with no Swift domain fallback. |
-| `ShellHostController.swift` | 365 | Cleaned below the report threshold: the root keeps the adopted observable shell snapshot, dependency assembly, startup, shutdown, and root lifecycle. Selected Space/Tab IDs are read-only snapshot projections; terminal runtime and active-task state come from `TerminalRuntimeRegistry`; manifest loading, projection, scheduling, and writes remain behind `ShellWorkspacePersistenceCoordinator`. Selection, space/tab lifecycle, actions, runtime projection, close/pane lifecycle, and automation adaptation live in focused `Controllers/Shell/ShellHost*` extensions while Rust shell-core and existing service coordinators retain domain authority. |
+| `ShellHostController.swift` | 360 | Cleaned below the report threshold: the root keeps the adopted observable shell snapshot, dependency assembly, startup, shutdown, and root lifecycle. Selected Space/Tab IDs are read-only snapshot projections; terminal runtime and active-task state come from `TerminalRuntimeRegistry`; manifest loading, projection, scheduling, and writes remain behind `ShellWorkspacePersistenceCoordinator`. Selection, space/tab lifecycle, actions, runtime projection, close/pane lifecycle, and automation adaptation live in focused `Controllers/Shell/ShellHost*` extensions while Rust shell-core and existing service coordinators retain domain authority. |
 | `Controllers/Shell/ShellHostControlCommandHandling.swift` | Removed | Deleted after in-process and socket-facing portable commands converged on `AlanShellLocalCommandExecutor`; no second portable mutation switch remains. |
-| `Controllers/Shell/ShellHostPlatformControlCommandHandling.swift` | 431 | Keeps only executor-result adoption, close guarding, descriptor-targeted terminal delivery, event/render diagnostics, and explicit platform effects. |
+| `Controllers/Shell/ShellHostPlatformControlCommandHandling.swift` | 479 | Keeps only executor-result adoption, close guarding, descriptor-targeted terminal delivery, event/render diagnostics, and explicit platform effects. |
 
 The first implementation batch targeted the production Swift legacy surface, not
 a line-count threshold. Manifest parity helpers and the Swift standard action

--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostCloseAndPaneLifecycle.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostCloseAndPaneLifecycle.swift
@@ -2,24 +2,6 @@ import Foundation
 
 #if os(macOS)
 extension ShellHostController {
-    func pane(paneID: String) -> ShellPane? {
-        shellState.panes.first { $0.paneID == paneID }
-    }
-
-    private func nextID(prefix: String, existing: [String]) -> String {
-        let nextOrdinal = existing
-            .compactMap { identifier -> Int? in
-                let components = identifier.split(separator: "_")
-                guard let last = components.last else { return nil }
-                return Int(last)
-            }
-            .max()
-            .map { $0 + 1 }
-            ?? (existing.isEmpty ? 1 : existing.count + 1)
-
-        return "\(prefix)_\(nextOrdinal)"
-    }
-
     func closeTab(tabID: String) -> ShellTabCloseResult {
         if let impact = closeGuardImpact(for: .tab(tabID)) {
             return .requiresConfirmation(impact)
@@ -98,7 +80,28 @@ extension ShellHostController {
         return applyClosePaneMutation(paneID: paneID) == .closed
     }
 
-    func confirmAndApplyClose(_ impact: ShellCloseGuardImpact) -> Bool {
+    @discardableResult
+    func requestCloseWindow() -> Bool {
+        requestCloseShellSurface(scope: .window)
+    }
+
+    @discardableResult
+    func requestTerminateApp() -> Bool {
+        requestCloseShellSurface(scope: .app)
+    }
+
+    private func requestCloseShellSurface(scope: ShellCloseGuardScope) -> Bool {
+        // Flush any debounced restore content before tearing down so a clean exit
+        // never loses the most recent transcript.
+        persistenceCoordinator.flushWorkspacePersistence()
+        if let impact = closeGuardImpact(for: scope) {
+            return confirmAndApplyClose(impact)
+        }
+        shutdownTerminalRuntimes()
+        return true
+    }
+
+    private func confirmAndApplyClose(_ impact: ShellCloseGuardImpact) -> Bool {
         closeWorkflow.confirmAndPerformClose(
             impact: impact,
             recordDiagnostic: recordControlPlaneDiagnostic,
@@ -209,38 +212,6 @@ extension ShellHostController {
             return activeTaskState.protectsFromPruning
         }
         return terminalRuntimeRegistry.registeredContentIDs.contains(contentID)
-    }
-
-    func focusedPaneWorkingDirectory() -> String? {
-        guard let pane = focusedPane ?? selectedPane else { return nil }
-        let runtimeCwd = runtime(for: pane.paneID).paneMetadata.workingDirectory
-        return nonEmptyWorkingDirectory(runtimeCwd)
-            ?? nonEmptyWorkingDirectory(pane.cwd)
-    }
-
-    func targetTerminalProfileID(in requestedSpaceID: String?, explicit: String?) -> String? {
-        shellState.terminalProfileIDForNewTerminal(in: requestedSpaceID, explicit: explicit)
-    }
-
-    func targetTerminalProfileID(forSplitFromPaneID paneID: String, explicit: String?) -> String? {
-        shellState.terminalProfileIDForNewSplit(from: paneID, explicit: explicit)
-    }
-
-    private func nonEmptyWorkingDirectory(_ path: String?) -> String? {
-        guard let path else { return nil }
-        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
-    }
-
-    @discardableResult
-    func closePaneAfterChildExitIfNeeded(
-        paneID: String,
-        processExited: Bool
-    ) -> Bool {
-        guard processExited else { return false }
-        guard pane(paneID: paneID) != nil else { return false }
-        guard !terminalAutoCloseIsSuppressed(paneID: paneID) else { return false }
-        return applyClosePaneMutation(paneID: paneID) == .closed
     }
 
     private func terminalAutoCloseIsSuppressed(paneID: String) -> Bool {
@@ -399,46 +370,6 @@ extension ShellHostController {
             tabID: result.tabID,
             paneID: result.paneID
         )
-    }
-
-    private var totalTabCount: Int {
-        shellState.spaces.reduce(into: 0) { partialResult, space in
-            partialResult += space.tabs.count
-        }
-    }
-
-    func strongestAttention(in panes: [ShellPane]) -> ShellAttentionState {
-        let now = Date()
-        return panes
-            .map { shellEffectiveAttention(for: $0, now: now) }
-            .max(by: { Self.attentionRank(for: $0) < Self.attentionRank(for: $1) })
-            ?? .idle
-    }
-
-    func publishControlPlaneState(
-        pinSnapshotTabIDs: Set<String> = [],
-        coalesced: Bool = false
-    ) {
-        persistenceCoordinator.publishControlPlaneState(
-            state: shellState,
-            terminalRuntimeRegistry: terminalRuntimeRegistry,
-            controlPlane: controlPlane,
-            pinSnapshotTabIDs: pinSnapshotTabIDs,
-            coalesced: coalesced
-        )
-    }
-
-    static func attentionRank(for attention: ShellAttentionState) -> Int {
-        switch attention {
-        case .idle:
-            return 0
-        case .active:
-            return 1
-        case .notable:
-            return 2
-        case .awaitingUser:
-            return 3
-        }
     }
 }
 #endif

--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostProjectionAndSelection.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostProjectionAndSelection.swift
@@ -2,6 +2,10 @@ import Foundation
 
 #if os(macOS)
 extension ShellHostController {
+    func pane(paneID: String) -> ShellPane? {
+        shellState.panes.first { $0.paneID == paneID }
+    }
+
     var spaces: [ShellSpace] {
         shellState.spaces
     }
@@ -480,27 +484,6 @@ extension ShellHostController {
     private func canRequestTerminalFocus(for paneID: String) -> Bool {
         guard let pane = pane(paneID: paneID) else { return false }
         return paneHasTerminalContent(pane, in: shellState.contentStateProjection())
-    }
-
-    @discardableResult
-    func requestCloseWindow() -> Bool {
-        requestCloseShellSurface(scope: .window)
-    }
-
-    @discardableResult
-    func requestTerminateApp() -> Bool {
-        requestCloseShellSurface(scope: .app)
-    }
-
-    private func requestCloseShellSurface(scope: ShellCloseGuardScope) -> Bool {
-        // Flush any debounced restore content before tearing down so a clean exit
-        // never loses the most recent transcript.
-        persistenceCoordinator.flushWorkspacePersistence()
-        if let impact = closeGuardImpact(for: scope) {
-            return confirmAndApplyClose(impact)
-        }
-        shutdownTerminalRuntimes()
-        return true
     }
 
     func terminalHostDidRequestActivation(paneID: String) {

--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostRuntimeProjection.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostRuntimeProjection.swift
@@ -57,10 +57,9 @@ extension ShellHostController {
             if effectProjection.processExited {
                 routeActivityNotificationIfNeeded(from: pane, nextActivity: effectProjection.activity)
             }
-            if closePaneAfterChildExitIfNeeded(
-                paneID: paneID,
-                processExited: effectProjection.processExited
-            ) {
+            if effectProjection.processExited,
+               closePaneAfterTerminalRuntimeExit(paneID: paneID)
+            {
                 return
             }
 
@@ -174,10 +173,9 @@ extension ShellHostController {
         if effectProjection.processExited {
             routeActivityNotificationIfNeeded(from: pane, nextActivity: effectProjection.activity)
         }
-        if closePaneAfterChildExitIfNeeded(
-            paneID: paneID,
-            processExited: effectProjection.processExited
-        ) {
+        if effectProjection.processExited,
+           closePaneAfterTerminalRuntimeExit(paneID: paneID)
+        {
             return
         }
 
@@ -577,6 +575,40 @@ extension ShellHostController {
         shellState.spaces
             .flatMap(\.tabs)
             .first { $0.contains(paneID: paneID) }
+    }
+
+    func strongestAttention(in panes: [ShellPane]) -> ShellAttentionState {
+        let now = Date()
+        return panes
+            .map { shellEffectiveAttention(for: $0, now: now) }
+            .max(by: { Self.attentionRank(for: $0) < Self.attentionRank(for: $1) })
+            ?? .idle
+    }
+
+    func publishControlPlaneState(
+        pinSnapshotTabIDs: Set<String> = [],
+        coalesced: Bool = false
+    ) {
+        persistenceCoordinator.publishControlPlaneState(
+            state: shellState,
+            terminalRuntimeRegistry: terminalRuntimeRegistry,
+            controlPlane: controlPlane,
+            pinSnapshotTabIDs: pinSnapshotTabIDs,
+            coalesced: coalesced
+        )
+    }
+
+    static func attentionRank(for attention: ShellAttentionState) -> Int {
+        switch attention {
+        case .idle:
+            return 0
+        case .active:
+            return 1
+        case .notable:
+            return 2
+        case .awaitingUser:
+            return 3
+        }
     }
 
     private func reconcilePaneZoomState() {

--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostSpaceAndTabLifecycle.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostSpaceAndTabLifecycle.swift
@@ -331,6 +331,19 @@ extension ShellHostController {
         return true
     }
 
+    private func focusedPaneWorkingDirectory() -> String? {
+        guard let pane = focusedPane ?? selectedPane else { return nil }
+        let runtimeCwd = runtime(for: pane.paneID).paneMetadata.workingDirectory
+        return nonEmptyWorkingDirectory(runtimeCwd)
+            ?? nonEmptyWorkingDirectory(pane.cwd)
+    }
+
+    private func nonEmptyWorkingDirectory(_ path: String?) -> String? {
+        guard let path else { return nil }
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     @discardableResult
     func openContentTab(
         _ contentIntent: ShellContentIntent = .terminal(
@@ -348,7 +361,7 @@ extension ShellHostController {
             case .terminal(let launchTarget, let title, let workingDirectory):
                 switch launchTarget {
                 case .shell:
-                    let resolvedTerminalProfileID = targetTerminalProfileID(
+                    let resolvedTerminalProfileID = shellState.terminalProfileIDForNewTerminal(
                         in: spaceID,
                         explicit: terminalProfileID
                     )
@@ -463,7 +476,7 @@ extension ShellHostController {
         workingDirectory: String? = nil,
         terminalProfileID: String? = nil
     ) -> String? {
-        let resolvedTerminalProfileID = targetTerminalProfileID(
+        let resolvedTerminalProfileID = shellState.terminalProfileIDForNewTerminal(
             in: spaceID,
             explicit: terminalProfileID
         )
@@ -487,7 +500,7 @@ extension ShellHostController {
         workingDirectory: String? = nil,
         terminalProfileID: String? = nil
     ) throws -> ShellStateMutationResult {
-        let resolvedTerminalProfileID = targetTerminalProfileID(
+        let resolvedTerminalProfileID = shellState.terminalProfileIDForNewTerminal(
             in: spaceID,
             explicit: terminalProfileID
         )
@@ -587,8 +600,8 @@ extension ShellHostController {
         contentIntent: ShellContentIntent? = nil,
         terminalProfileID: String? = nil
     ) -> String? {
-        let resolvedTerminalProfileID = targetTerminalProfileID(
-            forSplitFromPaneID: paneID,
+        let resolvedTerminalProfileID = shellState.terminalProfileIDForNewSplit(
+            from: paneID,
             explicit: terminalProfileID
         )
         let result: ShellStateMutationResult

--- a/openspec/changes/deepen-macos-shell-host-ownership/tasks.md
+++ b/openspec/changes/deepen-macos-shell-host-ownership/tasks.md
@@ -45,10 +45,10 @@
   stateful reporter.
 - [x] 4.3 Delete `TerminalContentLifecycleAdapter` after its active-mount
   projection and lifecycle calls move to shell state and the runtime registry.
-- [ ] 4.4 Verify and retain the projection, publication-policy, metadata,
+- [x] 4.4 Verify and retain the projection, publication-policy, metadata,
   activity-normalization, stateful reporter, and C ABI adapters only at their
   real complexity boundaries.
-- [ ] 4.5 Remove displaced controller workflow extensions and shallow forwarding
+- [x] 4.5 Remove displaced controller workflow extensions and shallow forwarding
   without creating one class per extension or a new adapter framework.
 
 ## 5. Verify And Deliver The Stack


### PR DESCRIPTION
## Summary

- colocate close, launch-context, and runtime-projection helpers with their existing controller owners
- delete duplicate terminal-exit forwarding and unused/shallow controller helpers
- document why the remaining terminal and Shell Core C ABI adapters retain real projection, policy, normalization, state, or boundary complexity

## Validation

- `openspec validate deepen-macos-shell-host-ownership --strict`
- `just quality`
- `just apple-shell-focused-tests`
- `just install-dev`
- `just apple-shell-ui-smoke`

Alan Dev validation used `Alan Dev.app` (`app.alanworks.macos.dev`); stable Alan was not touched.