### PR TITLE
fix(macos): bind architecture ratchet to repo

### DIFF
--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -30,9 +30,9 @@ shell_architecture_current_inventory="$(mktemp)"
 shell_architecture_base_tree="$(mktemp -d)"
 trap 'rm -f "$warning_inventory" "$warning_inventory_sorted" "$warning_baseline_body" "$warning_baseline_sorted" "$base_warning_baseline" "$shell_architecture_base_inventory" "$shell_architecture_current_inventory"; rm -rf "$shell_architecture_base_tree"' EXIT
 
-git_command=(git)
+git_command=(git -C "$REPO_ROOT")
 if [[ -n "${ALAN_QUALITY_GIT_DIR:-}" ]]; then
-    git_command+=(--git-dir="$ALAN_QUALITY_GIT_DIR")
+    git_command=(git --git-dir="$ALAN_QUALITY_GIT_DIR")
 fi
 base_ref="${ALAN_QUALITY_BASE_REF:-HEAD}"
 

--- a/clients/apple/scripts/test-architecture-maintainability.sh
+++ b/clients/apple/scripts/test-architecture-maintainability.sh
@@ -35,6 +35,7 @@ git -C "$fixture" \
     commit --quiet --allow-empty -m head
 
 probe="$fixture/clients/apple/alan-macos/App/AlanMacUpdateController.swift"
+cd "$(dirname "$fixture")"
 cat >>"$probe" <<'SWIFT'
 
 #if os(macOS)


### PR DESCRIPTION
## Summary
- resolve architecture ratchet Git refs from the checker repo instead of the caller cwd
- run the permanent self-test outside its fixture repository so `HEAD^` coverage cannot pass accidentally

## Verification
- `bash clients/apple/scripts/test-architecture-maintainability.sh`
- checker invoked directly from `/private/tmp` with `--strict`
- `just quality`