### PR TITLE
fix(security): update h2 past unbounded DATA frame issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,9 +1552,9 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
Updates h2 from 0.4.13 to 0.4.16 to resolve RUSTSEC-2026-0258 (unbounded empty DATA frames).

Validation: cargo check --locked --workspace --all-targets; cargo audit (only existing allowed warnings remain).