### PR TITLE
fix(macos): verify active-work quit confirmation

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -62,6 +62,7 @@ Xcode target.
 | `Services/Terminal/ManagedUserTerminalPtyRuntime.swift` | 764 | Darwin, Foundation; macOS gates | Privileged-helper Managed User PTY provider, handle, renderer proxy, and raw-byte bridge | `Services/Terminal/` |
 | `Services/Terminal/TerminalPtyContracts.swift` | 125 | Foundation; macOS gates | PTY lifecycle, dimensions, exit, attachment, handle, runtime, and provider contracts | `Services/Terminal/` |
 | `Services/Terminal/TerminalPtyControlSequenceResponder.swift` | 223 | Foundation; macOS gates | Bounded PTY control-sequence parser and terminal query responses | `Services/Terminal/` |
+| `Services/Terminal/TerminalShellIntegration.swift` | 131 | Foundation | Shared zsh/Bash launch projection for bundled Ghostty shell integration | `Services/Terminal/` |
 | `Services/Terminal/TerminalPtyRuntime.swift` | 67 | Darwin, Foundation; macOS gates | Content-keyed PTY handle registry, local/Managed User dispatch, and shared socket setup | `Services/Terminal/` |
 | `Services/Terminal/TerminalRuntimeDelivery.swift` | 104 | Foundation; macOS gates | Stable terminal delivery codes and result construction | `Services/Terminal/` |
 | `Services/Terminal/TerminalSurfaceContracts.swift` | 263 | AppKit, Foundation, GhosttyKit; macOS/Ghostty gates | Surface lifecycle, teardown, transcript, event-surface, and runtime-service contracts | `Services/Terminal/` |

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -62,7 +62,7 @@ Xcode target.
 | `Services/Terminal/ManagedUserTerminalPtyRuntime.swift` | 764 | Darwin, Foundation; macOS gates | Privileged-helper Managed User PTY provider, handle, renderer proxy, and raw-byte bridge | `Services/Terminal/` |
 | `Services/Terminal/TerminalPtyContracts.swift` | 125 | Foundation; macOS gates | PTY lifecycle, dimensions, exit, attachment, handle, runtime, and provider contracts | `Services/Terminal/` |
 | `Services/Terminal/TerminalPtyControlSequenceResponder.swift` | 223 | Foundation; macOS gates | Bounded PTY control-sequence parser and terminal query responses | `Services/Terminal/` |
-| `Services/Terminal/TerminalShellIntegration.swift` | 131 | Foundation | Shared zsh/Bash launch projection for bundled Ghostty shell integration | `Services/Terminal/` |
+| `Services/Terminal/TerminalShellIntegration.swift` | 149 | Foundation | Shared zsh/Bash/fish launch projection for bundled Ghostty shell integration | `Services/Terminal/` |
 | `Services/Terminal/TerminalPtyRuntime.swift` | 67 | Darwin, Foundation; macOS gates | Content-keyed PTY handle registry, local/Managed User dispatch, and shared socket setup | `Services/Terminal/` |
 | `Services/Terminal/TerminalRuntimeDelivery.swift` | 104 | Foundation; macOS gates | Stable terminal delivery codes and result construction | `Services/Terminal/` |
 | `Services/Terminal/TerminalSurfaceContracts.swift` | 263 | AppKit, Foundation, GhosttyKit; macOS/Ghostty gates | Surface lifecycle, teardown, transcript, event-surface, and runtime-service contracts | `Services/Terminal/` |

--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -77,6 +77,8 @@
 		A12900000000000000000007 /* Services/Terminal/TerminalSelectionClipboardAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12900000000000000000107 /* Services/Terminal/TerminalSelectionClipboardAdapter.swift */; };
 		A12900000000000000000008 /* Services/Terminal/TerminalSemanticCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12900000000000000000108 /* Services/Terminal/TerminalSemanticCommands.swift */; };
 		A12900000000000000000009 /* Services/Terminal/TerminalSurfaceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12900000000000000000109 /* Services/Terminal/TerminalSurfaceState.swift */; };
+		A12A00000000000000000001 /* Services/Terminal/TerminalShellIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12A00000000000000000101 /* Services/Terminal/TerminalShellIntegration.swift */; };
+		A12A00000000000000000002 /* Services/Terminal/TerminalShellIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12A00000000000000000101 /* Services/Terminal/TerminalShellIntegration.swift */; };
 		AA1B2C3D4E5F6A7B8C9D0E1F /* Views/Shell/Controls/ShellFormControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2C3D4E5F6A7B8C9D0E1F2A /* Views/Shell/Controls/ShellFormControls.swift */; };
 		0000000000000000000000F0 /* Views/Shell/ShellSpaceCreationForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000000000000000000001F0 /* Views/Shell/ShellSpaceCreationForm.swift */; };
 		00000000000000000000001B /* Views/Shell/ShellWorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000011B /* Views/Shell/ShellWorkspaceView.swift */; };
@@ -284,6 +286,7 @@
 		A12900000000000000000107 /* Services/Terminal/TerminalSelectionClipboardAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalSelectionClipboardAdapter.swift; sourceTree = "<group>"; };
 		A12900000000000000000108 /* Services/Terminal/TerminalSemanticCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalSemanticCommands.swift; sourceTree = "<group>"; };
 		A12900000000000000000109 /* Services/Terminal/TerminalSurfaceState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalSurfaceState.swift; sourceTree = "<group>"; };
+		A12A00000000000000000101 /* Services/Terminal/TerminalShellIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalShellIntegration.swift; sourceTree = "<group>"; };
 		BB2C3D4E5F6A7B8C9D0E1F2A /* Views/Shell/Controls/ShellFormControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Views/Shell/Controls/ShellFormControls.swift"; sourceTree = "<group>"; };
 		0000000000000000000001F0 /* Views/Shell/ShellSpaceCreationForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/Shell/ShellSpaceCreationForm.swift; sourceTree = "<group>"; };
 		00000000000000000000011B /* Views/Shell/ShellWorkspaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/Shell/ShellWorkspaceView.swift; sourceTree = "<group>"; };
@@ -648,6 +651,7 @@
 				A12800000000000000000105 /* Services/Terminal/TerminalPtyContracts.swift */,
 				A12800000000000000000106 /* Services/Terminal/TerminalPtyControlSequenceResponder.swift */,
 				A12800000000000000000107 /* Services/Terminal/TerminalPtyRuntime.swift */,
+				A12A00000000000000000101 /* Services/Terminal/TerminalShellIntegration.swift */,
 				A12800000000000000000108 /* Services/Terminal/TerminalRuntimeDelivery.swift */,
 				A12800000000000000000109 /* Services/Terminal/TerminalSurfaceContracts.swift */,
 				A1280000000000000000010A /* Services/Terminal/TerminalTranscriptCapture.swift */,
@@ -905,6 +909,7 @@
 				A12800000000000000000005 /* Services/Terminal/TerminalPtyContracts.swift in Sources */,
 				A12800000000000000000006 /* Services/Terminal/TerminalPtyControlSequenceResponder.swift in Sources */,
 				A12800000000000000000007 /* Services/Terminal/TerminalPtyRuntime.swift in Sources */,
+				A12A00000000000000000001 /* Services/Terminal/TerminalShellIntegration.swift in Sources */,
 				A12800000000000000000008 /* Services/Terminal/TerminalRuntimeDelivery.swift in Sources */,
 				A12800000000000000000009 /* Services/Terminal/TerminalSurfaceContracts.swift in Sources */,
 				A1280000000000000000000A /* Services/Terminal/TerminalTranscriptCapture.swift in Sources */,
@@ -1053,6 +1058,7 @@
 				A11000000000000000000014 /* Services/Shell/AlanPrivilegedHelperManagedUserService.swift in Sources */,
 				A11000000000000000000016 /* Services/Shell/AlanPrivilegedHelperPTYSessionStore.swift in Sources */,
 				A11000000000000000000018 /* Services/Shell/AlanPrivilegedHelperPTYSupport.swift in Sources */,
+				A12A00000000000000000002 /* Services/Terminal/TerminalShellIntegration.swift in Sources */,
 				A11000000000000000000006 /* AlanPrivilegedHelperPtySpawn.c in Sources */,
 				A11000000000000000000001 /* main.swift in Sources */,
 			);

--- a/clients/apple/alan-macos/App/AlanMacAppStartup.swift
+++ b/clients/apple/alan-macos/App/AlanMacAppStartup.swift
@@ -189,7 +189,8 @@ enum AlanMacAppStartup {
             shell: request.shell,
             contentID: "privileged-helper-live-smoke-\(UUID().uuidString)",
             columns: 80,
-            rows: 24
+            rows: 24,
+            shellIntegrationResourcesPath: nil
         )
         switch client.startManagedUserPTY(startRequest) {
         case .success(let session):

--- a/clients/apple/alan-macos/GhosttyLiveHost.swift
+++ b/clients/apple/alan-macos/GhosttyLiveHost.swift
@@ -34,7 +34,6 @@ final class AlanGhosttyLiveHost: NSObject {
     private var renderPriority: TerminalRuntimeRenderPriority = .hiddenBackground
     private let terminalModeTracker = AlanTerminalModeTracker()
     private var didEmitNonConfirmingCloseRequest = false
-    private var foregroundCommandStartedAt: Date?
 
     func attach(
         to canvasView: AlanGhosttyCanvasView,
@@ -158,9 +157,6 @@ final class AlanGhosttyLiveHost: NSObject {
         guard let surface else { return false }
         let handled = ghostty_surface_key(surface, keyEvent)
         ghostty_surface_refresh(surface)
-        if handled, isCommandSubmissionKey(keyEvent) {
-            markForegroundCommandStarted()
-        }
         return handled
     }
 
@@ -204,22 +200,14 @@ final class AlanGhosttyLiveHost: NSObject {
 
     func sendProgrammaticText(_ text: String) {
         guard let surface, !text.isEmpty else { return }
-        let isCommandSubmission = isCommandSubmissionText(text)
-        recordProgrammaticCommandSubmission(in: text)
         text.withCString { cString in
             ghostty_surface_text(surface, cString, UInt(strlen(cString)))
         }
         ghostty_surface_refresh(surface)
         updateMetadata(
             summary: "input committed",
-            attention: .active,
-            activeTaskState: isCommandSubmission ? .foregroundCommand : nil
+            attention: .active
         )
-    }
-
-    func recordProgrammaticCommandSubmission(in text: String) {
-        guard isCommandSubmissionText(text) else { return }
-        markForegroundCommandStarted()
     }
 
     func sendPreedit(_ text: String?) {
@@ -845,8 +833,10 @@ final class AlanGhosttyLiveHost: NSObject {
             return true
 
         case GHOSTTY_ACTION_COMMAND_FINISHED:
-            let exitCode = action.action.command_finished.exit_code
+            let completion = action.action.command_finished
+            let exitCode = completion.exit_code
             let finishedAt = Date()
+            let durationMilliseconds = Int(clamping: completion.duration / 1_000_000)
             let summary: String
             if exitCode < 0 {
                 summary = "command finished"
@@ -856,8 +846,6 @@ final class AlanGhosttyLiveHost: NSObject {
                 summary = "command failed (\(exitCode))"
             }
             performOnMain {
-                let durationMilliseconds = self.commandDurationMilliseconds(finishedAt: finishedAt)
-                self.foregroundCommandStartedAt = nil
                 let activity = exitCode >= 0
                     ? TerminalActivitySnapshot.commandCompletion(
                         exitCode: Int(exitCode),
@@ -1066,34 +1054,7 @@ final class AlanGhosttyLiveHost: NSObject {
         onMetadataChange?(snapshot)
     }
 
-    private func isCommandSubmissionKey(_ keyEvent: ghostty_input_key_s) -> Bool {
-        keyEvent.action == GHOSTTY_ACTION_PRESS
-            && (
-                keyEvent.keycode == AlanGhosttyKeyCode.returnKey
-                    || keyEvent.keycode == AlanGhosttyKeyCode.keypadEnter
-            )
-    }
-
-    private func isCommandSubmissionText(_ text: String) -> Bool {
-        text.contains("\n") || text.contains("\r")
-    }
-
-    private func markForegroundCommandStarted() {
-        if foregroundCommandStartedAt == nil {
-            foregroundCommandStartedAt = .now
-        }
-        updateMetadata(attention: .active, activeTaskState: .foregroundCommand)
-    }
-
-    private func commandDurationMilliseconds(finishedAt: Date) -> Int? {
-        guard let foregroundCommandStartedAt else { return nil }
-        let duration = finishedAt.timeIntervalSince(foregroundCommandStartedAt)
-        guard duration >= 0 else { return nil }
-        return Int((duration * 1_000).rounded())
-    }
-
     private func resetMetadata() {
-        foregroundCommandStartedAt = nil
         guard metadata != .placeholder else { return }
         metadata = .placeholder
         onMetadataChange?(.placeholder)

--- a/clients/apple/alan-macos/GhosttyLiveHost.swift
+++ b/clients/apple/alan-macos/GhosttyLiveHost.swift
@@ -35,7 +35,6 @@ final class AlanGhosttyLiveHost: NSObject {
     private let terminalModeTracker = AlanTerminalModeTracker()
     private var didEmitNonConfirmingCloseRequest = false
     private var foregroundCommandStartedAt: Date?
-    private var queuedForegroundCommandSubmissions = 0
 
     func attach(
         to canvasView: AlanGhosttyCanvasView,
@@ -160,7 +159,7 @@ final class AlanGhosttyLiveHost: NSObject {
         let handled = ghostty_surface_key(surface, keyEvent)
         ghostty_surface_refresh(surface)
         if handled, isCommandSubmissionKey(keyEvent) {
-            markForegroundCommandStarted(commandCount: 1, queuesWhileActive: false)
+            markForegroundCommandStarted()
         }
         return handled
     }
@@ -219,9 +218,8 @@ final class AlanGhosttyLiveHost: NSObject {
     }
 
     func recordProgrammaticCommandSubmission(in text: String) {
-        let commandCount = commandSubmissionCount(in: text)
-        guard commandCount > 0 else { return }
-        markForegroundCommandStarted(commandCount: commandCount, queuesWhileActive: true)
+        guard isCommandSubmissionText(text) else { return }
+        markForegroundCommandStarted()
     }
 
     func sendPreedit(_ text: String?) {
@@ -859,9 +857,7 @@ final class AlanGhosttyLiveHost: NSObject {
             }
             performOnMain {
                 let durationMilliseconds = self.commandDurationMilliseconds(finishedAt: finishedAt)
-                let hasQueuedForegroundCommand = self.advanceForegroundCommandTracking(
-                    finishedAt: finishedAt
-                )
+                self.foregroundCommandStartedAt = nil
                 let activity = exitCode >= 0
                     ? TerminalActivitySnapshot.commandCompletion(
                         exitCode: Int(exitCode),
@@ -874,7 +870,7 @@ final class AlanGhosttyLiveHost: NSObject {
                     attention: exitCode == 0 ? .active : .notable,
                     processExited: false,
                     lastCommandExitCode: Int(exitCode),
-                    activeTaskState: hasQueuedForegroundCommand ? .foregroundCommand : .inactive,
+                    activeTaskState: .inactive,
                     activity: activity,
                     clearActivity: exitCode < 0
                 )
@@ -1079,35 +1075,12 @@ final class AlanGhosttyLiveHost: NSObject {
     }
 
     private func isCommandSubmissionText(_ text: String) -> Bool {
-        commandSubmissionCount(in: text) > 0
+        text.contains("\n") || text.contains("\r")
     }
 
-    private func commandSubmissionCount(in text: String) -> Int {
-        var count = 0
-        var previousWasCarriageReturn = false
-        for character in text {
-            if character == "\r" {
-                count += 1
-                previousWasCarriageReturn = true
-            } else if character == "\n" {
-                if !previousWasCarriageReturn {
-                    count += 1
-                }
-                previousWasCarriageReturn = false
-            } else {
-                previousWasCarriageReturn = false
-            }
-        }
-        return count
-    }
-
-    private func markForegroundCommandStarted(commandCount: Int, queuesWhileActive: Bool) {
-        let commandCount = max(commandCount, 1)
+    private func markForegroundCommandStarted() {
         if foregroundCommandStartedAt == nil {
             foregroundCommandStartedAt = .now
-            queuedForegroundCommandSubmissions = commandCount
-        } else if queuesWhileActive {
-            queuedForegroundCommandSubmissions += commandCount
         }
         updateMetadata(attention: .active, activeTaskState: .foregroundCommand)
     }
@@ -1119,20 +1092,8 @@ final class AlanGhosttyLiveHost: NSObject {
         return Int((duration * 1_000).rounded())
     }
 
-    private func advanceForegroundCommandTracking(finishedAt: Date) -> Bool {
-        if queuedForegroundCommandSubmissions > 1 {
-            queuedForegroundCommandSubmissions -= 1
-            foregroundCommandStartedAt = finishedAt
-            return true
-        }
-        queuedForegroundCommandSubmissions = 0
-        foregroundCommandStartedAt = nil
-        return false
-    }
-
     private func resetMetadata() {
         foregroundCommandStartedAt = nil
-        queuedForegroundCommandSubmissions = 0
         guard metadata != .placeholder else { return }
         metadata = .placeholder
         onMetadataChange?(.placeholder)

--- a/clients/apple/alan-macos/GhosttyLiveHost.swift
+++ b/clients/apple/alan-macos/GhosttyLiveHost.swift
@@ -206,12 +206,7 @@ final class AlanGhosttyLiveHost: NSObject {
     func sendProgrammaticText(_ text: String) {
         guard let surface, !text.isEmpty else { return }
         let isCommandSubmission = isCommandSubmissionText(text)
-        if isCommandSubmission {
-            markForegroundCommandStarted(
-                commandCount: commandSubmissionCount(in: text),
-                queuesWhileActive: true
-            )
-        }
+        recordProgrammaticCommandSubmission(in: text)
         text.withCString { cString in
             ghostty_surface_text(surface, cString, UInt(strlen(cString)))
         }
@@ -221,6 +216,12 @@ final class AlanGhosttyLiveHost: NSObject {
             attention: .active,
             activeTaskState: isCommandSubmission ? .foregroundCommand : nil
         )
+    }
+
+    func recordProgrammaticCommandSubmission(in text: String) {
+        let commandCount = commandSubmissionCount(in: text)
+        guard commandCount > 0 else { return }
+        markForegroundCommandStarted(commandCount: commandCount, queuesWhileActive: true)
     }
 
     func sendPreedit(_ text: String?) {

--- a/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperContracts.swift
+++ b/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperContracts.swift
@@ -265,6 +265,7 @@ struct AlanManagedUserPTYStartRequest: Codable, Equatable {
     let contentID: String
     let columns: Int
     let rows: Int
+    let shellIntegrationResourcesPath: String?
 }
 
 struct AlanManagedUserPTYSession: Codable, Equatable {

--- a/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperContracts.swift
+++ b/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperContracts.swift
@@ -298,10 +298,17 @@ struct AlanManagedUserPTYReadRequest: Codable, Equatable {
     let maxBytes: Int
 }
 
+enum AlanManagedUserPTYForegroundProcessGroupState: String, Codable, Equatable {
+    case shell
+    case foreground
+    case unavailable
+}
+
 struct AlanManagedUserPTYOutputChunk: Codable, Equatable {
     let sessionID: String
     let data: Data
     let final: Bool
+    let foregroundProcessGroupState: AlanManagedUserPTYForegroundProcessGroupState
     let sanitizedMessage: String?
 }
 

--- a/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperManagedUserService.swift
+++ b/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperManagedUserService.swift
@@ -421,7 +421,7 @@ final class AlanPrivilegedHelperManagedUserService {
             accountName: request.accountName,
             home: request.homeDirectory,
             shell: request.shell
-        )
+        ).map { "\($0.key)=\($0.value)" }.sorted()
         let result = request.shell.withCString { executable in
             request.homeDirectory.withCString { workingDirectory in
                 request.accountName.withCString { accountName in

--- a/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperManagedUserWire.swift
+++ b/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperManagedUserWire.swift
@@ -88,6 +88,7 @@ struct AlanXPCManagedUserPTYStartRequest: Codable, Equatable {
     let contentID: String
     let columns: Int
     let rows: Int
+    let shellIntegrationResourcesPath: String?
 }
 
 struct AlanXPCManagedUserPTYSession: Codable, Equatable {

--- a/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperManagedUserWire.swift
+++ b/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperManagedUserWire.swift
@@ -108,10 +108,17 @@ struct AlanXPCManagedUserPTYReadRequest: Codable, Equatable {
     let maxBytes: Int
 }
 
+enum AlanXPCManagedUserPTYForegroundProcessGroupState: String, Codable, Equatable {
+    case shell
+    case foreground
+    case unavailable
+}
+
 struct AlanXPCManagedUserPTYOutputChunk: Codable, Equatable {
     let sessionID: String
     let data: Data
     let final: Bool
+    let foregroundProcessGroupState: AlanXPCManagedUserPTYForegroundProcessGroupState
     let sanitizedMessage: String?
 }
 

--- a/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSessionStore.swift
+++ b/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSessionStore.swift
@@ -25,13 +25,20 @@ final class AlanPrivilegedHelperPTYSessionStore {
         case .success(let account):
             var master: Int32 = -1
             var pid: pid_t = 0
-            let shellName = URL(fileURLWithPath: request.shell).lastPathComponent
-            let argvValues = ["-\(shellName)"]
-            let envValues = AlanPrivilegedHelperPTYSupport.environment(
-                accountName: request.accountName,
-                home: request.homeDirectory,
-                shell: request.shell
+            let shellLaunch = AlanTerminalShellLaunch.integratingGhostty(
+                executablePath: request.shell,
+                arguments: ["-l"],
+                environment: AlanPrivilegedHelperPTYSupport.environment(
+                    accountName: request.accountName,
+                    home: request.homeDirectory,
+                    shell: request.shell
+                ),
+                resourcesPath: request.shellIntegrationResourcesPath
             )
+            let argvValues = [shellLaunch.argumentZero] + shellLaunch.arguments
+            let envValues = shellLaunch.environment.map {
+                "\($0.key)=\($0.value)"
+            }.sorted()
             let workingDirectory = request.workingDirectory.isEmpty
                 ? request.homeDirectory
                 : request.workingDirectory

--- a/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSessionStore.swift
+++ b/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSessionStore.swift
@@ -120,6 +120,7 @@ final class AlanPrivilegedHelperPTYSessionStore {
         }
 
         let maxBytes = max(1, min(request.maxBytes, 64 * 1024))
+        let foregroundProcessGroupState = foregroundProcessGroupState(for: session)
         var buffer = [UInt8](repeating: 0, count: maxBytes)
         let count = Darwin.read(session.masterFileDescriptor, &buffer, maxBytes)
         if count > 0 {
@@ -128,6 +129,7 @@ final class AlanPrivilegedHelperPTYSessionStore {
                     sessionID: request.sessionID,
                     data: Data(buffer.prefix(count)),
                     final: false,
+                    foregroundProcessGroupState: foregroundProcessGroupState,
                     sanitizedMessage: "Privileged helper read Managed User PTY output."
                 )
             )
@@ -138,6 +140,7 @@ final class AlanPrivilegedHelperPTYSessionStore {
                     sessionID: request.sessionID,
                     data: Data(),
                     final: true,
+                    foregroundProcessGroupState: foregroundProcessGroupState,
                     sanitizedMessage: "Managed User PTY output stream ended."
                 )
             )
@@ -148,6 +151,7 @@ final class AlanPrivilegedHelperPTYSessionStore {
                     sessionID: request.sessionID,
                     data: Data(),
                     final: false,
+                    foregroundProcessGroupState: foregroundProcessGroupState,
                     sanitizedMessage: nil
                 )
             )
@@ -226,8 +230,22 @@ final class AlanPrivilegedHelperPTYSessionStore {
         case .kill:
             signalNumber = SIGKILL
         }
-        if kill(-session.processID, signalNumber) != 0 {
-            _ = kill(session.processID, signalNumber)
+        let foregroundProcessGroupID = foregroundProcessGroupID(for: session)
+        let targetProcessGroupID = foregroundProcessGroupID ?? session.processID
+        var result = kill(-targetProcessGroupID, signalNumber)
+        if result != 0, targetProcessGroupID != session.processID {
+            result = kill(-session.processID, signalNumber)
+        }
+        if result != 0 {
+            result = kill(session.processID, signalNumber)
+        }
+        guard result == 0 else {
+            return rejected(
+                .signalManagedUserPTY,
+                sessionID: request.sessionID,
+                accountName: session.accountName,
+                message: "Managed User PTY signal delivery failed."
+            )
         }
         return accepted(.signalManagedUserPTY, session: session, message: "Privileged helper signaled PTY session.")
     }
@@ -255,6 +273,11 @@ final class AlanPrivilegedHelperPTYSessionStore {
                 code: nil,
                 message: "Managed User PTY session was already absent."
             )
+        }
+        if let foregroundProcessGroupID = foregroundProcessGroupID(for: session),
+           foregroundProcessGroupID != session.processID
+        {
+            _ = kill(-foregroundProcessGroupID, SIGTERM)
         }
         _ = kill(-session.processID, SIGTERM)
         _ = kill(session.processID, SIGTERM)
@@ -288,6 +311,22 @@ final class AlanPrivilegedHelperPTYSessionStore {
             close(session.masterFileDescriptor)
             session.masterFileDescriptor = -1
         }
+    }
+
+    private func foregroundProcessGroupState(
+        for session: AlanPrivilegedHelperPTYSession
+    ) -> AlanXPCManagedUserPTYForegroundProcessGroupState {
+        guard let foregroundProcessGroupID = foregroundProcessGroupID(for: session) else {
+            return .unavailable
+        }
+        return foregroundProcessGroupID == session.processID ? .shell : .foreground
+    }
+
+    private func foregroundProcessGroupID(
+        for session: AlanPrivilegedHelperPTYSession
+    ) -> pid_t? {
+        let foregroundProcessGroupID = tcgetpgrp(session.masterFileDescriptor)
+        return foregroundProcessGroupID > 0 ? foregroundProcessGroupID : nil
     }
 
     private func setNonBlocking(_ fileDescriptor: Int32) {

--- a/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSupport.swift
+++ b/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSupport.swift
@@ -21,14 +21,14 @@ enum AlanPrivilegedHelperPTYSupport {
         accountName: String,
         home: String,
         shell: String
-    ) -> [String] {
+    ) -> [String: String] {
         [
-            "HOME=\(home)",
-            "USER=\(accountName)",
-            "LOGNAME=\(accountName)",
-            "SHELL=\(shell)",
-            "TERM=xterm-256color",
-            "PATH=/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+            "HOME": home,
+            "USER": accountName,
+            "LOGNAME": accountName,
+            "SHELL": shell,
+            "TERM": "xterm-256color",
+            "PATH": "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin",
         ]
     }
 

--- a/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperXPC.swift
+++ b/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperXPC.swift
@@ -269,7 +269,7 @@ struct AlanPrivilegedHelperXPCApplyResultPayload: Codable, Equatable {
 }
 
 struct AlanPrivilegedHelperProtocolStatus: Codable, Equatable {
-    static let currentVersion = 4
+    static let currentVersion = 5
 
     let protocolVersion: Int
 }

--- a/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperXPC.swift
+++ b/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperXPC.swift
@@ -269,7 +269,7 @@ struct AlanPrivilegedHelperXPCApplyResultPayload: Codable, Equatable {
 }
 
 struct AlanPrivilegedHelperProtocolStatus: Codable, Equatable {
-    static let currentVersion = 3
+    static let currentVersion = 4
 
     let protocolVersion: Int
 }

--- a/clients/apple/alan-macos/Services/Terminal/DarwinTerminalPtyRuntime.swift
+++ b/clients/apple/alan-macos/Services/Terminal/DarwinTerminalPtyRuntime.swift
@@ -16,6 +16,7 @@ private func alanDarwinPtySpawn(
 
 @MainActor
 final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
+    private let maxPendingRendererReplayBytes = 1024 * 1024
     private struct PendingDirectPtyInputChunk {
         var data: Data
         var countedBytesRemaining: Int
@@ -38,16 +39,27 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
     private var rendererProxy: AlanDarwinTerminalPtyRendererProxy?
     private var pendingDirectPtyInputChunks: [PendingDirectPtyInputChunk] = []
     private var directPtyInputWriteSource: DispatchSourceWrite?
+    private var rendererlessOutputSource: DispatchSourceRead?
+    private var processGroupTimer: DispatchSourceTimer?
+    private var semanticShellActivityState: AlanTerminalPtyShellActivityState?
+    private var processGroupShellActivityState: AlanTerminalPtyShellActivityState?
+    private var pendingRendererReplayChunks: [Data] = []
+    private var pendingRendererReplayBytes = 0
     private(set) var shellActivityState: AlanTerminalPtyShellActivityState = .unknown
     var onShellActivityStateChange: ((AlanTerminalPtyShellActivityState) -> Void)?
 
     init(contentID: String, bootRequest: AlanTerminalBootRequest) {
         self.contentID = contentID
         self.bootRequest = bootRequest
+        if !bootRequest.strategy.launchesInteractiveShell {
+            shellActivityState = .foregroundCommand
+        }
         launch()
     }
 
     deinit {
+        rendererlessOutputSource?.cancel()
+        processGroupTimer?.cancel()
         rendererProxy?.invalidate()
         directPtyInputWriteSource?.cancel()
         if masterFileDescriptor >= 0 {
@@ -61,7 +73,7 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
             rendererProxyDidInvalidate(rendererProxy)
         }
         if rendererProxy == nil {
-            drainAvailableOutput()
+            _ = drainAvailableOutput()
         }
         return AlanTerminalPtyRuntimeSnapshot(
             contentID: contentID,
@@ -181,9 +193,17 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
             rawSignal = SIGKILL
         }
 
-        let target = processGroupID.map { -$0 } ?? processID
+        let foregroundProcessGroupID = currentForegroundProcessGroupID()
+        let targetProcessGroupID = foregroundProcessGroupID ?? processGroupID
+        let target = targetProcessGroupID.map { -$0 } ?? processID
         var result = Darwin.kill(target, rawSignal)
-        if result != 0, processGroupID != nil {
+        if result != 0,
+           let processGroupID,
+           processGroupID != targetProcessGroupID
+        {
+            result = Darwin.kill(-processGroupID, rawSignal)
+        }
+        if result != 0 {
             result = Darwin.kill(processID, rawSignal)
         }
         guard result == 0 else {
@@ -234,6 +254,8 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
         setNoSigpipeSocketOption(descriptors[0])
         setNoSigpipeSocketOption(descriptors[1])
 
+        stopRendererlessOutputDraining()
+        _ = drainAvailableOutput()
         let proxy = AlanDarwinTerminalPtyRendererProxy(
             ptyHandle: self,
             hostFileDescriptor: descriptors[0],
@@ -241,7 +263,10 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
             outputProcessor: outputProcessor
         )
         rendererProxy = proxy
-        proxy.start()
+        let replayChunks = pendingRendererReplayChunks
+        pendingRendererReplayChunks.removeAll()
+        pendingRendererReplayBytes = 0
+        proxy.start(initialRendererOutput: replayChunks)
 
         return .attached(
             AlanTerminalPtyRendererAttachment(
@@ -264,14 +289,14 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
         var collected = Data()
         var buffer = [UInt8](repeating: 0, count: 4096)
 
-        while true {
+        while collected.count < 64 * 1024 {
             let count = Darwin.read(masterFileDescriptor, &buffer, buffer.count)
             if count > 0 {
                 collected.append(buffer, count: count)
                 continue
             }
             if count == 0 {
-                refreshExitStatus()
+                _ = refreshExitStatus()
                 break
             }
             if errno == EAGAIN || errno == EWOULDBLOCK {
@@ -283,23 +308,28 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
         guard !collected.isEmpty else { return [] }
         let response = outputProcessor.process(collected)
         if let transition = response.shellActivityTransition {
-            recordShellActivityState(transition)
+            recordSemanticShellActivityState(transition)
         }
         if response.didRespond {
             _ = writePtyProtocolResponse(response.ptyResponse)
         }
-
         guard !response.rendererOutput.isEmpty else { return [] }
-        rendererProxy?.forwardPtyOutput(response.rendererOutput)
-        let text = String(decoding: response.rendererOutput, as: UTF8.self)
-        let lines = transcriptLines(from: text)
-        transcriptRingBufferLines.append(contentsOf: lines)
-        if transcriptRingBufferLines.count > TerminalTranscriptSnapshot.defaultMaxRows {
-            transcriptRingBufferLines = Array(
-                transcriptRingBufferLines.suffix(TerminalTranscriptSnapshot.defaultMaxRows)
-            )
+        appendPendingRendererReplay(response.rendererOutput)
+        recordPtyOutput(response.rendererOutput)
+        return transcriptLines(
+            from: String(decoding: response.rendererOutput, as: UTF8.self)
+        )
+    }
+
+    private func appendPendingRendererReplay(_ data: Data) {
+        guard !data.isEmpty else { return }
+        pendingRendererReplayChunks.append(data)
+        pendingRendererReplayBytes += data.count
+        while pendingRendererReplayBytes > maxPendingRendererReplayBytes,
+              pendingRendererReplayChunks.count > 1
+        {
+            pendingRendererReplayBytes -= pendingRendererReplayChunks.removeFirst().count
         }
-        return lines
     }
 
     @discardableResult
@@ -404,7 +434,84 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
         }
     }
 
-    fileprivate func recordShellActivityState(_ state: AlanTerminalPtyShellActivityState) {
+    fileprivate func recordSemanticShellActivityState(
+        _ state: AlanTerminalPtyShellActivityState
+    ) {
+        semanticShellActivityState = state
+        reconcileShellActivityState()
+    }
+
+    fileprivate func recordProcessGroupShellActivityState(
+        _ state: AlanTerminalPtyShellActivityState
+    ) {
+        processGroupShellActivityState = state
+        reconcileShellActivityState()
+    }
+
+    private func reconcileShellActivityState() {
+        let state: AlanTerminalPtyShellActivityState
+        if !bootRequest.strategy.launchesInteractiveShell {
+            state = semanticShellActivityState ?? .foregroundCommand
+        } else if semanticShellActivityState == .foregroundCommand
+            || processGroupShellActivityState == .foregroundCommand
+        {
+            state = .foregroundCommand
+        } else if semanticShellActivityState == .shellInput
+            || processGroupShellActivityState == .shellInput
+        {
+            state = .shellInput
+        } else {
+            state = .unknown
+        }
+        recordShellActivityState(state)
+    }
+
+    private func startRendererlessOutputDraining() {
+        guard rendererlessOutputSource == nil, masterFileDescriptor >= 0 else { return }
+        let source = DispatchSource.makeReadSource(
+            fileDescriptor: masterFileDescriptor,
+            queue: .main
+        )
+        source.setEventHandler { [weak self] in
+            _ = self?.drainAvailableOutput()
+        }
+        source.resume()
+        rendererlessOutputSource = source
+    }
+
+    private func stopRendererlessOutputDraining() {
+        rendererlessOutputSource?.cancel()
+        rendererlessOutputSource = nil
+    }
+
+    private func startProcessGroupObservation() {
+        guard processGroupTimer == nil, processGroupID != nil else { return }
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now(), repeating: .milliseconds(30))
+        timer.setEventHandler { [weak self] in
+            self?.observeForegroundProcessGroup()
+        }
+        timer.resume()
+        processGroupTimer = timer
+    }
+
+    private func observeForegroundProcessGroup() {
+        guard masterFileDescriptor >= 0, let processGroupID else { return }
+        guard let foregroundProcessGroupID = currentForegroundProcessGroupID() else { return }
+        recordProcessGroupShellActivityState(
+            foregroundProcessGroupID == processGroupID
+                ? .shellInput
+                : .foregroundCommand
+        )
+    }
+
+    private func currentForegroundProcessGroupID() -> pid_t? {
+        guard masterFileDescriptor >= 0 else { return nil }
+        let foregroundProcessGroupID = tcgetpgrp(masterFileDescriptor)
+        return foregroundProcessGroupID > 0 ? foregroundProcessGroupID : nil
+    }
+
+    private func recordShellActivityState(_ state: AlanTerminalPtyShellActivityState) {
         guard state != shellActivityState else { return }
         shellActivityState = state
         onShellActivityStateChange?(state)
@@ -414,7 +521,11 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
         _ invalidatedProxy: AlanDarwinTerminalPtyRendererProxy
     ) {
         guard rendererProxy === invalidatedProxy else { return }
+        appendPendingRendererReplay(
+            invalidatedProxy.takeInvalidationHandoffOutput()
+        )
         rendererProxy = nil
+        startRendererlessOutputDraining()
     }
 
     @discardableResult
@@ -445,6 +556,9 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
             exitStatus = .exitCode(status)
         }
         phase = .exited
+        processGroupTimer?.cancel()
+        processGroupTimer = nil
+        recordShellActivityState(.shellInput)
         return exitStatus
     }
 
@@ -499,6 +613,10 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
         preseedFishPrimaryDeviceAttributesResponseIfNeeded()
         phase = .running
         resizeRequests.append(AlanTerminalPtyDimensions(columns: 80, rows: 24))
+        startRendererlessOutputDraining()
+        if bootRequest.strategy.launchesInteractiveShell {
+            startProcessGroupObservation()
+        }
     }
 
     private func preseedFishPrimaryDeviceAttributesResponseIfNeeded() {
@@ -534,6 +652,7 @@ private final class AlanDarwinTerminalPtyRendererProxy {
         label: "dev.alan.terminal.pty.renderer",
         qos: .userInitiated
     )
+    private let ioQueueKey = DispatchSpecificKey<UInt8>()
     private let invalidationLock = NSLock()
     private var rendererInputSource: DispatchSourceRead?
     private var ptyOutputSource: DispatchSourceRead?
@@ -541,6 +660,7 @@ private final class AlanDarwinTerminalPtyRendererProxy {
     private var rendererOutputWriteSource: DispatchSourceWrite?
     private var pendingPtyInputChunks: [PendingPtyInputChunk] = []
     private var pendingRendererOutput = Data()
+    private var invalidationHandoffOutput = Data()
     private var isInvalidated = false
 
     init(
@@ -553,49 +673,64 @@ private final class AlanDarwinTerminalPtyRendererProxy {
         self.hostFileDescriptor = hostFileDescriptor
         self.ptyFileDescriptor = ptyFileDescriptor
         self.outputProcessor = outputProcessor
+        ioQueue.setSpecific(key: ioQueueKey, value: 1)
     }
 
     deinit {
         invalidate()
     }
 
-    func start() {
-        let inputSource = DispatchSource.makeReadSource(
-            fileDescriptor: hostFileDescriptor,
-            queue: ioQueue
-        )
-        inputSource.setEventHandler { [weak self] in
-            self?.drainRendererInput()
-        }
-        inputSource.setCancelHandler { [hostFileDescriptor] in
-            close(hostFileDescriptor)
-        }
-        inputSource.resume()
-        rendererInputSource = inputSource
+    func start(initialRendererOutput: [Data]) {
+        performOnIOQueue {
+            guard !invalidated else { return }
 
-        let outputSource = DispatchSource.makeReadSource(
-            fileDescriptor: ptyFileDescriptor,
-            queue: ioQueue
-        )
-        outputSource.setEventHandler { [weak self] in
-            self?.drainPtyOutput()
+            let inputSource = DispatchSource.makeReadSource(
+                fileDescriptor: hostFileDescriptor,
+                queue: ioQueue
+            )
+            inputSource.setEventHandler { [weak self] in
+                self?.drainRendererInput()
+            }
+            inputSource.setCancelHandler { [hostFileDescriptor] in
+                close(hostFileDescriptor)
+            }
+            rendererInputSource = inputSource
+            inputSource.resume()
+
+            let outputSource = DispatchSource.makeReadSource(
+                fileDescriptor: ptyFileDescriptor,
+                queue: ioQueue
+            )
+            outputSource.setEventHandler { [weak self] in
+                self?.drainPtyOutput()
+            }
+            ptyOutputSource = outputSource
+            outputSource.resume()
+
+            for chunk in initialRendererOutput {
+                guard forwardPtyOutputOnQueue(chunk) else {
+                    invalidate()
+                    return
+                }
+            }
         }
-        outputSource.resume()
-        ptyOutputSource = outputSource
     }
 
     func invalidate() {
         guard markInvalidated() else { return }
-        rendererInputSource?.cancel()
-        rendererInputSource = nil
-        ptyOutputSource?.cancel()
-        ptyOutputSource = nil
-        ptyInputWriteSource?.cancel()
-        ptyInputWriteSource = nil
-        rendererOutputWriteSource?.cancel()
-        rendererOutputWriteSource = nil
-        pendingPtyInputChunks.removeAll()
-        pendingRendererOutput.removeAll()
+        performOnIOQueue {
+            rendererInputSource?.cancel()
+            rendererInputSource = nil
+            ptyOutputSource?.cancel()
+            ptyOutputSource = nil
+            ptyInputWriteSource?.cancel()
+            ptyInputWriteSource = nil
+            rendererOutputWriteSource?.cancel()
+            rendererOutputWriteSource = nil
+            pendingPtyInputChunks.removeAll()
+            invalidationHandoffOutput.append(pendingRendererOutput)
+            pendingRendererOutput.removeAll()
+        }
         Task { @MainActor [weak self, weak ptyHandle] in
             guard let self else { return }
             ptyHandle?.rendererProxyDidInvalidate(self)
@@ -616,13 +751,28 @@ private final class AlanDarwinTerminalPtyRendererProxy {
         return true
     }
 
-    func forwardPtyOutput(_ data: Data) {
-        guard !invalidated, !data.isEmpty else { return }
-        pendingRendererOutput.append(data)
-        guard drainPendingRendererOutput() else {
-            invalidate()
-            return
+    private func performOnIOQueue(_ operation: () -> Void) {
+        if DispatchQueue.getSpecific(key: ioQueueKey) != nil {
+            operation()
+        } else {
+            ioQueue.sync(execute: operation)
         }
+    }
+
+    fileprivate func takeInvalidationHandoffOutput() -> Data {
+        var output = Data()
+        performOnIOQueue {
+            output = invalidationHandoffOutput
+            invalidationHandoffOutput.removeAll()
+        }
+        return output
+    }
+
+    private func forwardPtyOutputOnQueue(_ data: Data) -> Bool {
+        guard !invalidated else { return false }
+        guard !data.isEmpty else { return true }
+        pendingRendererOutput.append(data)
+        return drainPendingRendererOutput()
     }
 
     private func drainRendererInput() {
@@ -684,7 +834,7 @@ private final class AlanDarwinTerminalPtyRendererProxy {
         let response = outputProcessor.process(collected)
         if let transition = response.shellActivityTransition {
             Task { @MainActor [weak self] in
-                self?.ptyHandle?.recordShellActivityState(transition)
+                self?.ptyHandle?.recordSemanticShellActivityState(transition)
             }
         }
         if response.didRespond {
@@ -695,9 +845,12 @@ private final class AlanDarwinTerminalPtyRendererProxy {
         }
 
         guard !response.rendererOutput.isEmpty else { return }
-        forwardPtyOutput(response.rendererOutput)
         Task { @MainActor [weak self] in
             self?.ptyHandle?.recordPtyOutput(response.rendererOutput)
+        }
+        guard forwardPtyOutputOnQueue(response.rendererOutput) else {
+            invalidate()
+            return
         }
     }
 

--- a/clients/apple/alan-macos/Services/Terminal/DarwinTerminalPtyRuntime.swift
+++ b/clients/apple/alan-macos/Services/Terminal/DarwinTerminalPtyRuntime.swift
@@ -38,6 +38,8 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
     private var rendererProxy: AlanDarwinTerminalPtyRendererProxy?
     private var pendingDirectPtyInputChunks: [PendingDirectPtyInputChunk] = []
     private var directPtyInputWriteSource: DispatchSourceWrite?
+    private(set) var shellActivityState: AlanTerminalPtyShellActivityState = .unknown
+    var onShellActivityStateChange: ((AlanTerminalPtyShellActivityState) -> Void)?
 
     init(contentID: String, bootRequest: AlanTerminalBootRequest) {
         self.contentID = contentID
@@ -274,6 +276,9 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
 
         guard !collected.isEmpty else { return [] }
         let response = controlSequenceResponder.process(collected)
+        if let transition = response.shellActivityTransition {
+            recordShellActivityState(transition)
+        }
         if response.didRespond {
             _ = writePtyProtocolResponse(response.ptyResponse)
         }
@@ -391,6 +396,12 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
                 transcriptRingBufferLines.suffix(TerminalTranscriptSnapshot.defaultMaxRows)
             )
         }
+    }
+
+    fileprivate func recordShellActivityState(_ state: AlanTerminalPtyShellActivityState) {
+        guard state != shellActivityState else { return }
+        shellActivityState = state
+        onShellActivityStateChange?(state)
     }
 
     @discardableResult
@@ -640,6 +651,11 @@ private final class AlanDarwinTerminalPtyRendererProxy {
 
         guard !collected.isEmpty else { return }
         let response = controlSequenceResponder.process(collected)
+        if let transition = response.shellActivityTransition {
+            Task { @MainActor [weak self] in
+                self?.ptyHandle?.recordShellActivityState(transition)
+            }
+        }
         if response.didRespond {
             guard enqueuePtyInput(response.ptyResponse, countedBytes: 0) else {
                 invalidate()

--- a/clients/apple/alan-macos/Services/Terminal/DarwinTerminalPtyRuntime.swift
+++ b/clients/apple/alan-macos/Services/Terminal/DarwinTerminalPtyRuntime.swift
@@ -42,6 +42,7 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
     private var processGroupTimer: DispatchSourceTimer?
     private var semanticShellActivityState: AlanTerminalPtyShellActivityState?
     private var processGroupShellActivityState: AlanTerminalPtyShellActivityState?
+    private var idleProcessGroupTracker: AlanTerminalPtyIdleProcessGroupTracker?
     private var pendingRendererReplay = AlanTerminalPtyBoundedReplayBuffer(
         maxBytes: 1024 * 1024
     )
@@ -479,13 +480,14 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
     }
 
     private func observeForegroundProcessGroup() {
-        guard masterFileDescriptor >= 0, let processGroupID else { return }
+        guard masterFileDescriptor >= 0, var idleProcessGroupTracker else { return }
         guard let foregroundProcessGroupID = currentForegroundProcessGroupID() else { return }
-        recordProcessGroupShellActivityState(
-            foregroundProcessGroupID == processGroupID
-                ? .shellInput
-                : .foregroundCommand
+        let state = idleProcessGroupTracker.observe(
+            foregroundProcessGroupID: foregroundProcessGroupID,
+            semanticState: semanticShellActivityState
         )
+        self.idleProcessGroupTracker = idleProcessGroupTracker
+        recordProcessGroupShellActivityState(state)
     }
 
     private func currentForegroundProcessGroupID() -> pid_t? {
@@ -592,6 +594,11 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
         setNonBlocking(master)
         processID = spawnedPid
         processGroupID = spawnedPid
+        idleProcessGroupTracker = AlanTerminalPtyIdleProcessGroupTracker(
+            initialIdleProcessGroupID: spawnedPid,
+            allowsIdleProcessGroupRebase:
+                bootRequest.strategy.allowsInteractiveShellProcessGroupRebase
+        )
         masterFileDescriptor = master
         preseedFishPrimaryDeviceAttributesResponseIfNeeded()
         phase = .running

--- a/clients/apple/alan-macos/Services/Terminal/DarwinTerminalPtyRuntime.swift
+++ b/clients/apple/alan-macos/Services/Terminal/DarwinTerminalPtyRuntime.swift
@@ -34,7 +34,7 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
     fileprivate var masterFileDescriptor: Int32 = -1
     private var transcriptRingBufferLines: [String] = []
     private var acceptedInputBytes = 0
-    private var controlSequenceResponder = AlanTerminalPtyControlSequenceResponder()
+    private let outputProcessor = AlanTerminalPtyControlSequenceProcessor()
     private var rendererProxy: AlanDarwinTerminalPtyRendererProxy?
     private var pendingDirectPtyInputChunks: [PendingDirectPtyInputChunk] = []
     private var directPtyInputWriteSource: DispatchSourceWrite?
@@ -57,7 +57,12 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
 
     var snapshot: AlanTerminalPtyRuntimeSnapshot {
         refreshExitStatus()
-        drainAvailableOutput()
+        if let rendererProxy, rendererProxy.invalidated {
+            rendererProxyDidInvalidate(rendererProxy)
+        }
+        if rendererProxy == nil {
+            drainAvailableOutput()
+        }
         return AlanTerminalPtyRuntimeSnapshot(
             contentID: contentID,
             bootRequest: bootRequest,
@@ -192,6 +197,10 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
     }
 
     func makeRendererAttachment() -> AlanTerminalPtyRendererAttachmentResult {
+        if let rendererProxy {
+            rendererProxy.invalidate()
+            rendererProxyDidInvalidate(rendererProxy)
+        }
         refreshExitStatus()
         guard exitStatus == nil else {
             return .rejected(
@@ -225,14 +234,11 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
         setNoSigpipeSocketOption(descriptors[0])
         setNoSigpipeSocketOption(descriptors[1])
 
-        rendererProxy?.invalidate()
-        let rendererControlSequenceResponder = controlSequenceResponder
-        controlSequenceResponder = AlanTerminalPtyControlSequenceResponder()
         let proxy = AlanDarwinTerminalPtyRendererProxy(
             ptyHandle: self,
             hostFileDescriptor: descriptors[0],
             ptyFileDescriptor: masterFileDescriptor,
-            controlSequenceResponder: rendererControlSequenceResponder
+            outputProcessor: outputProcessor
         )
         rendererProxy = proxy
         proxy.start()
@@ -254,7 +260,7 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
 
     @discardableResult
     func drainAvailableOutput() -> [String] {
-        guard masterFileDescriptor >= 0 else { return [] }
+        guard rendererProxy == nil, masterFileDescriptor >= 0 else { return [] }
         var collected = Data()
         var buffer = [UInt8](repeating: 0, count: 4096)
 
@@ -275,7 +281,7 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
         }
 
         guard !collected.isEmpty else { return [] }
-        let response = controlSequenceResponder.process(collected)
+        let response = outputProcessor.process(collected)
         if let transition = response.shellActivityTransition {
             recordShellActivityState(transition)
         }
@@ -404,6 +410,13 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
         onShellActivityStateChange?(state)
     }
 
+    fileprivate func rendererProxyDidInvalidate(
+        _ invalidatedProxy: AlanDarwinTerminalPtyRendererProxy
+    ) {
+        guard rendererProxy === invalidatedProxy else { return }
+        rendererProxy = nil
+    }
+
     @discardableResult
     func refreshExitStatus() -> AlanTerminalProcessExitStatus? {
         guard exitStatus == nil, let processID else {
@@ -497,7 +510,7 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
             return Darwin.write(masterFileDescriptor, baseAddress, buffer.count)
         }
         guard written == response.count else { return }
-        controlSequenceResponder.suppressNextPrimaryDeviceAttributesResponse()
+        outputProcessor.suppressNextPrimaryDeviceAttributesResponse()
     }
 
     private func setNonBlocking(_ fileDescriptor: Int32) {
@@ -516,29 +529,30 @@ private final class AlanDarwinTerminalPtyRendererProxy {
     private weak var ptyHandle: AlanDarwinTerminalPtyHandle?
     private let hostFileDescriptor: Int32
     private let ptyFileDescriptor: Int32
+    private let outputProcessor: AlanTerminalPtyControlSequenceProcessor
     private let ioQueue = DispatchQueue(
         label: "dev.alan.terminal.pty.renderer",
         qos: .userInitiated
     )
+    private let invalidationLock = NSLock()
     private var rendererInputSource: DispatchSourceRead?
     private var ptyOutputSource: DispatchSourceRead?
     private var ptyInputWriteSource: DispatchSourceWrite?
     private var rendererOutputWriteSource: DispatchSourceWrite?
     private var pendingPtyInputChunks: [PendingPtyInputChunk] = []
     private var pendingRendererOutput = Data()
-    private var controlSequenceResponder = AlanTerminalPtyControlSequenceResponder()
     private var isInvalidated = false
 
     init(
         ptyHandle: AlanDarwinTerminalPtyHandle,
         hostFileDescriptor: Int32,
         ptyFileDescriptor: Int32,
-        controlSequenceResponder: AlanTerminalPtyControlSequenceResponder = AlanTerminalPtyControlSequenceResponder()
+        outputProcessor: AlanTerminalPtyControlSequenceProcessor
     ) {
         self.ptyHandle = ptyHandle
         self.hostFileDescriptor = hostFileDescriptor
         self.ptyFileDescriptor = ptyFileDescriptor
-        self.controlSequenceResponder = controlSequenceResponder
+        self.outputProcessor = outputProcessor
     }
 
     deinit {
@@ -571,8 +585,7 @@ private final class AlanDarwinTerminalPtyRendererProxy {
     }
 
     func invalidate() {
-        guard !isInvalidated else { return }
-        isInvalidated = true
+        guard markInvalidated() else { return }
         rendererInputSource?.cancel()
         rendererInputSource = nil
         ptyOutputSource?.cancel()
@@ -583,10 +596,28 @@ private final class AlanDarwinTerminalPtyRendererProxy {
         rendererOutputWriteSource = nil
         pendingPtyInputChunks.removeAll()
         pendingRendererOutput.removeAll()
+        Task { @MainActor [weak self, weak ptyHandle] in
+            guard let self else { return }
+            ptyHandle?.rendererProxyDidInvalidate(self)
+        }
+    }
+
+    fileprivate var invalidated: Bool {
+        invalidationLock.lock()
+        defer { invalidationLock.unlock() }
+        return isInvalidated
+    }
+
+    private func markInvalidated() -> Bool {
+        invalidationLock.lock()
+        defer { invalidationLock.unlock() }
+        guard !isInvalidated else { return false }
+        isInvalidated = true
+        return true
     }
 
     func forwardPtyOutput(_ data: Data) {
-        guard !isInvalidated, !data.isEmpty else { return }
+        guard !invalidated, !data.isEmpty else { return }
         pendingRendererOutput.append(data)
         guard drainPendingRendererOutput() else {
             invalidate()
@@ -595,7 +626,7 @@ private final class AlanDarwinTerminalPtyRendererProxy {
     }
 
     private func drainRendererInput() {
-        guard !isInvalidated else { return }
+        guard !invalidated else { return }
         guard drainPendingPtyInput() else {
             invalidate()
             return
@@ -627,7 +658,7 @@ private final class AlanDarwinTerminalPtyRendererProxy {
     }
 
     private func drainPtyOutput() {
-        guard !isInvalidated else { return }
+        guard !invalidated else { return }
         var collected = Data()
         var buffer = [UInt8](repeating: 0, count: 4096)
 
@@ -650,7 +681,7 @@ private final class AlanDarwinTerminalPtyRendererProxy {
         }
 
         guard !collected.isEmpty else { return }
-        let response = controlSequenceResponder.process(collected)
+        let response = outputProcessor.process(collected)
         if let transition = response.shellActivityTransition {
             Task { @MainActor [weak self] in
                 self?.ptyHandle?.recordShellActivityState(transition)
@@ -682,7 +713,7 @@ private final class AlanDarwinTerminalPtyRendererProxy {
     }
 
     private func drainPendingPtyInput() -> Bool {
-        guard !isInvalidated else { return false }
+        guard !invalidated else { return false }
         var acceptedInputBytes = 0
 
         while !pendingPtyInputChunks.isEmpty {
@@ -725,7 +756,7 @@ private final class AlanDarwinTerminalPtyRendererProxy {
     }
 
     private func ensurePtyInputWriteSource() {
-        guard !isInvalidated, ptyInputWriteSource == nil else { return }
+        guard !invalidated, ptyInputWriteSource == nil else { return }
         let writeSource = DispatchSource.makeWriteSource(
             fileDescriptor: ptyFileDescriptor,
             queue: ioQueue
@@ -747,7 +778,7 @@ private final class AlanDarwinTerminalPtyRendererProxy {
     }
 
     private func drainPendingRendererOutput() -> Bool {
-        guard !isInvalidated else { return false }
+        guard !invalidated else { return false }
 
         while !pendingRendererOutput.isEmpty {
             let result = pendingRendererOutput.withUnsafeBytes { rawBuffer -> Int in
@@ -773,7 +804,7 @@ private final class AlanDarwinTerminalPtyRendererProxy {
     }
 
     private func ensureRendererOutputWriteSource() {
-        guard !isInvalidated, rendererOutputWriteSource == nil else { return }
+        guard !invalidated, rendererOutputWriteSource == nil else { return }
         let writeSource = DispatchSource.makeWriteSource(
             fileDescriptor: hostFileDescriptor,
             queue: ioQueue

--- a/clients/apple/alan-macos/Services/Terminal/DarwinTerminalPtyRuntime.swift
+++ b/clients/apple/alan-macos/Services/Terminal/DarwinTerminalPtyRuntime.swift
@@ -40,7 +40,7 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
     private var directPtyInputWriteSource: DispatchSourceWrite?
     private var rendererlessOutputSource: DispatchSourceRead?
     private var processGroupTimer: DispatchSourceTimer?
-    private var semanticShellActivityState: AlanTerminalPtyShellActivityState?
+    private var semanticShellState: AlanTerminalPtySemanticShellState?
     private var processGroupShellActivityState: AlanTerminalPtyShellActivityState?
     private var idleProcessGroupTracker: AlanTerminalPtyIdleProcessGroupTracker?
     private var pendingRendererReplay = AlanTerminalPtyBoundedReplayBuffer(
@@ -306,8 +306,8 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
 
         guard !collected.isEmpty else { return [] }
         let response = outputProcessor.process(collected)
-        if let transition = response.shellActivityTransition {
-            recordSemanticShellActivityState(transition)
+        if let transition = response.semanticShellStateTransition {
+            recordSemanticShellState(transition)
         }
         if response.didRespond {
             _ = writePtyProtocolResponse(response.ptyResponse)
@@ -426,10 +426,10 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
         }
     }
 
-    fileprivate func recordSemanticShellActivityState(
-        _ state: AlanTerminalPtyShellActivityState
+    fileprivate func recordSemanticShellState(
+        _ state: AlanTerminalPtySemanticShellState
     ) {
-        semanticShellActivityState = state
+        semanticShellState = state
         reconcileShellActivityState()
     }
 
@@ -444,7 +444,7 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
         recordShellActivityState(
             AlanTerminalPtyShellActivityResolver.resolve(
                 launchesInteractiveShell: bootRequest.strategy.launchesInteractiveShell,
-                semanticState: semanticShellActivityState,
+                semanticState: semanticShellState,
                 processGroupState: processGroupShellActivityState
             )
         )
@@ -484,7 +484,7 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
         guard let foregroundProcessGroupID = currentForegroundProcessGroupID() else { return }
         let state = idleProcessGroupTracker.observe(
             foregroundProcessGroupID: foregroundProcessGroupID,
-            semanticState: semanticShellActivityState
+            semanticState: semanticShellState
         )
         self.idleProcessGroupTracker = idleProcessGroupTracker
         recordProcessGroupShellActivityState(state)
@@ -822,9 +822,9 @@ private final class AlanDarwinTerminalPtyRendererProxy {
 
         guard !collected.isEmpty else { return }
         let response = outputProcessor.process(collected)
-        if let transition = response.shellActivityTransition {
+        if let transition = response.semanticShellStateTransition {
             Task { @MainActor [weak self] in
-                self?.ptyHandle?.recordSemanticShellActivityState(transition)
+                self?.ptyHandle?.recordSemanticShellState(transition)
             }
         }
         if response.didRespond {

--- a/clients/apple/alan-macos/Services/Terminal/DarwinTerminalPtyRuntime.swift
+++ b/clients/apple/alan-macos/Services/Terminal/DarwinTerminalPtyRuntime.swift
@@ -16,7 +16,6 @@ private func alanDarwinPtySpawn(
 
 @MainActor
 final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
-    private let maxPendingRendererReplayBytes = 1024 * 1024
     private struct PendingDirectPtyInputChunk {
         var data: Data
         var countedBytesRemaining: Int
@@ -43,8 +42,9 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
     private var processGroupTimer: DispatchSourceTimer?
     private var semanticShellActivityState: AlanTerminalPtyShellActivityState?
     private var processGroupShellActivityState: AlanTerminalPtyShellActivityState?
-    private var pendingRendererReplayChunks: [Data] = []
-    private var pendingRendererReplayBytes = 0
+    private var pendingRendererReplay = AlanTerminalPtyBoundedReplayBuffer(
+        maxBytes: 1024 * 1024
+    )
     private(set) var shellActivityState: AlanTerminalPtyShellActivityState = .unknown
     var onShellActivityStateChange: ((AlanTerminalPtyShellActivityState) -> Void)?
 
@@ -263,9 +263,7 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
             outputProcessor: outputProcessor
         )
         rendererProxy = proxy
-        let replayChunks = pendingRendererReplayChunks
-        pendingRendererReplayChunks.removeAll()
-        pendingRendererReplayBytes = 0
+        let replayChunks = pendingRendererReplay.takeChunks()
         proxy.start(initialRendererOutput: replayChunks)
 
         return .attached(
@@ -322,14 +320,7 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
     }
 
     private func appendPendingRendererReplay(_ data: Data) {
-        guard !data.isEmpty else { return }
-        pendingRendererReplayChunks.append(data)
-        pendingRendererReplayBytes += data.count
-        while pendingRendererReplayBytes > maxPendingRendererReplayBytes,
-              pendingRendererReplayChunks.count > 1
-        {
-            pendingRendererReplayBytes -= pendingRendererReplayChunks.removeFirst().count
-        }
+        pendingRendererReplay.append(data)
     }
 
     @discardableResult
@@ -449,21 +440,13 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
     }
 
     private func reconcileShellActivityState() {
-        let state: AlanTerminalPtyShellActivityState
-        if !bootRequest.strategy.launchesInteractiveShell {
-            state = semanticShellActivityState ?? .foregroundCommand
-        } else if semanticShellActivityState == .foregroundCommand
-            || processGroupShellActivityState == .foregroundCommand
-        {
-            state = .foregroundCommand
-        } else if semanticShellActivityState == .shellInput
-            || processGroupShellActivityState == .shellInput
-        {
-            state = .shellInput
-        } else {
-            state = .unknown
-        }
-        recordShellActivityState(state)
+        recordShellActivityState(
+            AlanTerminalPtyShellActivityResolver.resolve(
+                launchesInteractiveShell: bootRequest.strategy.launchesInteractiveShell,
+                semanticState: semanticShellActivityState,
+                processGroupState: processGroupShellActivityState
+            )
+        )
     }
 
     private func startRendererlessOutputDraining() {

--- a/clients/apple/alan-macos/Services/Terminal/DarwinTerminalPtyRuntime.swift
+++ b/clients/apple/alan-macos/Services/Terminal/DarwinTerminalPtyRuntime.swift
@@ -550,15 +550,29 @@ final class AlanDarwinTerminalPtyHandle: AlanTerminalPtyHandle {
     private func launch() {
         var master: Int32 = -1
         var spawnedPid: pid_t = 0
-        let arguments = [bootRequest.executablePath] + bootRequest.arguments
         let environment = ProcessInfo.processInfo.environment.merging(bootRequest.environment) {
             _, newValue in newValue
         }
+        let shellLaunch = bootRequest.strategy.launchesInteractiveShell
+            ? AlanTerminalShellLaunch.integratingGhostty(
+                executablePath: bootRequest.executablePath,
+                arguments: bootRequest.arguments,
+                environment: environment,
+                resourcesPath: environment["GHOSTTY_RESOURCES_DIR"]
+            )
+            : AlanTerminalShellLaunch(
+                argumentZero: bootRequest.executablePath,
+                arguments: bootRequest.arguments,
+                environment: environment
+            )
+        let arguments = [shellLaunch.argumentZero] + shellLaunch.arguments
 
         let spawnResult = bootRequest.executablePath.withCString { executablePath in
             bootRequest.workingDirectory.withCString { workingDirectory in
                 withCStringArray(arguments) { argv in
-                    withCStringArray(environment.map { "\($0.key)=\($0.value)" }.sorted()) { envp in
+                    withCStringArray(shellLaunch.environment.map {
+                        "\($0.key)=\($0.value)"
+                    }.sorted()) { envp in
                         alanDarwinPtySpawn(
                             executablePath,
                             argv,

--- a/clients/apple/alan-macos/Services/Terminal/GhosttyTerminalSurfaceHandle.swift
+++ b/clients/apple/alan-macos/Services/Terminal/GhosttyTerminalSurfaceHandle.swift
@@ -95,9 +95,10 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
             lastAppliedPtyGrid = nil
         }
         guard currentSnapshot.teardownStatus != .completed else { return }
+        let metadata = metadataApplyingPtyShellActivity(metadataWithBootProfile(bootProfile))
         updateSnapshot(
             lifecyclePhase: bootProfile == nil ? .pending : .attachable,
-            metadata: metadataWithBootProfile(bootProfile)
+            metadata: metadata
         )
     }
 
@@ -445,15 +446,17 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
         let activeTaskState: ShellTabActiveTaskState
         if metadata.processExited {
             activeTaskState = .inactive
-        } else {
-            switch ptyHandle?.shellActivityState ?? .unknown {
+        } else if let ptyHandle {
+            switch ptyHandle.shellActivityState {
             case .unknown:
-                return metadata
+                activeTaskState = .unknown
             case .shellInput:
                 activeTaskState = .inactive
             case .foregroundCommand:
                 activeTaskState = .foregroundCommand
             }
+        } else {
+            return metadata
         }
 
         guard metadata.activeTaskState != activeTaskState else { return metadata }

--- a/clients/apple/alan-macos/Services/Terminal/GhosttyTerminalSurfaceHandle.swift
+++ b/clients/apple/alan-macos/Services/Terminal/GhosttyTerminalSurfaceHandle.swift
@@ -447,13 +447,17 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
         if metadata.processExited {
             activeTaskState = .inactive
         } else if let ptyHandle {
-            switch ptyHandle.shellActivityState {
-            case .unknown:
-                activeTaskState = .unknown
-            case .shellInput:
+            if ptyHandle.snapshot.hasLiveChildProcess {
+                switch ptyHandle.shellActivityState {
+                case .unknown:
+                    activeTaskState = .unknown
+                case .shellInput:
+                    activeTaskState = .inactive
+                case .foregroundCommand:
+                    activeTaskState = .foregroundCommand
+                }
+            } else {
                 activeTaskState = .inactive
-            case .foregroundCommand:
-                activeTaskState = .foregroundCommand
             }
         } else {
             return metadata

--- a/clients/apple/alan-macos/Services/Terminal/GhosttyTerminalSurfaceHandle.swift
+++ b/clients/apple/alan-macos/Services/Terminal/GhosttyTerminalSurfaceHandle.swift
@@ -25,6 +25,7 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
     private var latestHostRuntime: TerminalHostRuntimeSnapshot?
     private var lastAppliedPtyGrid: AlanTerminalPtyDimensions?
     private var transcriptRingBufferLines: [String] = []
+    private var metadataObserver: ((TerminalPaneMetadataSnapshot) -> Void)?
     private(set) var seededTranscriptSnapshot: TerminalTranscriptSnapshot?
 #if canImport(GhosttyKit)
     private let liveHost = AlanGhosttyLiveHost()
@@ -82,10 +83,15 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
         self.paneID = paneID
         self.bootProfile = bootProfile
         if let bootProfile {
-            ptyHandle = ptyRuntime.handle(
+            ptyHandle?.onShellActivityStateChange = nil
+            let ptyHandle = ptyRuntime.handle(
                 forTerminalContentID: contentID,
                 bootRequest: bootProfile.bootRequest
             )
+            ptyHandle.onShellActivityStateChange = { [weak self] _ in
+                self?.publishPtyShellActivity()
+            }
+            self.ptyHandle = ptyHandle
             lastAppliedPtyGrid = nil
         }
         guard currentSnapshot.teardownStatus != .completed else { return }
@@ -122,6 +128,7 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
             onMetadataChange(currentSnapshot.metadata)
             return
         }
+        metadataObserver = onMetadataChange
 
         updateSnapshot(lifecyclePhase: .bootstrapping, attachedViewCount: 1)
         let diagnostics = bootstrap.ensureReady()
@@ -165,6 +172,7 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
         }
         liveHost.onMetadataChange = { [weak self] metadata in
             guard let self else { return }
+            let metadata = metadataApplyingPtyShellActivity(metadata)
             updateSnapshot(metadata: metadata)
             onMetadataChange(metadata)
         }
@@ -192,7 +200,7 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
         resizePtyToRendererGridIfAvailable()
         updateSnapshot(
             lifecyclePhase: liveHost.isSurfaceReady ? .attached : .attachable,
-            metadata: liveHost.latestMetadata
+            metadata: metadataApplyingPtyShellActivity(liveHost.latestMetadata)
         )
 #else
         let renderer = TerminalRendererSnapshot(
@@ -258,7 +266,7 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
             )
         }
 
-        return recordInputDelivery(ptyHandle.writeInput(text), text: text)
+        return recordDelivery(ptyHandle.writeInput(text))
     }
 
     func sendControlKey(_ key: TerminalRuntimeControlKey) -> TerminalRuntimeDeliveryResult {
@@ -301,7 +309,7 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
         case .returnKey:
             text = "\r"
         }
-        return recordInputDelivery(ptyHandle.writeInput(text), text: text)
+        return recordDelivery(ptyHandle.writeInput(text))
     }
 
     func requestGracefulShutdown(
@@ -362,8 +370,10 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
 #if canImport(GhosttyKit)
         liveHost.teardown()
 #endif
+        ptyHandle?.onShellActivityStateChange = nil
         _ = ptyHandle?.terminateForCleanup()
         ptyHandle = nil
+        metadataObserver = nil
         updateSnapshot(
             lifecyclePhase: .closed,
             metadata: .placeholder,
@@ -396,18 +406,6 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
         return delivery
     }
 
-    private func recordInputDelivery(
-        _ delivery: TerminalRuntimeDeliveryResult,
-        text: String
-    ) -> TerminalRuntimeDeliveryResult {
-#if canImport(GhosttyKit)
-        if delivery.applied {
-            liveHost.recordProgrammaticCommandSubmission(in: text)
-        }
-#endif
-        return recordDelivery(delivery)
-    }
-
     private func resizePtyToRendererGridIfAvailable() {
         guard let rendererGrid = rendererTerminalGridForPtyResize else { return }
         guard rendererGrid.isUsable else { return }
@@ -430,6 +428,47 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
         }
 #endif
         return nil
+    }
+
+    private func publishPtyShellActivity() {
+        let metadata = metadataApplyingPtyShellActivity(currentSnapshot.metadata)
+        guard metadata.activeTaskState != currentSnapshot.metadata.activeTaskState else {
+            return
+        }
+        updateSnapshot(metadata: metadata)
+        metadataObserver?(metadata)
+    }
+
+    private func metadataApplyingPtyShellActivity(
+        _ metadata: TerminalPaneMetadataSnapshot
+    ) -> TerminalPaneMetadataSnapshot {
+        let activeTaskState: ShellTabActiveTaskState
+        if metadata.processExited {
+            activeTaskState = .inactive
+        } else {
+            switch ptyHandle?.shellActivityState ?? .unknown {
+            case .unknown:
+                return metadata
+            case .shellInput:
+                activeTaskState = .inactive
+            case .foregroundCommand:
+                activeTaskState = .foregroundCommand
+            }
+        }
+
+        guard metadata.activeTaskState != activeTaskState else { return metadata }
+        return TerminalPaneMetadataSnapshot(
+            title: metadata.title,
+            workingDirectory: metadata.workingDirectory,
+            summary: metadata.summary,
+            attention: metadata.attention,
+            processExited: metadata.processExited,
+            lastCommandExitCode: metadata.lastCommandExitCode,
+            lastUpdatedAt: metadata.lastUpdatedAt,
+            activeTaskState: activeTaskState,
+            activity: metadata.activity,
+            clearsActivity: metadata.clearsActivity
+        )
     }
 
     private func updateSnapshot(

--- a/clients/apple/alan-macos/Services/Terminal/GhosttyTerminalSurfaceHandle.swift
+++ b/clients/apple/alan-macos/Services/Terminal/GhosttyTerminalSurfaceHandle.swift
@@ -88,10 +88,10 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
                 forTerminalContentID: contentID,
                 bootRequest: bootProfile.bootRequest
             )
+            self.ptyHandle = ptyHandle
             ptyHandle.onShellActivityStateChange = { [weak self] _ in
                 self?.publishPtyShellActivity()
             }
-            self.ptyHandle = ptyHandle
             lastAppliedPtyGrid = nil
         }
         guard currentSnapshot.teardownStatus != .completed else { return }

--- a/clients/apple/alan-macos/Services/Terminal/GhosttyTerminalSurfaceHandle.swift
+++ b/clients/apple/alan-macos/Services/Terminal/GhosttyTerminalSurfaceHandle.swift
@@ -258,7 +258,7 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
             )
         }
 
-        return recordDelivery(ptyHandle.writeInput(text))
+        return recordInputDelivery(ptyHandle.writeInput(text), text: text)
     }
 
     func sendControlKey(_ key: TerminalRuntimeControlKey) -> TerminalRuntimeDeliveryResult {
@@ -301,7 +301,7 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
         case .returnKey:
             text = "\r"
         }
-        return recordDelivery(ptyHandle.writeInput(text))
+        return recordInputDelivery(ptyHandle.writeInput(text), text: text)
     }
 
     func requestGracefulShutdown(
@@ -394,6 +394,18 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
     ) -> TerminalRuntimeDeliveryResult {
         updateSnapshot(lastDelivery: delivery)
         return delivery
+    }
+
+    private func recordInputDelivery(
+        _ delivery: TerminalRuntimeDeliveryResult,
+        text: String
+    ) -> TerminalRuntimeDeliveryResult {
+#if canImport(GhosttyKit)
+        if delivery.applied {
+            liveHost.recordProgrammaticCommandSubmission(in: text)
+        }
+#endif
+        return recordDelivery(delivery)
     }
 
     private func resizePtyToRendererGridIfAvailable() {

--- a/clients/apple/alan-macos/Services/Terminal/ManagedUserTerminalPtyRuntime.swift
+++ b/clients/apple/alan-macos/Services/Terminal/ManagedUserTerminalPtyRuntime.swift
@@ -165,7 +165,7 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
     private let helperQueue: DispatchQueue
     private let outputProcessor = AlanTerminalPtyControlSequenceProcessor()
     private var outputPump: AlanHelperManagedUserPtyOutputPump?
-    private var semanticShellActivityState: AlanTerminalPtyShellActivityState?
+    private var semanticShellState: AlanTerminalPtySemanticShellState?
     private var processGroupShellActivityState: AlanTerminalPtyShellActivityState?
     private var pendingRendererReplay = AlanTerminalPtyBoundedReplayBuffer(
         maxBytes: 1024 * 1024
@@ -528,8 +528,8 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
     @MainActor
     private func applyHelperOutput(_ output: AlanHelperManagedUserPtyProcessedOutput) {
         applyHelperOutputChunk(output.chunk, rendererOutput: output.rendererOutput)
-        if let transition = output.shellActivityTransition {
-            recordSemanticShellActivityState(transition)
+        if let transition = output.semanticShellStateTransition {
+            recordSemanticShellState(transition)
         }
         switch output.chunk.foregroundProcessGroupState {
         case .shell:
@@ -581,10 +581,10 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
         acceptedInputBytes += byteCount
     }
 
-    private func recordSemanticShellActivityState(
-        _ state: AlanTerminalPtyShellActivityState
+    private func recordSemanticShellState(
+        _ state: AlanTerminalPtySemanticShellState
     ) {
-        semanticShellActivityState = state
+        semanticShellState = state
         reconcileShellActivityState()
     }
 
@@ -599,7 +599,7 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
         recordShellActivityState(
             AlanTerminalPtyShellActivityResolver.resolve(
                 launchesInteractiveShell: bootRequest.strategy.launchesInteractiveShell,
-                semanticState: semanticShellActivityState,
+                semanticState: semanticShellState,
                 processGroupState: processGroupShellActivityState
             )
         )
@@ -625,7 +625,7 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
 fileprivate struct AlanHelperManagedUserPtyProcessedOutput {
     let chunk: AlanManagedUserPTYOutputChunk
     let rendererOutput: Data
-    let shellActivityTransition: AlanTerminalPtyShellActivityState?
+    let semanticShellStateTransition: AlanTerminalPtySemanticShellState?
     let responseFailure: AlanPrivilegedHelperDiagnostic?
 }
 
@@ -670,7 +670,7 @@ private func readHelperManagedUserPtyProcessedOutput(
         return AlanHelperManagedUserPtyProcessedOutput(
             chunk: chunk,
             rendererOutput: response.rendererOutput,
-            shellActivityTransition: response.shellActivityTransition,
+            semanticShellStateTransition: response.semanticShellStateTransition,
             responseFailure: responseFailure
         )
     }

--- a/clients/apple/alan-macos/Services/Terminal/ManagedUserTerminalPtyRuntime.swift
+++ b/clients/apple/alan-macos/Services/Terminal/ManagedUserTerminalPtyRuntime.swift
@@ -163,6 +163,7 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
     private var rendererProxy: AlanHelperManagedUserPtyRendererProxy?
     private var observedFinalOutputChunk = false
     private let helperQueue: DispatchQueue
+    private let outputProcessor = AlanTerminalPtyControlSequenceProcessor()
     private(set) var shellActivityState: AlanTerminalPtyShellActivityState = .unknown
     var onShellActivityStateChange: ((AlanTerminalPtyShellActivityState) -> Void)?
 
@@ -190,7 +191,12 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
 
     var snapshot: AlanTerminalPtyRuntimeSnapshot {
         applyPendingProxyOutput()
-        _ = drainAvailableOutput()
+        if let rendererProxy, rendererProxy.invalidated {
+            rendererProxyDidInvalidate(rendererProxy)
+        }
+        if rendererProxy == nil {
+            _ = drainAvailableOutput()
+        }
         refreshExitObservation()
         if observedFinalOutputChunk, exitStatus == nil {
             exitStatus = .unknown
@@ -321,6 +327,10 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
     }
 
     func makeRendererAttachment() -> AlanTerminalPtyRendererAttachmentResult {
+        if let rendererProxy {
+            rendererProxy.invalidate()
+            rendererProxyDidInvalidate(rendererProxy)
+        }
         refreshExitObservation()
         guard exitStatus == nil else {
             return .rejected(
@@ -354,13 +364,13 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
         setNoSigpipeSocketOption(descriptors[0])
         setNoSigpipeSocketOption(descriptors[1])
 
-        rendererProxy?.invalidate()
         let proxy = AlanHelperManagedUserPtyRendererProxy(
             ptyHandle: self,
             helperClient: helperClient,
             sessionID: session.sessionID,
             hostFileDescriptor: descriptors[0],
-            ioQueue: helperQueue
+            ioQueue: helperQueue,
+            outputProcessor: outputProcessor
         )
         rendererProxy = proxy
         proxy.start()
@@ -417,22 +427,47 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
 
     @discardableResult
     fileprivate func drainAvailableOutput(maxBytes: Int = 4096) -> Data {
-        guard exitStatus == nil else { return Data() }
+        guard rendererProxy == nil, exitStatus == nil else { return Data() }
         var collected = Data()
 
         while true {
-            switch helperQueue.sync(execute: {
+            let result = helperQueue.sync {
                 helperClient.readManagedUserPTY(
                     AlanManagedUserPTYReadRequest(
                         sessionID: session.sessionID,
                         maxBytes: maxBytes
                     )
-                )
-            }) {
-            case .success(let chunk):
-                applyHelperOutputChunk(chunk)
+                ).map { chunk in
+                    let response = outputProcessor.process(chunk.data)
+                    let responseFailure: AlanPrivilegedHelperDiagnostic?
+                    if response.didRespond {
+                        let result = helperClient.writeManagedUserPTY(
+                            AlanManagedUserPTYInputRequest(
+                                sessionID: session.sessionID,
+                                data: response.ptyResponse
+                            )
+                        )
+                        responseFailure = result.accepted ? nil : result.diagnostic
+                    } else {
+                        responseFailure = nil
+                    }
+                    return AlanHelperManagedUserPtyProcessedOutput(
+                        chunk: chunk,
+                        rendererOutput: response.rendererOutput,
+                        shellActivityTransition: response.shellActivityTransition,
+                        responseFailure: responseFailure
+                    )
+                }
+            }
+            switch result {
+            case .success(let output):
+                applyHelperOutput(output)
+                if output.responseFailure != nil {
+                    return collected
+                }
+                let chunk = output.chunk
                 guard !chunk.data.isEmpty else { return collected }
-                collected.append(chunk.data)
+                collected.append(output.rendererOutput)
             case .failure(let diagnostic):
                 applyHelperOutputFailure(diagnostic)
                 return collected
@@ -444,13 +479,49 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
     fileprivate func applyPendingProxyOutput() {
         guard let rendererProxy else { return }
         let updates = rendererProxy.drainPendingOutputUpdates()
-        updates.chunks.forEach(applyHelperOutputChunk)
-        updates.failures.forEach(applyHelperOutputFailure)
-        updates.shellActivityStates.forEach(recordShellActivityState)
+        applyPendingProxyOutputUpdates(updates)
     }
 
     @MainActor
-    fileprivate func applyHelperOutputChunk(_ chunk: AlanManagedUserPTYOutputChunk) {
+    fileprivate func rendererProxyDidInvalidate(
+        _ invalidatedProxy: AlanHelperManagedUserPtyRendererProxy
+    ) {
+        guard rendererProxy === invalidatedProxy else { return }
+        let updates = invalidatedProxy.drainPendingOutputUpdates()
+        rendererProxy = nil
+        applyPendingProxyOutputUpdates(updates)
+    }
+
+    @MainActor
+    private func applyPendingProxyOutputUpdates(
+        _ updates: [AlanHelperManagedUserPtyPendingOutputUpdate]
+    ) {
+        for update in updates {
+            switch update {
+            case .output(let output):
+                applyHelperOutput(output)
+            case .failure(let diagnostic):
+                applyHelperOutputFailure(diagnostic)
+            }
+        }
+    }
+
+    @MainActor
+    private func applyHelperOutput(_ output: AlanHelperManagedUserPtyProcessedOutput) {
+        applyHelperOutputChunk(output.chunk, rendererOutput: output.rendererOutput)
+        if let transition = output.shellActivityTransition {
+            recordShellActivityState(transition)
+        }
+        if let responseFailure = output.responseFailure {
+            applyHelperOutputFailure(responseFailure)
+        }
+    }
+
+    @MainActor
+    fileprivate func applyHelperOutputChunk(
+        _ chunk: AlanManagedUserPTYOutputChunk,
+        rendererOutput: Data? = nil
+    ) {
         if chunk.final {
             observedFinalOutputChunk = true
             inputClosed = true
@@ -458,7 +529,7 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
             invalidateRendererProxy()
         }
         guard !chunk.data.isEmpty else { return }
-        let text = String(decoding: chunk.data, as: UTF8.self)
+        let text = String(decoding: rendererOutput ?? chunk.data, as: UTF8.self)
         transcriptRingBufferLines.append(contentsOf: transcriptLines(from: text))
         if transcriptRingBufferLines.count > TerminalTranscriptSnapshot.defaultMaxRows {
             transcriptRingBufferLines = Array(
@@ -495,22 +566,32 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
 
 }
 
+private struct AlanHelperManagedUserPtyProcessedOutput {
+    let chunk: AlanManagedUserPTYOutputChunk
+    let rendererOutput: Data
+    let shellActivityTransition: AlanTerminalPtyShellActivityState?
+    let responseFailure: AlanPrivilegedHelperDiagnostic?
+}
+
+private enum AlanHelperManagedUserPtyPendingOutputUpdate {
+    case output(AlanHelperManagedUserPtyProcessedOutput)
+    case failure(AlanPrivilegedHelperDiagnostic)
+}
+
 private final class AlanHelperManagedUserPtyRendererProxy {
     private weak var ptyHandle: AlanHelperManagedUserPtyHandle?
     private let helperClient: AlanPrivilegedHelperClienting
     private let sessionID: String
     private let hostFileDescriptor: Int32
     private let ioQueue: DispatchQueue
+    private let outputProcessor: AlanTerminalPtyControlSequenceProcessor
     private let invalidationLock = NSLock()
     private let pendingOutputLock = NSLock()
     private var rendererInputSource: DispatchSourceRead?
     private var helperOutputTimer: DispatchSourceTimer?
     private var rendererOutputWriteSource: DispatchSourceWrite?
-    private var controlSequenceResponder = AlanTerminalPtyControlSequenceResponder()
     private var isInvalidated = false
-    private var pendingOutputChunks: [AlanManagedUserPTYOutputChunk] = []
-    private var pendingOutputFailures: [AlanPrivilegedHelperDiagnostic] = []
-    private var pendingShellActivityStates: [AlanTerminalPtyShellActivityState] = []
+    private var pendingOutputUpdates: [AlanHelperManagedUserPtyPendingOutputUpdate] = []
     private var pendingRendererOutput = Data()
 
     init(
@@ -518,13 +599,15 @@ private final class AlanHelperManagedUserPtyRendererProxy {
         helperClient: AlanPrivilegedHelperClienting,
         sessionID: String,
         hostFileDescriptor: Int32,
-        ioQueue: DispatchQueue
+        ioQueue: DispatchQueue,
+        outputProcessor: AlanTerminalPtyControlSequenceProcessor
     ) {
         self.ptyHandle = ptyHandle
         self.helperClient = helperClient
         self.sessionID = sessionID
         self.hostFileDescriptor = hostFileDescriptor
         self.ioQueue = ioQueue
+        self.outputProcessor = outputProcessor
     }
 
     deinit {
@@ -563,9 +646,13 @@ private final class AlanHelperManagedUserPtyRendererProxy {
         rendererOutputWriteSource?.cancel()
         rendererOutputWriteSource = nil
         pendingRendererOutput.removeAll()
+        Task { @MainActor [weak self, weak ptyHandle] in
+            guard let self else { return }
+            ptyHandle?.rendererProxyDidInvalidate(self)
+        }
     }
 
-    private var invalidated: Bool {
+    fileprivate var invalidated: Bool {
         invalidationLock.lock()
         defer { invalidationLock.unlock() }
         return isInvalidated
@@ -579,25 +666,17 @@ private final class AlanHelperManagedUserPtyRendererProxy {
         return true
     }
 
-    fileprivate func drainPendingOutputUpdates() -> (
-        chunks: [AlanManagedUserPTYOutputChunk],
-        failures: [AlanPrivilegedHelperDiagnostic],
-        shellActivityStates: [AlanTerminalPtyShellActivityState]
-    ) {
+    fileprivate func drainPendingOutputUpdates() -> [AlanHelperManagedUserPtyPendingOutputUpdate] {
         pendingOutputLock.lock()
         defer { pendingOutputLock.unlock() }
-        let chunks = pendingOutputChunks
-        let failures = pendingOutputFailures
-        let shellActivityStates = pendingShellActivityStates
-        pendingOutputChunks.removeAll()
-        pendingOutputFailures.removeAll()
-        pendingShellActivityStates.removeAll()
-        return (chunks, failures, shellActivityStates)
+        let updates = pendingOutputUpdates
+        pendingOutputUpdates.removeAll()
+        return updates
     }
 
-    private func enqueueOutputChunk(_ chunk: AlanManagedUserPTYOutputChunk) {
+    private func enqueueOutputUpdate(_ update: AlanHelperManagedUserPtyPendingOutputUpdate) {
         pendingOutputLock.lock()
-        pendingOutputChunks.append(chunk)
+        pendingOutputUpdates.append(update)
         pendingOutputLock.unlock()
         Task { @MainActor [weak self] in
             self?.ptyHandle?.applyPendingProxyOutput()
@@ -605,21 +684,7 @@ private final class AlanHelperManagedUserPtyRendererProxy {
     }
 
     private func enqueueOutputFailure(_ diagnostic: AlanPrivilegedHelperDiagnostic) {
-        pendingOutputLock.lock()
-        pendingOutputFailures.append(diagnostic)
-        pendingOutputLock.unlock()
-        Task { @MainActor [weak self] in
-            self?.ptyHandle?.applyPendingProxyOutput()
-        }
-    }
-
-    private func enqueueShellActivityState(_ state: AlanTerminalPtyShellActivityState) {
-        pendingOutputLock.lock()
-        pendingShellActivityStates.append(state)
-        pendingOutputLock.unlock()
-        Task { @MainActor [weak self] in
-            self?.ptyHandle?.applyPendingProxyOutput()
-        }
+        enqueueOutputUpdate(.failure(diagnostic))
     }
 
     private func drainRendererInput() {
@@ -658,11 +723,34 @@ private final class AlanHelperManagedUserPtyRendererProxy {
             )
             let output: Data
             let isFinal: Bool
+            let response: AlanTerminalPtyControlSequenceResponse
+            let responseFailure: AlanPrivilegedHelperDiagnostic?
             switch readResult {
             case .success(let chunk):
                 output = chunk.data
                 isFinal = chunk.final
-                enqueueOutputChunk(chunk)
+                response = outputProcessor.process(output)
+                if response.didRespond {
+                    let result = helperClient.writeManagedUserPTY(
+                        AlanManagedUserPTYInputRequest(
+                            sessionID: sessionID,
+                            data: response.ptyResponse
+                        )
+                    )
+                    responseFailure = result.accepted ? nil : result.diagnostic
+                } else {
+                    responseFailure = nil
+                }
+                enqueueOutputUpdate(
+                    .output(
+                        AlanHelperManagedUserPtyProcessedOutput(
+                            chunk: chunk,
+                            rendererOutput: response.rendererOutput,
+                            shellActivityTransition: response.shellActivityTransition,
+                            responseFailure: responseFailure
+                        )
+                    )
+                )
             case .failure(let diagnostic):
                 enqueueOutputFailure(diagnostic)
                 invalidate()
@@ -675,11 +763,7 @@ private final class AlanHelperManagedUserPtyRendererProxy {
                 return
             }
 
-            let response = controlSequenceResponder.process(output)
-            if let transition = response.shellActivityTransition {
-                enqueueShellActivityState(transition)
-            }
-            if response.didRespond, !writeHelperInput(response.ptyResponse) {
+            if responseFailure != nil {
                 invalidate()
                 return
             }

--- a/clients/apple/alan-macos/Services/Terminal/ManagedUserTerminalPtyRuntime.swift
+++ b/clients/apple/alan-macos/Services/Terminal/ManagedUserTerminalPtyRuntime.swift
@@ -447,9 +447,7 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
         }
         refreshExitObservation()
         if exitStatus == nil {
-            inputClosed = true
-            phase = .exited
-            exitStatus = .unknown
+            transitionToExited(.unknown)
         }
         return .accepted("terminated")
     }
@@ -459,19 +457,29 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
         guard let observation = helperClient.observeManagedUserPTYExit(sessionID: session.sessionID) else {
             return
         }
+        let observedExitStatus: AlanTerminalProcessExitStatus?
         if let code = observation.exitCode {
-            exitStatus = .exitCode(code)
+            observedExitStatus = .exitCode(code)
         } else if let signal = observation.terminatingSignal {
-            exitStatus = .signal(signal)
+            observedExitStatus = .signal(signal)
         } else if observation.final {
-            exitStatus = .unknown
+            observedExitStatus = .unknown
+        } else {
+            observedExitStatus = nil
         }
-        if exitStatus != nil {
-            inputClosed = true
-            phase = .exited
-            outputPump?.invalidate()
-            invalidateRendererProxy()
+        guard let observedExitStatus else { return }
+        transitionToExited(observedExitStatus)
+    }
+
+    private func transitionToExited(_ observedExitStatus: AlanTerminalProcessExitStatus) {
+        if let outputPump {
+            applyOutputUpdates(outputPump.stopAndTakePendingUpdates())
         }
+        exitStatus = observedExitStatus
+        inputClosed = true
+        phase = .exited
+        recordShellActivityState(.shellInput)
+        invalidateRendererProxy()
     }
 
     @discardableResult
@@ -544,6 +552,9 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
         }
         if let responseFailure = output.responseFailure {
             applyHelperOutputFailure(responseFailure)
+        }
+        if output.chunk.final {
+            recordShellActivityState(.shellInput)
         }
     }
 
@@ -739,6 +750,13 @@ fileprivate final class AlanHelperManagedUserPtyOutputPump {
     func takePendingUpdates() -> [AlanHelperManagedUserPtyPendingOutputUpdate] {
         ioQueue.sync {
             takePendingUpdatesOnQueue()
+        }
+    }
+
+    func stopAndTakePendingUpdates() -> [AlanHelperManagedUserPtyPendingOutputUpdate] {
+        ioQueue.sync {
+            stopOnQueue()
+            return takePendingUpdatesOnQueue()
         }
     }
 

--- a/clients/apple/alan-macos/Services/Terminal/ManagedUserTerminalPtyRuntime.swift
+++ b/clients/apple/alan-macos/Services/Terminal/ManagedUserTerminalPtyRuntime.swift
@@ -90,6 +90,8 @@ final class AlanUnavailableManagedUserPtyHandle: AlanTerminalPtyHandle {
     let contentID: String
     let bootRequest: AlanTerminalBootRequest
     private let reason: String
+    let shellActivityState: AlanTerminalPtyShellActivityState = .unknown
+    var onShellActivityStateChange: ((AlanTerminalPtyShellActivityState) -> Void)?
 
     init(
         contentID: String,
@@ -161,6 +163,8 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
     private var rendererProxy: AlanHelperManagedUserPtyRendererProxy?
     private var observedFinalOutputChunk = false
     private let helperQueue: DispatchQueue
+    private(set) var shellActivityState: AlanTerminalPtyShellActivityState = .unknown
+    var onShellActivityStateChange: ((AlanTerminalPtyShellActivityState) -> Void)?
 
     init(
         contentID: String,
@@ -442,6 +446,7 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
         let updates = rendererProxy.drainPendingOutputUpdates()
         updates.chunks.forEach(applyHelperOutputChunk)
         updates.failures.forEach(applyHelperOutputFailure)
+        updates.shellActivityStates.forEach(recordShellActivityState)
     }
 
     @MainActor
@@ -477,6 +482,12 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
         acceptedInputBytes += byteCount
     }
 
+    fileprivate func recordShellActivityState(_ state: AlanTerminalPtyShellActivityState) {
+        guard state != shellActivityState else { return }
+        shellActivityState = state
+        onShellActivityStateChange?(state)
+    }
+
     private func invalidateRendererProxy() {
         rendererProxy?.invalidate()
         rendererProxy = nil
@@ -499,6 +510,7 @@ private final class AlanHelperManagedUserPtyRendererProxy {
     private var isInvalidated = false
     private var pendingOutputChunks: [AlanManagedUserPTYOutputChunk] = []
     private var pendingOutputFailures: [AlanPrivilegedHelperDiagnostic] = []
+    private var pendingShellActivityStates: [AlanTerminalPtyShellActivityState] = []
     private var pendingRendererOutput = Data()
 
     init(
@@ -569,15 +581,18 @@ private final class AlanHelperManagedUserPtyRendererProxy {
 
     fileprivate func drainPendingOutputUpdates() -> (
         chunks: [AlanManagedUserPTYOutputChunk],
-        failures: [AlanPrivilegedHelperDiagnostic]
+        failures: [AlanPrivilegedHelperDiagnostic],
+        shellActivityStates: [AlanTerminalPtyShellActivityState]
     ) {
         pendingOutputLock.lock()
         defer { pendingOutputLock.unlock() }
         let chunks = pendingOutputChunks
         let failures = pendingOutputFailures
+        let shellActivityStates = pendingShellActivityStates
         pendingOutputChunks.removeAll()
         pendingOutputFailures.removeAll()
-        return (chunks, failures)
+        pendingShellActivityStates.removeAll()
+        return (chunks, failures, shellActivityStates)
     }
 
     private func enqueueOutputChunk(_ chunk: AlanManagedUserPTYOutputChunk) {
@@ -592,6 +607,15 @@ private final class AlanHelperManagedUserPtyRendererProxy {
     private func enqueueOutputFailure(_ diagnostic: AlanPrivilegedHelperDiagnostic) {
         pendingOutputLock.lock()
         pendingOutputFailures.append(diagnostic)
+        pendingOutputLock.unlock()
+        Task { @MainActor [weak self] in
+            self?.ptyHandle?.applyPendingProxyOutput()
+        }
+    }
+
+    private func enqueueShellActivityState(_ state: AlanTerminalPtyShellActivityState) {
+        pendingOutputLock.lock()
+        pendingShellActivityStates.append(state)
         pendingOutputLock.unlock()
         Task { @MainActor [weak self] in
             self?.ptyHandle?.applyPendingProxyOutput()
@@ -652,6 +676,9 @@ private final class AlanHelperManagedUserPtyRendererProxy {
             }
 
             let response = controlSequenceResponder.process(output)
+            if let transition = response.shellActivityTransition {
+                enqueueShellActivityState(transition)
+            }
             if response.didRespond, !writeHelperInput(response.ptyResponse) {
                 invalidate()
                 return

--- a/clients/apple/alan-macos/Services/Terminal/ManagedUserTerminalPtyRuntime.swift
+++ b/clients/apple/alan-macos/Services/Terminal/ManagedUserTerminalPtyRuntime.swift
@@ -148,6 +148,7 @@ final class AlanUnavailableManagedUserPtyHandle: AlanTerminalPtyHandle {
 
 @MainActor
 final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
+    private let maxPendingRendererReplayBytes = 1024 * 1024
     let contentID: String
     let bootRequest: AlanTerminalBootRequest
     let helperClient: AlanPrivilegedHelperClienting
@@ -164,6 +165,11 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
     private var observedFinalOutputChunk = false
     private let helperQueue: DispatchQueue
     private let outputProcessor = AlanTerminalPtyControlSequenceProcessor()
+    private var outputPump: AlanHelperManagedUserPtyOutputPump?
+    private var semanticShellActivityState: AlanTerminalPtyShellActivityState?
+    private var processGroupShellActivityState: AlanTerminalPtyShellActivityState?
+    private var pendingRendererReplayChunks: [Data] = []
+    private var pendingRendererReplayBytes = 0
     private(set) var shellActivityState: AlanTerminalPtyShellActivityState = .unknown
     var onShellActivityStateChange: ((AlanTerminalPtyShellActivityState) -> Void)?
 
@@ -183,20 +189,28 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
             label: "dev.alan.terminal.managed-user-pty.\(contentID)",
             qos: .userInteractive
         )
+        let outputPump = AlanHelperManagedUserPtyOutputPump(
+            ptyHandle: self,
+            helperClient: helperClient,
+            sessionID: session.sessionID,
+            ioQueue: helperQueue,
+            outputProcessor: outputProcessor
+        )
+        self.outputPump = outputPump
+        outputPump.start()
     }
 
     deinit {
+        outputPump?.invalidate()
         rendererProxy?.invalidate()
     }
 
     var snapshot: AlanTerminalPtyRuntimeSnapshot {
-        applyPendingProxyOutput()
+        applyPendingOutput()
         if let rendererProxy, rendererProxy.invalidated {
             rendererProxyDidInvalidate(rendererProxy)
         }
-        if rendererProxy == nil {
-            _ = drainAvailableOutput()
-        }
+        _ = drainAvailableOutput()
         refreshExitObservation()
         if observedFinalOutputChunk, exitStatus == nil {
             exitStatus = .unknown
@@ -364,16 +378,48 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
         setNoSigpipeSocketOption(descriptors[0])
         setNoSigpipeSocketOption(descriptors[1])
 
+        guard let outputPump else {
+            close(descriptors[0])
+            close(descriptors[1])
+            return .rejected(
+                .rejected(
+                    "managed_user_helper_pty_unavailable",
+                    message: "Managed User helper PTY output service is unavailable."
+                )
+            )
+        }
         let proxy = AlanHelperManagedUserPtyRendererProxy(
             ptyHandle: self,
             helperClient: helperClient,
             sessionID: session.sessionID,
             hostFileDescriptor: descriptors[0],
-            ioQueue: helperQueue,
-            outputProcessor: outputProcessor
+            ioQueue: helperQueue
         )
-        rendererProxy = proxy
-        proxy.start()
+        let preparation = outputPump.attachRendererProxy(
+            proxy,
+            replayChunks: pendingRendererReplayChunks,
+            maxBytes: 4096
+        )
+        if preparation.attached {
+            rendererProxy = proxy
+            pendingRendererReplayChunks.removeAll()
+            pendingRendererReplayBytes = 0
+        }
+        applyOutputUpdates(preparation.updates)
+        guard preparation.attached,
+              exitStatus == nil,
+              phase == .running || phase == .inputClosed,
+              !proxy.invalidated
+        else {
+            proxy.invalidate()
+            close(descriptors[1])
+            return .rejected(
+                .rejected(
+                    "managed_user_helper_renderer_attachment_failed",
+                    message: "Managed User helper renderer attachment failed."
+                )
+            )
+        }
 
         return .attached(
             AlanTerminalPtyRendererAttachment(
@@ -421,65 +467,58 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
         if exitStatus != nil {
             inputClosed = true
             phase = .exited
+            outputPump?.invalidate()
             invalidateRendererProxy()
         }
     }
 
     @discardableResult
     fileprivate func drainAvailableOutput(maxBytes: Int = 4096) -> Data {
-        guard rendererProxy == nil, exitStatus == nil else { return Data() }
-        var collected = Data()
+        guard exitStatus == nil, let outputPump else {
+            return Data()
+        }
+        return applyOutputUpdates(
+            outputPump.pollSynchronously(maxBytes: maxBytes)
+        )
+    }
 
-        while true {
-            let result = helperQueue.sync {
-                helperClient.readManagedUserPTY(
-                    AlanManagedUserPTYReadRequest(
-                        sessionID: session.sessionID,
-                        maxBytes: maxBytes
-                    )
-                ).map { chunk in
-                    let response = outputProcessor.process(chunk.data)
-                    let responseFailure: AlanPrivilegedHelperDiagnostic?
-                    if response.didRespond {
-                        let result = helperClient.writeManagedUserPTY(
-                            AlanManagedUserPTYInputRequest(
-                                sessionID: session.sessionID,
-                                data: response.ptyResponse
-                            )
-                        )
-                        responseFailure = result.accepted ? nil : result.diagnostic
-                    } else {
-                        responseFailure = nil
-                    }
-                    return AlanHelperManagedUserPtyProcessedOutput(
-                        chunk: chunk,
-                        rendererOutput: response.rendererOutput,
-                        shellActivityTransition: response.shellActivityTransition,
-                        responseFailure: responseFailure
-                    )
-                }
-            }
-            switch result {
-            case .success(let output):
+    @discardableResult
+    fileprivate func applyOutputUpdates(
+        _ updates: [AlanHelperManagedUserPtyPendingOutputUpdate]
+    ) -> Data {
+        var collected = Data()
+        for update in updates {
+            switch update {
+            case .output(let output, let routedToRenderer):
                 applyHelperOutput(output)
-                if output.responseFailure != nil {
-                    return collected
+                if !routedToRenderer {
+                    appendPendingRendererReplay(output.rendererOutput)
                 }
-                let chunk = output.chunk
-                guard !chunk.data.isEmpty else { return collected }
                 collected.append(output.rendererOutput)
             case .failure(let diagnostic):
                 applyHelperOutputFailure(diagnostic)
-                return collected
             }
+        }
+        return collected
+    }
+
+    private func appendPendingRendererReplay(_ data: Data) {
+        guard !data.isEmpty else { return }
+        pendingRendererReplayChunks.append(data)
+        pendingRendererReplayBytes += data.count
+        while pendingRendererReplayBytes > maxPendingRendererReplayBytes,
+              pendingRendererReplayChunks.count > 1
+        {
+            pendingRendererReplayBytes -= pendingRendererReplayChunks.removeFirst().count
         }
     }
 
-    @MainActor
-    fileprivate func applyPendingProxyOutput() {
-        guard let rendererProxy else { return }
-        let updates = rendererProxy.drainPendingOutputUpdates()
-        applyPendingProxyOutputUpdates(updates)
+    fileprivate func applyPendingOutput(
+        from pendingOutputPump: AlanHelperManagedUserPtyOutputPump? = nil
+    ) {
+        if let pendingOutputPump, outputPump !== pendingOutputPump { return }
+        guard let outputPump else { return }
+        applyOutputUpdates(outputPump.takePendingUpdates())
     }
 
     @MainActor
@@ -487,30 +526,26 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
         _ invalidatedProxy: AlanHelperManagedUserPtyRendererProxy
     ) {
         guard rendererProxy === invalidatedProxy else { return }
-        let updates = invalidatedProxy.drainPendingOutputUpdates()
+        appendPendingRendererReplay(
+            invalidatedProxy.takeInvalidationHandoffOutput()
+        )
         rendererProxy = nil
-        applyPendingProxyOutputUpdates(updates)
-    }
-
-    @MainActor
-    private func applyPendingProxyOutputUpdates(
-        _ updates: [AlanHelperManagedUserPtyPendingOutputUpdate]
-    ) {
-        for update in updates {
-            switch update {
-            case .output(let output):
-                applyHelperOutput(output)
-            case .failure(let diagnostic):
-                applyHelperOutputFailure(diagnostic)
-            }
-        }
+        outputPump?.setRendererProxy(nil)
     }
 
     @MainActor
     private func applyHelperOutput(_ output: AlanHelperManagedUserPtyProcessedOutput) {
         applyHelperOutputChunk(output.chunk, rendererOutput: output.rendererOutput)
         if let transition = output.shellActivityTransition {
-            recordShellActivityState(transition)
+            recordSemanticShellActivityState(transition)
+        }
+        switch output.chunk.foregroundProcessGroupState {
+        case .shell:
+            recordProcessGroupShellActivityState(.shellInput)
+        case .foreground:
+            recordProcessGroupShellActivityState(.foregroundCommand)
+        case .unavailable:
+            break
         }
         if let responseFailure = output.responseFailure {
             applyHelperOutputFailure(responseFailure)
@@ -544,6 +579,7 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
         inputClosed = true
         phase = .failed
         exitStatus = .unknown
+        outputPump?.invalidate()
         invalidateRendererProxy()
         transcriptRingBufferLines.append(diagnostic.sanitizedMessage)
     }
@@ -553,59 +589,130 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
         acceptedInputBytes += byteCount
     }
 
-    fileprivate func recordShellActivityState(_ state: AlanTerminalPtyShellActivityState) {
+    private func recordSemanticShellActivityState(
+        _ state: AlanTerminalPtyShellActivityState
+    ) {
+        semanticShellActivityState = state
+        reconcileShellActivityState()
+    }
+
+    private func recordProcessGroupShellActivityState(
+        _ state: AlanTerminalPtyShellActivityState
+    ) {
+        processGroupShellActivityState = state
+        reconcileShellActivityState()
+    }
+
+    private func reconcileShellActivityState() {
+        let state: AlanTerminalPtyShellActivityState
+        if semanticShellActivityState == .foregroundCommand
+            || processGroupShellActivityState == .foregroundCommand
+        {
+            state = .foregroundCommand
+        } else if semanticShellActivityState == .shellInput
+            || processGroupShellActivityState == .shellInput
+        {
+            state = .shellInput
+        } else {
+            state = .unknown
+        }
+        recordShellActivityState(state)
+    }
+
+    private func recordShellActivityState(_ state: AlanTerminalPtyShellActivityState) {
         guard state != shellActivityState else { return }
         shellActivityState = state
         onShellActivityStateChange?(state)
     }
 
     private func invalidateRendererProxy() {
-        rendererProxy?.invalidate()
-        rendererProxy = nil
+        guard let rendererProxy else {
+            outputPump?.setRendererProxy(nil)
+            return
+        }
+        rendererProxy.invalidate()
+        rendererProxyDidInvalidate(rendererProxy)
     }
 
 }
 
-private struct AlanHelperManagedUserPtyProcessedOutput {
+fileprivate struct AlanHelperManagedUserPtyProcessedOutput {
     let chunk: AlanManagedUserPTYOutputChunk
     let rendererOutput: Data
     let shellActivityTransition: AlanTerminalPtyShellActivityState?
     let responseFailure: AlanPrivilegedHelperDiagnostic?
 }
 
-private enum AlanHelperManagedUserPtyPendingOutputUpdate {
-    case output(AlanHelperManagedUserPtyProcessedOutput)
+fileprivate enum AlanHelperManagedUserPtyPendingOutputUpdate {
+    case output(
+        AlanHelperManagedUserPtyProcessedOutput,
+        routedToRenderer: Bool
+    )
     case failure(AlanPrivilegedHelperDiagnostic)
 }
 
-private final class AlanHelperManagedUserPtyRendererProxy {
+fileprivate struct AlanHelperManagedUserPtyRendererPreparation {
+    let attached: Bool
+    let updates: [AlanHelperManagedUserPtyPendingOutputUpdate]
+}
+
+private func readHelperManagedUserPtyProcessedOutput(
+    helperClient: AlanPrivilegedHelperClienting,
+    sessionID: String,
+    maxBytes: Int,
+    outputProcessor: AlanTerminalPtyControlSequenceProcessor
+) -> Result<AlanHelperManagedUserPtyProcessedOutput, AlanPrivilegedHelperDiagnostic> {
+    helperClient.readManagedUserPTY(
+        AlanManagedUserPTYReadRequest(
+            sessionID: sessionID,
+            maxBytes: maxBytes
+        )
+    ).map { chunk in
+        let response = outputProcessor.process(chunk.data)
+        let responseFailure: AlanPrivilegedHelperDiagnostic?
+        if response.didRespond {
+            let result = helperClient.writeManagedUserPTY(
+                AlanManagedUserPTYInputRequest(
+                    sessionID: sessionID,
+                    data: response.ptyResponse
+                )
+            )
+            responseFailure = result.accepted ? nil : result.diagnostic
+        } else {
+            responseFailure = nil
+        }
+        return AlanHelperManagedUserPtyProcessedOutput(
+            chunk: chunk,
+            rendererOutput: response.rendererOutput,
+            shellActivityTransition: response.shellActivityTransition,
+            responseFailure: responseFailure
+        )
+    }
+}
+
+fileprivate final class AlanHelperManagedUserPtyOutputPump {
     private weak var ptyHandle: AlanHelperManagedUserPtyHandle?
     private let helperClient: AlanPrivilegedHelperClienting
     private let sessionID: String
-    private let hostFileDescriptor: Int32
     private let ioQueue: DispatchQueue
     private let outputProcessor: AlanTerminalPtyControlSequenceProcessor
-    private let invalidationLock = NSLock()
-    private let pendingOutputLock = NSLock()
-    private var rendererInputSource: DispatchSourceRead?
-    private var helperOutputTimer: DispatchSourceTimer?
-    private var rendererOutputWriteSource: DispatchSourceWrite?
-    private var isInvalidated = false
-    private var pendingOutputUpdates: [AlanHelperManagedUserPtyPendingOutputUpdate] = []
-    private var pendingRendererOutput = Data()
+    private var timer: DispatchSourceTimer?
+    private var pendingUpdates: [AlanHelperManagedUserPtyPendingOutputUpdate] = []
+    private var publishScheduled = false
+    private var lastForegroundProcessGroupState:
+        AlanManagedUserPTYForegroundProcessGroupState = .unavailable
+    private weak var rendererProxy: AlanHelperManagedUserPtyRendererProxy?
 
     init(
         ptyHandle: AlanHelperManagedUserPtyHandle,
         helperClient: AlanPrivilegedHelperClienting,
         sessionID: String,
-        hostFileDescriptor: Int32,
         ioQueue: DispatchQueue,
         outputProcessor: AlanTerminalPtyControlSequenceProcessor
     ) {
         self.ptyHandle = ptyHandle
         self.helperClient = helperClient
         self.sessionID = sessionID
-        self.hostFileDescriptor = hostFileDescriptor
         self.ioQueue = ioQueue
         self.outputProcessor = outputProcessor
     }
@@ -615,6 +722,223 @@ private final class AlanHelperManagedUserPtyRendererProxy {
     }
 
     func start() {
+        ioQueue.sync {
+            guard timer == nil else { return }
+            let timer = DispatchSource.makeTimerSource(queue: ioQueue)
+            timer.schedule(deadline: .now(), repeating: .milliseconds(30))
+            timer.setEventHandler { [weak self] in
+                self?.pollAndPublishOnQueue(maxBytes: 4096)
+            }
+            timer.resume()
+            self.timer = timer
+        }
+    }
+
+    func pollSynchronously(
+        maxBytes: Int
+    ) -> [AlanHelperManagedUserPtyPendingOutputUpdate] {
+        ioQueue.sync {
+            pollOnQueue(maxBytes: maxBytes)
+            return takePendingUpdatesOnQueue()
+        }
+    }
+
+    func takePendingUpdates() -> [AlanHelperManagedUserPtyPendingOutputUpdate] {
+        ioQueue.sync {
+            takePendingUpdatesOnQueue()
+        }
+    }
+
+    func setRendererProxy(_ rendererProxy: AlanHelperManagedUserPtyRendererProxy?) {
+        ioQueue.sync {
+            self.rendererProxy = rendererProxy
+        }
+    }
+
+    func attachRendererProxy(
+        _ rendererProxy: AlanHelperManagedUserPtyRendererProxy,
+        replayChunks: [Data],
+        maxBytes: Int
+    ) -> AlanHelperManagedUserPtyRendererPreparation {
+        ioQueue.sync {
+            pollOnQueue(maxBytes: maxBytes)
+            let updates = takePendingUpdatesOnQueue()
+            rendererProxy.startOnOutputPumpQueue()
+
+            for chunk in replayChunks {
+                let route = rendererProxy.routeRendererOutputFromOutputPump(chunk)
+                guard route.accepted, route.healthy else {
+                    rendererProxy.invalidate()
+                    return AlanHelperManagedUserPtyRendererPreparation(
+                        attached: false,
+                        updates: updates
+                    )
+                }
+            }
+            var preparedUpdates: [AlanHelperManagedUserPtyPendingOutputUpdate] = []
+            for update in updates {
+                guard case .output(let output, _) = update,
+                      !output.rendererOutput.isEmpty
+                else {
+                    preparedUpdates.append(update)
+                    continue
+                }
+                let route = rendererProxy.routeRendererOutputFromOutputPump(
+                    output.rendererOutput
+                )
+                guard route.accepted, route.healthy else {
+                    rendererProxy.invalidate()
+                    return AlanHelperManagedUserPtyRendererPreparation(
+                        attached: false,
+                        updates: updates
+                    )
+                }
+                preparedUpdates.append(
+                    .output(output, routedToRenderer: true)
+                )
+            }
+            self.rendererProxy = rendererProxy
+            return AlanHelperManagedUserPtyRendererPreparation(
+                attached: true,
+                updates: preparedUpdates
+            )
+        }
+    }
+
+    func invalidate() {
+        ioQueue.sync {
+            timer?.cancel()
+            timer = nil
+            pendingUpdates.removeAll()
+            publishScheduled = false
+        }
+    }
+
+    private func pollAndPublishOnQueue(maxBytes: Int) {
+        pollOnQueue(maxBytes: maxBytes)
+        guard !pendingUpdates.isEmpty, !publishScheduled else { return }
+        publishScheduled = true
+        DispatchQueue.main.async { [weak self, weak ptyHandle] in
+            guard let self else { return }
+            ptyHandle?.applyPendingOutput(from: self)
+        }
+    }
+
+    private func pollOnQueue(maxBytes: Int) {
+        var remainingBytes = 64 * 1024
+        while remainingBytes > 0 {
+            switch readHelperManagedUserPtyProcessedOutput(
+                helperClient: helperClient,
+                sessionID: sessionID,
+                maxBytes: min(max(1, maxBytes), remainingBytes),
+                outputProcessor: outputProcessor
+            ) {
+            case .success(let output):
+                remainingBytes -= min(remainingBytes, output.chunk.data.count)
+                var routedToRenderer = false
+                if !output.rendererOutput.isEmpty,
+                   let rendererProxy
+                {
+                    let route = rendererProxy.routeRendererOutputFromOutputPump(
+                        output.rendererOutput
+                    )
+                    routedToRenderer = route.accepted
+                    if !route.healthy {
+                        rendererProxy.invalidate()
+                        self.rendererProxy = nil
+                    }
+                }
+                let processGroupChanged =
+                    output.chunk.foregroundProcessGroupState != .unavailable
+                    && output.chunk.foregroundProcessGroupState
+                        != lastForegroundProcessGroupState
+                if output.chunk.foregroundProcessGroupState != .unavailable {
+                    lastForegroundProcessGroupState =
+                        output.chunk.foregroundProcessGroupState
+                }
+                if !output.chunk.data.isEmpty
+                    || output.chunk.final
+                    || output.responseFailure != nil
+                    || processGroupChanged
+                {
+                    pendingUpdates.append(
+                        .output(
+                            output,
+                            routedToRenderer: routedToRenderer
+                        )
+                    )
+                }
+                guard !output.chunk.data.isEmpty,
+                      output.responseFailure == nil,
+                      !output.chunk.final
+                else {
+                    if output.chunk.final || output.responseFailure != nil {
+                        stopOnQueue()
+                    }
+                    return
+                }
+            case .failure(let diagnostic):
+                pendingUpdates.append(.failure(diagnostic))
+                stopOnQueue()
+                return
+            }
+        }
+    }
+
+    private func takePendingUpdatesOnQueue() -> [AlanHelperManagedUserPtyPendingOutputUpdate] {
+        let updates = pendingUpdates
+        pendingUpdates.removeAll()
+        publishScheduled = false
+        return updates
+    }
+
+    private func stopOnQueue() {
+        timer?.cancel()
+        timer = nil
+    }
+}
+
+fileprivate final class AlanHelperManagedUserPtyRendererProxy {
+    fileprivate struct OutputRoute {
+        let accepted: Bool
+        let healthy: Bool
+    }
+
+    private weak var ptyHandle: AlanHelperManagedUserPtyHandle?
+    private let helperClient: AlanPrivilegedHelperClienting
+    private let sessionID: String
+    private let hostFileDescriptor: Int32
+    private let ioQueue: DispatchQueue
+    private let ioQueueKey = DispatchSpecificKey<UInt8>()
+    private let invalidationLock = NSLock()
+    private var rendererInputSource: DispatchSourceRead?
+    private var rendererOutputWriteSource: DispatchSourceWrite?
+    private var isInvalidated = false
+    private var pendingRendererOutput = Data()
+    private var invalidationHandoffOutput = Data()
+
+    init(
+        ptyHandle: AlanHelperManagedUserPtyHandle,
+        helperClient: AlanPrivilegedHelperClienting,
+        sessionID: String,
+        hostFileDescriptor: Int32,
+        ioQueue: DispatchQueue
+    ) {
+        self.ptyHandle = ptyHandle
+        self.helperClient = helperClient
+        self.sessionID = sessionID
+        self.hostFileDescriptor = hostFileDescriptor
+        self.ioQueue = ioQueue
+        ioQueue.setSpecific(key: ioQueueKey, value: 1)
+    }
+
+    deinit {
+        invalidate()
+    }
+
+    fileprivate func startOnOutputPumpQueue() {
+        dispatchPrecondition(condition: .onQueue(ioQueue))
+        guard !invalidated else { return }
         let inputSource = DispatchSource.makeReadSource(
             fileDescriptor: hostFileDescriptor,
             queue: ioQueue
@@ -625,27 +949,20 @@ private final class AlanHelperManagedUserPtyRendererProxy {
         inputSource.setCancelHandler { [hostFileDescriptor] in
             close(hostFileDescriptor)
         }
-        inputSource.resume()
         rendererInputSource = inputSource
-
-        let timer = DispatchSource.makeTimerSource(queue: ioQueue)
-        timer.schedule(deadline: .now(), repeating: .milliseconds(30))
-        timer.setEventHandler { [weak self] in
-            self?.pollHelperOutput()
-        }
-        timer.resume()
-        helperOutputTimer = timer
+        inputSource.resume()
     }
 
     func invalidate() {
         guard markInvalidated() else { return }
-        rendererInputSource?.cancel()
-        rendererInputSource = nil
-        helperOutputTimer?.cancel()
-        helperOutputTimer = nil
-        rendererOutputWriteSource?.cancel()
-        rendererOutputWriteSource = nil
-        pendingRendererOutput.removeAll()
+        performOnIOQueue {
+            rendererInputSource?.cancel()
+            rendererInputSource = nil
+            rendererOutputWriteSource?.cancel()
+            rendererOutputWriteSource = nil
+            invalidationHandoffOutput.append(pendingRendererOutput)
+            pendingRendererOutput.removeAll()
+        }
         Task { @MainActor [weak self, weak ptyHandle] in
             guard let self else { return }
             ptyHandle?.rendererProxyDidInvalidate(self)
@@ -666,25 +983,21 @@ private final class AlanHelperManagedUserPtyRendererProxy {
         return true
     }
 
-    fileprivate func drainPendingOutputUpdates() -> [AlanHelperManagedUserPtyPendingOutputUpdate] {
-        pendingOutputLock.lock()
-        defer { pendingOutputLock.unlock() }
-        let updates = pendingOutputUpdates
-        pendingOutputUpdates.removeAll()
-        return updates
-    }
-
-    private func enqueueOutputUpdate(_ update: AlanHelperManagedUserPtyPendingOutputUpdate) {
-        pendingOutputLock.lock()
-        pendingOutputUpdates.append(update)
-        pendingOutputLock.unlock()
-        Task { @MainActor [weak self] in
-            self?.ptyHandle?.applyPendingProxyOutput()
+    private func performOnIOQueue(_ operation: () -> Void) {
+        if DispatchQueue.getSpecific(key: ioQueueKey) != nil {
+            operation()
+        } else {
+            ioQueue.sync(execute: operation)
         }
     }
 
-    private func enqueueOutputFailure(_ diagnostic: AlanPrivilegedHelperDiagnostic) {
-        enqueueOutputUpdate(.failure(diagnostic))
+    fileprivate func takeInvalidationHandoffOutput() -> Data {
+        var output = Data()
+        performOnIOQueue {
+            output = invalidationHandoffOutput
+            invalidationHandoffOutput.removeAll()
+        }
+        return output
     }
 
     private func drainRendererInput() {
@@ -712,73 +1025,6 @@ private final class AlanHelperManagedUserPtyRendererProxy {
         }
     }
 
-    private func pollHelperOutput() {
-        guard !invalidated else { return }
-        while true {
-            let readResult = helperClient.readManagedUserPTY(
-                AlanManagedUserPTYReadRequest(
-                    sessionID: sessionID,
-                    maxBytes: 4096
-                )
-            )
-            let output: Data
-            let isFinal: Bool
-            let response: AlanTerminalPtyControlSequenceResponse
-            let responseFailure: AlanPrivilegedHelperDiagnostic?
-            switch readResult {
-            case .success(let chunk):
-                output = chunk.data
-                isFinal = chunk.final
-                response = outputProcessor.process(output)
-                if response.didRespond {
-                    let result = helperClient.writeManagedUserPTY(
-                        AlanManagedUserPTYInputRequest(
-                            sessionID: sessionID,
-                            data: response.ptyResponse
-                        )
-                    )
-                    responseFailure = result.accepted ? nil : result.diagnostic
-                } else {
-                    responseFailure = nil
-                }
-                enqueueOutputUpdate(
-                    .output(
-                        AlanHelperManagedUserPtyProcessedOutput(
-                            chunk: chunk,
-                            rendererOutput: response.rendererOutput,
-                            shellActivityTransition: response.shellActivityTransition,
-                            responseFailure: responseFailure
-                        )
-                    )
-                )
-            case .failure(let diagnostic):
-                enqueueOutputFailure(diagnostic)
-                invalidate()
-                return
-            }
-            guard !output.isEmpty else {
-                if isFinal {
-                    invalidate()
-                }
-                return
-            }
-
-            if responseFailure != nil {
-                invalidate()
-                return
-            }
-
-            if !response.rendererOutput.isEmpty, !forwardRendererOutput(response.rendererOutput) {
-                invalidate()
-                return
-            }
-            if isFinal {
-                invalidate()
-                return
-            }
-        }
-    }
-
     private func writeHelperInput(_ data: Data) -> Bool {
         guard !data.isEmpty, !invalidated else { return false }
         let result = helperClient.writeManagedUserPTY(
@@ -791,10 +1037,18 @@ private final class AlanHelperManagedUserPtyRendererProxy {
         return true
     }
 
-    private func forwardRendererOutput(_ data: Data) -> Bool {
-        guard !data.isEmpty, !invalidated else { return false }
+    fileprivate func routeRendererOutputFromOutputPump(_ data: Data) -> OutputRoute {
+        guard !data.isEmpty else {
+            return OutputRoute(accepted: true, healthy: true)
+        }
+        guard !invalidated else {
+            return OutputRoute(accepted: false, healthy: false)
+        }
         pendingRendererOutput.append(data)
-        return drainPendingRendererOutput()
+        return OutputRoute(
+            accepted: true,
+            healthy: drainPendingRendererOutput()
+        )
     }
 
     private func drainPendingRendererOutput() -> Bool {

--- a/clients/apple/alan-macos/Services/Terminal/ManagedUserTerminalPtyRuntime.swift
+++ b/clients/apple/alan-macos/Services/Terminal/ManagedUserTerminalPtyRuntime.swift
@@ -64,7 +64,10 @@ final class AlanHelperManagedUserPtyProvider: AlanManagedUserPtyProviding {
             shell: shell,
             contentID: contentID,
             columns: defaultDimensions.columns,
-            rows: defaultDimensions.rows
+            rows: defaultDimensions.rows,
+            shellIntegrationResourcesPath: bootRequest.environment[
+                "GHOSTTY_RESOURCES_DIR"
+            ]
         )
         switch helperClient.startManagedUserPTY(request) {
         case .success(let session):
@@ -677,6 +680,9 @@ private func readHelperManagedUserPtyProcessedOutput(
 }
 
 fileprivate final class AlanHelperManagedUserPtyOutputPump {
+    private let maxPendingOutputBytes = 1024 * 1024
+    private let maxPendingUpdateCount = 256
+
     private weak var ptyHandle: AlanHelperManagedUserPtyHandle?
     private let helperClient: AlanPrivilegedHelperClienting
     private let sessionID: String
@@ -684,6 +690,7 @@ fileprivate final class AlanHelperManagedUserPtyOutputPump {
     private let outputProcessor: AlanTerminalPtyControlSequenceProcessor
     private var timer: DispatchSourceTimer?
     private var pendingUpdates: [AlanHelperManagedUserPtyPendingOutputUpdate] = []
+    private var pendingOutputBytes = 0
     private var publishScheduled = false
     private var lastForegroundProcessGroupState:
         AlanManagedUserPTYForegroundProcessGroupState = .unavailable
@@ -796,6 +803,7 @@ fileprivate final class AlanHelperManagedUserPtyOutputPump {
             timer?.cancel()
             timer = nil
             pendingUpdates.removeAll()
+            pendingOutputBytes = 0
             publishScheduled = false
         }
     }
@@ -813,10 +821,16 @@ fileprivate final class AlanHelperManagedUserPtyOutputPump {
     private func pollOnQueue(maxBytes: Int) {
         var remainingBytes = 64 * 1024
         while remainingBytes > 0 {
+            guard pendingUpdates.count < maxPendingUpdateCount,
+                  pendingOutputBytes < maxPendingOutputBytes
+            else {
+                return
+            }
+            let pendingCapacity = maxPendingOutputBytes - pendingOutputBytes
             switch readHelperManagedUserPtyProcessedOutput(
                 helperClient: helperClient,
                 sessionID: sessionID,
-                maxBytes: min(max(1, maxBytes), remainingBytes),
+                maxBytes: min(max(1, maxBytes), remainingBytes, pendingCapacity),
                 outputProcessor: outputProcessor
             ) {
             case .success(let output):
@@ -853,6 +867,7 @@ fileprivate final class AlanHelperManagedUserPtyOutputPump {
                             routedToRenderer: routedToRenderer
                         )
                     )
+                    pendingOutputBytes += output.chunk.data.count
                 }
                 guard !output.chunk.data.isEmpty,
                       output.responseFailure == nil,
@@ -874,6 +889,7 @@ fileprivate final class AlanHelperManagedUserPtyOutputPump {
     private func takePendingUpdatesOnQueue() -> [AlanHelperManagedUserPtyPendingOutputUpdate] {
         let updates = pendingUpdates
         pendingUpdates.removeAll()
+        pendingOutputBytes = 0
         publishScheduled = false
         return updates
     }

--- a/clients/apple/alan-macos/Services/Terminal/ManagedUserTerminalPtyRuntime.swift
+++ b/clients/apple/alan-macos/Services/Terminal/ManagedUserTerminalPtyRuntime.swift
@@ -148,7 +148,6 @@ final class AlanUnavailableManagedUserPtyHandle: AlanTerminalPtyHandle {
 
 @MainActor
 final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
-    private let maxPendingRendererReplayBytes = 1024 * 1024
     let contentID: String
     let bootRequest: AlanTerminalBootRequest
     let helperClient: AlanPrivilegedHelperClienting
@@ -168,8 +167,9 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
     private var outputPump: AlanHelperManagedUserPtyOutputPump?
     private var semanticShellActivityState: AlanTerminalPtyShellActivityState?
     private var processGroupShellActivityState: AlanTerminalPtyShellActivityState?
-    private var pendingRendererReplayChunks: [Data] = []
-    private var pendingRendererReplayBytes = 0
+    private var pendingRendererReplay = AlanTerminalPtyBoundedReplayBuffer(
+        maxBytes: 1024 * 1024
+    )
     private(set) var shellActivityState: AlanTerminalPtyShellActivityState = .unknown
     var onShellActivityStateChange: ((AlanTerminalPtyShellActivityState) -> Void)?
 
@@ -397,13 +397,12 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
         )
         let preparation = outputPump.attachRendererProxy(
             proxy,
-            replayChunks: pendingRendererReplayChunks,
+            replayChunks: pendingRendererReplay.chunks,
             maxBytes: 4096
         )
         if preparation.attached {
             rendererProxy = proxy
-            pendingRendererReplayChunks.removeAll()
-            pendingRendererReplayBytes = 0
+            pendingRendererReplay.removeAll()
         }
         applyOutputUpdates(preparation.updates)
         guard preparation.attached,
@@ -503,14 +502,7 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
     }
 
     private func appendPendingRendererReplay(_ data: Data) {
-        guard !data.isEmpty else { return }
-        pendingRendererReplayChunks.append(data)
-        pendingRendererReplayBytes += data.count
-        while pendingRendererReplayBytes > maxPendingRendererReplayBytes,
-              pendingRendererReplayChunks.count > 1
-        {
-            pendingRendererReplayBytes -= pendingRendererReplayChunks.removeFirst().count
-        }
+        pendingRendererReplay.append(data)
     }
 
     fileprivate func applyPendingOutput(
@@ -604,19 +596,13 @@ final class AlanHelperManagedUserPtyHandle: AlanTerminalPtyHandle {
     }
 
     private func reconcileShellActivityState() {
-        let state: AlanTerminalPtyShellActivityState
-        if semanticShellActivityState == .foregroundCommand
-            || processGroupShellActivityState == .foregroundCommand
-        {
-            state = .foregroundCommand
-        } else if semanticShellActivityState == .shellInput
-            || processGroupShellActivityState == .shellInput
-        {
-            state = .shellInput
-        } else {
-            state = .unknown
-        }
-        recordShellActivityState(state)
+        recordShellActivityState(
+            AlanTerminalPtyShellActivityResolver.resolve(
+                launchesInteractiveShell: bootRequest.strategy.launchesInteractiveShell,
+                semanticState: semanticShellActivityState,
+                processGroupState: processGroupShellActivityState
+            )
+        )
     }
 
     private func recordShellActivityState(_ state: AlanTerminalPtyShellActivityState) {

--- a/clients/apple/alan-macos/Services/Terminal/TerminalBootResolution.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalBootResolution.swift
@@ -895,6 +895,9 @@ struct AlanShellBootProfile: Equatable {
         if let terminfoPath = ghostty.terminfoPath {
             environment["TERMINFO"] = terminfoPath
         }
+        if let resourcesPath = ghostty.resourcesPath {
+            environment["GHOSTTY_RESOURCES_DIR"] = resourcesPath
+        }
         if environment["TERM"]?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false {
             environment["TERM"] = "xterm-256color"
         }

--- a/clients/apple/alan-macos/Services/Terminal/TerminalBootResolution.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalBootResolution.swift
@@ -195,10 +195,38 @@ struct AlanCommandResolution: Equatable {
         )
     }
 
-    private static let sudoLoginShellCommand = "exec \"${SHELL:-/bin/zsh}\" -l"
+    private static let sudoLoginShellCommand = """
+    shell="${SHELL:-/bin/zsh}"
+    case "${shell##*/}" in
+      zsh)
+        integration="$GHOSTTY_RESOURCES_DIR/shell-integration/zsh"
+        if [ -r "$integration/.zshenv" ]; then
+          if [ "${ZDOTDIR+x}" = x ]; then
+            export GHOSTTY_ZSH_ZDOTDIR="$ZDOTDIR"
+          fi
+          export ZDOTDIR="$integration"
+        fi
+        ;;
+      bash)
+        integration="$GHOSTTY_RESOURCES_DIR/shell-integration/bash/ghostty.bash"
+        if [ -r "$integration" ]; then
+          export GHOSTTY_BASH_INJECT="1 --noprofile"
+          exec -a -bash "$shell" --rcfile "$integration"
+        fi
+        ;;
+      fish)
+        integration="$GHOSTTY_RESOURCES_DIR/shell-integration"
+        if [ -r "$integration/fish/vendor_conf.d/ghostty-shell-integration.fish" ]; then
+          export XDG_DATA_DIRS="$integration${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
+        fi
+        ;;
+    esac
+    exec "$shell" -l
+    """
 
     private static let sudoReinjectedEnvironmentAllowlist: Set<String> = [
         "COLORTERM",
+        "GHOSTTY_RESOURCES_DIR",
         "TERMINFO",
         "TERM_PROGRAM",
     ]

--- a/clients/apple/alan-macos/Services/Terminal/TerminalPtyContracts.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalPtyContracts.swift
@@ -216,6 +216,16 @@ struct AlanTerminalPtyRuntimeSnapshot: Equatable {
     let lastSignal: AlanTerminalPtySignal?
     let exitStatus: AlanTerminalProcessExitStatus?
     let transcriptLines: [String]
+
+    var hasLiveChildProcess: Bool {
+        guard exitStatus == nil else { return false }
+        switch phase {
+        case .running, .inputClosed:
+            return true
+        case .pending, .exited, .failed:
+            return false
+        }
+    }
 }
 
 @MainActor

--- a/clients/apple/alan-macos/Services/Terminal/TerminalPtyContracts.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalPtyContracts.swift
@@ -90,6 +90,36 @@ enum AlanTerminalPtyShellActivityResolver {
     }
 }
 
+struct AlanTerminalPtyIdleProcessGroupTracker {
+    private(set) var idleProcessGroupID: Int32
+    private var allowsIdleProcessGroupRebase: Bool
+
+    init(
+        initialIdleProcessGroupID: Int32,
+        allowsIdleProcessGroupRebase: Bool
+    ) {
+        self.idleProcessGroupID = initialIdleProcessGroupID
+        self.allowsIdleProcessGroupRebase = allowsIdleProcessGroupRebase
+    }
+
+    mutating func observe(
+        foregroundProcessGroupID: Int32,
+        semanticState: AlanTerminalPtyShellActivityState?
+    ) -> AlanTerminalPtyShellActivityState {
+        if foregroundProcessGroupID == idleProcessGroupID {
+            return .shellInput
+        }
+        if allowsIdleProcessGroupRebase,
+           semanticState != .foregroundCommand
+        {
+            idleProcessGroupID = foregroundProcessGroupID
+            allowsIdleProcessGroupRebase = false
+            return .shellInput
+        }
+        return .foregroundCommand
+    }
+}
+
 struct AlanTerminalPtyBoundedReplayBuffer {
     let maxBytes: Int
     private(set) var chunks: [Data] = []
@@ -150,6 +180,21 @@ extension AlanLaunchStrategy {
              .terminalProfileManagedUser:
             return true
         case .shellCommandEnv,
+             .terminalProfileCustomCommand:
+            return false
+        }
+    }
+
+    var allowsInteractiveShellProcessGroupRebase: Bool {
+        switch self {
+        case .terminalProfileSudoUser,
+             .terminalProfileSudoRoot:
+            return true
+        case .shellCommandEnv,
+             .loginShellOverride,
+             .loginShellEnv,
+             .loginShellFallback,
+             .terminalProfileManagedUser,
              .terminalProfileCustomCommand:
             return false
         }

--- a/clients/apple/alan-macos/Services/Terminal/TerminalPtyContracts.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalPtyContracts.swift
@@ -103,7 +103,7 @@ enum AlanTerminalPtyShellActivityResolver {
         case .shellInput:
             return .shellInput
         case nil:
-            return processGroupState ?? .unknown
+            return processGroupState == .foregroundCommand ? .foregroundCommand : .unknown
         }
     }
 }

--- a/clients/apple/alan-macos/Services/Terminal/TerminalPtyContracts.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalPtyContracts.swift
@@ -71,6 +71,7 @@ struct AlanTerminalPtyControlSequenceResponse: Equatable {
 }
 
 enum AlanTerminalPtyShellActivityState: Equatable {
+    /// No prompt marker has been observed; consumers must preserve this uncertainty conservatively.
     case unknown
     case shellInput
     case foregroundCommand

--- a/clients/apple/alan-macos/Services/Terminal/TerminalPtyContracts.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalPtyContracts.swift
@@ -63,15 +63,21 @@ struct AlanTerminalPtyRendererAttachment: Equatable {
 struct AlanTerminalPtyControlSequenceResponse: Equatable {
     let rendererOutput: Data
     let ptyResponse: Data
-    let shellActivityTransition: AlanTerminalPtyShellActivityState?
+    let semanticShellStateTransition: AlanTerminalPtySemanticShellState?
 
     var didRespond: Bool {
         !ptyResponse.isEmpty
     }
 }
 
+enum AlanTerminalPtySemanticShellState: Equatable {
+    case commandStarted
+    case commandFinished
+    case shellInput
+}
+
 enum AlanTerminalPtyShellActivityState: Equatable {
-    /// No prompt marker has been observed; consumers must preserve this uncertainty conservatively.
+    /// No semantic or process-group evidence is available; consumers preserve this conservatively.
     case unknown
     case shellInput
     case foregroundCommand
@@ -80,13 +86,25 @@ enum AlanTerminalPtyShellActivityState: Equatable {
 enum AlanTerminalPtyShellActivityResolver {
     static func resolve(
         launchesInteractiveShell: Bool,
-        semanticState: AlanTerminalPtyShellActivityState?,
+        semanticState: AlanTerminalPtySemanticShellState?,
         processGroupState: AlanTerminalPtyShellActivityState?
     ) -> AlanTerminalPtyShellActivityState {
         guard launchesInteractiveShell else {
-            return semanticState ?? .foregroundCommand
+            return .foregroundCommand
         }
-        return processGroupState ?? semanticState ?? .unknown
+        if processGroupState == .foregroundCommand {
+            return .foregroundCommand
+        }
+        switch semanticState {
+        case .commandStarted:
+            return .foregroundCommand
+        case .commandFinished:
+            return processGroupState == .shellInput ? .shellInput : .foregroundCommand
+        case .shellInput:
+            return .shellInput
+        case nil:
+            return processGroupState ?? .unknown
+        }
     }
 }
 
@@ -104,13 +122,13 @@ struct AlanTerminalPtyIdleProcessGroupTracker {
 
     mutating func observe(
         foregroundProcessGroupID: Int32,
-        semanticState: AlanTerminalPtyShellActivityState?
+        semanticState: AlanTerminalPtySemanticShellState?
     ) -> AlanTerminalPtyShellActivityState {
         if foregroundProcessGroupID == idleProcessGroupID {
             return .shellInput
         }
         if allowsIdleProcessGroupRebase,
-           semanticState != .foregroundCommand
+           semanticState != .commandStarted
         {
             idleProcessGroupID = foregroundProcessGroupID
             allowsIdleProcessGroupRebase = false

--- a/clients/apple/alan-macos/Services/Terminal/TerminalPtyContracts.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalPtyContracts.swift
@@ -77,6 +77,23 @@ enum AlanTerminalPtyShellActivityState: Equatable {
     case foregroundCommand
 }
 
+extension AlanLaunchStrategy {
+    var launchesInteractiveShell: Bool {
+        switch self {
+        case .loginShellOverride,
+             .loginShellEnv,
+             .loginShellFallback,
+             .terminalProfileSudoUser,
+             .terminalProfileSudoRoot,
+             .terminalProfileManagedUser:
+            return true
+        case .shellCommandEnv,
+             .terminalProfileCustomCommand:
+            return false
+        }
+    }
+}
+
 enum AlanTerminalPtyRendererAttachmentResult: Equatable {
     case attached(AlanTerminalPtyRendererAttachment)
     case rejected(AlanTerminalPtyOperationResult)

--- a/clients/apple/alan-macos/Services/Terminal/TerminalPtyContracts.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalPtyContracts.swift
@@ -77,6 +77,68 @@ enum AlanTerminalPtyShellActivityState: Equatable {
     case foregroundCommand
 }
 
+enum AlanTerminalPtyShellActivityResolver {
+    static func resolve(
+        launchesInteractiveShell: Bool,
+        semanticState: AlanTerminalPtyShellActivityState?,
+        processGroupState: AlanTerminalPtyShellActivityState?
+    ) -> AlanTerminalPtyShellActivityState {
+        guard launchesInteractiveShell else {
+            return semanticState ?? .foregroundCommand
+        }
+        return processGroupState ?? semanticState ?? .unknown
+    }
+}
+
+struct AlanTerminalPtyBoundedReplayBuffer {
+    let maxBytes: Int
+    private(set) var chunks: [Data] = []
+    private(set) var byteCount = 0
+
+    init(maxBytes: Int) {
+        precondition(maxBytes > 0)
+        self.maxBytes = maxBytes
+    }
+
+    mutating func append(_ data: Data) {
+        guard !data.isEmpty else { return }
+        if data.count >= maxBytes {
+            chunks = [Data(data.suffix(maxBytes))]
+            byteCount = maxBytes
+            return
+        }
+
+        chunks.append(data)
+        byteCount += data.count
+        trimOldestBytes(byteCount - maxBytes)
+    }
+
+    mutating func removeAll() {
+        chunks.removeAll()
+        byteCount = 0
+    }
+
+    mutating func takeChunks() -> [Data] {
+        let result = chunks
+        removeAll()
+        return result
+    }
+
+    private mutating func trimOldestBytes(_ requestedByteCount: Int) {
+        var remainingByteCount = max(0, requestedByteCount)
+        while remainingByteCount > 0, let firstChunk = chunks.first {
+            let removedByteCount = min(remainingByteCount, firstChunk.count)
+            if removedByteCount == firstChunk.count {
+                chunks.removeFirst()
+            } else {
+                chunks[0] = Data(firstChunk.dropFirst(removedByteCount))
+            }
+            byteCount -= removedByteCount
+            remainingByteCount -= removedByteCount
+        }
+    }
+}
+
 extension AlanLaunchStrategy {
     var launchesInteractiveShell: Bool {
         switch self {

--- a/clients/apple/alan-macos/Services/Terminal/TerminalPtyContracts.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalPtyContracts.swift
@@ -63,10 +63,17 @@ struct AlanTerminalPtyRendererAttachment: Equatable {
 struct AlanTerminalPtyControlSequenceResponse: Equatable {
     let rendererOutput: Data
     let ptyResponse: Data
+    let shellActivityTransition: AlanTerminalPtyShellActivityState?
 
     var didRespond: Bool {
         !ptyResponse.isEmpty
     }
+}
+
+enum AlanTerminalPtyShellActivityState: Equatable {
+    case unknown
+    case shellInput
+    case foregroundCommand
 }
 
 enum AlanTerminalPtyRendererAttachmentResult: Equatable {
@@ -92,6 +99,8 @@ protocol AlanTerminalPtyHandle: AnyObject {
     var bootRequest: AlanTerminalBootRequest { get }
     var snapshot: AlanTerminalPtyRuntimeSnapshot { get }
     var isInputReady: Bool { get }
+    var shellActivityState: AlanTerminalPtyShellActivityState { get }
+    var onShellActivityStateChange: ((AlanTerminalPtyShellActivityState) -> Void)? { get set }
 
     func writeInput(_ text: String) -> TerminalRuntimeDeliveryResult
     func resize(columns: Int, rows: Int) -> AlanTerminalPtyOperationResult

--- a/clients/apple/alan-macos/Services/Terminal/TerminalPtyControlSequenceResponder.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalPtyControlSequenceResponder.swift
@@ -45,6 +45,7 @@ struct AlanTerminalPtyControlSequenceResponder: Equatable {
     mutating func process(_ data: Data) -> AlanTerminalPtyControlSequenceResponse {
         var rendererOutput: [UInt8] = []
         var ptyResponse: [UInt8] = []
+        var shellActivityTransition: AlanTerminalPtyShellActivityState?
 
         for byte in data {
             switch state {
@@ -101,11 +102,11 @@ struct AlanTerminalPtyControlSequenceResponder: Equatable {
             case .osc:
                 pendingControlSequence.append(byte)
                 if byte == Self.bellByte {
-                    Self.completeOSCSequence(
+                    shellActivityTransition = Self.completeOSCSequence(
                         pendingControlSequence,
                         rendererOutput: &rendererOutput,
                         ptyResponse: &ptyResponse
-                    )
+                    ) ?? shellActivityTransition
                     pendingControlSequence.removeAll(keepingCapacity: true)
                     state = .normal
                 } else if byte == Self.escapeByte {
@@ -119,11 +120,11 @@ struct AlanTerminalPtyControlSequenceResponder: Equatable {
             case .oscEscape:
                 pendingControlSequence.append(byte)
                 if byte == Self.backslashByte {
-                    Self.completeOSCSequence(
+                    shellActivityTransition = Self.completeOSCSequence(
                         pendingControlSequence,
                         rendererOutput: &rendererOutput,
                         ptyResponse: &ptyResponse
-                    )
+                    ) ?? shellActivityTransition
                     pendingControlSequence.removeAll(keepingCapacity: true)
                     state = .normal
                 } else if pendingControlSequence.count > Self.maxBufferedControlSequenceBytes {
@@ -138,7 +139,8 @@ struct AlanTerminalPtyControlSequenceResponder: Equatable {
 
         return AlanTerminalPtyControlSequenceResponse(
             rendererOutput: Data(rendererOutput),
-            ptyResponse: Data(ptyResponse)
+            ptyResponse: Data(ptyResponse),
+            shellActivityTransition: shellActivityTransition
         )
     }
 
@@ -186,37 +188,71 @@ struct AlanTerminalPtyControlSequenceResponder: Equatable {
         _ bytes: [UInt8],
         rendererOutput: inout [UInt8],
         ptyResponse: inout [UInt8]
-    ) {
+    ) -> AlanTerminalPtyShellActivityState? {
         if isBackgroundColorQuery(bytes) {
             ptyResponse.append(contentsOf: backgroundColorResponse)
-        } else {
-            rendererOutput.append(contentsOf: bytes)
+            return nil
         }
+        rendererOutput.append(contentsOf: bytes)
+        return shellActivityTransition(in: bytes)
     }
 
     private static func isBackgroundColorQuery(_ bytes: [UInt8]) -> Bool {
-        let payloadRange: Range<Int>
+        guard let payloadRange = oscPayloadRange(in: bytes) else { return false }
+        let payload = String(decoding: bytes[payloadRange], as: UTF8.self)
+        return payload == "11;?"
+    }
+
+    private static func shellActivityTransition(
+        in bytes: [UInt8]
+    ) -> AlanTerminalPtyShellActivityState? {
+        guard let payloadRange = oscPayloadRange(in: bytes) else { return nil }
+        let payload = bytes[payloadRange]
+        let prefix = Array("133;".utf8)
+        guard payload.starts(with: prefix), payload.count >= prefix.count + 1 else {
+            return nil
+        }
+
+        let actionIndex = payload.index(payload.startIndex, offsetBy: prefix.count)
+        let action = payload[actionIndex]
+        let trailingIndex = payload.index(after: actionIndex)
+        guard trailingIndex == payload.endIndex || payload[trailingIndex] == UInt8(ascii: ";") else {
+            return nil
+        }
+
+        switch action {
+        case UInt8(ascii: "C"):
+            return .foregroundCommand
+        case UInt8(ascii: "A"),
+             UInt8(ascii: "B"),
+             UInt8(ascii: "I"),
+             UInt8(ascii: "N"),
+             UInt8(ascii: "P"):
+            return .shellInput
+        default:
+            return nil
+        }
+    }
+
+    private static func oscPayloadRange(in bytes: [UInt8]) -> Range<Int>? {
         if bytes.first == escapeByte {
-            guard bytes.count >= 6, bytes[1] == rightBracketByte else { return false }
+            guard bytes.count >= 4, bytes[1] == rightBracketByte else { return nil }
             if bytes.last == bellByte {
-                payloadRange = 2..<(bytes.count - 1)
-            } else if bytes.count >= 7,
+                return 2..<(bytes.count - 1)
+            }
+            if bytes.count >= 5,
                 bytes[bytes.count - 2] == escapeByte,
                 bytes.last == backslashByte
             {
-                payloadRange = 2..<(bytes.count - 2)
-            } else {
-                return false
+                return 2..<(bytes.count - 2)
             }
-        } else if bytes.first == oscByte {
-            guard bytes.count >= 5, bytes.last == bellByte else { return false }
-            payloadRange = 1..<(bytes.count - 1)
-        } else {
-            return false
+            return nil
         }
-
-        let payload = String(decoding: bytes[payloadRange], as: UTF8.self)
-        return payload == "11;?"
+        if bytes.first == oscByte {
+            guard bytes.count >= 3, bytes.last == bellByte else { return nil }
+            return 1..<(bytes.count - 1)
+        }
+        return nil
     }
 }
 

--- a/clients/apple/alan-macos/Services/Terminal/TerminalPtyControlSequenceResponder.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalPtyControlSequenceResponder.swift
@@ -256,4 +256,21 @@ struct AlanTerminalPtyControlSequenceResponder: Equatable {
     }
 }
 
+final class AlanTerminalPtyControlSequenceProcessor {
+    private let lock = NSLock()
+    private var responder = AlanTerminalPtyControlSequenceResponder()
+
+    func process(_ data: Data) -> AlanTerminalPtyControlSequenceResponse {
+        lock.lock()
+        defer { lock.unlock() }
+        return responder.process(data)
+    }
+
+    func suppressNextPrimaryDeviceAttributesResponse() {
+        lock.lock()
+        responder.suppressNextPrimaryDeviceAttributesResponse()
+        lock.unlock()
+    }
+}
+
 #endif

--- a/clients/apple/alan-macos/Services/Terminal/TerminalPtyControlSequenceResponder.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalPtyControlSequenceResponder.swift
@@ -45,7 +45,7 @@ struct AlanTerminalPtyControlSequenceResponder: Equatable {
     mutating func process(_ data: Data) -> AlanTerminalPtyControlSequenceResponse {
         var rendererOutput: [UInt8] = []
         var ptyResponse: [UInt8] = []
-        var shellActivityTransition: AlanTerminalPtyShellActivityState?
+        var semanticShellStateTransition: AlanTerminalPtySemanticShellState?
 
         for byte in data {
             switch state {
@@ -102,11 +102,11 @@ struct AlanTerminalPtyControlSequenceResponder: Equatable {
             case .osc:
                 pendingControlSequence.append(byte)
                 if byte == Self.bellByte {
-                    shellActivityTransition = Self.completeOSCSequence(
+                    semanticShellStateTransition = Self.completeOSCSequence(
                         pendingControlSequence,
                         rendererOutput: &rendererOutput,
                         ptyResponse: &ptyResponse
-                    ) ?? shellActivityTransition
+                    ) ?? semanticShellStateTransition
                     pendingControlSequence.removeAll(keepingCapacity: true)
                     state = .normal
                 } else if byte == Self.escapeByte {
@@ -120,11 +120,11 @@ struct AlanTerminalPtyControlSequenceResponder: Equatable {
             case .oscEscape:
                 pendingControlSequence.append(byte)
                 if byte == Self.backslashByte {
-                    shellActivityTransition = Self.completeOSCSequence(
+                    semanticShellStateTransition = Self.completeOSCSequence(
                         pendingControlSequence,
                         rendererOutput: &rendererOutput,
                         ptyResponse: &ptyResponse
-                    ) ?? shellActivityTransition
+                    ) ?? semanticShellStateTransition
                     pendingControlSequence.removeAll(keepingCapacity: true)
                     state = .normal
                 } else if pendingControlSequence.count > Self.maxBufferedControlSequenceBytes {
@@ -140,7 +140,7 @@ struct AlanTerminalPtyControlSequenceResponder: Equatable {
         return AlanTerminalPtyControlSequenceResponse(
             rendererOutput: Data(rendererOutput),
             ptyResponse: Data(ptyResponse),
-            shellActivityTransition: shellActivityTransition
+            semanticShellStateTransition: semanticShellStateTransition
         )
     }
 
@@ -188,13 +188,13 @@ struct AlanTerminalPtyControlSequenceResponder: Equatable {
         _ bytes: [UInt8],
         rendererOutput: inout [UInt8],
         ptyResponse: inout [UInt8]
-    ) -> AlanTerminalPtyShellActivityState? {
+    ) -> AlanTerminalPtySemanticShellState? {
         if isBackgroundColorQuery(bytes) {
             ptyResponse.append(contentsOf: backgroundColorResponse)
             return nil
         }
         rendererOutput.append(contentsOf: bytes)
-        return shellActivityTransition(in: bytes)
+        return semanticShellStateTransition(in: bytes)
     }
 
     private static func isBackgroundColorQuery(_ bytes: [UInt8]) -> Bool {
@@ -203,9 +203,9 @@ struct AlanTerminalPtyControlSequenceResponder: Equatable {
         return payload == "11;?"
     }
 
-    private static func shellActivityTransition(
+    private static func semanticShellStateTransition(
         in bytes: [UInt8]
-    ) -> AlanTerminalPtyShellActivityState? {
+    ) -> AlanTerminalPtySemanticShellState? {
         guard let payloadRange = oscPayloadRange(in: bytes) else { return nil }
         let payload = bytes[payloadRange]
         let prefix = Array("133;".utf8)
@@ -222,7 +222,9 @@ struct AlanTerminalPtyControlSequenceResponder: Equatable {
 
         switch action {
         case UInt8(ascii: "C"):
-            return .foregroundCommand
+            return .commandStarted
+        case UInt8(ascii: "D"):
+            return .commandFinished
         case UInt8(ascii: "A"),
              UInt8(ascii: "B"),
              UInt8(ascii: "I"),

--- a/clients/apple/alan-macos/Services/Terminal/TerminalShellIntegration.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalShellIntegration.swift
@@ -50,6 +50,24 @@ struct AlanTerminalShellLaunch: Equatable {
                 resourcesPath: resourcesPath,
                 fileManager: fileManager
             )
+        case "fish":
+            let integrationRoot = "\(resourcesPath)/shell-integration"
+            guard fileManager.fileExists(
+                atPath: "\(integrationRoot)/fish/vendor_conf.d/ghostty-shell-integration.fish"
+            ) else {
+                return unchanged
+            }
+            var integratedEnvironment = environment
+            integratedEnvironment["GHOSTTY_RESOURCES_DIR"] = resourcesPath
+            integratedEnvironment["XDG_DATA_DIRS"] = [
+                integrationRoot,
+                environment["XDG_DATA_DIRS"],
+            ].compactMap { $0 }.joined(separator: ":")
+            return AlanTerminalShellLaunch(
+                argumentZero: executablePath,
+                arguments: arguments,
+                environment: integratedEnvironment
+            )
         default:
             return unchanged
         }

--- a/clients/apple/alan-macos/Services/Terminal/TerminalShellIntegration.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalShellIntegration.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+struct AlanTerminalShellLaunch: Equatable {
+    let argumentZero: String
+    let arguments: [String]
+    let environment: [String: String]
+
+    static func integratingGhostty(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        resourcesPath: String?,
+        fileManager: FileManager = .default
+    ) -> AlanTerminalShellLaunch {
+        let unchanged = AlanTerminalShellLaunch(
+            argumentZero: executablePath,
+            arguments: arguments,
+            environment: environment
+        )
+        guard let resourcesPath,
+              !resourcesPath.isEmpty
+        else {
+            return unchanged
+        }
+
+        switch URL(fileURLWithPath: executablePath).lastPathComponent {
+        case "zsh":
+            let integrationDirectory = "\(resourcesPath)/shell-integration/zsh"
+            guard fileManager.fileExists(
+                atPath: "\(integrationDirectory)/.zshenv"
+            ) else {
+                return unchanged
+            }
+            var integratedEnvironment = environment
+            integratedEnvironment["GHOSTTY_RESOURCES_DIR"] = resourcesPath
+            if let existingZdotdir = environment["ZDOTDIR"] {
+                integratedEnvironment["GHOSTTY_ZSH_ZDOTDIR"] = existingZdotdir
+            }
+            integratedEnvironment["ZDOTDIR"] = integrationDirectory
+            return AlanTerminalShellLaunch(
+                argumentZero: executablePath,
+                arguments: arguments,
+                environment: integratedEnvironment
+            )
+        case "bash":
+            return integratingGhosttyBash(
+                arguments: arguments,
+                environment: environment,
+                executablePath: executablePath,
+                resourcesPath: resourcesPath,
+                fileManager: fileManager
+            )
+        default:
+            return unchanged
+        }
+    }
+
+    private static func integratingGhosttyBash(
+        arguments: [String],
+        environment: [String: String],
+        executablePath: String,
+        resourcesPath: String,
+        fileManager: FileManager
+    ) -> AlanTerminalShellLaunch {
+        let unchanged = AlanTerminalShellLaunch(
+            argumentZero: executablePath,
+            arguments: arguments,
+            environment: environment
+        )
+        let scriptPath = "\(resourcesPath)/shell-integration/bash/ghostty.bash"
+        guard fileManager.fileExists(atPath: scriptPath),
+              !arguments.contains(where: {
+                  $0.hasPrefix("-")
+                      && !$0.hasPrefix("--")
+                      && $0.dropFirst().contains("c")
+              })
+        else {
+            return unchanged
+        }
+
+        var injectionArguments = ["1"]
+        var rcfile: String?
+        var retainedArguments: [String] = []
+        var requestsLoginShell = false
+        var suppressesProfile = false
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            if argument == "-l" || argument == "--login" {
+                requestsLoginShell = true
+            } else if argument == "--noprofile" {
+                injectionArguments.append(argument)
+                suppressesProfile = true
+            } else if argument == "--norc" {
+                injectionArguments.append(argument)
+            } else if argument == "--rcfile" || argument == "--init-file" {
+                rcfile = arguments.indices.contains(index + 1)
+                    ? arguments[index + 1]
+                    : nil
+                index += 1
+            } else {
+                retainedArguments.append(argument)
+            }
+            index += 1
+        }
+        if requestsLoginShell, !suppressesProfile {
+            // Bash loads the login profile before the injected rcfile. Tell the
+            // Ghostty script not to load it a second time.
+            injectionArguments.append("--noprofile")
+        }
+        let integratedArguments =
+            (suppressesProfile ? ["--noprofile"] : [])
+            + ["--rcfile", scriptPath]
+            + retainedArguments
+
+        var integratedEnvironment = environment
+        integratedEnvironment["GHOSTTY_RESOURCES_DIR"] = resourcesPath
+        integratedEnvironment["GHOSTTY_BASH_INJECT"] =
+            injectionArguments.joined(separator: " ")
+        if let rcfile {
+            integratedEnvironment["GHOSTTY_BASH_RCFILE"] = rcfile
+        }
+        return AlanTerminalShellLaunch(
+            argumentZero: requestsLoginShell
+                ? "-\(URL(fileURLWithPath: executablePath).lastPathComponent)"
+                : executablePath,
+            arguments: integratedArguments,
+            environment: integratedEnvironment
+        )
+    }
+}

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -1262,6 +1262,16 @@ require_pattern \
     "case \\.foregroundCommand:" \
     "terminal active-task projection must use Alan-owned PTY shell activity"
 
+require_pattern \
+    "clients/apple/alan-macos/Services/Terminal/DarwinTerminalPtyRuntime.swift" \
+    "private let outputProcessor = AlanTerminalPtyControlSequenceProcessor\\(\\)" \
+    "Darwin PTY direct and renderer drains must share one control-sequence processor"
+
+require_pattern \
+    "clients/apple/alan-macos/Services/Terminal/ManagedUserTerminalPtyRuntime.swift" \
+    "private let outputProcessor = AlanTerminalPtyControlSequenceProcessor\\(\\)" \
+    "Managed User PTY direct and renderer drains must share one control-sequence processor"
+
 reject_pattern \
     "clients/apple/alan-macos" \
     "queuedForegroundCommandSubmissions|commandSubmissionCount|queuesWhileActive|advanceForegroundCommandTracking|isCommandSubmissionText|recordProgrammaticCommandSubmission|foregroundCommandStartedAt" \
@@ -2861,6 +2871,11 @@ require_pattern \
     "clients/apple/scripts/test-terminal-runtime-service.swift" \
     "verifiesManagedUserRendererAttachmentBridgesHelperSession" \
     "terminal runtime tests must prove managed_user renderer attachment bridges helper PTY sessions"
+
+require_pattern \
+    "clients/apple/scripts/test-terminal-runtime-service.swift" \
+    "verifiesManagedUserDirectDrainReportsShellActivity" \
+    "terminal runtime tests must prove managed_user direct drains publish PTY shell activity"
 
 require_pattern \
     "clients/apple/scripts/test-shell-ui-smoke.sh" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -1267,35 +1267,10 @@ require_pattern \
     "if foregroundCommandStartedAt == nil" \
     "foreground command duration tracking must preserve the original command start time"
 
-require_pattern \
+reject_pattern \
     "clients/apple/alan-macos/GhosttyLiveHost.swift" \
-    "queuesWhileActive: true" \
-    "text-delivered queued commands must extend foreground command duration tracking while another command is active"
-
-require_pattern \
-    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
-    "queuedForegroundCommandSubmissions \\+= commandCount" \
-    "foreground command duration tracking must preserve split-submission queued command counts"
-
-require_pattern \
-    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
-    "private var queuedForegroundCommandSubmissions = 0" \
-    "foreground command duration tracking must retain queued pasted command submissions"
-
-require_pattern \
-    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
-    "private func commandSubmissionCount\\(in text: String\\)" \
-    "foreground command duration tracking must count newline-delimited pasted commands"
-
-require_pattern \
-    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
-    "advanceForegroundCommandTracking" \
-    "foreground command duration tracking must re-arm after queued command completion"
-
-require_pattern \
-    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
-    "hasQueuedForegroundCommand \\? \\.foregroundCommand : \\.inactive" \
-    "queued pasted commands must keep tab activity protected until the final completion"
+    "queuedForegroundCommandSubmissions|commandSubmissionCount|queuesWhileActive|advanceForegroundCommandTracking" \
+    "terminal active-task tracking must not infer queued commands from input newline counts"
 
 require_pattern \
     "clients/apple/alan-macos/Views/Shell/Terminal/ShellTerminalLeafView.swift" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -669,8 +669,8 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperXPC.swift" \
-    "static let currentVersion = 3" \
-    "managed terminal account diagnosis schema changes must advance the helper protocol"
+    "static let currentVersion = 4" \
+    "managed-user foreground-process schema changes must advance the helper protocol"
 
 require_pattern \
     "clients/apple/alan-macos/Services/Shell/ShellCoreFFIManagedTerminalAccountAdapter.swift" \
@@ -791,6 +791,36 @@ require_pattern \
     "clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSessionStore.swift" \
     "session\\.pendingInput\\.append\\(eof\\)" \
     "managed_user helper EOF must use the pending input queue"
+
+require_pattern \
+    "clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSessionStore.swift" \
+    "tcgetpgrp\\(session\\.masterFileDescriptor\\)" \
+    "managed_user shell activity must come from the helper-owned PTY foreground process group"
+
+require_pattern \
+    "clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSessionStore.swift" \
+    "let targetProcessGroupID = foregroundProcessGroupID \\?\\? session\\.processID" \
+    "managed_user PTY signals must target the helper-owned foreground process group"
+
+require_pattern \
+    "clients/apple/alan-macos/Services/Terminal/DarwinTerminalPtyRuntime.swift" \
+    "tcgetpgrp\\(masterFileDescriptor\\)" \
+    "local shell activity must come from the Alan-owned PTY foreground process group"
+
+require_pattern \
+    "clients/apple/alan-macos/Services/Terminal/DarwinTerminalPtyRuntime.swift" \
+    "let targetProcessGroupID = foregroundProcessGroupID \\?\\? processGroupID" \
+    "local PTY signals must target the Alan-owned foreground process group"
+
+require_pattern \
+    "clients/apple/scripts/test-terminal-runtime-service.swift" \
+    "verifiesDarwinPtyTracksUnintegratedShellActivityWithoutRenderer" \
+    "terminal runtime tests must cover rendererless shells without OSC integration"
+
+require_pattern \
+    "clients/apple/scripts/test-terminal-runtime-service.swift" \
+    "verifiesManagedUserProcessGroupActivityWithoutRenderer" \
+    "managed_user tests must cover rendererless helper foreground-process activity"
 
 require_pattern \
     "clients/apple/scripts/test-terminal-runtime-service.swift" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -1253,24 +1253,19 @@ require_pattern \
     "terminal.send_text must resolve PaneSlot targets before terminal delivery"
 
 require_pattern \
-    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
-    "let isCommandSubmission = isCommandSubmissionText\\(text\\)" \
-    "text-delivered terminal commands must start foreground command duration tracking"
+    "clients/apple/alan-macos/Services/Terminal/TerminalPtyControlSequenceResponder.swift" \
+    "case UInt8\\(ascii: \"C\"\\):" \
+    "Alan-owned PTY output must recognize the OSC 133 foreground-command transition"
 
 require_pattern \
-    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
-    "private func isCommandSubmissionText\\(_ text: String\\)" \
-    "foreground command detection must include pasted/control text submissions"
-
-require_pattern \
-    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
-    "if foregroundCommandStartedAt == nil" \
-    "foreground command duration tracking must preserve the original command start time"
+    "clients/apple/alan-macos/Services/Terminal/GhosttyTerminalSurfaceHandle.swift" \
+    "case \\.foregroundCommand:" \
+    "terminal active-task projection must use Alan-owned PTY shell activity"
 
 reject_pattern \
-    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
-    "queuedForegroundCommandSubmissions|commandSubmissionCount|queuesWhileActive|advanceForegroundCommandTracking" \
-    "terminal active-task tracking must not infer queued commands from input newline counts"
+    "clients/apple/alan-macos" \
+    "queuedForegroundCommandSubmissions|commandSubmissionCount|queuesWhileActive|advanceForegroundCommandTracking|isCommandSubmissionText|recordProgrammaticCommandSubmission|foregroundCommandStartedAt" \
+    "terminal active-task tracking must not infer shell execution from input text"
 
 require_pattern \
     "clients/apple/alan-macos/Views/Shell/Terminal/ShellTerminalLeafView.swift" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -669,8 +669,8 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperXPC.swift" \
-    "static let currentVersion = 4" \
-    "managed-user foreground-process schema changes must advance the helper protocol"
+    "static let currentVersion = 5" \
+    "managed-user shell-integration schema changes must advance the helper protocol"
 
 require_pattern \
     "clients/apple/alan-macos/Services/Shell/ShellCoreFFIManagedTerminalAccountAdapter.swift" \
@@ -814,8 +814,8 @@ require_pattern \
 
 require_pattern \
     "clients/apple/scripts/test-terminal-runtime-service.swift" \
-    "verifiesDarwinPtyTracksUnintegratedShellActivityWithoutRenderer" \
-    "terminal runtime tests must cover rendererless shells without OSC integration"
+    "verifiesDarwinPtyTracksIntegratedShellBuiltinsWithoutRenderer" \
+    "terminal runtime tests must cover rendererless shell builtins without manual OSC markers"
 
 require_pattern \
     "clients/apple/scripts/test-terminal-runtime-service.swift" \

--- a/clients/apple/scripts/smoke-privileged-helper-live.sh
+++ b/clients/apple/scripts/smoke-privileged-helper-live.sh
@@ -50,6 +50,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperManagedUserService.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSessionStore.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSupport.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalShellIntegration.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperService.swift" \
     "$REPO_ROOT/clients/apple/scripts/smoke-privileged-helper-live.swift" \
     "$BUILD_DIR/AlanPrivilegedHelperPtySpawn.o" \

--- a/clients/apple/scripts/smoke-privileged-helper-live.swift
+++ b/clients/apple/scripts/smoke-privileged-helper-live.swift
@@ -102,7 +102,8 @@ struct PrivilegedHelperLiveSmoke {
             shell: request.shell,
             contentID: "privileged-helper-live-smoke-\(UUID().uuidString)",
             columns: 80,
-            rows: 24
+            rows: 24,
+            shellIntegrationResourcesPath: nil
         )
         let startResponse = xpcClient.perform(
             operation: .startManagedUserPTY,

--- a/clients/apple/scripts/support/AlanPrivilegedHelperFakeClient.swift
+++ b/clients/apple/scripts/support/AlanPrivilegedHelperFakeClient.swift
@@ -4,17 +4,75 @@ import Foundation
 final class AlanPrivilegedHelperFakeClient: AlanPrivilegedHelperClienting {
     var helperStatus: AlanPrivilegedHelperStatus
     var diagnosesByAccount: [String: AlanManagedUserDiagnosis]
-    var deniedOperation: AlanPrivilegedHelperOperation?
+    private let ptyStateLock = NSLock()
+    private var storedDeniedOperation: AlanPrivilegedHelperOperation?
+    var deniedOperation: AlanPrivilegedHelperOperation? {
+        get {
+            ptyStateLock.lock()
+            defer { ptyStateLock.unlock() }
+            return storedDeniedOperation
+        }
+        set {
+            ptyStateLock.lock()
+            storedDeniedOperation = newValue
+            ptyStateLock.unlock()
+        }
+    }
     var appliedPlans: [AlanManagedUserHelperPlan] = []
     var startedPTYRequests: [AlanManagedUserPTYStartRequest] = []
-    var readPTYRequests: [AlanManagedUserPTYReadRequest] = []
-    var writtenPTYInputRequests: [AlanManagedUserPTYInputRequest] = []
+    private var storedReadPTYRequests: [AlanManagedUserPTYReadRequest] = []
+    var readPTYRequests: [AlanManagedUserPTYReadRequest] {
+        ptyStateLock.lock()
+        defer { ptyStateLock.unlock() }
+        return storedReadPTYRequests
+    }
+    private var storedWrittenPTYInputRequests: [AlanManagedUserPTYInputRequest] = []
+    var writtenPTYInputRequests: [AlanManagedUserPTYInputRequest] {
+        ptyStateLock.lock()
+        defer { ptyStateLock.unlock() }
+        return storedWrittenPTYInputRequests
+    }
     var resizedPTYRequests: [AlanManagedUserPTYResizeRequest] = []
     var closedPTYInputSessionIDs: [String] = []
     var signaledPTYRequests: [AlanManagedUserPTYSignalRequest] = []
     var terminatedPTYSessionIDs: [String] = []
-    var exitObservationsBySessionID: [String: AlanManagedUserPTYExitObservation] = [:]
-    var outputChunksBySessionID: [String: [Data]] = [:]
+    private var storedExitObservationsBySessionID:
+        [String: AlanManagedUserPTYExitObservation] = [:]
+    var exitObservationsBySessionID: [String: AlanManagedUserPTYExitObservation] {
+        get {
+            ptyStateLock.lock()
+            defer { ptyStateLock.unlock() }
+            return storedExitObservationsBySessionID
+        }
+        set {
+            ptyStateLock.lock()
+            storedExitObservationsBySessionID = newValue
+            ptyStateLock.unlock()
+        }
+    }
+    private var storedOutputChunksBySessionID: [String: [Data]] = [:]
+    var outputChunksBySessionID: [String: [Data]] {
+        get {
+            ptyStateLock.lock()
+            defer { ptyStateLock.unlock() }
+            return storedOutputChunksBySessionID
+        }
+        set {
+            ptyStateLock.lock()
+            storedOutputChunksBySessionID = newValue
+            ptyStateLock.unlock()
+        }
+    }
+
+    func enqueueOutputChunks(_ chunks: [Data], sessionID: String) {
+        ptyStateLock.lock()
+        storedOutputChunksBySessionID[sessionID, default: []].append(contentsOf: chunks)
+        ptyStateLock.unlock()
+    }
+
+    private var foregroundProcessGroupStatesBySessionID:
+        [String: [AlanManagedUserPTYForegroundProcessGroupState]] = [:]
+    private let foregroundProcessGroupStateLock = NSLock()
     private var startedPTYSessionAccounts: [String: String] = [:]
 
     init(
@@ -107,7 +165,9 @@ final class AlanPrivilegedHelperFakeClient: AlanPrivilegedHelperClienting {
     func readManagedUserPTY(
         _ request: AlanManagedUserPTYReadRequest
     ) -> Result<AlanManagedUserPTYOutputChunk, AlanPrivilegedHelperDiagnostic> {
-        readPTYRequests.append(request)
+        ptyStateLock.lock()
+        storedReadPTYRequests.append(request)
+        ptyStateLock.unlock()
         guard helperStatus.isHealthy, deniedOperation != .readManagedUserPTY else {
             return .failure(
                 diagnostic(
@@ -118,18 +178,30 @@ final class AlanPrivilegedHelperFakeClient: AlanPrivilegedHelperClienting {
                 )
             )
         }
-        var queued = outputChunksBySessionID[request.sessionID] ?? []
-        let data = queued.isEmpty ? Data() : queued.removeFirst()
-        outputChunksBySessionID[request.sessionID] = queued
+        let data = nextOutputChunk(sessionID: request.sessionID)
+        let foregroundProcessGroupState = nextForegroundProcessGroupState(
+            sessionID: request.sessionID
+        )
         let final = data.isEmpty && exitObservationsBySessionID[request.sessionID]?.final == true
         return .success(
             AlanManagedUserPTYOutputChunk(
                 sessionID: request.sessionID,
                 data: data,
                 final: final,
+                foregroundProcessGroupState: foregroundProcessGroupState,
                 sanitizedMessage: data.isEmpty ? nil : "Privileged helper returned PTY output."
             )
         )
+    }
+
+    func enqueueForegroundProcessGroupStates(
+        _ states: [AlanManagedUserPTYForegroundProcessGroupState],
+        sessionID: String
+    ) {
+        foregroundProcessGroupStateLock.lock()
+        foregroundProcessGroupStatesBySessionID[sessionID, default: []]
+            .append(contentsOf: states)
+        foregroundProcessGroupStateLock.unlock()
     }
 
     func writeManagedUserPTY(_ request: AlanManagedUserPTYInputRequest) -> AlanManagedUserPTYControlResult {
@@ -139,7 +211,9 @@ final class AlanPrivilegedHelperFakeClient: AlanPrivilegedHelperClienting {
             successMessage: "Privileged helper accepted PTY input."
         )
         if result.accepted {
-            writtenPTYInputRequests.append(request)
+            ptyStateLock.lock()
+            storedWrittenPTYInputRequests.append(request)
+            ptyStateLock.unlock()
         }
         return result
     }
@@ -235,6 +309,34 @@ final class AlanPrivilegedHelperFakeClient: AlanPrivilegedHelperClienting {
             accountName: accountName,
             message: successMessage
         )
+    }
+
+    private func nextForegroundProcessGroupState(
+        sessionID: String
+    ) -> AlanManagedUserPTYForegroundProcessGroupState {
+        foregroundProcessGroupStateLock.lock()
+        defer { foregroundProcessGroupStateLock.unlock() }
+        guard var states = foregroundProcessGroupStatesBySessionID[sessionID],
+              !states.isEmpty
+        else {
+            return .unavailable
+        }
+        let state = states.removeFirst()
+        foregroundProcessGroupStatesBySessionID[sessionID] = states
+        return state
+    }
+
+    private func nextOutputChunk(sessionID: String) -> Data {
+        ptyStateLock.lock()
+        defer { ptyStateLock.unlock() }
+        guard var chunks = storedOutputChunksBySessionID[sessionID],
+              !chunks.isEmpty
+        else {
+            return Data()
+        }
+        let chunk = chunks.removeFirst()
+        storedOutputChunksBySessionID[sessionID] = chunks
+        return chunk
     }
 
     private func diagnostic(

--- a/clients/apple/scripts/support/AlanPrivilegedHelperFakeClient.swift
+++ b/clients/apple/scripts/support/AlanPrivilegedHelperFakeClient.swift
@@ -51,6 +51,7 @@ final class AlanPrivilegedHelperFakeClient: AlanPrivilegedHelperClienting {
         }
     }
     private var storedOutputChunksBySessionID: [String: [Data]] = [:]
+    private var storedFinalPTYReadSessionIDs: Set<String> = []
     var outputChunksBySessionID: [String: [Data]] {
         get {
             ptyStateLock.lock()
@@ -67,6 +68,12 @@ final class AlanPrivilegedHelperFakeClient: AlanPrivilegedHelperClienting {
     func enqueueOutputChunks(_ chunks: [Data], sessionID: String) {
         ptyStateLock.lock()
         storedOutputChunksBySessionID[sessionID, default: []].append(contentsOf: chunks)
+        ptyStateLock.unlock()
+    }
+
+    func markNextEmptyPTYReadFinal(sessionID: String) {
+        ptyStateLock.lock()
+        storedFinalPTYReadSessionIDs.insert(sessionID)
         ptyStateLock.unlock()
     }
 
@@ -182,7 +189,11 @@ final class AlanPrivilegedHelperFakeClient: AlanPrivilegedHelperClienting {
         let foregroundProcessGroupState = nextForegroundProcessGroupState(
             sessionID: request.sessionID
         )
-        let final = data.isEmpty && exitObservationsBySessionID[request.sessionID]?.final == true
+        let final = data.isEmpty
+            && (
+                consumeFinalPTYRead(sessionID: request.sessionID)
+                    || exitObservationsBySessionID[request.sessionID]?.final == true
+            )
         return .success(
             AlanManagedUserPTYOutputChunk(
                 sessionID: request.sessionID,
@@ -337,6 +348,12 @@ final class AlanPrivilegedHelperFakeClient: AlanPrivilegedHelperClienting {
         let chunk = chunks.removeFirst()
         storedOutputChunksBySessionID[sessionID] = chunks
         return chunk
+    }
+
+    private func consumeFinalPTYRead(sessionID: String) -> Bool {
+        ptyStateLock.lock()
+        defer { ptyStateLock.unlock() }
+        return storedFinalPTYReadSessionIDs.remove(sessionID) != nil
     }
 
     private func diagnostic(

--- a/clients/apple/scripts/support/TerminalRuntimeTestDoubles.swift
+++ b/clients/apple/scripts/support/TerminalRuntimeTestDoubles.swift
@@ -84,6 +84,8 @@ final class FakeAlanTerminalPtyHandle: AlanTerminalPtyHandle {
     private(set) var inputClosed = false
     private(set) var exitStatus: AlanTerminalProcessExitStatus?
     private var transcriptRingBufferLines: [String] = []
+    private(set) var shellActivityState: AlanTerminalPtyShellActivityState = .unknown
+    var onShellActivityStateChange: ((AlanTerminalPtyShellActivityState) -> Void)?
 
     init(contentID: String, bootRequest: AlanTerminalBootRequest) {
         self.contentID = contentID
@@ -200,6 +202,12 @@ final class FakeAlanTerminalPtyHandle: AlanTerminalPtyHandle {
     func markExited(_ status: AlanTerminalProcessExitStatus) {
         exitStatus = status
         phase = .exited
+    }
+
+    func recordShellActivityState(_ state: AlanTerminalPtyShellActivityState) {
+        guard state != shellActivityState else { return }
+        shellActivityState = state
+        onShellActivityStateChange?(state)
     }
 }
 

--- a/clients/apple/scripts/test-shell-core-ffi-adapter.sh
+++ b/clients/apple/scripts/test-shell-core-ffi-adapter.sh
@@ -56,6 +56,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperManagedUserService.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSessionStore.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSupport.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalShellIntegration.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperService.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellActionCoordinator.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellCoreFFIAdapter.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.sh
+++ b/clients/apple/scripts/test-shell-runtime-metadata.sh
@@ -99,6 +99,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperManagedUserService.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSessionStore.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSupport.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalShellIntegration.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperService.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperAppClient.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/TerminalRuntimeSnapshots.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -8512,6 +8512,19 @@ private enum ShellRuntimeMetadataTests {
             boot.command.arguments.contains { $0.hasPrefix("ALAN_SHELL_BINDING_FILE=") },
             "sudo user boot command must preserve the shell binding file for the target shell"
         )
+        expect(
+            boot.command.arguments.contains { $0.hasPrefix("GHOSTTY_RESOURCES_DIR=") },
+            "sudo user boot command must preserve bundled shell integration resources"
+        )
+        expect(
+            boot.command.arguments.contains {
+                $0.contains("case \"${shell##*/}\"")
+                    && $0.contains("GHOSTTY_BASH_INJECT")
+                    && $0.contains("XDG_DATA_DIRS")
+                    && $0.contains("ZDOTDIR")
+            },
+            "sudo user boot command must inject prompt semantics for zsh, Bash, and fish"
+        )
 
         let rootPane = ShellPane(
             paneID: "pane_root_profile",

--- a/clients/apple/scripts/test-shell-settings-surface.sh
+++ b/clients/apple/scripts/test-shell-settings-surface.sh
@@ -116,6 +116,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperManagedUserService.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSessionStore.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSupport.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalShellIntegration.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperService.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellLocalFolderOpener.swift" \
     "$REPO_ROOT/clients/apple/scripts/support/AlanPrivilegedHelperFakeRequirementChecker.swift" \

--- a/clients/apple/scripts/test-shell-settings-surface.swift
+++ b/clients/apple/scripts/test-shell-settings-surface.swift
@@ -345,8 +345,9 @@ private func testPrivilegedHelperXPCBoundaryIsTypedAndChannelScoped() throws {
     try expect(
         oldHelperStatus.state == .outdated
             && oldHelperStatus.installedVersion == "2"
-            && oldHelperStatus.expectedVersion == "3",
-        "v2 helper responses must require a v3 update before diagnosis"
+            && oldHelperStatus.expectedVersion
+                == String(AlanPrivilegedHelperProtocolStatus.currentVersion),
+        "outdated helper responses must require the current protocol before diagnosis"
     )
 
     let stableIdentity = AlanInstallChannel.stable.privilegedHelperIdentity(

--- a/clients/apple/scripts/test-shell-settings-surface.swift
+++ b/clients/apple/scripts/test-shell-settings-surface.swift
@@ -440,7 +440,8 @@ private func testPrivilegedHelperXPCBoundaryIsTypedAndChannelScoped() throws {
                     shell: "/bin/bash",
                     contentID: "content-invalid",
                     columns: 80,
-                    rows: 24
+                    rows: 24,
+                    shellIntegrationResourcesPath: nil
                 )
             ),
             operationID: "op-start-invalid"

--- a/clients/apple/scripts/test-shell-ui-smoke.sh
+++ b/clients/apple/scripts/test-shell-ui-smoke.sh
@@ -945,7 +945,7 @@ run_restart_restore_step() {
 
     cwd_json=$(json_escape_fragment "$RESTART_RESTORE_CWD")
     before_json=$(json_escape_fragment "$before_token")
-    printf -v terminal_payload 'cd \\"%s\\"; echo %s; sleep 30\\n' \
+    printf -v terminal_payload 'cd \\"%s\\"\\necho %s\\nsleep 30\\n' \
         "$cwd_json" "$before_json"
     if ! terminal_result=$(send_terminal_payload_until_applied \
         "$pane_id" \

--- a/clients/apple/scripts/test-shell-ui-smoke.sh
+++ b/clients/apple/scripts/test-shell-ui-smoke.sh
@@ -831,12 +831,14 @@ on run argv
             end repeat
             if foundClearTerminal and not clickedClearTerminal then error "clear terminal menu item disabled"
             if not clickedClearTerminal then keystroke "k" using command down
+        else if actionName is "quit" then
+            keystroke "q" using command down
         else if actionName is "quit-confirm" then
             keystroke "q" using command down
             set closeDeadline to (current date) + timeoutSeconds
             repeat
                 set matches to every process whose unix id is targetPID
-                if (count of matches) = 0 then return
+                if (count of matches) = 0 then error "alan process exited before close confirmation appeared"
                 set targetProcess to item 1 of matches
                 try
                     set frontmost of targetProcess to true
@@ -854,13 +856,12 @@ on run argv
                     end repeat
                 on error
                     set matches to every process whose unix id is targetPID
-                    if (count of matches) = 0 then return
+                    if (count of matches) = 0 then error "alan process exited before close confirmation appeared"
                     error "close confirmation lookup failed"
                 end try
-                key code 36
                 delay 0.25
                 set matches to every process whose unix id is targetPID
-                if (count of matches) = 0 then return
+                if (count of matches) = 0 then error "alan process exited before close confirmation appeared"
                 if (current date) > closeDeadline then error "close confirmation did not appear"
                 delay 0.25
             end repeat
@@ -900,7 +901,8 @@ run_ui_step() {
 }
 
 quit_smoke_app_for_restart() {
-    if run_ui_step quit-confirm; then
+    local action="${1:-quit}"
+    if run_ui_step "$action"; then
         return 0
     fi
     if ! kill -0 "$APP_PID" 2>/dev/null; then
@@ -956,7 +958,7 @@ run_restart_restore_step() {
     sleep 1
     capture_step restart-before-quit
 
-    quit_smoke_app_for_restart
+    quit_smoke_app_for_restart quit-confirm
     wait_for_app_exit "restart restore confirmed quit"
 
     wait_for_file "$manifest_path" "workspace manifest after restart restore quit"

--- a/clients/apple/scripts/test-shell-ui-smoke.sh
+++ b/clients/apple/scripts/test-shell-ui-smoke.sh
@@ -595,6 +595,11 @@ control_terminal_send_return() {
 }"
 }
 
+control_terminal_send_eof() {
+    local pane_slot_id="$1"
+    control_terminal_send_text_payload "$pane_slot_id" "\\u0004" "terminal-eof"
+}
+
 control_tab_open_cwd() {
     local cwd="$1"
     local request_id
@@ -928,6 +933,8 @@ run_restart_restore_step() {
     local restored_pane_id
     local cwd_result
     local clear_deadline
+    local stdin_token
+    local stdin_json
 
     manifest_path=$(workspace_manifest_path)
     tab_result=$(control_tab_open_cwd "$RESTART_RESTORE_CWD")
@@ -1014,8 +1021,36 @@ run_restart_restore_step() {
     sleep 1
     capture_step restart-clear
 
+    stdin_token="alan-ui-smoke-stdin-$$"
+    stdin_json=$(json_escape_fragment "$stdin_token")
+    if ! terminal_result=$(send_terminal_payload_until_applied \
+        "$restored_pane_id" \
+        "cat\\n" \
+        "restart-stdin-cat")
+    then
+        require_control_applied "$terminal_result" "restart stdin cat command"
+    fi
+    require_control_applied "$terminal_result" "restart stdin cat command"
+    sleep 0.5
+
+    printf -v terminal_payload '%s\\n' "$stdin_json"
+    if ! terminal_result=$(send_terminal_payload_until_applied \
+        "$restored_pane_id" \
+        "$terminal_payload" \
+        "restart-stdin-line")
+    then
+        require_control_applied "$terminal_result" "restart stdin line"
+    fi
+    require_control_applied "$terminal_result" "restart stdin line"
+    sleep 0.5
+
+    terminal_result=$(control_terminal_send_eof "$restored_pane_id")
+    require_control_applied "$terminal_result" "restart stdin EOF"
+    append_manifest "restart_stdin_eof_token=$stdin_token"
+    sleep 1
+
     quit_smoke_app_for_restart
-    wait_for_app_exit "restart restore post-clear confirmed quit"
+    wait_for_app_exit "restart restore post-stdin quit"
 
     info "relaunching alan smoke app after restored transcript clear"
     if [[ "$LAUNCH_MODE" == "direct" ]]; then

--- a/clients/apple/scripts/test-shell-ui-smoke.sh
+++ b/clients/apple/scripts/test-shell-ui-smoke.sh
@@ -832,7 +832,7 @@ on run argv
             if foundClearTerminal and not clickedClearTerminal then error "clear terminal menu item disabled"
             if not clickedClearTerminal then keystroke "k" using command down
         else if actionName is "quit-confirm" then
-            keystroke "q" using {command down, option down}
+            keystroke "q" using command down
             set closeDeadline to (current date) + timeoutSeconds
             repeat
                 set matches to every process whose unix id is targetPID

--- a/clients/apple/scripts/test-terminal-runtime-service.sh
+++ b/clients/apple/scripts/test-terminal-runtime-service.sh
@@ -105,6 +105,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalPtyContracts.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalPtyControlSequenceResponder.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalPtyRuntime.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalShellIntegration.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/ManagedUserTerminalPtyRuntime.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/DarwinTerminalPtyRuntime.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/GhosttyProcessBootstrap.swift" \

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -316,8 +316,8 @@ private enum TerminalRuntimeServiceTests {
                 launchesInteractiveShell: true,
                 semanticState: nil,
                 processGroupState: .shellInput
-            ) == .shellInput,
-            "an unintegrated shell must use its known idle process-group baseline"
+            ) == .unknown,
+            "a matching shell process group without prompt semantics must remain protected"
         )
         expect(
             AlanTerminalPtyShellActivityResolver.resolve(
@@ -476,6 +476,18 @@ private enum TerminalRuntimeServiceTests {
                     environment: [:]
                 ),
             "bash integration must not rewrite non-interactive commands"
+        )
+
+        let fish = AlanTerminalShellLaunch.integratingGhostty(
+            executablePath: "/opt/homebrew/bin/fish",
+            arguments: ["-l"],
+            environment: ["XDG_DATA_DIRS": "/usr/local/share:/usr/share"],
+            resourcesPath: resourcesPath
+        )
+        expect(
+            fish.environment["XDG_DATA_DIRS"]
+                == "\(resourcesPath)/shell-integration:/usr/local/share:/usr/share",
+            "fish integration must prepend the bundled vendor configuration root"
         )
     }
 
@@ -2065,6 +2077,9 @@ private enum TerminalRuntimeServiceTests {
             bootProfile: profile
         )
         let sessionID = "fake-\(contentID)"
+        helper.outputChunksBySessionID[sessionID] = [
+            Data("\u{1B}]133;A\u{7}".utf8)
+        ]
         helper.enqueueForegroundProcessGroupStates([.shell], sessionID: sessionID)
 
         let idleDeadline = Date().addingTimeInterval(1)
@@ -2094,6 +2109,9 @@ private enum TerminalRuntimeServiceTests {
             "Managed User foreground-process observation must protect rendererless work"
         )
 
+        helper.outputChunksBySessionID[sessionID] = [
+            Data("\u{1B}]133;D;0\u{7}\u{1B}]133;A\u{7}".utf8)
+        ]
         helper.enqueueForegroundProcessGroupStates([.shell], sessionID: sessionID)
         let returnedDeadline = Date().addingTimeInterval(1)
         while Date() < returnedDeadline

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -15,7 +15,7 @@ private enum TerminalRuntimeServiceTests {
         verifiesSourceTreeRepositoryRootInference()
         verifiesControlSequenceResponderAnswersPrimaryDeviceAttributes()
         verifiesControlSequenceResponderReportsShellActivity()
-        verifiesShellActivityResolverPrioritizesKnownProcessGroup()
+        verifiesShellActivityResolverCombinesSemanticAndProcessEvidence()
         verifiesPtySnapshotClassifiesOnlyLiveChildPhases()
         verifiesIdleProcessGroupTrackerRebasesOnlyForInteractiveWrappers()
         verifiesBoundedReplayBufferTrimsOversizedHandoffChunks()
@@ -214,7 +214,7 @@ private enum TerminalRuntimeServiceTests {
 
         var response = responder.process(Data("\u{1B}]133;C\u{7}".utf8))
         expect(
-            response.shellActivityTransition == .foregroundCommand,
+            response.semanticShellStateTransition == .commandStarted,
             "OSC 133 C must report foreground command activity"
         )
         expect(
@@ -224,25 +224,25 @@ private enum TerminalRuntimeServiceTests {
 
         response = responder.process(Data("stdin line\n".utf8))
         expect(
-            response.shellActivityTransition == nil,
+            response.semanticShellStateTransition == nil,
             "ordinary newline-delimited PTY input or output must not be treated as a command"
         )
 
         response = responder.process(Data("\u{1B}]133;D;0\u{7}".utf8))
         expect(
-            response.shellActivityTransition == nil,
-            "command completion must remain active until shell integration returns to a prompt"
+            response.semanticShellStateTransition == .commandFinished,
+            "OSC 133 D must preserve command completion as distinct semantic evidence"
         )
 
         response = responder.process(Data("\u{1B}]133;A;cl=line\u{7}".utf8))
         expect(
-            response.shellActivityTransition == .shellInput,
+            response.semanticShellStateTransition == .shellInput,
             "OSC 133 prompt start must report shell input readiness"
         )
 
         response = responder.process(Data("\u{1B}]133;Cextra\u{7}".utf8))
         expect(
-            response.shellActivityTransition == nil,
+            response.semanticShellStateTransition == nil,
             "malformed OSC 133 command markers must not change shell activity"
         )
 
@@ -250,30 +250,46 @@ private enum TerminalRuntimeServiceTests {
             Data("\u{1B}]133;A\u{7}\u{1B}]133;C;aid=next\u{1B}\\".utf8)
         )
         expect(
-            response.shellActivityTransition == .foregroundCommand,
+            response.semanticShellStateTransition == .commandStarted,
             "the last semantic transition in one PTY chunk must win"
         )
 
         response = responder.process(Data("\u{1B}]133;".utf8))
         expect(
-            response.shellActivityTransition == nil,
+            response.semanticShellStateTransition == nil,
             "partial shell integration markers must be buffered across PTY chunks"
         )
         response = responder.process(Data("B\u{7}".utf8))
         expect(
-            response.shellActivityTransition == .shellInput,
+            response.semanticShellStateTransition == .shellInput,
             "split OSC 133 prompt markers must preserve semantic state"
         )
     }
 
-    private static func verifiesShellActivityResolverPrioritizesKnownProcessGroup() {
+    private static func verifiesShellActivityResolverCombinesSemanticAndProcessEvidence() {
         expect(
             AlanTerminalPtyShellActivityResolver.resolve(
                 launchesInteractiveShell: true,
-                semanticState: .foregroundCommand,
+                semanticState: .commandStarted,
+                processGroupState: .shellInput
+            ) == .foregroundCommand,
+            "semantic command start must protect same-process-group builtins and exec"
+        )
+        expect(
+            AlanTerminalPtyShellActivityResolver.resolve(
+                launchesInteractiveShell: true,
+                semanticState: .commandFinished,
                 processGroupState: .shellInput
             ) == .shellInput,
-            "a known idle process group must clear stale semantic foreground activity"
+            "semantic completion plus the idle shell process group must clear foreground activity"
+        )
+        expect(
+            AlanTerminalPtyShellActivityResolver.resolve(
+                launchesInteractiveShell: true,
+                semanticState: .commandFinished,
+                processGroupState: nil
+            ) == .foregroundCommand,
+            "semantic completion without process-group or prompt evidence must remain protected"
         )
         expect(
             AlanTerminalPtyShellActivityResolver.resolve(
@@ -286,10 +302,18 @@ private enum TerminalRuntimeServiceTests {
         expect(
             AlanTerminalPtyShellActivityResolver.resolve(
                 launchesInteractiveShell: true,
-                semanticState: .foregroundCommand,
+                semanticState: .commandStarted,
                 processGroupState: nil
             ) == .foregroundCommand,
             "semantic activity must remain the fallback when process-group state is unavailable"
+        )
+        expect(
+            AlanTerminalPtyShellActivityResolver.resolve(
+                launchesInteractiveShell: true,
+                semanticState: nil,
+                processGroupState: .shellInput
+            ) == .shellInput,
+            "an unintegrated shell must use its known idle process-group baseline"
         )
         expect(
             AlanTerminalPtyShellActivityResolver.resolve(
@@ -328,7 +352,7 @@ private enum TerminalRuntimeServiceTests {
         expect(
             wrapperTracker.observe(
                 foregroundProcessGroupID: 21,
-                semanticState: .foregroundCommand
+                semanticState: .commandStarted
             ) == .foregroundCommand,
             "a wrapper must not rebase to a process group known to be a foreground command"
         )
@@ -614,12 +638,13 @@ private enum TerminalRuntimeServiceTests {
                 + "surface=\(String(describing: surface.snapshot.metadata.activeTaskState))"
         )
 
-        let semanticMarker = "alan_stale_osc_\(UUID().uuidString)"
+        let semanticMarker = "alan_same_pgrp_\(UUID().uuidString)"
         expect(
             surface.sendControlText(
-                "printf '\(semanticMarker)\\033]133;C\\a\\n'\n"
+                "printf '\(semanticMarker)\\033]133;C\\a\\n'; "
+                    + "read -r; printf '\\033]133;D;0\\a'\n"
             ).applied,
-            "the unintegrated shell must accept a command that emits an unmatched OSC start"
+            "the unintegrated shell must accept a semantic long-running builtin command"
         )
         let semanticOutputDeadline = Date().addingTimeInterval(2)
         while Date() < semanticOutputDeadline
@@ -629,7 +654,22 @@ private enum TerminalRuntimeServiceTests {
         }
         expect(
             handle.snapshot.transcriptLines.joined(separator: "\n").contains(semanticMarker),
-            "the stale-OSC regression must observe its semantic command-start output"
+            "the same-process-group regression must observe its semantic command-start output"
+        )
+        let semanticForegroundDeadline = Date().addingTimeInterval(2)
+        while Date() < semanticForegroundDeadline
+            && surface.snapshot.metadata.activeTaskState != .foregroundCommand
+        {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        expect(
+            surface.snapshot.metadata.activeTaskState == .foregroundCommand,
+            "semantic command start must protect a builtin running in the shell process group"
+        )
+
+        expect(
+            surface.sendControlText("builtin input\n").applied,
+            "rendererless input must unblock the same-process-group builtin"
         )
         let semanticIdleDeadline = Date().addingTimeInterval(2)
         while Date() < semanticIdleDeadline
@@ -639,7 +679,7 @@ private enum TerminalRuntimeServiceTests {
         }
         expect(
             surface.snapshot.metadata.activeTaskState == .inactive,
-            "a known idle process group must clear an unmatched OSC command-start marker"
+            "semantic completion plus the idle shell process group must clear builtin activity"
         )
 
         expect(

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -16,6 +16,7 @@ private enum TerminalRuntimeServiceTests {
     static func run() {
         verifiesSourceTreeRepositoryRootInference()
         verifiesControlSequenceResponderAnswersPrimaryDeviceAttributes()
+        verifiesControlSequenceResponderReportsShellActivity()
         verifiesGhosttyTerminfoEnvironmentProjection()
         verifiesBootProfileExposesStructuredBootRequest()
         verifiesManagedUserLaunchResolutionUsesHelperIdentityWithoutSudo()
@@ -162,6 +163,63 @@ private enum TerminalRuntimeServiceTests {
             "non-query OSC sequences must continue to Ghostty unchanged"
         )
         expect(response.ptyResponse.isEmpty, "non-query OSC sequences must not emit PTY responses")
+    }
+
+    private static func verifiesControlSequenceResponderReportsShellActivity() {
+        var responder = AlanTerminalPtyControlSequenceResponder()
+
+        var response = responder.process(Data("\u{1B}]133;C\u{7}".utf8))
+        expect(
+            response.shellActivityTransition == .foregroundCommand,
+            "OSC 133 C must report foreground command activity"
+        )
+        expect(
+            response.rendererOutput == Data("\u{1B}]133;C\u{7}".utf8),
+            "shell activity markers must continue to Ghostty unchanged"
+        )
+
+        response = responder.process(Data("stdin line\n".utf8))
+        expect(
+            response.shellActivityTransition == nil,
+            "ordinary newline-delimited PTY input or output must not be treated as a command"
+        )
+
+        response = responder.process(Data("\u{1B}]133;D;0\u{7}".utf8))
+        expect(
+            response.shellActivityTransition == nil,
+            "command completion must remain active until shell integration returns to a prompt"
+        )
+
+        response = responder.process(Data("\u{1B}]133;A;cl=line\u{7}".utf8))
+        expect(
+            response.shellActivityTransition == .shellInput,
+            "OSC 133 prompt start must report shell input readiness"
+        )
+
+        response = responder.process(Data("\u{1B}]133;Cextra\u{7}".utf8))
+        expect(
+            response.shellActivityTransition == nil,
+            "malformed OSC 133 command markers must not change shell activity"
+        )
+
+        response = responder.process(
+            Data("\u{1B}]133;A\u{7}\u{1B}]133;C;aid=next\u{1B}\\".utf8)
+        )
+        expect(
+            response.shellActivityTransition == .foregroundCommand,
+            "the last semantic transition in one PTY chunk must win"
+        )
+
+        response = responder.process(Data("\u{1B}]133;".utf8))
+        expect(
+            response.shellActivityTransition == nil,
+            "partial shell integration markers must be buffered across PTY chunks"
+        )
+        response = responder.process(Data("B\u{7}".utf8))
+        expect(
+            response.shellActivityTransition == .shellInput,
+            "split OSC 133 prompt markers must preserve semantic state"
+        )
     }
 
     private static func verifiesGhosttyTerminfoEnvironmentProjection() {
@@ -956,9 +1014,11 @@ private enum TerminalRuntimeServiceTests {
             forTerminalContentID: "content_terminal_managed_user_renderer",
             bootRequest: request
         )
+        var observedShellActivity: [AlanTerminalPtyShellActivityState] = []
+        handle.onShellActivityStateChange = { observedShellActivity.append($0) }
         helper.outputChunksBySessionID["fake-content_terminal_managed_user_renderer"] = [
-            Data("helper-output-a\n".utf8),
-            Data("helper-output-b\n".utf8),
+            Data("\u{1B}]133;C\u{7}helper-output-a\n".utf8),
+            Data("helper-output-b\n\u{1B}]133;D;0\u{7}\u{1B}]133;A\u{7}".utf8),
         ]
 
         var rendererFileDescriptor: Int32?
@@ -1007,6 +1067,11 @@ private enum TerminalRuntimeServiceTests {
         expect(
             transcriptObserved,
             "managed_user renderer attachment must update the fallback transcript from helper output"
+        )
+        expect(
+            observedShellActivity == [.foregroundCommand, .shellInput],
+            "managed_user renderer output must publish OSC 133 activity through the PTY handle; "
+                + "observed \(observedShellActivity)"
         )
 
         let binaryRendererInput = Data([0xff, 0x00, 0x1b, 0x7f])
@@ -1076,6 +1141,21 @@ private enum TerminalRuntimeServiceTests {
         expect(
             handle.deliveredText == ["pwd\n"],
             "surface delivery must write to the PTY handle rather than Ghostty renderer text"
+        )
+        expect(
+            surface.snapshot.metadata.activeTaskState == .inactive,
+            "accepted newline text must not infer foreground command activity"
+        )
+
+        handle.recordShellActivityState(.foregroundCommand)
+        expect(
+            surface.snapshot.metadata.activeTaskState == .foregroundCommand,
+            "Alan-owned PTY shell activity must protect the terminal surface"
+        )
+        handle.recordShellActivityState(.shellInput)
+        expect(
+            surface.snapshot.metadata.activeTaskState == .inactive,
+            "returning to shell input must clear foreground command protection"
         )
 
         let shutdown = surface.requestGracefulShutdown(reason: .paneClose)

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -1251,6 +1251,10 @@ private enum TerminalRuntimeServiceTests {
         surface.configure(mountedAtPaneID: "pane_surface_pty", bootProfile: profile)
 
         expect(!surface.isSurfaceReady, "renderer must not be required for PTY delivery readiness")
+        expect(
+            surface.snapshot.metadata.activeTaskState == .unknown,
+            "unknown PTY shell activity must fail closed before any input is delivered"
+        )
 
         let delivery = surface.sendControlText("pwd\n")
         let handle = runtime.existingHandle(forTerminalContentID: contentID)
@@ -1261,8 +1265,12 @@ private enum TerminalRuntimeServiceTests {
             "surface delivery must write to the PTY handle rather than Ghostty renderer text"
         )
         expect(
-            surface.snapshot.metadata.activeTaskState == .inactive,
-            "accepted newline text must not infer foreground command activity"
+            handle.shellActivityState == .unknown,
+            "accepted newline text must not infer PTY shell activity"
+        )
+        expect(
+            surface.snapshot.metadata.activeTaskState == .unknown,
+            "unknown PTY shell activity must fail closed until a prompt marker is observed"
         )
 
         handle.recordShellActivityState(.foregroundCommand)

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -5,15 +5,13 @@ import Foundation
 @main
 struct TerminalRuntimeServiceTestRunner {
     static func main() async {
-        await MainActor.run {
-            TerminalRuntimeServiceTests.run()
-        }
+        await TerminalRuntimeServiceTests.run()
     }
 }
 
 @MainActor
 private enum TerminalRuntimeServiceTests {
-    static func run() {
+    static func run() async {
         verifiesSourceTreeRepositoryRootInference()
         verifiesControlSequenceResponderAnswersPrimaryDeviceAttributes()
         verifiesControlSequenceResponderReportsShellActivity()
@@ -26,10 +24,13 @@ private enum TerminalRuntimeServiceTests {
         verifiesWindowRuntimeDefaultPtyRuntimeWiresHelperProvider()
         verifiesManagedUserSurfaceRoutesHelperPtyLifecycleControls()
         verifiesManagedUserDirectDrainReportsShellActivity()
+        await verifiesManagedUserProcessGroupActivityWithoutRenderer()
         verifiesManagedUserRendererAttachmentBridgesHelperSession()
         verifiesAlanGhosttySurfaceDeliveryUsesPtyRuntimeWithoutRenderer()
         verifiesDarwinPtyBackendLaunchesLocalShell()
         verifiesDarwinPtyBackendKeepsLoginShellAlive()
+        await verifiesDarwinPtyTracksUnintegratedShellActivityWithoutRenderer()
+        await verifiesDarwinPtyReplaysRendererlessOutputOnAttachment()
         verifiesRuntimeCwdDoesNotRequireSurfaceRecreation()
         verifiesInstallDiscoveryChangesDoNotRequireSurfaceRecreation()
         verifiesDevChannelPropagatesInstallChannelEnvironment()
@@ -299,6 +300,10 @@ private enum TerminalRuntimeServiceTests {
         expect(handle.snapshot.phase == .running, "Darwin PTY runtime must start running")
         expect(handle.isInputReady, "Darwin PTY runtime must start input-ready")
         expect(
+            handle.shellActivityState == .foregroundCommand,
+            "custom-command PTY runtimes must remain active from launch until completion"
+        )
+        expect(
             waitForDarwinPtyOutput(handle, contains: "ready"),
             "Darwin PTY runtime must capture child output"
         )
@@ -377,6 +382,183 @@ private enum TerminalRuntimeServiceTests {
         expect(
             waitForDarwinPtyOutput(handle, contains: marker, timeout: 4),
             "login shell PTY runtime must execute input over the PTY"
+        )
+    }
+
+    private static func verifiesDarwinPtyTracksUnintegratedShellActivityWithoutRenderer() async {
+        let command = AlanCommandResolution(
+            strategy: .loginShellFallback,
+            executablePath: "/bin/bash",
+            launchPath: "/bin/bash",
+            arguments: ["--noprofile", "--norc"],
+            bootCommand: "/bin/bash --noprofile --norc",
+            surfaceCommand: nil,
+            summary: "Unintegrated login shell",
+            detail: nil,
+            repoRoot: nil,
+            candidates: []
+        )
+        let contentID = "content_terminal_unintegrated_shell_activity"
+        let profile = sampleBootProfile(
+            workingDirectory: "/tmp",
+            command: command,
+            environment: [
+                "ALAN_SHELL_CONTENT_ID": contentID,
+                "TERM": "xterm-256color",
+            ]
+        )
+        let runtime = AlanDarwinTerminalPtyRuntime()
+        let surface = AlanGhosttySurfaceHandle(
+            contentID: contentID,
+            paneID: "pane_unintegrated_shell_activity",
+            bootstrap: FakeAlanGhosttyProcessBootstrap(),
+            ptyRuntime: runtime
+        )
+        surface.configure(
+            mountedAtPaneID: "pane_unintegrated_shell_activity",
+            bootProfile: profile
+        )
+        let handle = runtime.existingHandle(forTerminalContentID: contentID)
+            as! AlanDarwinTerminalPtyHandle
+        defer {
+            if handle.snapshot.exitStatus == nil {
+                _ = handle.writeInput("exit\n")
+                if waitForDarwinPtyExit(handle, timeout: 1) == nil {
+                    _ = handle.sendSignal(.kill)
+                    _ = waitForDarwinPtyExit(handle)
+                }
+            }
+        }
+
+        let idleDeadline = Date().addingTimeInterval(3)
+        while Date() < idleDeadline
+            && surface.snapshot.metadata.activeTaskState != .inactive
+        {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        expect(
+            surface.snapshot.metadata.activeTaskState == .inactive,
+            "an unintegrated idle login shell must not remain permanently unknown; "
+                + "PTY=\(handle.shellActivityState) "
+                + "surface=\(String(describing: surface.snapshot.metadata.activeTaskState))"
+        )
+
+        expect(
+            surface.sendControlText("sleep 30\n").applied,
+            "rendererless control delivery must reach the unintegrated login shell"
+        )
+        let foregroundDeadline = Date().addingTimeInterval(1)
+        while Date() < foregroundDeadline
+            && surface.snapshot.metadata.activeTaskState != .foregroundCommand
+        {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        expect(
+            surface.snapshot.metadata.activeTaskState == .foregroundCommand,
+            "rendererless PTY process-group activity must protect a foreground command"
+        )
+
+        expect(
+            handle.sendSignal(.interrupt).accepted,
+            "graceful shutdown must signal the actual foreground process group"
+        )
+        let returnedDeadline = Date().addingTimeInterval(3)
+        while Date() < returnedDeadline
+            && surface.snapshot.metadata.activeTaskState != .inactive
+        {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        expect(
+            surface.snapshot.metadata.activeTaskState == .inactive,
+            "the shell must return to idle after foreground-process-group interruption"
+        )
+    }
+
+    private static func verifiesDarwinPtyReplaysRendererlessOutputOnAttachment() async {
+        let replayMarker = "alan_renderer_replay_\(UUID().uuidString)"
+        let liveMarker = "alan_renderer_live_\(UUID().uuidString)"
+        let command =
+            "$| = 1; print \"\(replayMarker)\\n\"; "
+            + "scalar <STDIN>; print \"\(liveMarker)\\n\"; while (1) { sleep 1; }"
+        let request = AlanTerminalBootRequest(
+            strategy: .terminalProfileCustomCommand,
+            executablePath: "/usr/bin/perl",
+            arguments: ["-e", command],
+            workingDirectory: "/tmp",
+            environment: ["TERM": "xterm-256color"],
+            bootCommand: command,
+            rendererCompatibilityCommand: nil,
+            managedUserAccountName: nil,
+            terminalProfile: nil
+        )
+        let runtime = AlanDarwinTerminalPtyRuntime()
+        let handle = runtime.handle(
+            forTerminalContentID: "content_terminal_renderer_replay",
+            bootRequest: request
+        ) as! AlanDarwinTerminalPtyHandle
+        defer {
+            if handle.snapshot.exitStatus == nil {
+                _ = handle.sendSignal(.kill)
+                _ = waitForDarwinPtyExit(handle)
+            }
+        }
+
+        let outputDeadline = Date().addingTimeInterval(2)
+        while Date() < outputDeadline
+            && !handle.snapshot.transcriptLines.joined(separator: "\n").contains(replayMarker)
+        {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        expect(
+            handle.snapshot.transcriptLines.joined(separator: "\n").contains(replayMarker),
+            "rendererless PTY output must be captured before renderer attachment"
+        )
+
+        let rendererFileDescriptor: Int32
+        switch handle.makeRendererAttachment() {
+        case .attached(let attachment):
+            rendererFileDescriptor = attachment.readFileDescriptor
+        case .rejected(let rejection):
+            fail("renderer replay requires a PTY attachment: \(rejection.code)")
+        }
+        defer { close(rendererFileDescriptor) }
+
+        let continueInput = Data("continue\n".utf8)
+        let writtenBytes = continueInput.withUnsafeBytes { rawBuffer -> Int in
+            guard let baseAddress = rawBuffer.baseAddress else { return -1 }
+            return Darwin.write(rendererFileDescriptor, baseAddress, rawBuffer.count)
+        }
+        expect(
+            writtenBytes == continueInput.count,
+            "renderer ordering test must deliver post-attachment PTY input"
+        )
+
+        var rendererOutput = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        let replayDeadline = Date().addingTimeInterval(1)
+        while Date() < replayDeadline
+            && !String(decoding: rendererOutput, as: UTF8.self).contains(liveMarker)
+        {
+            let count = Darwin.read(rendererFileDescriptor, &buffer, buffer.count)
+            if count > 0 {
+                rendererOutput.append(buffer, count: count)
+            } else {
+                try? await Task.sleep(nanoseconds: 20_000_000)
+            }
+        }
+        let renderedText = String(decoding: rendererOutput, as: UTF8.self)
+        expect(
+            renderedText.contains(replayMarker),
+            "renderer attachment must replay output consumed while no renderer was present"
+        )
+        guard let replayRange = renderedText.range(of: replayMarker),
+              let liveRange = renderedText.range(of: liveMarker)
+        else {
+            fail("renderer attachment must deliver both replayed and live PTY output")
+        }
+        expect(
+            replayRange.lowerBound < liveRange.lowerBound,
+            "renderer attachment must deliver replayed output before post-attachment PTY output"
         )
     }
 
@@ -1021,6 +1203,7 @@ private enum TerminalRuntimeServiceTests {
             Data("\u{1B}]133;C\u{7}helper-output-a\n".utf8),
             Data("helper-output-b\n\u{1B}]133;D;0\u{7}\u{1B}]133;A\u{7}".utf8),
         ]
+        _ = handle.snapshot
 
         var rendererFileDescriptor: Int32?
         defer {
@@ -1049,6 +1232,42 @@ private enum TerminalRuntimeServiceTests {
         guard let rendererFileDescriptor else {
             fail("managed_user renderer attachment must expose a renderer file descriptor")
         }
+        helper.enqueueOutputChunks(
+            [Data("helper-output-live\n".utf8)],
+            sessionID: "fake-content_terminal_managed_user_renderer"
+        )
+        var replayedRendererOutput = Data()
+        var rendererOutputBuffer = [UInt8](repeating: 0, count: 4096)
+        let replayDeadline = Date().addingTimeInterval(1)
+        while Date() < replayDeadline
+            && !String(decoding: replayedRendererOutput, as: UTF8.self)
+                .contains("helper-output-live")
+        {
+            let count = Darwin.read(
+                rendererFileDescriptor,
+                &rendererOutputBuffer,
+                rendererOutputBuffer.count
+            )
+            if count > 0 {
+                replayedRendererOutput.append(rendererOutputBuffer, count: count)
+            } else {
+                RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+            }
+        }
+        let renderedText = String(decoding: replayedRendererOutput, as: UTF8.self)
+        expect(
+            renderedText.contains("helper-output-b"),
+            "managed_user renderer attachment must replay helper output drained before attachment"
+        )
+        guard let replayRange = renderedText.range(of: "helper-output-b"),
+              let liveRange = renderedText.range(of: "helper-output-live")
+        else {
+            fail("managed_user renderer attachment must deliver replayed and live helper output")
+        }
+        expect(
+            replayRange.lowerBound < liveRange.lowerBound,
+            "managed_user renderer attachment must deliver replayed output before live helper output"
+        )
         let transcriptObserved = waitForPtyOutput(handle, contains: "helper-output-b")
         let helperReadDeadline = Date().addingTimeInterval(1)
         while Date() < helperReadDeadline
@@ -1215,10 +1434,18 @@ private enum TerminalRuntimeServiceTests {
         )
 
         close(rendererFileDescriptor)
-        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
-        helper.outputChunksBySessionID[sessionID] = [
-            Data("\u{1B}]133;D;0\u{7}\u{1B}]133;A\u{7}".utf8)
-        ]
+        let detachedOutputMarker = "helper-output-after-renderer-detach"
+        helper.enqueueOutputChunks(
+            [
+                Data(
+                    (
+                        "\(detachedOutputMarker)\n"
+                            + "\u{1B}]133;D;0\u{7}\u{1B}]133;A\u{7}"
+                    ).utf8
+                )
+            ],
+            sessionID: sessionID
+        )
         let detachedDeadline = Date().addingTimeInterval(1)
         while Date() < detachedDeadline
             && handle.shellActivityState != .shellInput
@@ -1232,6 +1459,118 @@ private enum TerminalRuntimeServiceTests {
                     == [.foregroundCommand, .shellInput, .foregroundCommand, .shellInput],
             "managed_user direct drains must resume after renderer detachment; "
                 + "observed \(observedShellActivity)"
+        )
+
+        let reattachedFileDescriptor: Int32
+        switch handle.makeRendererAttachment() {
+        case .attached(let attachment):
+            reattachedFileDescriptor = attachment.readFileDescriptor
+        case .rejected(let rejection):
+            fail("managed_user detach replay requires reattachment: \(rejection.code)")
+        }
+        defer { close(reattachedFileDescriptor) }
+        var reattachedOutput = Data()
+        var reattachedBuffer = [UInt8](repeating: 0, count: 4096)
+        let reattachedDeadline = Date().addingTimeInterval(1)
+        while Date() < reattachedDeadline
+            && !String(decoding: reattachedOutput, as: UTF8.self)
+                .contains(detachedOutputMarker)
+        {
+            let count = Darwin.read(
+                reattachedFileDescriptor,
+                &reattachedBuffer,
+                reattachedBuffer.count
+            )
+            if count > 0 {
+                reattachedOutput.append(reattachedBuffer, count: count)
+            } else {
+                RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+            }
+        }
+        expect(
+            String(decoding: reattachedOutput, as: UTF8.self)
+                .contains(detachedOutputMarker),
+            "managed_user renderer detachment must hand off unread output for reattachment"
+        )
+    }
+
+    private static func verifiesManagedUserProcessGroupActivityWithoutRenderer() async {
+        let contentID = "content_terminal_managed_user_process_group"
+        let command = AlanCommandResolution(
+            strategy: .terminalProfileManagedUser,
+            executablePath: nil,
+            launchPath: "",
+            arguments: [],
+            bootCommand: "managed_user 'lab'",
+            surfaceCommand: nil,
+            summary: "Managed User lab",
+            detail: nil,
+            repoRoot: nil,
+            candidates: [],
+            managedUserAccountName: "lab"
+        )
+        let profile = sampleBootProfile(
+            workingDirectory: "/Users/lab",
+            command: command,
+            environment: [
+                "ALAN_SHELL_CONTENT_ID": contentID,
+                "ALAN_MANAGED_USER_ACCOUNT": "lab",
+            ]
+        )
+        let helper = AlanPrivilegedHelperFakeClient(channel: .dev)
+        let runtime = AlanDarwinTerminalPtyRuntime(
+            managedUserPtyProvider: AlanHelperManagedUserPtyProvider(helperClient: helper)
+        )
+        let surface = AlanGhosttySurfaceHandle(
+            contentID: contentID,
+            paneID: "pane_managed_user_process_group",
+            bootstrap: FakeAlanGhosttyProcessBootstrap(),
+            ptyRuntime: runtime
+        )
+        surface.configure(
+            mountedAtPaneID: "pane_managed_user_process_group",
+            bootProfile: profile
+        )
+        let sessionID = "fake-\(contentID)"
+        helper.enqueueForegroundProcessGroupStates([.shell], sessionID: sessionID)
+
+        let idleDeadline = Date().addingTimeInterval(1)
+        while Date() < idleDeadline
+            && surface.snapshot.metadata.activeTaskState != .inactive
+        {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        expect(
+            surface.snapshot.metadata.activeTaskState == .inactive,
+            "Managed User foreground-process observation must identify an idle helper shell"
+        )
+
+        helper.enqueueForegroundProcessGroupStates([.foreground], sessionID: sessionID)
+        expect(
+            surface.sendControlText("sleep 30\n").applied,
+            "Managed User rendererless input must continue through the helper"
+        )
+        let foregroundDeadline = Date().addingTimeInterval(1)
+        while Date() < foregroundDeadline
+            && surface.snapshot.metadata.activeTaskState != .foregroundCommand
+        {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        expect(
+            surface.snapshot.metadata.activeTaskState == .foregroundCommand,
+            "Managed User foreground-process observation must protect rendererless work"
+        )
+
+        helper.enqueueForegroundProcessGroupStates([.shell], sessionID: sessionID)
+        let returnedDeadline = Date().addingTimeInterval(1)
+        while Date() < returnedDeadline
+            && surface.snapshot.metadata.activeTaskState != .inactive
+        {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        expect(
+            surface.snapshot.metadata.activeTaskState == .inactive,
+            "Managed User foreground-process observation must return to idle"
         )
     }
 
@@ -2360,7 +2699,7 @@ private enum TerminalRuntimeServiceTests {
             if transcript.contains(needle) {
                 return true
             }
-            usleep(50_000)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
         }
         return false
     }
@@ -2391,7 +2730,7 @@ private enum TerminalRuntimeServiceTests {
                 _ = handle.drainAvailableOutput()
                 return status
             }
-            usleep(50_000)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
         }
         return handle.refreshExitStatus()
     }

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -19,6 +19,7 @@ private enum TerminalRuntimeServiceTests {
         verifiesPtySnapshotClassifiesOnlyLiveChildPhases()
         verifiesIdleProcessGroupTrackerRebasesOnlyForInteractiveWrappers()
         verifiesBoundedReplayBufferTrimsOversizedHandoffChunks()
+        verifiesGhosttyShellIntegrationLaunchContract()
         verifiesGhosttyTerminfoEnvironmentProjection()
         verifiesBootProfileExposesStructuredBootRequest()
         verifiesManagedUserLaunchResolutionUsesHelperIdentityWithoutSudo()
@@ -26,6 +27,7 @@ private enum TerminalRuntimeServiceTests {
         verifiesManagedUserPtyRuntimeFailsClosedWithoutSudoFallback()
         verifiesFailedPtyDoesNotProjectActiveWork()
         verifiesManagedUserPtyRuntimeUsesHelperProviderWhenAvailable()
+        verifiesManagedUserOutputPumpBackpressuresBeforeMainActorDrain()
         verifiesWindowRuntimeDefaultPtyRuntimeWiresHelperProvider()
         verifiesManagedUserSurfaceRoutesHelperPtyLifecycleControls()
         verifiesManagedUserDirectDrainReportsShellActivity()
@@ -34,7 +36,7 @@ private enum TerminalRuntimeServiceTests {
         verifiesAlanGhosttySurfaceDeliveryUsesPtyRuntimeWithoutRenderer()
         verifiesDarwinPtyBackendLaunchesLocalShell()
         verifiesDarwinPtyBackendKeepsLoginShellAlive()
-        await verifiesDarwinPtyTracksUnintegratedShellActivityWithoutRenderer()
+        await verifiesDarwinPtyTracksIntegratedShellBuiltinsWithoutRenderer()
         await verifiesDarwinPtyReplaysRendererlessOutputOnAttachment()
         verifiesRuntimeCwdDoesNotRequireSurfaceRecreation()
         verifiesInstallDiscoveryChangesDoNotRequireSurfaceRecreation()
@@ -419,6 +421,62 @@ private enum TerminalRuntimeServiceTests {
         )
     }
 
+    private static func verifiesGhosttyShellIntegrationLaunchContract() {
+        guard let repoRoot = inferredAlanRepoRoot() else {
+            fail("terminal runtime tests must resolve the Alan repository root")
+        }
+        let resourcesPath = "\(repoRoot)/clients/apple/ghostty-resources"
+        let zsh = AlanTerminalShellLaunch.integratingGhostty(
+            executablePath: "/bin/zsh",
+            arguments: ["-l"],
+            environment: ["ZDOTDIR": "/tmp/user-zdotdir"],
+            resourcesPath: resourcesPath
+        )
+        expect(
+            zsh.arguments == ["-l"]
+                && zsh.environment["ZDOTDIR"]
+                    == "\(resourcesPath)/shell-integration/zsh"
+                && zsh.environment["GHOSTTY_ZSH_ZDOTDIR"]
+                    == "/tmp/user-zdotdir",
+            "zsh integration must preserve the user ZDOTDIR behind Ghostty startup injection"
+        )
+
+        let bash = AlanTerminalShellLaunch.integratingGhostty(
+            executablePath: "/bin/bash",
+            arguments: ["--noprofile", "--norc"],
+            environment: ["HOME": "/Users/test", "ENV": "/tmp/user-env"],
+            resourcesPath: resourcesPath
+        )
+        expect(
+            bash.argumentZero == "/bin/bash"
+                && bash.arguments
+                    == [
+                        "--noprofile",
+                        "--rcfile",
+                        "\(resourcesPath)/shell-integration/bash/ghostty.bash",
+                    ]
+                && bash.environment["GHOSTTY_BASH_INJECT"]
+                    == "1 --noprofile --norc",
+            "bash integration must use the native rcfile startup contract"
+        )
+
+        let nonInteractive = AlanTerminalShellLaunch.integratingGhostty(
+            executablePath: "/bin/bash",
+            arguments: ["-lc", "echo hi"],
+            environment: [:],
+            resourcesPath: resourcesPath
+        )
+        expect(
+            nonInteractive
+                == AlanTerminalShellLaunch(
+                    argumentZero: "/bin/bash",
+                    arguments: ["-lc", "echo hi"],
+                    environment: [:]
+                ),
+            "bash integration must not rewrite non-interactive commands"
+        )
+    }
+
     private static func verifiesGhosttyTerminfoEnvironmentProjection() {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("alan-ghostty-terminfo-\(UUID().uuidString)", isDirectory: true)
@@ -580,7 +638,10 @@ private enum TerminalRuntimeServiceTests {
         )
     }
 
-    private static func verifiesDarwinPtyTracksUnintegratedShellActivityWithoutRenderer() async {
+    private static func verifiesDarwinPtyTracksIntegratedShellBuiltinsWithoutRenderer() async {
+        guard let repoRoot = inferredAlanRepoRoot() else {
+            fail("shell integration regression must resolve the Alan repository root")
+        }
         let command = AlanCommandResolution(
             strategy: .loginShellFallback,
             executablePath: "/bin/bash",
@@ -588,29 +649,31 @@ private enum TerminalRuntimeServiceTests {
             arguments: ["--noprofile", "--norc"],
             bootCommand: "/bin/bash --noprofile --norc",
             surfaceCommand: nil,
-            summary: "Unintegrated login shell",
+            summary: "Automatically integrated login shell",
             detail: nil,
             repoRoot: nil,
             candidates: []
         )
-        let contentID = "content_terminal_unintegrated_shell_activity"
+        let contentID = "content_terminal_integrated_shell_activity"
         let profile = sampleBootProfile(
             workingDirectory: "/tmp",
             command: command,
             environment: [
                 "ALAN_SHELL_CONTENT_ID": contentID,
+                "GHOSTTY_RESOURCES_DIR": "\(repoRoot)/clients/apple/ghostty-resources",
+                "HOME": FileManager.default.homeDirectoryForCurrentUser.path,
                 "TERM": "xterm-256color",
             ]
         )
         let runtime = AlanDarwinTerminalPtyRuntime()
         let surface = AlanGhosttySurfaceHandle(
             contentID: contentID,
-            paneID: "pane_unintegrated_shell_activity",
+            paneID: "pane_integrated_shell_activity",
             bootstrap: FakeAlanGhosttyProcessBootstrap(),
             ptyRuntime: runtime
         )
         surface.configure(
-            mountedAtPaneID: "pane_unintegrated_shell_activity",
+            mountedAtPaneID: "pane_integrated_shell_activity",
             bootProfile: profile
         )
         let handle = runtime.existingHandle(forTerminalContentID: contentID)
@@ -633,18 +696,17 @@ private enum TerminalRuntimeServiceTests {
         }
         expect(
             surface.snapshot.metadata.activeTaskState == .inactive,
-            "an unintegrated idle login shell must not remain permanently unknown; "
+            "an automatically integrated idle login shell must publish prompt state; "
                 + "PTY=\(handle.shellActivityState) "
                 + "surface=\(String(describing: surface.snapshot.metadata.activeTaskState))"
         )
 
-        let semanticMarker = "alan_same_pgrp_\(UUID().uuidString)"
+        let semanticMarker = "alan_builtin_\(UUID().uuidString)"
         expect(
             surface.sendControlText(
-                "printf '\(semanticMarker)\\033]133;C\\a\\n'; "
-                    + "read -r; printf '\\033]133;D;0\\a'\n"
+                "printf '%s\\n' '\(semanticMarker)'; read -r\n"
             ).applied,
-            "the unintegrated shell must accept a semantic long-running builtin command"
+            "the integrated shell must accept a long-running builtin without manual OSC markers"
         )
         let semanticOutputDeadline = Date().addingTimeInterval(2)
         while Date() < semanticOutputDeadline
@@ -654,7 +716,7 @@ private enum TerminalRuntimeServiceTests {
         }
         expect(
             handle.snapshot.transcriptLines.joined(separator: "\n").contains(semanticMarker),
-            "the same-process-group regression must observe its semantic command-start output"
+            "the builtin regression must observe command output without manual OSC markers"
         )
         let semanticForegroundDeadline = Date().addingTimeInterval(2)
         while Date() < semanticForegroundDeadline
@@ -664,7 +726,10 @@ private enum TerminalRuntimeServiceTests {
         }
         expect(
             surface.snapshot.metadata.activeTaskState == .foregroundCommand,
-            "semantic command start must protect a builtin running in the shell process group"
+            "automatic shell integration must protect a builtin running in the shell process group; "
+                + "PTY=\(handle.shellActivityState) "
+                + "surface=\(String(describing: surface.snapshot.metadata.activeTaskState)) "
+                + "transcript=\(handle.snapshot.transcriptLines.joined(separator: "|"))"
         )
 
         expect(
@@ -679,12 +744,12 @@ private enum TerminalRuntimeServiceTests {
         }
         expect(
             surface.snapshot.metadata.activeTaskState == .inactive,
-            "semantic completion plus the idle shell process group must clear builtin activity"
+            "automatic shell completion must clear builtin activity"
         )
 
         expect(
             surface.sendControlText("sleep 30\n").applied,
-            "rendererless control delivery must reach the unintegrated login shell"
+            "rendererless control delivery must reach the integrated login shell"
         )
         let foregroundDeadline = Date().addingTimeInterval(1)
         while Date() < foregroundDeadline
@@ -1304,6 +1369,56 @@ private enum TerminalRuntimeServiceTests {
         expect(
             helper.startedPTYRequests.first?.accountName == "lab",
             "window runtime default PTY runtime must issue helper startManagedUserPTY requests"
+        )
+    }
+
+    private static func verifiesManagedUserOutputPumpBackpressuresBeforeMainActorDrain() {
+        let contentID = "content_terminal_managed_user_bounded_output"
+        let sessionID = "fake-\(contentID)"
+        let request = AlanTerminalBootRequest(
+            strategy: .terminalProfileManagedUser,
+            executablePath: "",
+            arguments: [],
+            workingDirectory: "/Users/lab",
+            environment: [
+                "ALAN_SHELL_CONTENT_ID": contentID,
+                "ALAN_MANAGED_USER_ACCOUNT": "lab",
+            ],
+            bootCommand: "managed_user 'lab'",
+            rendererCompatibilityCommand: nil,
+            managedUserAccountName: "lab",
+            terminalProfile: nil
+        )
+        let helper = AlanPrivilegedHelperFakeClient(channel: .dev)
+        helper.outputChunksBySessionID[sessionID] = Array(
+            repeating: Data(repeating: UInt8(ascii: "x"), count: 4096),
+            count: 400
+        )
+        let runtime = AlanDarwinTerminalPtyRuntime(
+            managedUserPtyProvider: AlanHelperManagedUserPtyProvider(helperClient: helper)
+        )
+        let handle = runtime.handle(
+            forTerminalContentID: contentID,
+            bootRequest: request
+        )
+
+        usleep(800_000)
+        let readsBeforeMainActorDrain = helper.readPTYRequests.count
+        expect(
+            readsBeforeMainActorDrain <= 256,
+            "managed_user output pumping must stop at its worker-side pending-output bound"
+        )
+        expect(
+            readsBeforeMainActorDrain < 400,
+            "managed_user output pumping must not drain an unbounded helper backlog while "
+                + "the main actor is blocked"
+        )
+
+        _ = handle.snapshot
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        expect(
+            helper.readPTYRequests.count > readsBeforeMainActorDrain,
+            "managed_user output pumping must resume after the main actor drains pending updates"
         )
     }
 

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -16,6 +16,7 @@ private enum TerminalRuntimeServiceTests {
         verifiesControlSequenceResponderAnswersPrimaryDeviceAttributes()
         verifiesControlSequenceResponderReportsShellActivity()
         verifiesShellActivityResolverPrioritizesKnownProcessGroup()
+        verifiesPtySnapshotClassifiesOnlyLiveChildPhases()
         verifiesIdleProcessGroupTrackerRebasesOnlyForInteractiveWrappers()
         verifiesBoundedReplayBufferTrimsOversizedHandoffChunks()
         verifiesGhosttyTerminfoEnvironmentProjection()
@@ -23,6 +24,7 @@ private enum TerminalRuntimeServiceTests {
         verifiesManagedUserLaunchResolutionUsesHelperIdentityWithoutSudo()
         verifiesFakePtyRuntimeCapturesLaunchAndLifecycle()
         verifiesManagedUserPtyRuntimeFailsClosedWithoutSudoFallback()
+        verifiesFailedPtyDoesNotProjectActiveWork()
         verifiesManagedUserPtyRuntimeUsesHelperProviderWhenAvailable()
         verifiesWindowRuntimeDefaultPtyRuntimeWiresHelperProvider()
         verifiesManagedUserSurfaceRoutesHelperPtyLifecycleControls()
@@ -168,6 +170,43 @@ private enum TerminalRuntimeServiceTests {
             "non-query OSC sequences must continue to Ghostty unchanged"
         )
         expect(response.ptyResponse.isEmpty, "non-query OSC sequences must not emit PTY responses")
+    }
+
+    private static func verifiesPtySnapshotClassifiesOnlyLiveChildPhases() {
+        let request = sampleBootProfile(workingDirectory: "/tmp").bootRequest
+        let cases: [
+            (
+                phase: AlanTerminalPtyRuntimePhase,
+                exitStatus: AlanTerminalProcessExitStatus?,
+                expectsLiveChild: Bool
+            )
+        ] = [
+            (.pending, nil, false),
+            (.running, nil, true),
+            (.inputClosed, nil, true),
+            (.exited, .exitCode(0), false),
+            (.failed, .unknown, false),
+            (.running, .signal(SIGTERM), false),
+        ]
+
+        for item in cases {
+            let snapshot = AlanTerminalPtyRuntimeSnapshot(
+                contentID: "content_terminal_lifecycle_\(item.phase.rawValue)",
+                bootRequest: request,
+                phase: item.phase,
+                dimensions: nil,
+                acceptedInputBytes: 0,
+                inputClosed: item.phase == .inputClosed,
+                lastSignal: nil,
+                exitStatus: item.exitStatus,
+                transcriptLines: []
+            )
+            expect(
+                snapshot.hasLiveChildProcess == item.expectsLiveChild,
+                "PTY phase \(item.phase.rawValue) with exit \(String(describing: item.exitStatus)) "
+                    + "must classify live-child ownership precisely"
+            )
+        }
     }
 
     private static func verifiesControlSequenceResponderReportsShellActivity() {
@@ -991,6 +1030,58 @@ private enum TerminalRuntimeServiceTests {
                 "unavailable managed_user renderer attachment must be rejected with helper diagnostics"
             )
         }
+    }
+
+    private static func verifiesFailedPtyDoesNotProjectActiveWork() {
+        let contentID = "content_terminal_managed_user_failed_activity"
+        let command = AlanCommandResolution(
+            strategy: .terminalProfileManagedUser,
+            executablePath: nil,
+            launchPath: "",
+            arguments: [],
+            bootCommand: "managed_user 'lab'",
+            surfaceCommand: nil,
+            summary: "Managed User lab",
+            detail: nil,
+            repoRoot: nil,
+            candidates: [],
+            managedUserAccountName: "lab"
+        )
+        let profile = sampleBootProfile(
+            workingDirectory: "/Users/lab",
+            command: command,
+            environment: [
+                "ALAN_SHELL_CONTENT_ID": contentID,
+                "ALAN_MANAGED_USER_ACCOUNT": "lab",
+            ]
+        )
+        let runtime = AlanDarwinTerminalPtyRuntime()
+        let surface = AlanGhosttySurfaceHandle(
+            contentID: contentID,
+            paneID: "pane_managed_user_failed_activity",
+            bootstrap: FakeAlanGhosttyProcessBootstrap(),
+            ptyRuntime: runtime
+        )
+
+        surface.configure(
+            mountedAtPaneID: "pane_managed_user_failed_activity",
+            bootProfile: profile
+        )
+
+        let handle = runtime.existingHandle(forTerminalContentID: contentID)
+        expect(
+            handle?.snapshot.phase == .failed
+                && handle?.snapshot.exitStatus == .unknown,
+            "the unavailable Managed User fixture must represent a failed PTY with no live child"
+        )
+        expect(
+            handle?.shellActivityState == .unknown,
+            "failed PTY activity must remain unknown rather than pretending a prompt was observed"
+        )
+        expect(
+            surface.snapshot.metadata.activeTaskState == .inactive,
+            "a failed PTY with no live child must not be projected as active work"
+        )
     }
 
     private static func verifiesManagedUserPtyRuntimeUsesHelperProviderWhenAvailable() {

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -28,6 +28,8 @@ private enum TerminalRuntimeServiceTests {
         verifiesFailedPtyDoesNotProjectActiveWork()
         verifiesManagedUserPtyRuntimeUsesHelperProviderWhenAvailable()
         verifiesManagedUserOutputPumpBackpressuresBeforeMainActorDrain()
+        verifiesManagedUserExitDrainsPendingOutputAndPublishesIdle()
+        verifiesManagedUserFinalChunkPublishesIdle()
         verifiesWindowRuntimeDefaultPtyRuntimeWiresHelperProvider()
         verifiesManagedUserSurfaceRoutesHelperPtyLifecycleControls()
         verifiesManagedUserDirectDrainReportsShellActivity()
@@ -1419,6 +1421,131 @@ private enum TerminalRuntimeServiceTests {
         expect(
             helper.readPTYRequests.count > readsBeforeMainActorDrain,
             "managed_user output pumping must resume after the main actor drains pending updates"
+        )
+    }
+
+    private static func verifiesManagedUserExitDrainsPendingOutputAndPublishesIdle() {
+        let contentID = "content_terminal_managed_user_exit_drain"
+        let sessionID = "fake-\(contentID)"
+        let request = AlanTerminalBootRequest(
+            strategy: .terminalProfileManagedUser,
+            executablePath: "",
+            arguments: [],
+            workingDirectory: "/Users/lab",
+            environment: [
+                "ALAN_SHELL_CONTENT_ID": contentID,
+                "ALAN_MANAGED_USER_ACCOUNT": "lab",
+            ],
+            bootCommand: "managed_user 'lab'",
+            rendererCompatibilityCommand: nil,
+            managedUserAccountName: "lab",
+            terminalProfile: nil
+        )
+        let helper = AlanPrivilegedHelperFakeClient(channel: .dev)
+        let runtime = AlanDarwinTerminalPtyRuntime(
+            managedUserPtyProvider: AlanHelperManagedUserPtyProvider(helperClient: helper)
+        )
+        let handle = runtime.handle(
+            forTerminalContentID: contentID,
+            bootRequest: request
+        )
+        var observedShellActivity: [AlanTerminalPtyShellActivityState] = []
+        handle.onShellActivityStateChange = { observedShellActivity.append($0) }
+        helper.outputChunksBySessionID[sessionID] = [
+            Data("\u{1B}]133;C\u{7}managed-user-final-output\n".utf8)
+        ]
+
+        let workerDrainDeadline = Date().addingTimeInterval(1)
+        while Date() < workerDrainDeadline
+            && helper.outputChunksBySessionID[sessionID]?.isEmpty != true
+        {
+            usleep(10_000)
+        }
+        expect(
+            helper.outputChunksBySessionID[sessionID]?.isEmpty == true,
+            "managed_user exit race must begin after the worker has consumed final output"
+        )
+        helper.exitObservationsBySessionID[sessionID] = AlanManagedUserPTYExitObservation(
+            sessionID: sessionID,
+            final: true,
+            exitCode: 0,
+            terminatingSignal: nil,
+            sanitizedMessage: "Fake helper PTY session exited."
+        )
+        let rejectedWrite = handle.writeInput("too-late")
+        let snapshot = handle.snapshot
+
+        expect(
+            !rejectedWrite.applied && rejectedWrite.errorCode == "terminal_child_exited",
+            "managed_user controls must observe helper exit before accepting more input"
+        )
+        expect(
+            snapshot.transcriptLines.joined(separator: "\n")
+                .contains("managed-user-final-output"),
+            "managed_user exit observation must drain output already consumed by the worker"
+        )
+        expect(
+            snapshot.exitStatus?.diagnosticsValue == "exit:0"
+                && snapshot.phase == .exited,
+            "managed_user exit observation must preserve helper lifecycle truth"
+        )
+        expect(
+            handle.shellActivityState == .shellInput
+                && observedShellActivity == [.foregroundCommand, .shellInput],
+            "managed_user exit must publish an inactive transition after final output; "
+                + "observed \(observedShellActivity)"
+        )
+    }
+
+    private static func verifiesManagedUserFinalChunkPublishesIdle() {
+        let contentID = "content_terminal_managed_user_final_chunk"
+        let sessionID = "fake-\(contentID)"
+        let request = AlanTerminalBootRequest(
+            strategy: .terminalProfileManagedUser,
+            executablePath: "",
+            arguments: [],
+            workingDirectory: "/Users/lab",
+            environment: [
+                "ALAN_SHELL_CONTENT_ID": contentID,
+                "ALAN_MANAGED_USER_ACCOUNT": "lab",
+            ],
+            bootCommand: "managed_user 'lab'",
+            rendererCompatibilityCommand: nil,
+            managedUserAccountName: "lab",
+            terminalProfile: nil
+        )
+        let helper = AlanPrivilegedHelperFakeClient(channel: .dev)
+        let runtime = AlanDarwinTerminalPtyRuntime(
+            managedUserPtyProvider: AlanHelperManagedUserPtyProvider(helperClient: helper)
+        )
+        guard let handle = runtime.handle(
+            forTerminalContentID: contentID,
+            bootRequest: request
+        ) as? AlanHelperManagedUserPtyHandle else {
+            fail("managed_user final-chunk regression requires the helper-backed PTY handle")
+        }
+        var observedShellActivity: [AlanTerminalPtyShellActivityState] = []
+        handle.onShellActivityStateChange = { observedShellActivity.append($0) }
+        helper.outputChunksBySessionID[sessionID] = [
+            Data("\u{1B}]133;C\u{7}running-until-eof\n".utf8)
+        ]
+        _ = handle.snapshot
+        expect(
+            handle.shellActivityState == .foregroundCommand,
+            "managed_user final-chunk regression must begin with protected activity"
+        )
+
+        helper.markNextEmptyPTYReadFinal(sessionID: sessionID)
+        _ = handle.snapshot
+        expect(
+            handle.shellActivityState == .shellInput
+                && observedShellActivity == [.foregroundCommand, .shellInput],
+            "managed_user final EOF chunk must publish inactive activity; "
+                + "observed \(observedShellActivity)"
+        )
+        expect(
+            handle.snapshot.phase == .exited,
+            "managed_user final EOF chunk must publish exited lifecycle truth"
         )
     }
 

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -16,6 +16,7 @@ private enum TerminalRuntimeServiceTests {
         verifiesControlSequenceResponderAnswersPrimaryDeviceAttributes()
         verifiesControlSequenceResponderReportsShellActivity()
         verifiesShellActivityResolverPrioritizesKnownProcessGroup()
+        verifiesIdleProcessGroupTrackerRebasesOnlyForInteractiveWrappers()
         verifiesBoundedReplayBufferTrimsOversizedHandoffChunks()
         verifiesGhosttyTerminfoEnvironmentProjection()
         verifiesBootProfileExposesStructuredBootRequest()
@@ -258,6 +259,68 @@ private enum TerminalRuntimeServiceTests {
                 processGroupState: .shellInput
             ) == .foregroundCommand,
             "a custom command must remain foreground from launch"
+        )
+    }
+
+    private static func verifiesIdleProcessGroupTrackerRebasesOnlyForInteractiveWrappers() {
+        var directShellTracker = AlanTerminalPtyIdleProcessGroupTracker(
+            initialIdleProcessGroupID: 10,
+            allowsIdleProcessGroupRebase: false
+        )
+        expect(
+            directShellTracker.observe(
+                foregroundProcessGroupID: 10,
+                semanticState: nil
+            ) == .shellInput,
+            "a direct interactive shell process group must be the idle baseline"
+        )
+        expect(
+            directShellTracker.observe(
+                foregroundProcessGroupID: 11,
+                semanticState: nil
+            ) == .foregroundCommand,
+            "a direct interactive shell must not rebase to a foreground command"
+        )
+
+        var wrapperTracker = AlanTerminalPtyIdleProcessGroupTracker(
+            initialIdleProcessGroupID: 20,
+            allowsIdleProcessGroupRebase: true
+        )
+        expect(
+            wrapperTracker.observe(
+                foregroundProcessGroupID: 21,
+                semanticState: .foregroundCommand
+            ) == .foregroundCommand,
+            "a wrapper must not rebase to a process group known to be a foreground command"
+        )
+        expect(
+            wrapperTracker.idleProcessGroupID == 20,
+            "a rejected foreground candidate must leave the wrapper baseline unchanged"
+        )
+        expect(
+            wrapperTracker.observe(
+                foregroundProcessGroupID: 22,
+                semanticState: .shellInput
+            ) == .shellInput,
+            "a sudo wrapper must rebase once to the actual interactive shell process group"
+        )
+        expect(
+            wrapperTracker.idleProcessGroupID == 22,
+            "the actual interactive shell process group must become the durable idle baseline"
+        )
+        expect(
+            wrapperTracker.observe(
+                foregroundProcessGroupID: 23,
+                semanticState: nil
+            ) == .foregroundCommand,
+            "a rebased sudo shell must classify later process groups as foreground commands"
+        )
+        expect(
+            wrapperTracker.observe(
+                foregroundProcessGroupID: 22,
+                semanticState: nil
+            ) == .shellInput,
+            "the rebased sudo shell process group must remain the idle baseline"
         )
     }
 

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -15,6 +15,8 @@ private enum TerminalRuntimeServiceTests {
         verifiesSourceTreeRepositoryRootInference()
         verifiesControlSequenceResponderAnswersPrimaryDeviceAttributes()
         verifiesControlSequenceResponderReportsShellActivity()
+        verifiesShellActivityResolverPrioritizesKnownProcessGroup()
+        verifiesBoundedReplayBufferTrimsOversizedHandoffChunks()
         verifiesGhosttyTerminfoEnvironmentProjection()
         verifiesBootProfileExposesStructuredBootRequest()
         verifiesManagedUserLaunchResolutionUsesHelperIdentityWithoutSudo()
@@ -221,6 +223,73 @@ private enum TerminalRuntimeServiceTests {
         expect(
             response.shellActivityTransition == .shellInput,
             "split OSC 133 prompt markers must preserve semantic state"
+        )
+    }
+
+    private static func verifiesShellActivityResolverPrioritizesKnownProcessGroup() {
+        expect(
+            AlanTerminalPtyShellActivityResolver.resolve(
+                launchesInteractiveShell: true,
+                semanticState: .foregroundCommand,
+                processGroupState: .shellInput
+            ) == .shellInput,
+            "a known idle process group must clear stale semantic foreground activity"
+        )
+        expect(
+            AlanTerminalPtyShellActivityResolver.resolve(
+                launchesInteractiveShell: true,
+                semanticState: .shellInput,
+                processGroupState: .foregroundCommand
+            ) == .foregroundCommand,
+            "a known foreground process group must override stale semantic prompt activity"
+        )
+        expect(
+            AlanTerminalPtyShellActivityResolver.resolve(
+                launchesInteractiveShell: true,
+                semanticState: .foregroundCommand,
+                processGroupState: nil
+            ) == .foregroundCommand,
+            "semantic activity must remain the fallback when process-group state is unavailable"
+        )
+        expect(
+            AlanTerminalPtyShellActivityResolver.resolve(
+                launchesInteractiveShell: false,
+                semanticState: nil,
+                processGroupState: .shellInput
+            ) == .foregroundCommand,
+            "a custom command must remain foreground from launch"
+        )
+    }
+
+    private static func verifiesBoundedReplayBufferTrimsOversizedHandoffChunks() {
+        var replayBuffer = AlanTerminalPtyBoundedReplayBuffer(maxBytes: 8)
+        replayBuffer.append(Data("old".utf8))
+        replayBuffer.append(Data("0123456789".utf8))
+        expect(
+            replayBuffer.byteCount == 8,
+            "one oversized renderer handoff chunk must obey the replay byte cap"
+        )
+        expect(
+            replayBuffer.chunks.reduce(into: Data()) { $0.append($1) }
+                == Data("23456789".utf8),
+            "an oversized renderer handoff must preserve only its bounded tail"
+        )
+
+        replayBuffer.removeAll()
+        replayBuffer.append(Data("12345".utf8))
+        replayBuffer.append(Data("67890".utf8))
+        expect(
+            replayBuffer.byteCount == 8,
+            "multiple renderer replay chunks must obey the same byte cap"
+        )
+        expect(
+            replayBuffer.takeChunks().reduce(into: Data()) { $0.append($1) }
+                == Data("34567890".utf8),
+            "multi-chunk replay trimming must retain the newest exact byte tail"
+        )
+        expect(
+            replayBuffer.byteCount == 0 && replayBuffer.chunks.isEmpty,
+            "taking renderer replay chunks must atomically clear the buffer"
         )
     }
 
@@ -441,6 +510,34 @@ private enum TerminalRuntimeServiceTests {
             "an unintegrated idle login shell must not remain permanently unknown; "
                 + "PTY=\(handle.shellActivityState) "
                 + "surface=\(String(describing: surface.snapshot.metadata.activeTaskState))"
+        )
+
+        let semanticMarker = "alan_stale_osc_\(UUID().uuidString)"
+        expect(
+            surface.sendControlText(
+                "printf '\(semanticMarker)\\033]133;C\\a\\n'\n"
+            ).applied,
+            "the unintegrated shell must accept a command that emits an unmatched OSC start"
+        )
+        let semanticOutputDeadline = Date().addingTimeInterval(2)
+        while Date() < semanticOutputDeadline
+            && !handle.snapshot.transcriptLines.joined(separator: "\n").contains(semanticMarker)
+        {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        expect(
+            handle.snapshot.transcriptLines.joined(separator: "\n").contains(semanticMarker),
+            "the stale-OSC regression must observe its semantic command-start output"
+        )
+        let semanticIdleDeadline = Date().addingTimeInterval(2)
+        while Date() < semanticIdleDeadline
+            && surface.snapshot.metadata.activeTaskState != .inactive
+        {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        expect(
+            surface.snapshot.metadata.activeTaskState == .inactive,
+            "a known idle process group must clear an unmatched OSC command-start marker"
         )
 
         expect(

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -25,6 +25,7 @@ private enum TerminalRuntimeServiceTests {
         verifiesManagedUserPtyRuntimeUsesHelperProviderWhenAvailable()
         verifiesWindowRuntimeDefaultPtyRuntimeWiresHelperProvider()
         verifiesManagedUserSurfaceRoutesHelperPtyLifecycleControls()
+        verifiesManagedUserDirectDrainReportsShellActivity()
         verifiesManagedUserRendererAttachmentBridgesHelperSession()
         verifiesAlanGhosttySurfaceDeliveryUsesPtyRuntimeWithoutRenderer()
         verifiesDarwinPtyBackendLaunchesLocalShell()
@@ -1049,6 +1050,17 @@ private enum TerminalRuntimeServiceTests {
             fail("managed_user renderer attachment must expose a renderer file descriptor")
         }
         let transcriptObserved = waitForPtyOutput(handle, contains: "helper-output-b")
+        let helperReadDeadline = Date().addingTimeInterval(1)
+        while Date() < helperReadDeadline
+            && helper.readPTYRequests.filter({
+                $0 == AlanManagedUserPTYReadRequest(
+                    sessionID: "fake-content_terminal_managed_user_renderer",
+                    maxBytes: 4096
+                )
+            }).count < 3
+        {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        }
         let snapshot = handle.snapshot
         let helperReadCount = helper.readPTYRequests.filter {
             $0 == AlanManagedUserPTYReadRequest(
@@ -1114,6 +1126,112 @@ private enum TerminalRuntimeServiceTests {
             stableExitSnapshot.exitStatus?.diagnosticsValue == "exit:0"
                 && stableExitSnapshot.phase == .exited,
             "managed_user renderer read failures after exit must not replace exited state with failure"
+        )
+    }
+
+    private static func verifiesManagedUserDirectDrainReportsShellActivity() {
+        let contentID = "content_terminal_managed_user_direct_drain"
+        let request = AlanTerminalBootRequest(
+            strategy: .terminalProfileManagedUser,
+            executablePath: "",
+            arguments: [],
+            workingDirectory: "/Users/lab",
+            environment: [
+                "ALAN_SHELL_CONTENT_ID": contentID,
+                "ALAN_MANAGED_USER_ACCOUNT": "lab",
+            ],
+            bootCommand: "managed_user 'lab'",
+            rendererCompatibilityCommand: nil,
+            managedUserAccountName: "lab",
+            terminalProfile: nil
+        )
+        let helper = AlanPrivilegedHelperFakeClient(channel: .dev)
+        let runtime = AlanDarwinTerminalPtyRuntime(
+            managedUserPtyProvider: AlanHelperManagedUserPtyProvider(helperClient: helper)
+        )
+        let handle = runtime.handle(
+            forTerminalContentID: contentID,
+            bootRequest: request
+        )
+        var observedShellActivity: [AlanTerminalPtyShellActivityState] = []
+        handle.onShellActivityStateChange = { observedShellActivity.append($0) }
+        let sessionID = "fake-\(contentID)"
+        helper.outputChunksBySessionID[sessionID] = [
+            Data("\u{1B}]133;".utf8),
+            Data("C\u{7}running\n".utf8),
+        ]
+
+        _ = handle.snapshot
+        expect(
+            handle.shellActivityState == .foregroundCommand
+                && observedShellActivity == [.foregroundCommand],
+            "managed_user direct snapshot drains must publish split OSC 133 command-start activity; "
+                + "observed \(observedShellActivity)"
+        )
+
+        helper.outputChunksBySessionID[sessionID] = [
+            Data("\u{1B}]133;D;0\u{7}\u{1B}]133;A\u{7}".utf8)
+        ]
+        _ = handle.snapshot
+        expect(
+            handle.shellActivityState == .shellInput
+                && observedShellActivity == [.foregroundCommand, .shellInput],
+            "managed_user direct snapshot drains must publish prompt activity; "
+                + "observed \(observedShellActivity)"
+        )
+
+        helper.outputChunksBySessionID[sessionID] = [
+            Data("\u{1B}]133;".utf8)
+        ]
+        _ = handle.snapshot
+        expect(
+            handle.shellActivityState == .shellInput,
+            "an incomplete direct-drain OSC marker must not publish activity"
+        )
+
+        helper.outputChunksBySessionID[sessionID] = [
+            Data("C\u{7}renderer-running\n".utf8)
+        ]
+        let rendererFileDescriptor: Int32
+        switch handle.makeRendererAttachment() {
+        case .attached(let attachment):
+            rendererFileDescriptor = attachment.readFileDescriptor
+        case .rejected(let rejection):
+            fail("managed_user parser handoff requires a renderer attachment: \(rejection.code)")
+        }
+        let rendererDeadline = Date().addingTimeInterval(1)
+        while Date() < rendererDeadline
+            && handle.shellActivityState != .foregroundCommand
+        {
+            _ = handle.snapshot
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        }
+        expect(
+            handle.shellActivityState == .foregroundCommand
+                && observedShellActivity
+                    == [.foregroundCommand, .shellInput, .foregroundCommand],
+            "managed_user renderer attachment must continue the direct drain parser state; "
+                + "observed \(observedShellActivity)"
+        )
+
+        close(rendererFileDescriptor)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        helper.outputChunksBySessionID[sessionID] = [
+            Data("\u{1B}]133;D;0\u{7}\u{1B}]133;A\u{7}".utf8)
+        ]
+        let detachedDeadline = Date().addingTimeInterval(1)
+        while Date() < detachedDeadline
+            && handle.shellActivityState != .shellInput
+        {
+            _ = handle.snapshot
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        }
+        expect(
+            handle.shellActivityState == .shellInput
+                && observedShellActivity
+                    == [.foregroundCommand, .shellInput, .foregroundCommand, .shellInput],
+            "managed_user direct drains must resume after renderer detachment; "
+                + "observed \(observedShellActivity)"
         )
     }
 

--- a/clients/apple/scripts/test-terminal-surface-controller.sh
+++ b/clients/apple/scripts/test-terminal-surface-controller.sh
@@ -55,6 +55,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperManagedUserService.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSessionStore.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperPTYSupport.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalShellIntegration.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/AlanPrivilegedHelperService.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellTitlePresentation.swift" \


### PR DESCRIPTION
## Summary

- send exact Command-Q from the Alan Dev UI smoke and require the active-work confirmation to appear
- make the Alan-owned PTY process group the renderer-independent authority for shell idle versus foreground execution, while retaining OSC 133 as richer semantic evidence
- keep one long-lived output pump per Darwin or Managed User PTY session, independent of renderer attachment
- continuously drain rendererless PTY output into a bounded 1 MiB replay buffer and preserve old-before-live ordering across attach, detach, and reattach
- signal the true foreground process group, with the session root process group used only as a fallback
- advance the Managed User helper protocol to version 4 so foreground process-group state is reported as a typed value

## Root cause

The original smoke sent Option-Command-Q, so it never exercised the exact close path. Correcting that exposed a deeper ownership error: terminal activity and output progress were coupled to the Ghostty renderer even though the PTY session outlives any renderer.

Input bytes cannot identify command lifecycle, and OSC 133 is not universally emitted by macOS Bash or custom processes. The PTY already owns the kernel-level foreground process-group relationship, so the runtime must derive its conservative idle or foreground state from `tcgetpgrp` and use protocol markers only to enrich that state.

The renderer coupling also allowed Managed User output to bypass the shared parser, left rendererless output undrained, permitted replay and live output to race, and could signal the shell process group instead of the actual foreground command. The final model gives each PTY session one serialized output owner and one activity owner for its entire lifetime. Renderer attachment is only a routing change.

## Permanent regressions

- a real Bash PTY without shell integration is idle at a prompt, becomes foreground while `sleep 30` runs, receives SIGINT through the true foreground process group, and returns to idle
- a custom command is foreground from launch
- Darwin and Managed User output produced without a renderer is drained and replayed before post-attachment live output
- Managed User output already read during renderer invalidation is handed back to bounded replay rather than lost
- helper foreground-process-group state transitions correctly without a renderer
- `static func` and `HEAD^` remain accepted by the architecture checker while illegal multiline static shared state is rejected

## Validation

- `bash clients/apple/scripts/test-terminal-runtime-service.sh` passed repeatedly
- `bash clients/apple/scripts/check-shell-contracts.sh`
- `just apple-shell-focused-tests`
- `just quality` with 0 architecture warnings
- `openspec validate deepen-macos-shell-host-ownership --strict`
- signed and installed `Alan Dev.app`, then completed the full `just apple-shell-ui-smoke` including active `sleep 30`, exact Command-Q confirmation, restart restore, stdin plus EOF, and stale-confirmation checks

Only `Alan Dev.app` (`app.alanworks.macos.dev`) was rebuilt and launched. Stable Alan was not touched.